### PR TITLE
[Woo POS] Design iteration on Simple Products banner

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -82,8 +82,8 @@ private extension ItemListView {
                 .font(Constants.bannerSubtitleFont)
                 .accessibilityElement(children: .combine)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, Constants.bannerVerticalPadding)
-            Spacer()
             VStack {
                 Button(action: {
                     viewModel.dismissBanner()

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -57,7 +57,7 @@ private extension ItemListView {
     }
 
     var bannerCardView: some View {
-        HStack(alignment: .top) {
+        HStack(alignment: .top, spacing: 0) {
             VStack {
                 Spacer()
                 Image(systemName: "info.circle")

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -75,9 +75,7 @@ private extension ItemListView {
                     .accessibilityAddTraits(.isHeader)
                 VStack(alignment: .leading, spacing: Constants.bannerTextSpacing) {
                     Text(Localization.headerBannerSubtitle)
-                    Text(Localization.headerBannerHint)
-                    Text(Localization.headerBannerLearnMoreHint)
-                        .linkStyle()
+                    bannerHintAndLearnMoreText
                 }
                 .font(Constants.bannerSubtitleFont)
                 .accessibilityElement(children: .combine)
@@ -107,6 +105,13 @@ private extension ItemListView {
             viewModel.simpleProductsInfoButtonTapped()
         }
         .padding(.horizontal, Constants.bannerCardPadding)
+    }
+
+    private var bannerHintAndLearnMoreText: Text {
+        Text(Localization.headerBannerHint + " ") +
+        Text(Localization.headerBannerLearnMoreHint)
+            .font(.body)
+            .foregroundColor(Color(.accent))
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -78,6 +78,7 @@ private extension ItemListView {
                     bannerHintAndLearnMoreText
                 }
                 .font(Constants.bannerSubtitleFont)
+                .lineSpacing(Constants.bannerTextSpacing)
                 .accessibilityElement(children: .combine)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -140,7 +141,7 @@ private extension ItemListView {
         static let bannerSubtitleFont: POSFontStyle = .posDetailRegular
         static let bannerCornerRadius: CGFloat = 8
         static let bannerVerticalPadding: CGFloat = 26
-        static let bannerTextSpacing: CGFloat = 2
+        static let bannerTextSpacing: CGFloat = 4
         static let bannerTitleSpacing: CGFloat = 8
         static let infoIconPadding: CGFloat = 16
         static let bannerInfoIconSize: CGFloat = 44

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -111,7 +111,7 @@ private extension ItemListView {
     private var bannerHintAndLearnMoreText: Text {
         Text(Localization.headerBannerHint + " ") +
         Text(Localization.headerBannerLearnMoreHint)
-            .font(.body)
+            .font(POSFontStyle.posDetailEmphasized.font())
             .foregroundColor(Color(.accent))
     }
 

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
@@ -19,6 +19,7 @@ struct SimpleProductsOnlyInformation: View {
                 Group {
                     Text(Localization.simpleProductsOnlyIssueMessage)
                     Text(Localization.simpleProductsOnlyFutureMessage)
+                        .padding(.bottom, Constants.textToModalBottomPadding)
                 }
                 .font(.posBodyRegular)
 
@@ -63,6 +64,7 @@ private extension SimpleProductsOnlyInformation {
         static let hintBackgroundCornerRadius: CGFloat = 8
         static let contentBlockSpacing: CGFloat = 40
         static let textSpacing: CGFloat = 16
+        static let textToModalBottomPadding: CGFloat = 8
     }
 
     enum Localization {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13939
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR updates the Simple Products banner following the design feedback on https://github.com/woocommerce/woocommerce-ios/issues/13859 and TfaZ4LUkEwEGrxfnEFzvJj-fi-4650_22247

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-09-12 at 16 29 23](https://github.com/user-attachments/assets/757d14c1-62db-4046-a98f-6ed7c5b0e73f) | ![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-09-12 at 16 22 32](https://github.com/user-attachments/assets/17c3df33-0cb4-4f09-928d-48ba5699263e) | 

## Changes
- Removed spacing in banner's HStack. This caused the icon to show un-even spacing to the right.

<img width="844" alt="Screenshot 2024-09-12 at 16 30 54" src="https://github.com/user-attachments/assets/3c92ab25-b36f-4329-bc8a-f0ca0ae4f936">

- Adjusted text to fill out more available space, while aligned to the left 

<img width="884" alt="Screenshot 2024-09-12 at 16 34 17" src="https://github.com/user-attachments/assets/22ca1f58-bb8b-41f8-9473-cad4b16568a0">

- Update `Learn More` to be interpolated within the rest of the text, rather than appearing on a separate line. Also adjusted the height between lines.

<img width="640" alt="Screenshot 2024-09-12 at 16 35 05" src="https://github.com/user-attachments/assets/e0da382d-bc39-4da1-b834-063256e2ccb3">


## Testing
* Run a fresh app install, or add the following line to the `ItemListViewModel` init: 
```
UserDefaults.standard.set(false, forKey: BannerState.isSimpleProductsOnlyBannerDismissedKey)
``` 
* Run the POS and observe the Simple Products banner appears
* Observe that the items above have been addressed: 
  * Even spacing to both sides of the (i) icon
  * Text is occupying more available space
  * "Learn More" appears as follow-up to the rest of the text, rather than on a separate line


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.