### PR TITLE
Blaze: Fix the layout of loading state and error state of objective picker view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
@@ -17,12 +17,15 @@ struct BlazeCampaignObjectivePickerView: View {
 
     var body: some View {
         NavigationStack {
-            Group {
+            VStack {
                 if viewModel.fetchedData.isNotEmpty {
                     optionList
                 } else if viewModel.isSyncingData {
+                    Spacer()
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                    Spacer()
                 } else if viewModel.syncError != nil {
+                    Spacer()
                     ErrorStateView(title: Localization.errorMessage,
                                    image: .errorImage,
                                    actionTitle: Localization.tryAgain,
@@ -31,6 +34,7 @@ struct BlazeCampaignObjectivePickerView: View {
                             await viewModel.syncData()
                         }
                     })
+                    Spacer()
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
@@ -34,6 +34,7 @@ struct BlazeCampaignObjectivePickerView: View {
                             await viewModel.syncData()
                         }
                     })
+                    .multilineTextAlignment(.center)
                     Spacer()
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
@@ -17,15 +17,12 @@ struct BlazeCampaignObjectivePickerView: View {
 
     var body: some View {
         NavigationStack {
-            VStack {
+            Group {
                 if viewModel.fetchedData.isNotEmpty {
                     optionList
                 } else if viewModel.isSyncingData {
-                    Spacer()
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                    Spacer()
                 } else if viewModel.syncError != nil {
-                    Spacer()
                     ErrorStateView(title: Localization.errorMessage,
                                    image: .errorImage,
                                    actionTitle: Localization.tryAgain,
@@ -35,9 +32,9 @@ struct BlazeCampaignObjectivePickerView: View {
                         }
                     })
                     .multilineTextAlignment(.center)
-                    Spacer()
                 }
             }
+            .frame(maxHeight: .infinity)
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle(Localization.title)
             .toolbar {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13942 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a quick fix for the Blaze campaign objective picker by pushing the footer view to the bottom in the loading and error states.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- If you tested campaign objective before, log out of the app to clear the cached data.
- Log in to a store eligible for Blaze.
- Disconnect the internet connection.
- Start the Blaze campaign creation flow and select the objective list.
- Confirm that in the loading state, the footer is at the bottom of the screen.
- When the request time out, confirm that in the error state, the footer is at the bottom of the screen.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After 
--- | ---
<img src="https://github.com/user-attachments/assets/3cb241f6-18b9-4ae1-a688-9e0ef5da700e" width=320 /> | <img src="https://github.com/user-attachments/assets/dc33d39f-cfae-47ff-9c4d-d162e130d3f0" width=320 />
<img src="https://github.com/user-attachments/assets/d09a51bc-a63f-431c-bd89-99ed48702eb5" width=320 /> | <img src="https://github.com/user-attachments/assets/3f952136-7ab1-4af5-9280-84f2d77f45e9" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
