### PR TITLE
Blaze: Navigate to campaign creation after tapping on local notifications 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fixed the incorrect navigation title of the product selector in the Blaze campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13903]
 - [*] Payments: Fixed an issue to ensure the payment onboarding state is reset after logout and login. [https://github.com/woocommerce/woocommerce-ios/pull/13897]
 - [*] Blaze: Open blaze campaign detail page upon tapping push notification. [https://github.com/woocommerce/woocommerce-ios/pull/13843]
+- [*] Blaze: Tapping on no campaign reminder navigates to campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13944]
 - [internal] Updated dependencies for Xcode 16 Support [https://github.com/woocommerce/woocommerce-ios/pull/13911]
 
 20.3

--- a/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
@@ -63,6 +63,11 @@ final class DefaultBlazeLocalNotificationScheduler: BlazeLocalNotificationSchedu
                 }
 
                 userDefaults.setBlazeNoCampaignReminderOpened(true)
+
+                let siteID = response.notification.request.content.userInfo[Constants.siteIDKey] as? Int64
+                if let siteID {
+                    // TODO: switch site if needed then open campaign creation
+                }
             }
             .store(in: &subscriptions)
     }
@@ -133,7 +138,7 @@ private extension DefaultBlazeLocalNotificationScheduler {
 
         Task { @MainActor in
             let notification = LocalNotification(scenario: LocalNotification.Scenario.blazeNoCampaignReminder,
-                                                 userInfo: [:])
+                                                 userInfo: [Constants.siteIDKey: siteID])
             await scheduler.cancel(scenario: .blazeNoCampaignReminder)
             DDLogDebug("Blaze: Schedule local notification for date \(notificationTime).")
             await scheduler.schedule(notification: notification,
@@ -147,6 +152,7 @@ private extension DefaultBlazeLocalNotificationScheduler {
 private extension DefaultBlazeLocalNotificationScheduler {
     enum Constants {
         static let daysDurationNoCampaignReminderNotification = 30
+        static let siteIDKey = "site_id"
     }
 }
 

--- a/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
@@ -64,9 +64,14 @@ final class DefaultBlazeLocalNotificationScheduler: BlazeLocalNotificationSchedu
 
                 userDefaults.setBlazeNoCampaignReminderOpened(true)
 
-                let siteID = response.notification.request.content.userInfo[Constants.siteIDKey] as? Int64
-                if let siteID {
-                    // TODO: switch site if needed then open campaign creation
+                guard let siteID = response.notification.request.content.userInfo[Constants.siteIDKey] as? Int64 else {
+                    return
+                }
+                Task { @MainActor [weak self] in
+                    guard let self, await isEligibleForBlaze() else {
+                        return
+                    }
+                    MainTabBarController.navigateToBlazeCampaignCreation(for: siteID)
                 }
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -24,8 +24,12 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
     /// View model for the list.
     private let viewModel: BlazeCampaignListViewModel
 
-    init(viewModel: BlazeCampaignListViewModel) {
+    private var startsCampaignCreationOnAppear: Bool
+
+    init(viewModel: BlazeCampaignListViewModel,
+         startsCampaignCreationOnAppear: Bool = false) {
         self.viewModel = viewModel
+        self.startsCampaignCreationOnAppear = startsCampaignCreationOnAppear
         super.init(rootView: BlazeCampaignListView(viewModel: viewModel))
 
         rootView.onCreateCampaign = { [weak self] in
@@ -36,6 +40,14 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
     @available(*, unavailable)
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if startsCampaignCreationOnAppear {
+            startsCampaignCreationOnAppear = false
+            startCampaignCreation()
+        }
     }
 }
 
@@ -65,17 +77,21 @@ private extension BlazeCampaignListHostingController {
 struct BlazeCampaignListHostingControllerRepresentable: UIViewControllerRepresentable {
     private let siteID: Int64
     private let selectedCampaignID: String?
+    private let startsCampaignCreationOnAppear: Bool
 
     init(siteID: Int64,
-         selectedCampaignID: String? = nil) {
+         selectedCampaignID: String? = nil,
+         startsCampaignCreationOnAppear: Bool = false) {
         self.siteID = siteID
         self.selectedCampaignID = selectedCampaignID
+        self.startsCampaignCreationOnAppear = startsCampaignCreationOnAppear
     }
     func makeUIViewController(context: Context) -> BlazeCampaignListHostingController {
 
         let viewModel = BlazeCampaignListViewModel(siteID: siteID,
                                                    selectedCampaignID: selectedCampaignID ?? nil)
-        return BlazeCampaignListHostingController(viewModel: viewModel)
+        return BlazeCampaignListHostingController(viewModel: viewModel,
+                                                  startsCampaignCreationOnAppear: startsCampaignCreationOnAppear)
     }
 
     func updateUIViewController(_ uiViewController: BlazeCampaignListHostingController, context: Context) {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -177,6 +177,8 @@ private extension HubMenu {
                 reviewDetailView(parcel: parcel)
             case .blazeCampaignDetails(let campaignID):
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, selectedCampaignID: campaignID)
+            case .blazeCampaignCreation:
+                BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, startsCampaignCreationOnAppear: true)
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -58,6 +58,10 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         viewModel.navigateToDestination(.blazeCampaignDetails(campaignID: campaignID))
     }
 
+    func showBlazeCampaignCreation() {
+        viewModel.navigateToDestination(.blazeCampaignCreation)
+    }
+
     /// Pushes the Settings & Privacy screen onto the navigation stack.
     ///
     func showPrivacySettings() {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -18,6 +18,7 @@ enum HubMenuNavigationDestination: Hashable {
     case settings
     case blaze
     case blazeCampaignDetails(campaignID: String)
+    case blazeCampaignCreation
     case wooCommerceAdmin
     case viewStore
     case inbox

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -489,6 +489,21 @@ extension MainTabBarController {
         })
     }
 
+    static func navigateToBlazeCampaignCreation(for siteID: Int64) {
+        showStore(with: Int64(siteID), onCompletion: { storeIsShown in
+            // It failed to show the campaign's store.
+            guard storeIsShown else {
+                return
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.blazeScreenTransitionsDelay) {
+                switchToHubMenuTab() { hubMenuViewController in
+                    hubMenuViewController?.showBlazeCampaignCreation()
+                }
+            }
+        })
+    }
+
     static func presentOrderCreationFlow(for customerID: Int64, billing: Address?, shipping: Address?) {
         switchToOrdersTab {
             let tabBar = AppDelegate.shared.tabBarController


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13935 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the navigation to campaign creation upon tapping on local notifications for no Blaze campaign reminders. The site ID was restored for the user info of the notifications and is used to handle store switching and checking for eligibility.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Build the app to a physical device to test notifications.
- If you tested Blaze local notifications before, log out and log in again to a test store eligible for Blaze to ensure that local notifications can be scheduled again.
- Schedule a few non-evergreen campaigns (from web or mobile app). Note down the start time and duration of the latest campaign. i.e. The campaign that ends the last based on start_time and duration_days values.
- Send the app to background or kill the app
- Add 30 days to the start time and duration of the latest campaign.
- Change the device time to one or two minutes before the above calculated time.
- Wait for the notification to arrive.
- Tap on the notification and the app should be opened and navigate to the hub menu tab > Blaze > campaign creation.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on iPhone 12 Pro iOS 17.6.1 and confirmed that tapping on no campaign reminders navigate to the campaign creation flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/c449ca26-30bb-4fd5-b8de-d2d5386c9dea



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.