### PR TITLE
Use named block parameters in `new_hotfix_release` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -387,42 +387,38 @@ platform :ios do
   # bundle exec fastlane new_hotfix_release skip_confirm:true version:10.6.1
   #####################################################################################
   desc 'Creates a new hotfix branch for the given version:x.y.z. The branch will be cut from the tag x.y of the previous release'
-  lane :new_hotfix_release do |options|
+  lane :new_hotfix_release do |version:, skip_confirm: false|
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
 
-    new_version = options[:version] || UI.input('Version number for the new hotfix?')
-
     # Parse the provided version into an AppVersion object
-    parsed_version = VERSION_FORMATTER.parse(new_version)
+    parsed_version = VERSION_FORMATTER.parse(version)
     build_code_hotfix = BUILD_CODE_FORMATTER.build_code(version: parsed_version)
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
 
     # Check versions
     UI.important <<-MESSAGE
 
-      New hotfix version: #{new_version}
+      New hotfix version: #{version}
       New build code: #{build_code_hotfix}
       Branching from tag: #{previous_version}
 
     MESSAGE
-    unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
-      UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.")
-    end
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Check tags
-    UI.user_error!("Version #{new_version} already exists! Abort!") if git_tag_exists(tag: new_version)
+    UI.user_error!("Version #{version} already exists! Abort!") if git_tag_exists(tag: version)
     UI.user_error!("Version #{previous_version} is not tagged! A hotfix branch cannot be created.") unless git_tag_exists(tag: previous_version)
 
     # Create the hotfix branch
     UI.message('Creating hotfix branch...')
-    Fastlane::Helper::GitHelper.create_branch("release/#{new_version}", from: previous_version)
+    Fastlane::Helper::GitHelper.create_branch("release/#{version}", from: previous_version)
     UI.success("Done! New hotfix branch is: #{git_branch}")
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file
     UI.message('Bumping hotfix version and build code...')
     VERSION_FILE.write(
-      version_short: new_version,
+      version_short: version,
       version_long: build_code_hotfix
     )
     commit_version_bump


### PR DESCRIPTION
Similar to #13793.

## Description

While working on https://github.com/Automattic/simplenote-ios/pull/1655 in the context of paaHJt-6ps-p2, I noticed `new_hotfix_release` lane used `options`. Updating it was a matter of a few SLOC.



## Steps to reproduce
N.A.

## Testing information
N.A. - I reviewed the changes carefully and trust you'll do the same. 

This lane will run when we'll build a new hotfix, which we can't know ahead of time. Having said that, we can hack it a bit and test most of it:

```diff
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -389,7 +389,7 @@ platform :ios do
   desc 'Creates a new hotfix branch for the given version:x.y.z. The branch will be cut from the tag x.y of the previous release'
   lane :new_hotfix_release do |version:, skip_confirm: false|
     # Verify that there's nothing in progress in the working copy
-    ensure_git_status_clean
+    # ensure_git_status_clean
 
     # Parse the provided version into an AppVersion object
     parsed_version = VERSION_FORMATTER.parse(version)
@@ -424,7 +424,7 @@ platform :ios do
     commit_version_bump
 
     # Push the newly created hotfix branch
-    push_to_git_remote(tags: false)
+    # push_to_git_remote(tags: false)
 
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
   end
```

The result on my end of running `bundle exec fastlane new_hotfix_release version:20.2.1`:

```
wcios  test [8$ 2?] 💎 v3.2.2 took 7s
➜ bf new_hotfix_release version:20.2.1

[✔] 🚀
[16:24:28]: ------------------------------
[16:24:28]: --- Step: default_platform ---
[16:24:28]: ------------------------------
[16:24:28]: Driving the lane 'ios new_hotfix_release' 🚀
[16:24:28]: -------------------
[16:24:28]: --- Step: is_ci ---
[16:24:28]: -------------------
[16:24:28]: ---------------------------------------
[16:24:28]: --- Step: check_for_toolkit_updates ---
[16:24:28]: ---------------------------------------
[16:24:28]: Currently using release toolkit version 12.0.0.
[16:24:28]: Checking for updates now...
[16:24:29]: There is a newest version 12.1.0 of the release toolkit!
[16:24:29]: Do you want to run bundle update now? (y/n)
n
[16:24:39]: -------------------
[16:24:39]: --- Step: is_ci ---
[16:24:39]: -------------------
[16:24:39]: ----------------------
[16:24:39]: --- Step: setup_ci ---
[16:24:39]: ----------------------
[16:24:39]: Not running on CI, skipping CI setup
[16:24:39]:
      New hotfix version: 20.2.1
      New build code: 20.2.1.0
      Branching from tag: 20.2


[16:24:39]: Do you want to continue? (y/n)
y
[16:24:40]: ----------------------------
[16:24:40]: --- Step: git_tag_exists ---
[16:24:40]: ----------------------------
[16:24:40]: Shell command exited with exit status 1 instead of 0.
[16:24:40]: ----------------------------
[16:24:40]: --- Step: git_tag_exists ---
[16:24:40]: ----------------------------
[16:24:40]: Creating hotfix branch...
[16:24:40]: $ git branch --list release/20.2.1
[16:24:40]: $ git checkout 20.2
[16:24:41]: ▸ Note: switching to '20.2'.
[16:24:41]: ▸ You are in 'detached HEAD' state. You can look around, make experimental
[16:24:41]: ▸ changes and commit them, and you can discard any commits you make in this
[16:24:41]: ▸ state without impacting any branches by switching back to a branch.
[16:24:41]: ▸ If you want to create a new branch to retain commits you create, you may
[16:24:41]: ▸ do so (now or later) by using -c with the switch command. Example:
[16:24:41]: ▸ git switch -c <new-branch-name>
[16:24:41]: ▸ Or undo this operation with:
[16:24:41]: ▸ git switch -
[16:24:41]: ▸ Turn off this advice by setting config variable advice.detachedHead to false
[16:24:41]: ▸ HEAD is now at cb31f4183b Bump version number
[16:24:41]: $ git checkout -b release/20.2.1
[16:24:41]: ▸ Switched to a new branch 'release/20.2.1'
[16:24:41]: ------------------------
[16:24:41]: --- Step: git_branch ---
[16:24:41]: ------------------------
[16:24:41]: Done! New hotfix branch is: release/20.2.1
[16:24:41]: Bumping hotfix version and build code...
[16:24:41]: ------------------------
[16:24:41]: --- Step: git_commit ---
[16:24:41]: ------------------------
[16:24:41]: $ git commit -m Bump\ version\ number /Users/gio/Developer/a8c/wcios/config/Version.Public.xcconfig
[16:24:41]: ▸ [release/20.2.1 090d36d0ed] Bump version number
[16:24:41]: ▸ 1 file changed, 2 insertions(+), 2 deletions(-)
[16:24:41]: Successfully committed "["/Users/gio/Developer/a8c/wcios/config/Version.Public.xcconfig"]" 💾.
[16:24:41]: Done! New Release Version: 20.2.1. New Build Code: 20.2.1.0
[16:24:41]: fastlane.tools finished successfully 🎉
```

## Screenshots
N.A.

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.


## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.ar