### PR TITLE
[Shipping labels] Add view models to provide data from order items to items section

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -508,7 +508,8 @@ private extension OrderDetailsViewController {
             return
         }
 
-        let shippingLabelCreationVC = WooShippingCreateLabelsViewHostingController()
+        let shippingLabelCreationVM = WooShippingCreateLabelsViewModel(order: viewModel.order)
+        let shippingLabelCreationVC = WooShippingCreateLabelsViewHostingController(viewModel: shippingLabelCreationVM)
         shippingLabelCreationVC.modalPresentationStyle = .overFullScreen
         navigationController?.present(shippingLabelCreationVC, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRowViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Provides view data for `WooShippingItemRow`.
+///
+struct WooShippingItemRowViewModel: Identifiable {
+    /// Unique ID for the item row
+    let id = UUID()
+
+    /// URL for item image
+    let imageUrl: URL?
+
+    /// Label for item quantity
+    let quantityLabel: String
+
+    /// Item name
+    let name: String
+
+    /// Label for item details
+    let detailsLabel: String
+
+    /// Label for item weight
+    let weightLabel: String
+
+    /// Label for item price
+    let priceLabel: String
+}
+
+/// Convenience extension to provide data to `WooShippingItemRow`
+extension WooShippingItemRow {
+    init(viewModel: WooShippingItemRowViewModel) {
+        self.imageUrl = viewModel.imageUrl
+        self.quantityLabel = viewModel.quantityLabel
+        self.name = viewModel.name
+        self.detailsLabel = viewModel.detailsLabel
+        self.weightLabel = viewModel.weightLabel
+        self.priceLabel = viewModel.priceLabel
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
@@ -8,6 +8,9 @@ struct WooShippingItems: View {
     /// Label for the total item details
     let itemsDetailLabel: String
 
+    /// View models for items to ship
+    let items: [WooShippingItemRowViewModel]
+
     /// Whether the item list is collapsed
     @State private var isCollapsed: Bool = true
 
@@ -25,22 +28,11 @@ struct WooShippingItems: View {
         },
                         content: {
             VStack {
-                WooShippingItemRow(imageUrl: nil,
-                                   quantityLabel: "3",
-                                   name: "Little Nap Brazil 250g",
-                                   detailsLabel: "15×10×8cm • Espresso",
-                                   weightLabel: "275g",
-                                   priceLabel: "$60.00")
-                .padding()
-                .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
-                WooShippingItemRow(imageUrl: nil,
-                                   quantityLabel: "3",
-                                   name: "Little Nap Brazil 250g",
-                                   detailsLabel: "15×10×8cm • Espresso",
-                                   weightLabel: "275g",
-                                   priceLabel: "$60.00")
-                .padding()
-                .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+                ForEach(items) { item in
+                    WooShippingItemRow(viewModel: item)
+                        .padding()
+                        .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+                }
             }
         })
         .padding()
@@ -60,5 +52,18 @@ private extension WooShippingItems {
 }
 
 #Preview {
-    WooShippingItems(itemsCountLabel: "6 items", itemsDetailLabel: "825g  ·  $135.00")
+    WooShippingItems(itemsCountLabel: "6 items",
+                     itemsDetailLabel: "825g  ·  $135.00",
+                     items: [WooShippingItemRowViewModel(imageUrl: nil,
+                                                         quantityLabel: "3",
+                                                         name: "Little Nap Brazil 250g",
+                                                         detailsLabel: "15×10×8cm • Espresso",
+                                                         weightLabel: "275g",
+                                                         priceLabel: "$60.00"),
+                             WooShippingItemRowViewModel(imageUrl: nil,
+                                                         quantityLabel: "3",
+                                                         name: "Little Nap Brazil 250g",
+                                                         detailsLabel: "15×10×8cm • Espresso",
+                                                         weightLabel: "275g",
+                                                         priceLabel: "$60.00")])
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -1,16 +1,89 @@
 import Foundation
+import Yosemite
+import WooFoundation
 
 /// Provides view data for `WooShippingItems`.
 ///
-struct WooShippingItemsViewModel {
-    /// Label for the total number of items
-    let itemsCountLabel: String
+final class WooShippingItemsViewModel: ObservableObject {
+    private let order: Order
+    private let currencyFormatter: CurrencyFormatter
 
-    /// Label for the total item details
-    let itemsDetailLabel: String
+    /// Label with the total number of items to ship.
+    @Published var itemsCountLabel: String = ""
 
-    /// View models for items to ship
-    let items: [WooShippingItemRowViewModel]
+    /// Label with the details of the items to ship.
+    @Published var itemsDetailLabel: String = ""
+
+    /// View models for rows of items to ship.
+    @Published var itemRows: [WooShippingItemRowViewModel] = []
+
+    init(order: Order,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        self.order = order
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+
+        configureSectionHeader()
+        configureItemRows()
+    }
+}
+
+private extension WooShippingItemsViewModel {
+    /// Configures the labels in the section header.
+    ///
+    func configureSectionHeader() {
+        itemsCountLabel = generateItemsCountLabel()
+        itemsDetailLabel = generateItemsDetailLabel()
+    }
+
+    /// Configures the item rows.
+    ///
+    func configureItemRows() {
+        itemRows = generateItemRows()
+    }
+
+    /// Generates a label with the total number of items to ship.
+    ///
+    func generateItemsCountLabel() -> String {
+        let itemsCount = order.items
+            .map { $0.quantity }
+            .reduce(0, +)
+        return Localization.itemsCount(itemsCount)
+    }
+
+    /// Generates a label with the details of the items to ship.
+    ///
+    func generateItemsDetailLabel() -> String {
+        let formattedWeight = "1 kg" // TODO-13550: Get the total weight (each product/variation * item quantity) and weight unit
+        let formattedPrice = currencyFormatter.formatAmount(order.total) ?? order.total
+
+        return "\(formattedWeight) • \(formattedPrice)"
+    }
+
+    /// Generates an item row view model for each order item.
+    ///
+    func generateItemRows() -> [WooShippingItemRowViewModel] {
+        order.items.map { item in
+            return WooShippingItemRowViewModel(imageUrl: nil, // TODO-13550: Get the product/variation imageURL
+                                               quantityLabel: item.quantity.description,
+                                               name: item.name,
+                                               detailsLabel: "", // TODO-13550: Get the product details
+                                               weightLabel: "",  // TODO-13550: Get the product/variation weight
+                                               priceLabel: currencyFormatter.formatAmount(item.total) ?? item.total)
+        }
+    }
+}
+
+// MARK: Constants
+private extension WooShippingItemsViewModel {
+    enum Localization {
+        static func itemsCount(_ count: Decimal) -> String {
+            let formattedCount = NumberFormatter.localizedString(from: count as NSDecimalNumber, number: .decimal)
+            return String(format: Localization.itemsCountFormat, formattedCount)
+        }
+        static let itemsCountFormat = NSLocalizedString("wooShipping.createLabels.items.count",
+                                                        value: "%1$@ items",
+                                                        comment: "Total number of items to ship during shipping label creation.")
+    }
 }
 
 /// Convenience extension to provide data to `WooShippingItemRow`
@@ -18,6 +91,6 @@ extension WooShippingItems {
     init(viewModel: WooShippingItemsViewModel) {
         self.itemsCountLabel = viewModel.itemsCountLabel
         self.itemsDetailLabel = viewModel.itemsDetailLabel
-        self.items = viewModel.items
+        self.items = viewModel.itemRows
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -51,6 +51,7 @@ private extension WooShippingItemsViewModel {
     }
 
     /// Generates a label with the details of the items to ship.
+    /// This includes the total weight and total price of all items.
     ///
     func generateItemsDetailLabel() -> String {
         let formattedWeight = "1 kg" // TODO-13550: Get the total weight (each product/variation * item quantity) and weight unit

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Provides view data for `WooShippingItems`.
+///
+struct WooShippingItemsViewModel {
+    /// Label for the total number of items
+    let itemsCountLabel: String
+
+    /// Label for the total item details
+    let itemsDetailLabel: String
+
+    /// View models for items to ship
+    let items: [WooShippingItemRowViewModel]
+}
+
+/// Convenience extension to provide data to `WooShippingItemRow`
+extension WooShippingItems {
+    init(viewModel: WooShippingItemsViewModel) {
+        self.itemsCountLabel = viewModel.itemsCountLabel
+        self.itemsDetailLabel = viewModel.itemsDetailLabel
+        self.items = viewModel.items
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -67,10 +67,25 @@ private extension WooShippingItemsViewModel {
             return WooShippingItemRowViewModel(imageUrl: nil, // TODO-13550: Get the product/variation imageURL
                                                quantityLabel: item.quantity.description,
                                                name: item.name,
-                                               detailsLabel: "", // TODO-13550: Get the product details
+                                               detailsLabel: generateItemRowDetailsLabel(for: item),
                                                weightLabel: "",  // TODO-13550: Get the product/variation weight
                                                priceLabel: currencyFormatter.formatAmount(item.total) ?? item.total)
         }
+    }
+
+    /// Generates a details label for an item row.
+    ///
+    func generateItemRowDetailsLabel(for item: OrderItem) -> String {
+        let formattedDimensions: String? = nil // TODO-13550: Get the product/variation dimensions
+
+        let attributes: String? = {
+            guard item.attributes.isNotEmpty else {
+                return nil
+            }
+            return item.attributes.map { VariationAttributeViewModel(orderItemAttribute: $0) }.map(\.nameOrValue).joined(separator: ", ")
+        }()
+
+        return [formattedDimensions, attributes].compacted().joined(separator: " • ")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -20,7 +20,21 @@ struct WooShippingCreateLabelsView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                WooShippingItems(itemsCountLabel: "6 items", itemsDetailLabel: "825g  ·  $135.00")
+                // TODO-13550: Add view model to provide real data
+                WooShippingItems(itemsCountLabel: "6 items",
+                                 itemsDetailLabel: "825g  ·  $135.00",
+                                 items: [WooShippingItemRowViewModel(imageUrl: nil,
+                                                                     quantityLabel: "3",
+                                                                     name: "Little Nap Brazil 250g",
+                                                                     detailsLabel: "15×10×8cm • Espresso",
+                                                                     weightLabel: "275g",
+                                                                     priceLabel: "$60.00"),
+                                         WooShippingItemRowViewModel(imageUrl: nil,
+                                                                     quantityLabel: "30",
+                                                                     name: "Little Nap Brazil 250g",
+                                                                     detailsLabel: "15×10×8cm • Espresso",
+                                                                     weightLabel: "275g",
+                                                                     priceLabel: "$60.00")])
                     .padding()
             }
             .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -3,8 +3,11 @@ import SwiftUI
 /// Hosting controller for `WooShippingCreateLabelsView`.
 ///
 final class WooShippingCreateLabelsViewHostingController: UIHostingController<WooShippingCreateLabelsView> {
-    init() {
-        super.init(rootView: WooShippingCreateLabelsView())
+    let viewModel: WooShippingCreateLabelsViewModel
+
+    init(viewModel: WooShippingCreateLabelsViewModel) {
+        self.viewModel = viewModel
+        super.init(rootView: WooShippingCreateLabelsView(viewModel: viewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -15,26 +18,14 @@ final class WooShippingCreateLabelsViewHostingController: UIHostingController<Wo
 /// View to create shipping labels with the Woo Shipping extension.
 ///
 struct WooShippingCreateLabelsView: View {
+    @ObservedObject var viewModel: WooShippingCreateLabelsViewModel
+
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
             ScrollView {
-                // TODO-13550: Add view model to provide real data
-                WooShippingItems(viewModel: WooShippingItemsViewModel(itemsCountLabel: "6 items",
-                                                                      itemsDetailLabel: "825g  ·  $135.00",
-                                                                      items: [WooShippingItemRowViewModel(imageUrl: nil,
-                                                                                                          quantityLabel: "3",
-                                                                                                          name: "Little Nap Brazil 250g",
-                                                                                                          detailsLabel: "15×10×8cm • Espresso",
-                                                                                                          weightLabel: "275g",
-                                                                                                          priceLabel: "$60.00"),
-                                                                              WooShippingItemRowViewModel(imageUrl: nil,
-                                                                                                          quantityLabel: "3",
-                                                                                                          name: "Little Nap Brazil 250g",
-                                                                                                          detailsLabel: "15×10×8cm • Espresso",
-                                                                                                          weightLabel: "275g",
-                                                                                                          priceLabel: "$60.00")]))
+                WooShippingItems(viewModel: viewModel.items)
                     .padding()
             }
             .navigationTitle(Localization.title)
@@ -59,8 +50,4 @@ private extension WooShippingCreateLabelsView {
                                               value: "Cancel",
                                               comment: "Title of the button to dismiss the shipping label creation screen")
     }
-}
-
-#Preview {
-    WooShippingCreateLabelsView()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -21,20 +21,20 @@ struct WooShippingCreateLabelsView: View {
         NavigationStack {
             ScrollView {
                 // TODO-13550: Add view model to provide real data
-                WooShippingItems(itemsCountLabel: "6 items",
-                                 itemsDetailLabel: "825g  ·  $135.00",
-                                 items: [WooShippingItemRowViewModel(imageUrl: nil,
-                                                                     quantityLabel: "3",
-                                                                     name: "Little Nap Brazil 250g",
-                                                                     detailsLabel: "15×10×8cm • Espresso",
-                                                                     weightLabel: "275g",
-                                                                     priceLabel: "$60.00"),
-                                         WooShippingItemRowViewModel(imageUrl: nil,
-                                                                     quantityLabel: "30",
-                                                                     name: "Little Nap Brazil 250g",
-                                                                     detailsLabel: "15×10×8cm • Espresso",
-                                                                     weightLabel: "275g",
-                                                                     priceLabel: "$60.00")])
+                WooShippingItems(viewModel: WooShippingItemsViewModel(itemsCountLabel: "6 items",
+                                                                      itemsDetailLabel: "825g  ·  $135.00",
+                                                                      items: [WooShippingItemRowViewModel(imageUrl: nil,
+                                                                                                          quantityLabel: "3",
+                                                                                                          name: "Little Nap Brazil 250g",
+                                                                                                          detailsLabel: "15×10×8cm • Espresso",
+                                                                                                          weightLabel: "275g",
+                                                                                                          priceLabel: "$60.00"),
+                                                                              WooShippingItemRowViewModel(imageUrl: nil,
+                                                                                                          quantityLabel: "3",
+                                                                                                          name: "Little Nap Brazil 250g",
+                                                                                                          detailsLabel: "15×10×8cm • Espresso",
+                                                                                                          weightLabel: "275g",
+                                                                                                          priceLabel: "$60.00")]))
                     .padding()
             }
             .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Yosemite
+
+/// Provides view data for `WooShippingCreateLabelsView`.
+///
+final class WooShippingCreateLabelsViewModel: ObservableObject {
+    private let order: Order
+
+    /// View model for the items to ship.
+    @Published private(set) var items: WooShippingItemsViewModel
+
+    init(order: Order) {
+        self.order = order
+        self.items = WooShippingItemsViewModel(order: order)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -4,13 +4,10 @@ import Yosemite
 /// Provides view data for `WooShippingCreateLabelsView`.
 ///
 final class WooShippingCreateLabelsViewModel: ObservableObject {
-    private let order: Order
-
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
     init(order: Order) {
-        self.order = order
-        self.items = WooShippingItemsViewModel(order: order)
+        self.items = WooShippingItemsViewModel(orderItems: order.items)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2276,6 +2276,8 @@
 		CEAB739C2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */; };
 		CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */; };
 		CEC3CC6D2C93127300B93FBE /* WooShippingItemsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */; };
+		CEC3CC6F2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */; };
+		CEC3CC742C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
@@ -5318,6 +5320,8 @@
 		CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsView.swift; sourceTree = "<group>"; };
 		CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModel.swift; sourceTree = "<group>"; };
 		CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsViewModel.swift; sourceTree = "<group>"; };
+		CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsViewModel.swift; sourceTree = "<group>"; };
+		CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsViewModelTests.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -7490,6 +7494,7 @@
 		02F67FF325806DF000C3BAD2 /* Shipping Label */ = {
 			isa = PBXGroup;
 			children = (
+				CEC3CC722C9343BC00B93FBE /* WooShipping Create Shipping Labels */,
 				02464064258B122A00C10A7D /* Reprint Shipping Label */,
 				02F67FF425806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift */,
 				027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */,
@@ -11847,6 +11852,15 @@
 			children = (
 				CE6E11092C91DA3D00563DD4 /* WooShipping Items Section */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
+				CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */,
+			);
+			path = "WooShipping Create Shipping Labels";
+			sourceTree = "<group>";
+		};
+		CEC3CC722C9343BC00B93FBE /* WooShipping Create Shipping Labels */ = {
+			isa = PBXGroup;
+			children = (
+				CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -15402,6 +15416,7 @@
 				02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */,
 				7E7C5F8F2719BA7300315B61 /* ProductCategoryCellViewModel.swift in Sources */,
 				DE8AA0B32BBE55E40084D2CC /* DashboardViewHostingController.swift in Sources */,
+				CEC3CC6F2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift in Sources */,
 				DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
 				E1E649EB28461EDF0070B194 /* BetaFeaturesConfiguration.swift in Sources */,
 				26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */,
@@ -16500,6 +16515,7 @@
 				EEA693602B23303A00BAECA6 /* ProductCreationAISurveyUseCaseTests.swift in Sources */,
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
+				CEC3CC742C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift in Sources */,
 				26DDA4AB2C49627F005FBEBF /* DashboardTimestampStoreTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
 				DEF657AA2C8AC25C00ACD61E /* BlazeCampaignObjectivePickerViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2274,6 +2274,7 @@
 		CEA7C32D2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */; };
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEAB739C2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */; };
+		CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
@@ -5314,6 +5315,7 @@
 		CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GoogleAdsCampaignStatsTotals+UI.swift"; sourceTree = "<group>"; };
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsView.swift; sourceTree = "<group>"; };
+		CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModel.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -11739,6 +11741,7 @@
 			isa = PBXGroup;
 			children = (
 				CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */,
+				CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */,
 				CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */,
 			);
 			path = "WooShipping Items Section";
@@ -16065,6 +16068,7 @@
 				B6F3796C293794A000718561 /* AnalyticsHubYearToDateRangeData.swift in Sources */,
 				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
 				203163BB2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */,
+				CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */,
 				AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */,
 				203163B72C1C5EDF001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift in Sources */,
 				2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2275,6 +2275,7 @@
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEAB739C2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */; };
 		CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */; };
+		CEC3CC6D2C93127300B93FBE /* WooShippingItemsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
@@ -5316,6 +5317,7 @@
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsView.swift; sourceTree = "<group>"; };
 		CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModel.swift; sourceTree = "<group>"; };
+		CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsViewModel.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -11743,6 +11745,7 @@
 				CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */,
 				CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */,
 				CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */,
+				CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */,
 			);
 			path = "WooShipping Items Section";
 			sourceTree = "<group>";
@@ -16166,6 +16169,7 @@
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				02E3B62F2906322B007E0F13 /* AuthenticationFormFieldView.swift in Sources */,
 				029106C42BE34AA900C2248B /* CollapsibleCustomerCardViewModel.swift in Sources */,
+				CEC3CC6D2C93127300B93FBE /* WooShippingItemsViewModel.swift in Sources */,
 				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				8625C5132BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -13,50 +13,58 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_inits_with_expected_values_from_order_items() throws {
         // Given
-        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt",
-                                                                                   quantity: 1,
-                                                                                   total: "20",
-                                                                                   attributes: [OrderItemAttribute.fake().copy(value: "Red")]),
-                                                             OrderItem.fake().copy(quantity: 1)])
+        let orderItems = [OrderItem.fake().copy(name: "Shirt",
+                                                quantity: 1,
+                                                price: 10,
+                                                attributes: [OrderItemAttribute.fake().copy(value: "Red")]),
+                          OrderItem.fake().copy(quantity: 1, price: 2.5)]
 
         // When
-        let viewModel = WooShippingItemsViewModel(order: order, currencySettings: currencySettings)
+        let viewModel = WooShippingItemsViewModel(orderItems: orderItems, currencySettings: currencySettings)
 
         // Then
         // Section header labels have expected values
         assertEqual("2 items", viewModel.itemsCountLabel)
-        assertEqual("1 kg • $22.50", viewModel.itemsDetailLabel)
+        assertEqual("1 kg • $12.50", viewModel.itemsDetailLabel)
 
         // Section rows have expected values
         assertEqual(2, viewModel.itemRows.count)
         let firstItem = try XCTUnwrap(viewModel.itemRows.first)
         assertEqual("Shirt", firstItem.name)
         assertEqual("1", firstItem.quantityLabel)
-        assertEqual("$20.00", firstItem.priceLabel)
+        assertEqual("$10.00", firstItem.priceLabel)
         assertEqual("Red", firstItem.detailsLabel)
     }
 
     func test_total_items_count_handles_items_with_quantity_greater_than_one() {
         // Given
-        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt", quantity: 2, total: "20"), OrderItem.fake().copy(quantity: 1)])
+        let orderItems = [OrderItem.fake().copy(quantity: 2), OrderItem.fake().copy(quantity: 1)]
 
         // When
-        let viewModel = WooShippingItemsViewModel(order: order, currencySettings: currencySettings)
+        let viewModel = WooShippingItemsViewModel(orderItems: orderItems, currencySettings: currencySettings)
 
         // Then
         assertEqual("3 items", viewModel.itemsCountLabel)
     }
 
-    func test_item_row_details_label_handles_items_with_multiple_attributes() throws {
+    func test_total_items_details_handles_total_price_for_items_with_quantity_greater_than_one() {
         // Given
-        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt",
-                                                                                   quantity: 2,
-                                                                                   total: "20",
-                                                                                   attributes: [OrderItemAttribute.fake().copy(value: "Red"),
-                                                                                                OrderItemAttribute.fake().copy(value: "Small")])])
+        let orderItems = [OrderItem.fake().copy(quantity: 2, price: 10), OrderItem.fake().copy(quantity: 1, price: 2.5)]
 
         // When
-        let viewModel = WooShippingItemsViewModel(order: order, currencySettings: currencySettings)
+        let viewModel = WooShippingItemsViewModel(orderItems: orderItems, currencySettings: currencySettings)
+
+        // Then
+        assertEqual("1 kg • $22.50", viewModel.itemsDetailLabel)
+    }
+
+    func test_item_row_details_label_handles_items_with_multiple_attributes() throws {
+        // Given
+        let orderItems = [OrderItem.fake().copy(attributes: [OrderItemAttribute.fake().copy(value: "Red"),
+                                                             OrderItemAttribute.fake().copy(value: "Small")])]
+
+        // When
+        let viewModel = WooShippingItemsViewModel(orderItems: orderItems, currencySettings: currencySettings)
 
         // Then
         let firstItem = try XCTUnwrap(viewModel.itemRows.first)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -13,20 +13,27 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_inits_with_expected_values_from_order_items() throws {
         // Given
-        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt", quantity: 1, total: "20"), OrderItem.fake().copy(quantity: 1)])
+        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt",
+                                                                                   quantity: 1,
+                                                                                   total: "20",
+                                                                                   attributes: [OrderItemAttribute.fake().copy(value: "Red")]),
+                                                             OrderItem.fake().copy(quantity: 1)])
 
         // When
         let viewModel = WooShippingItemsViewModel(order: order, currencySettings: currencySettings)
 
         // Then
+        // Section header labels have expected values
         assertEqual("2 items", viewModel.itemsCountLabel)
         assertEqual("1 kg • $22.50", viewModel.itemsDetailLabel)
-        assertEqual(2, viewModel.itemRows.count)
 
+        // Section rows have expected values
+        assertEqual(2, viewModel.itemRows.count)
         let firstItem = try XCTUnwrap(viewModel.itemRows.first)
         assertEqual("Shirt", firstItem.name)
         assertEqual("1", firstItem.quantityLabel)
         assertEqual("$20.00", firstItem.priceLabel)
+        assertEqual("Red", firstItem.detailsLabel)
     }
 
     func test_total_items_count_handles_items_with_quantity_greater_than_one() {
@@ -38,6 +45,22 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
         // Then
         assertEqual("3 items", viewModel.itemsCountLabel)
+    }
+
+    func test_item_row_details_label_handles_items_with_multiple_attributes() throws {
+        // Given
+        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt",
+                                                                                   quantity: 2,
+                                                                                   total: "20",
+                                                                                   attributes: [OrderItemAttribute.fake().copy(value: "Red"),
+                                                                                                OrderItemAttribute.fake().copy(value: "Small")])])
+
+        // When
+        let viewModel = WooShippingItemsViewModel(order: order, currencySettings: currencySettings)
+
+        // Then
+        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
+        assertEqual("Red, Small", firstItem.detailsLabel)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -13,6 +13,24 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_inits_with_expected_values_from_order_items() throws {
         // Given
+        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt", quantity: 1, total: "20"), OrderItem.fake().copy(quantity: 1)])
+
+        // When
+        let viewModel = WooShippingItemsViewModel(order: order, currencySettings: currencySettings)
+
+        // Then
+        assertEqual("2 items", viewModel.itemsCountLabel)
+        assertEqual("1 kg • $22.50", viewModel.itemsDetailLabel)
+        assertEqual(2, viewModel.itemRows.count)
+
+        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
+        assertEqual("Shirt", firstItem.name)
+        assertEqual("1", firstItem.quantityLabel)
+        assertEqual("$20.00", firstItem.priceLabel)
+    }
+
+    func test_total_items_count_handles_items_with_quantity_greater_than_one() {
+        // Given
         let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt", quantity: 2, total: "20"), OrderItem.fake().copy(quantity: 1)])
 
         // When
@@ -20,13 +38,6 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
         // Then
         assertEqual("3 items", viewModel.itemsCountLabel)
-        assertEqual("1 kg • $22.50", viewModel.itemsDetailLabel)
-        assertEqual(2, viewModel.itemRows.count)
-
-        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
-        assertEqual("Shirt", firstItem.name)
-        assertEqual("2", firstItem.quantityLabel)
-        assertEqual("$20.00", firstItem.priceLabel)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import WooCommerce
+import WooFoundation
+import Yosemite
+
+final class WooShippingItemsViewModelTests: XCTestCase {
+
+    private var currencySettings: CurrencySettings!
+
+    override func setUp() {
+        currencySettings = CurrencySettings()
+    }
+
+    func test_inits_with_expected_values_from_order_items() throws {
+        // Given
+        let order = Order.fake().copy(total: "22.5", items: [OrderItem.fake().copy(name: "Shirt", quantity: 2, total: "20"), OrderItem.fake().copy(quantity: 1)])
+
+        // When
+        let viewModel = WooShippingItemsViewModel(order: order, currencySettings: currencySettings)
+
+        // Then
+        assertEqual("3 items", viewModel.itemsCountLabel)
+        assertEqual("1 kg • $22.50", viewModel.itemsDetailLabel)
+        assertEqual(2, viewModel.itemRows.count)
+
+        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
+        assertEqual("Shirt", firstItem.name)
+        assertEqual("2", firstItem.quantityLabel)
+        assertEqual("$20.00", firstItem.priceLabel)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13550
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds view models to provide data for the following new views in the new shipping labels flow for the Woo Shipping extension:

* `WooShippingCreateLabelsView`
* `WooShippingItems`
* `WooShippingItemRow`

A couple notes:

* For now, these view models only provide data from the order items. A future PR will also add data from the products or product variations corresponding to those order items, to fill in the data not provided in the order (e.g. image URL, product weight, product dimensions).
* For now, the views aren't as "dumb" as I'd like. I'm passing in the `Order` to get the item data for the views, and that causes some issues e.g. with the `WooShippingCreateLabelsView` preview. I accepted this for now because I didn't see a good way around it at this stage, but I hope to address it in a future PR.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the `processing` status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. In the shipping label flow, confirm the items section appears with the following details:
   1. The correct total number of items in the order (taking into account items with a quantity >1).
   2. The correct total price for all items in the order. (Note that the weight shown is a placeholder for now and will always say `1 kg`.)
   3. Expand the items section and confirm there is a row for each item in the order. (Note that for now virtual items will still be shown, but those will be filtered out in a future PR.)
   4. Confirm that each row shows the correct quantity, item name, item price (per unit), and a list of variation attributes for product variations.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/9f7e43c2-a577-4284-8b70-19709ea91ab2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.