### PR TITLE
Refactor error logging in NSManagedObjectContext extension

### DIFF
--- a/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
+++ b/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
@@ -51,7 +51,6 @@ extension NSManagedObjectContext: StorageType {
             result = try count(for: request)
         } catch {
             DDLogError("Error counting objects [\(T.entityName)]: \(error)")
-            assertionFailure()
         }
 
         return result
@@ -61,7 +60,8 @@ extension NSManagedObjectContext: StorageType {
     ///
     public func deleteObject<T: Object>(_ object: T) {
         guard let object = object as? NSManagedObject else {
-            logErrorAndExit("Invalid Object Kind")
+            DDLogError("Invalid Object Kind")
+            return
         }
 
         delete(object)
@@ -115,13 +115,14 @@ extension NSManagedObjectContext: StorageType {
     ///
     public func loadObject<T: Object>(ofType type: T.Type, with objectID: T.ObjectID) -> T? {
         guard let objectID = objectID as? NSManagedObjectID else {
-            logErrorAndExit("Invalid ObjectID Kind")
+            DDLogError("Invalid ObjectID Kind: \(objectID), for object type: \(T.self). This error is related to NSManagedObject and CoreData.")
+            return nil
         }
 
         do {
             return try existingObject(with: objectID) as? T
         } catch {
-            DDLogError("Error loading Object [\(T.entityName)]")
+            DDLogError("Error loading Object [\(T.entityName)] in context: \(self). This error is related to NSManagedObject and CoreData.")
         }
 
         return nil
@@ -138,7 +139,7 @@ extension NSManagedObjectContext: StorageType {
             try save()
         } catch {
             let nserror = error as NSError
-            logErrorAndExit("Unresolved error \(nserror), \(nserror.userInfo)")
+            DDLogError("Unresolved error \(nserror), \(nserror.userInfo) in context: \(self). This error is related to NSManagedObject and CoreData.")
         }
     }
 
@@ -163,8 +164,7 @@ extension NSManagedObjectContext: StorageType {
         do {
             objects = try fetch(request) as? [T]
         } catch {
-            DDLogError("Error loading Objects [\(T.entityName)")
-            assertionFailure()
+            DDLogError("Error loading Objects [\(T.entityName)] in context: \(self). This error is related to NSManagedObject and CoreData.")
         }
 
         return objects ?? []

--- a/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
+++ b/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
@@ -50,7 +50,7 @@ extension NSManagedObjectContext: StorageType {
         do {
             result = try count(for: request)
         } catch {
-            DDLogError("Error counting objects [\(T.entityName)]: \(error)")
+            DDLogError("countObjects failed. Error counting objects [\(T.entityName)]: \(error)")
         }
 
         return result
@@ -60,7 +60,10 @@ extension NSManagedObjectContext: StorageType {
     ///
     public func deleteObject<T: Object>(_ object: T) {
         guard let object = object as? NSManagedObject else {
-            DDLogError("Invalid Object Kind")
+            let errorMessage = "deleteObject failed. Invalid Object Kind \(type(of: object)) " +
+                               "for object type: \(T.self). This error is related to NSManagedObject " +
+                               "and CoreData."
+            DDLogError(errorMessage)
             return
         }
 
@@ -115,14 +118,19 @@ extension NSManagedObjectContext: StorageType {
     ///
     public func loadObject<T: Object>(ofType type: T.Type, with objectID: T.ObjectID) -> T? {
         guard let objectID = objectID as? NSManagedObjectID else {
-            DDLogError("Invalid ObjectID Kind: \(objectID), for object type: \(T.self). This error is related to NSManagedObject and CoreData.")
+            let errorMessage = "loadObject failed. Invalid ObjectID Kind: \(objectID), " +
+                               "for object type: \(T.self). This error is related to " +
+                               "NSManagedObject and CoreData."
+            DDLogError(errorMessage)
             return nil
         }
 
         do {
             return try existingObject(with: objectID) as? T
         } catch {
-            DDLogError("Error loading Object [\(T.entityName)] in context: \(self). This error is related to NSManagedObject and CoreData.")
+            let errorMessage = "loadObject failed. Error loading Object [\(T.entityName)] in context: " +
+                               "\(self). This error is related to NSManagedObject and CoreData."
+            DDLogError(errorMessage)
         }
 
         return nil
@@ -139,7 +147,10 @@ extension NSManagedObjectContext: StorageType {
             try save()
         } catch {
             let nserror = error as NSError
-            DDLogError("Unresolved error \(nserror), \(nserror.userInfo) in context: \(self). This error is related to NSManagedObject and CoreData.")
+            let errorMessage = "saveIfNeeded failed. Error \(nserror), " +
+                               "\(nserror.userInfo) in context: \(self). " +
+                               "This error is related to NSManagedObject and CoreData."
+            DDLogError(errorMessage)
         }
     }
 
@@ -164,7 +175,9 @@ extension NSManagedObjectContext: StorageType {
         do {
             objects = try fetch(request) as? [T]
         } catch {
-            DDLogError("Error loading Objects [\(T.entityName)] in context: \(self). This error is related to NSManagedObject and CoreData.")
+            let errorMessage = "loadObjects failed. Error loading Objects [\(T.entityName)] in context: " +
+                               "\(self). This error is related to NSManagedObject and CoreData."
+            DDLogError(errorMessage)
         }
 
         return objects ?? []


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/13874

## Description
Given all the crashes in https://github.com/woocommerce/woocommerce-ios/issues/13874 happening lately, this PR refactors the error handling in the `NSManagedObjectContext+Storage` extension to improve clarity and remove assertion failures that send the app in crash. It replaces fatal error logging with more informative error messages that provide context related to `NSManagedObject` and Core Data operations, since the log of these crashes in Sentry does not produce any valuable data to replicate the issues.

## Steps to reproduce
This should not have any impact on existing functionalities.

## Testing information
Just CI should pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
