### PR TITLE
[Shipping labels] Add data from products and variations to items section

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -7,6 +7,7 @@ import protocol Storage.StorageManagerType
 ///
 final class WooShippingItemsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
+    private let weightFormatter: WeightFormatter
 
     /// Data source for items to be shipped.
     private var dataSource: WooShippingItemsDataSource
@@ -21,9 +22,11 @@ final class WooShippingItemsViewModel: ObservableObject {
     @Published var itemRows: [WooShippingItemRowViewModel] = []
 
     init(dataSource: WooShippingItemsDataSource,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService) {
         self.dataSource = dataSource
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.weightFormatter = WeightFormatter(weightUnit: shippingSettingsService.weightUnit ?? "")
 
         configureSectionHeader()
         configureItemRows()
@@ -55,7 +58,15 @@ private extension WooShippingItemsViewModel {
     /// This includes the total weight and total price of all items.
     ///
     func generateItemsDetailLabel() -> String {
-        let formattedWeight = "1 kg" // TODO-13550: Get the total weight (each product/variation * item quantity) and weight unit
+        let totalWeight = dataSource.orderItems
+                    .map { item -> Double in
+                        let itemWeight = calculateWeight(for: item)
+                        let itemQuantity = Double(truncating: item.quantity as NSDecimalNumber)
+                        return itemWeight * itemQuantity
+                    }
+                    .reduce(0, +)
+                let formattedWeight = weightFormatter.formatWeight(weight: totalWeight)
+
         let itemsTotal = dataSource.orderItems.map { $0.price.decimalValue * $0.quantity }.reduce(0, +)
         let formattedPrice = currencyFormatter.formatAmount(itemsTotal) ?? itemsTotal.description
 
@@ -65,13 +76,14 @@ private extension WooShippingItemsViewModel {
     /// Generates an item row view model for each order item.
     ///
     func generateItemRows() -> [WooShippingItemRowViewModel] {
-        dataSource.orderItems.map { item in
-            WooShippingItemRowViewModel(imageUrl: nil, // TODO-13550: Get the product/variation imageURL
-                                        quantityLabel: item.quantity.description,
-                                        name: item.name,
-                                        detailsLabel: generateItemRowDetailsLabel(for: item),
-                                        weightLabel: "",  // TODO-13550: Get the product/variation weight
-                                        priceLabel: currencyFormatter.formatAmount(item.price.decimalValue) ?? item.price.description)
+            dataSource.orderItems.map { item in
+            let itemWeight = calculateWeight(for: item)
+            return WooShippingItemRowViewModel(imageUrl: nil, // TODO-13550: Get the product/variation imageURL
+                                               quantityLabel: item.quantity.description,
+                                               name: item.name,
+                                               detailsLabel: generateItemRowDetailsLabel(for: item),
+                                               weightLabel: weightFormatter.formatWeight(weight: itemWeight),
+                                               priceLabel: currencyFormatter.formatAmount(item.price.decimalValue) ?? item.price.description)
         }
     }
 
@@ -88,6 +100,29 @@ private extension WooShippingItemsViewModel {
         }()
 
         return [formattedDimensions, attributes].compacted().joined(separator: " • ")
+    }
+
+    /// Calculates the weight of the given item.
+    ///
+    func calculateWeight(for item: OrderItem) -> Double {
+        let itemWeight = {
+            let (product, productVariation) = getProductAndVariation(for: item)
+            if let productVariation {
+                return NumberFormatter.double(from: productVariation.weight ?? "") ?? .zero
+            } else {
+                return NumberFormatter.double(from: product?.weight ?? "") ?? .zero
+            }
+        }()
+        let quantity = Double(truncating: item.quantity as NSDecimalNumber)
+        return itemWeight * quantity
+    }
+
+    /// Finds the corresponding product and variation for the given item.
+    ///
+    func getProductAndVariation(for item: OrderItem) -> (Product?, ProductVariation?) {
+        let product = dataSource.products.first(where: { $0.productID == item.productID })
+        let productVariation = dataSource.productVariations.first(where: { $0.productVariationID == item.variationID })
+        return (product, productVariation)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -60,14 +60,8 @@ private extension WooShippingItemsViewModel {
     /// This includes the total weight and total price of all items.
     ///
     func generateItemsDetailLabel() -> String {
-        let totalWeight = dataSource.orderItems
-                    .map { item -> Double in
-                        let itemWeight = calculateWeight(for: item)
-                        let itemQuantity = Double(truncating: item.quantity as NSDecimalNumber)
-                        return itemWeight * itemQuantity
-                    }
-                    .reduce(0, +)
-                let formattedWeight = weightFormatter.formatWeight(weight: totalWeight)
+        let totalWeight = dataSource.orderItems.map { calculateWeight(for: $0) }.reduce(0, +)
+        let formattedWeight = weightFormatter.formatWeight(weight: totalWeight)
 
         let itemsTotal = dataSource.orderItems.map { $0.price.decimalValue * $0.quantity }.reduce(0, +)
         let formattedPrice = currencyFormatter.formatAmount(itemsTotal) ?? itemsTotal.description

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -72,9 +72,10 @@ private extension WooShippingItemsViewModel {
     /// Generates an item row view model for each order item.
     ///
     func generateItemRows() -> [WooShippingItemRowViewModel] {
-            dataSource.orderItems.map { item in
+        dataSource.orderItems.map { item in
+            let (product, variation) = getProductAndVariation(for: item)
             let itemWeight = calculateWeight(for: item)
-            return WooShippingItemRowViewModel(imageUrl: nil, // TODO-13550: Get the product/variation imageURL
+            return WooShippingItemRowViewModel(imageUrl: variation?.imageURL ?? product?.imageURL,
                                                quantityLabel: item.quantity.description,
                                                name: item.name,
                                                detailsLabel: generateItemRowDetailsLabel(for: item),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2280,6 +2280,7 @@
 		CEC3CC742C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */; };
 		CEC3CC762C934F5500B93FBE /* WooShippingItemsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC752C934F5500B93FBE /* WooShippingItemsDataSource.swift */; };
 		CEC3CC7C2C94A06500B93FBE /* WooShippingItemsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC7B2C94A06500B93FBE /* WooShippingItemsDataSourceTests.swift */; };
+		CEC3CC7A2C93537B00B93FBE /* MockShippingSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC792C93537B00B93FBE /* MockShippingSettingsService.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
@@ -5326,6 +5327,7 @@
 		CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsViewModelTests.swift; sourceTree = "<group>"; };
 		CEC3CC752C934F5500B93FBE /* WooShippingItemsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsDataSource.swift; sourceTree = "<group>"; };
 		CEC3CC7B2C94A06500B93FBE /* WooShippingItemsDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsDataSourceTests.swift; sourceTree = "<group>"; };
+		CEC3CC792C93537B00B93FBE /* MockShippingSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingSettingsService.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -9495,6 +9497,7 @@
 				DE7B17F82C1AA26B00A6C7D8 /* MockWooSubscriptionProductsEligibilityChecker.swift */,
 				DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */,
 				EE4C75DE2C86D2F500F9D860 /* BlazeLocalNotificationSchedulerSpy.swift */,
+				CEC3CC792C93537B00B93FBE /* MockShippingSettingsService.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -16927,6 +16930,7 @@
 				2609797C2A13D31500442249 /* PrivacyBannerPresentationUseCaseTests.swift in Sources */,
 				DE0134192A304A72000A6F54 /* ProductSharingMessageGenerationViewModelTests.swift in Sources */,
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
+				CEC3CC7A2C93537B00B93FBE /* MockShippingSettingsService.swift in Sources */,
 				B958A7D128B5281800823EEF /* UniversalLinkRouterTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,
 				039B7E6729F2855B00E21EF4 /* CardPresentPaymentOnboardingViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockShippingSettingsService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockShippingSettingsService.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Yosemite
+
+struct MockShippingSettingsService: ShippingSettingsService {
+    var dimensionUnit: String? = "in"
+
+    var weightUnit: String? = "oz"
+
+    func update(siteID: Int64) {
+        // no-op
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -44,8 +44,9 @@ final class WooShippingItemsViewModelTests: XCTestCase {
     func test_populates_item_data_from_products_and_variations() {
         // Given
         let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
-        let product = Product.fake().copy(productID: 1, weight: "5", dimensions: dimensions)
-        let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, weight: "3", dimensions: dimensions)
+        let image = ProductImage.fake().copy(src: "http://woocommerce.com/image.jpg")
+        let product = Product.fake().copy(productID: 1, weight: "5", dimensions: dimensions, images: [image])
+        let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, image: image, weight: "3", dimensions: dimensions)
         let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 1),
                           OrderItem.fake().copy(productID: variation.productID,
                                                 variationID: variation.productVariationID,
@@ -62,9 +63,12 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         assertEqual("8 oz • $0.00", viewModel.itemsDetailLabel)
 
         let productRow = viewModel.itemRows[0]
-        let variationRow = viewModel.itemRows[1]
+        XCTAssertNotNil(productRow.imageUrl)
         assertEqual("5 oz", productRow.weightLabel)
         assertEqual("20 x 35 x 5 in", productRow.detailsLabel)
+
+        let variationRow = viewModel.itemRows[1]
+        XCTAssertNotNil(variationRow.imageUrl)
         assertEqual("3 oz", variationRow.weightLabel)
         assertEqual("20 x 35 x 5 in • Red", variationRow.detailsLabel)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -43,12 +43,14 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_populates_item_data_from_products_and_variations() {
         // Given
-        let product = Product.fake().copy(productID: 1, weight: "5")
-        let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, weight: "3")
+        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
+        let product = Product.fake().copy(productID: 1, weight: "5", dimensions: dimensions)
+        let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, weight: "3", dimensions: dimensions)
         let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 2),
                           OrderItem.fake().copy(productID: variation.productID,
                                                 variationID: variation.productVariationID,
-                                                quantity: 1)]
+                                                quantity: 1,
+                                                attributes: [OrderItemAttribute.fake().copy(value: "Red")])]
         let dataSource = MockDataSource(orderItems: orderItems, products: [product], productVariations: [variation])
 
         // When
@@ -62,7 +64,9 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         let productRow = viewModel.itemRows[0]
         let variationRow = viewModel.itemRows[1]
         assertEqual("10 oz", productRow.weightLabel)
+        assertEqual("20 x 35 x 5 in", productRow.detailsLabel)
         assertEqual("3 oz", variationRow.weightLabel)
+        assertEqual("20 x 35 x 5 in • Red", variationRow.detailsLabel)
     }
 
     func test_total_items_count_handles_items_with_quantity_greater_than_one() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -46,7 +46,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
         let product = Product.fake().copy(productID: 1, weight: "5", dimensions: dimensions)
         let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, weight: "3", dimensions: dimensions)
-        let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 2),
+        let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 1),
                           OrderItem.fake().copy(productID: variation.productID,
                                                 variationID: variation.productVariationID,
                                                 quantity: 1,
@@ -59,11 +59,11 @@ final class WooShippingItemsViewModelTests: XCTestCase {
                                                   shippingSettingsService: shippingSettingsService)
 
         // Then
-        assertEqual("23 oz • $0.00", viewModel.itemsDetailLabel)
+        assertEqual("8 oz • $0.00", viewModel.itemsDetailLabel)
 
         let productRow = viewModel.itemRows[0]
         let variationRow = viewModel.itemRows[1]
-        assertEqual("10 oz", productRow.weightLabel)
+        assertEqual("5 oz", productRow.weightLabel)
         assertEqual("20 x 35 x 5 in", productRow.detailsLabel)
         assertEqual("3 oz", variationRow.weightLabel)
         assertEqual("20 x 35 x 5 in • Red", variationRow.detailsLabel)
@@ -81,10 +81,14 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         assertEqual("3 items", viewModel.itemsCountLabel)
     }
 
-    func test_total_items_details_handles_total_price_for_items_with_quantity_greater_than_one() {
+    func test_total_items_details_handles_items_with_quantity_greater_than_one() {
         // Given
-        let orderItems = [OrderItem.fake().copy(quantity: 2, price: 10), OrderItem.fake().copy(quantity: 1, price: 2.5)]
-        let dataSource = MockDataSource(orderItems: orderItems)
+        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
+        let product = Product.fake().copy(productID: 1, weight: "5", dimensions: dimensions)
+        let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, weight: "3", dimensions: dimensions)
+        let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 2, price: 10),
+                          OrderItem.fake().copy(productID: variation.productID, variationID: variation.productVariationID, quantity: 1, price: 2.5)]
+        let dataSource = MockDataSource(orderItems: orderItems, products: [product], productVariations: [variation])
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
@@ -92,7 +96,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
                                                   shippingSettingsService: shippingSettingsService)
 
         // Then
-        assertEqual("0 oz • $22.50", viewModel.itemsDetailLabel)
+        assertEqual("13 oz • $22.50", viewModel.itemsDetailLabel)
     }
 
     func test_item_row_details_label_handles_items_with_multiple_attributes() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13550
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds data from products and variations to the items section in the new Woo Shipping label creation flow.

It adds the following data:

* Total weight for all items in the order (per unit weight * quantity of all items), shown in the section header. This uses the weight unit (e.g. `kg` or `oz`) from `ShippingSettingsService`.
* Image for each item in the order. If the item is a product variation, it shows the variation image.
* Dimensions (length, width, and height) for each item in the order. This uses the dimension unit (e.g. `cm` or `in`) from `ShippingSettingsService`.
* Total weight for each item in the order (per unit weight * quantity). This uses the weight unit from `ShippingSettingsService`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. In the shipping label flow, confirm the items section appears with the following details:
   1. Total weight for all items in the order (taking into account the item quantity), with the expected weight unit.
   2. Image for all items in the order, with a placeholder if there is no product/variation image set.
   3. Dimensions for each item in the order, with the expected weight unit.
   4. Total weight for each item in the order (taking into account the item quantity), with the expected weight unit.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ccc1ffea-9ac2-45cc-9ca9-ae111a1b7fd1


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.