### PR TITLE
Blaze: Navigate to campaign creation after tapping on local notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.5
 -----
 - [*] Blaze: Schedule a reminder local notification asking to continue abandoned campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13950]
+- [*] Blaze: Handle tap on local notifications to open campaign creation. [https://github.com/woocommerce/woocommerce-ios/pull/13968]
 
 
 20.4

--- a/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
@@ -102,7 +102,7 @@ final class DefaultBlazeLocalNotificationScheduler: BlazeLocalNotificationSchedu
         }
 
         let notification = LocalNotification(scenario: LocalNotification.Scenario.blazeAbandonedCampaignCreationReminder,
-                                             userInfo: [:])
+                                             userInfo: [Constants.siteIDKey: siteID])
         await scheduler.cancel(scenario: .blazeAbandonedCampaignCreationReminder)
         DDLogDebug("Blaze: Schedule abandoned campaign creation local notification for date \(notificationTime).")
         await scheduler.schedule(notification: notification,
@@ -186,7 +186,7 @@ private extension DefaultBlazeLocalNotificationScheduler {
 
         Task { @MainActor in
             let notification = LocalNotification(scenario: LocalNotification.Scenario.blazeNoCampaignReminder,
-                                                 userInfo: [:])
+                                                 userInfo: [Constants.siteIDKey: siteID])
             await scheduler.cancel(scenario: .blazeNoCampaignReminder)
             DDLogDebug("Blaze: Schedule no campaign local notification for date \(notificationTime).")
             await scheduler.schedule(notification: notification,
@@ -199,6 +199,8 @@ private extension DefaultBlazeLocalNotificationScheduler {
 
 private extension DefaultBlazeLocalNotificationScheduler {
     enum Constants {
+        static let siteIDKey = "site_id"
+
         enum NoCampaignReminder {
             static let daysDurationForNotification = 30
         }

--- a/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
@@ -130,21 +130,21 @@ private extension DefaultBlazeLocalNotificationScheduler {
     /// Performs initial fetch from storage and updates results.
     func observeStorageAndScheduleNotifications() {
         blazeCampaignResultsController.onDidChangeContent = { [weak self] in
-            self?.scheduleLocalNotificationIfNeeded()
+            self?.scheduleNoCampaignReminderIfNeeded()
         }
         blazeCampaignResultsController.onDidResetContent = { [weak self] in
-            self?.scheduleLocalNotificationIfNeeded()
+            self?.scheduleNoCampaignReminderIfNeeded()
         }
 
         do {
             try blazeCampaignResultsController.performFetch()
-            scheduleLocalNotificationIfNeeded()
+            scheduleNoCampaignReminderIfNeeded()
         } catch {
             ServiceLocator.crashLogging.logError(error)
         }
     }
 
-    func scheduleLocalNotificationIfNeeded() {
+    func scheduleNoCampaignReminderIfNeeded() {
         guard !userDefaults.blazeNoCampaignReminderOpened() else {
             DDLogDebug("Blaze: User interacted with a previously scheduled no campaign local notification. Don't schedule again.")
             return

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -20,12 +20,15 @@ enum BlazeCampaignListSource: String {
 ///
 final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaignListView> {
     private var coordinator: BlazeCampaignCreationCoordinator?
+    private var startsCampaignCreationOnAppear: Bool
 
     /// View model for the list.
     private let viewModel: BlazeCampaignListViewModel
 
-    init(viewModel: BlazeCampaignListViewModel) {
+    init(viewModel: BlazeCampaignListViewModel,
+         startsCampaignCreationOnAppear: Bool = false) {
         self.viewModel = viewModel
+        self.startsCampaignCreationOnAppear = startsCampaignCreationOnAppear
         super.init(rootView: BlazeCampaignListView(viewModel: viewModel))
 
         rootView.onCreateCampaign = { [weak self] productID in
@@ -37,11 +40,19 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if startsCampaignCreationOnAppear {
+            startsCampaignCreationOnAppear = false
+            startCampaignCreation()
+        }
+    }
 }
 
 /// Private helper
 private extension BlazeCampaignListHostingController {
-    func startCampaignCreation(productID: Int64?) {
+    func startCampaignCreation(productID: Int64? = nil) {
         guard let navigationController else {
             return
         }
@@ -66,17 +77,21 @@ private extension BlazeCampaignListHostingController {
 struct BlazeCampaignListHostingControllerRepresentable: UIViewControllerRepresentable {
     private let siteID: Int64
     private let selectedCampaignID: String?
+    private let startsCampaignCreationOnAppear: Bool
 
     init(siteID: Int64,
-         selectedCampaignID: String? = nil) {
+         selectedCampaignID: String? = nil,
+         startsCampaignCreationOnAppear: Bool = false) {
         self.siteID = siteID
         self.selectedCampaignID = selectedCampaignID
+        self.startsCampaignCreationOnAppear = startsCampaignCreationOnAppear
     }
     func makeUIViewController(context: Context) -> BlazeCampaignListHostingController {
 
         let viewModel = BlazeCampaignListViewModel(siteID: siteID,
                                                    selectedCampaignID: selectedCampaignID ?? nil)
-        return BlazeCampaignListHostingController(viewModel: viewModel)
+        return BlazeCampaignListHostingController(viewModel: viewModel,
+                                                  startsCampaignCreationOnAppear: startsCampaignCreationOnAppear)
     }
 
     func updateUIViewController(_ uiViewController: BlazeCampaignListHostingController, context: Context) {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -177,6 +177,8 @@ private extension HubMenu {
                 reviewDetailView(parcel: parcel)
             case .blazeCampaignDetails(let campaignID):
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, selectedCampaignID: campaignID)
+            case .blazeCampaignCreation:
+                BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, startsCampaignCreationOnAppear: true)
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -58,6 +58,10 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         viewModel.navigateToDestination(.blazeCampaignDetails(campaignID: campaignID))
     }
 
+    func showBlazeCampaignCreation() {
+        viewModel.navigateToDestination(.blazeCampaignCreation)
+    }
+
     /// Pushes the Settings & Privacy screen onto the navigation stack.
     ///
     func showPrivacySettings() {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -18,6 +18,7 @@ enum HubMenuNavigationDestination: Hashable {
     case settings
     case blaze
     case blazeCampaignDetails(campaignID: String)
+    case blazeCampaignCreation
     case wooCommerceAdmin
     case viewStore
     case inbox

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -489,6 +489,21 @@ extension MainTabBarController {
         })
     }
 
+    static func navigateToBlazeCampaignCreation(for siteID: Int64) {
+        showStore(with: Int64(siteID), onCompletion: { storeIsShown in
+            // It failed to show the campaign's store.
+            guard storeIsShown else {
+                return
+            }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.blazeScreenTransitionsDelay) {
+                switchToHubMenuTab() { hubMenuViewController in
+                    hubMenuViewController?.showBlazeCampaignCreation()
+                }
+            }
+        })
+    }
+
     static func presentOrderCreationFlow(for customerID: Int64, billing: Address?, shipping: Address?) {
         switchToOrdersTab {
             let tabBar = AppDelegate.shared.tabBarController

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -495,7 +495,7 @@ extension MainTabBarController {
             guard storeIsShown else {
                 return
             }
-            
+
             DispatchQueue.main.asyncAfter(deadline: .now() + Constants.blazeScreenTransitionsDelay) {
                 switchToHubMenuTab() { hubMenuViewController in
                     hubMenuViewController?.showBlazeCampaignCreation()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
@@ -447,6 +447,29 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
             self.defaults[.blazeNoCampaignReminderOpened] == true
         }
     }
+
+    func test_it_triggers_store_switching_when_handling_user_response_to_local_notifcations() throws {
+        // Given
+        let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let switchStoreUseCase = MockSwitchStoreUseCase()
+        let sut = DefaultBlazeLocalNotificationScheduler(siteID: siteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager,
+                                                         userDefaults: defaults,
+                                                         pushNotesManager: pushNotesManager,
+                                                         blazeEligibilityChecker: blazeEligibilityChecker,
+                                                         switchStoreUseCase: switchStoreUseCase)
+        sut.observeNotificationUserResponse()
+
+        // When
+        let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: "",
+                                                              requestIdentifier: LocalNotification.Scenario.blazeNoCampaignReminder.identifier,
+                                                              notificationUserInfo: [:]))
+        pushNotesManager.sendLocalNotificationResponse(response)
+
+        // Then
+        XCTAssert(switchStoreUseCase.destinationStoreIDs == [siteID])
+    }
 }
 
 private extension BlazeLocalNotificationSchedulerTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
@@ -184,8 +184,10 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
             self.pushNotesManager.requestedLocalNotifications.isNotEmpty
         }
 
-        let scenario = pushNotesManager.requestedLocalNotifications.first?.scenario
-        XCTAssertEqual(scenario, LocalNotification.Scenario.blazeNoCampaignReminder)
+        let notification = try XCTUnwrap(pushNotesManager.requestedLocalNotifications.first)
+        XCTAssertEqual(notification.scenario, LocalNotification.Scenario.blazeNoCampaignReminder)
+        let siteIDFromNotification = try XCTUnwrap(notification.userInfo["site_id"] as? Int64)
+        XCTAssertEqual(siteID, siteIDFromNotification)
     }
 
     func test_no_campaign_notification_is_not_scheduled_when_only_evergreen_campaign_exists_in_storage() async throws {
@@ -323,8 +325,10 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
             self.pushNotesManager.requestedLocalNotifications.isNotEmpty
         }
 
-        let scenario = try XCTUnwrap(pushNotesManager.requestedLocalNotifications.first?.scenario)
-        XCTAssertEqual(scenario, LocalNotification.Scenario.blazeAbandonedCampaignCreationReminder)
+        let notification = try XCTUnwrap(pushNotesManager.requestedLocalNotifications.first)
+        XCTAssertEqual(notification.scenario, LocalNotification.Scenario.blazeAbandonedCampaignCreationReminder)
+        let siteIDFromNotification = try XCTUnwrap(notification.userInfo["site_id"] as? Int64)
+        XCTAssertEqual(siteID, siteIDFromNotification)
     }
 
     func test_abandoned_creation_notification_is_not_scheduled_when_store_is_not_eligible_for_blaze() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
@@ -464,7 +464,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         // When
         let response = try XCTUnwrap(MockNotificationResponse(actionIdentifier: "",
                                                               requestIdentifier: LocalNotification.Scenario.blazeNoCampaignReminder.identifier,
-                                                              notificationUserInfo: [:]))
+                                                              notificationUserInfo: ["site_id": siteID]))
         pushNotesManager.sendLocalNotificationResponse(response)
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -107,7 +107,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
 
 
     @MainActor
-    func test_order_statuses_are_loaded_from_storage_when_available_with_additional_any_and_trash_statuses() async {
+    func test_order_statuses_are_loaded_from_storage_when_available() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
@@ -125,7 +125,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
             .sorted()
 
         // Then
-        XCTAssertEqual(viewModel.allStatuses.map { $0.id }, (["any"] + statusSlugs + ["trash"]))
+        XCTAssertEqual(viewModel.allStatuses.map { $0.id }, (["any"] + statusSlugs))
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -107,7 +107,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
 
 
     @MainActor
-    func test_order_statuses_are_loaded_from_storage_when_available() async {
+    func test_order_statuses_are_loaded_from_storage_when_available_with_additional_any_and_trash_statuses() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
@@ -125,7 +125,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
             .sorted()
 
         // Then
-        XCTAssertEqual(viewModel.allStatuses.map { $0.id }, (["any"] + statusSlugs))
+        XCTAssertEqual(viewModel.allStatuses.map { $0.id }, (["any"] + statusSlugs + ["trash"]))
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13935 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the navigation to campaign creation upon tapping on local notifications for no Blaze campaign reminders. The site ID was restored for the user info of the notifications and is used to handle store switching and checking for eligibility.

Changes compared to the original PR #13944:
- Switching stores was added to ensure that Blaze eligibility check is done for the correct site.
- `scheduleLocalNotificationIfNeeded` was renamed to clarify the notification type.

Thanks to the change in #13950, the handle of taps on local notification should now work even when the app is not running.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Build the app to a physical device to test notifications.
- If you tested Blaze local notifications before, log out and log in again to a test store eligible for Blaze to ensure that local notifications can be scheduled again.
- Schedule a few non-evergreen campaigns (from web or mobile app). Note down the start time and duration of the latest campaign. i.e. The campaign that ends the last based on start_time and duration_days values.
- Send the app to background or kill the app
- Add 30 days to the start time and duration of the latest campaign.
- Change the device time to one or two minutes before the above calculated time.
- Wait for the notification to arrive.
- Tap on the notification and the app should be opened and navigate to the hub menu tab > Blaze > campaign creation.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPhone 12 Pro iOS 17.6.1 and confirmed that tapping on both no campaign reminders and abandoned campaign creation navigate to the campaign creation flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/864137e1-914f-40c5-bd74-f8a17e257d7a



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.