### PR TITLE
[Woo POS] Update POS success view design

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
@@ -3,12 +3,9 @@ import SwiftUI
 struct PointOfSaleCardPresentPaymentSuccessMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel
     let animation: POSCardPresentPaymentInLineMessageAnimation
-    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         VStack(alignment: .center, spacing: Constants.headerSpacing) {
-            successIcon
-                .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
             VStack(alignment: .center, spacing: Constants.textSpacing) {
                 Text(viewModel.title)
                     .font(.posTitleEmphasized)
@@ -26,48 +23,10 @@ struct PointOfSaleCardPresentPaymentSuccessMessageView: View {
         }
         .multilineTextAlignment(.center)
     }
-
-    private var successIcon: some View {
-        ZStack {
-            Circle()
-                .frame(width: Constants.imageSize.width, height: Constants.imageSize.height)
-                .shadow(color: Color(.wooCommerceEmerald(.shade80)).opacity(Constants.shadowOpacity),
-                        radius: Constants.shadowRadius, x: Constants.shadowSize.width, y: Constants.shadowSize.height)
-                .foregroundColor(circleBackgroundColor)
-            Image(systemName: Constants.imageName)
-                .font(.system(size: Constants.checkmarkSize, weight: .bold))
-                .foregroundColor(checkmarkColor)
-                .accessibilityHidden(true)
-        }
-    }
-
-    private var circleBackgroundColor: Color {
-        switch colorScheme {
-        case .dark:
-            Color(red: 0/255, green: 173/255, blue: 100/255)
-        default:
-            Color.white
-        }
-    }
-
-    private var checkmarkColor: Color {
-        switch colorScheme {
-        case .dark:
-            Color.white
-        default:
-            Color(.wooCommerceEmerald(.shade40))
-        }
-    }
 }
 
 private extension PointOfSaleCardPresentPaymentSuccessMessageView {
     enum Constants {
-        static let imageName: String = "checkmark"
-        static let imageSize: CGSize = .init(width: 165, height: 165)
-        static let checkmarkSize: CGFloat = 56
-        static let shadowOpacity: CGFloat = 0.16
-        static let shadowRadius: CGFloat = 16
-        static let shadowSize: CGSize = .init(width: 0, height: 8)
         static let headerSpacing: CGFloat = 56
         static let textSpacing: CGFloat = 16
     }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -205,11 +205,8 @@ private extension TotalsView {
         })
         .padding(Constants.newOrderButtonPadding)
         .foregroundColor(.posPrimaryTextInverted)
-        .overlay(
-            RoundedRectangle(cornerRadius: Constants.defaultBorderLineCornerRadius)
-                .stroke(Color.posPrimaryText, lineWidth: Constants.defaultBorderLineWidth)
-        )
         .background(Color.posOverlayFillInverted)
+        .cornerRadius(Constants.newOrderButtonCornerRadius)
     }
 
     @ViewBuilder
@@ -306,8 +303,7 @@ private extension TotalsView {
 private extension TotalsView {
     enum Constants {
         static let pricesIdealWidth: CGFloat = 382
-        static let defaultBorderLineWidth: CGFloat = 1
-        static let defaultBorderLineCornerRadius: CGFloat = 8
+        static let newOrderButtonCornerRadius: CGFloat = 8
 
         static let verticalSpacing: CGFloat = 56
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -204,11 +204,12 @@ private extension TotalsView {
             .frame(minWidth: UIScreen.main.bounds.width / 2)
         })
         .padding(Constants.newOrderButtonPadding)
-        .foregroundColor(Color.posPrimaryText)
+        .foregroundColor(.posPrimaryTextInverted)
         .overlay(
             RoundedRectangle(cornerRadius: Constants.defaultBorderLineCornerRadius)
                 .stroke(Color.posPrimaryText, lineWidth: Constants.defaultBorderLineWidth)
         )
+        .background(Color.posOverlayFillInverted)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -204,8 +204,8 @@ private extension TotalsView {
             .frame(minWidth: UIScreen.main.bounds.width / 2)
         })
         .padding(Constants.newOrderButtonPadding)
-        .foregroundColor(.posPrimaryTextInverted)
-        .background(Color.posOverlayFillInverted)
+        .foregroundColor(Constants.posPrimaryTextInverted)
+        .background(Constants.posOverlayFillInverted)
         .cornerRadius(Constants.newOrderButtonCornerRadius)
     }
 
@@ -335,6 +335,24 @@ private extension TotalsView {
         static let matchedGeometryTotalId: String = "pos_totals_view_total_matched_geometry_id"
 
         static let totalsFieldsHideAnimationDelay: CGFloat = 0.3
+
+        static var posOverlayFillInverted: Color {
+            Color(
+                UIColor(
+                    light: .black,
+                    dark: .white
+                )
+            )
+        }
+
+        static var posPrimaryTextInverted: Color {
+            Color(
+                UIColor(
+                    light: UIColor(.white),
+                    dark: UIColor(.black)
+                )
+            )
+        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -46,10 +46,28 @@ extension Color {
         )
     }
 
+    static var posOverlayFillInverted: Color {
+        Color(
+            UIColor(
+                light: .black,
+                dark: .white
+            )
+        )
+    }
+
     // MARK: - Text
 
     static var posPrimaryText: Color {
         return Color.primary
+    }
+
+    static var posPrimaryTextInverted: Color {
+        return Color(
+            UIColor(
+                light: UIColor(.white),
+                dark: UIColor(.black)
+            )
+        )
     }
 
     static var posSecondaryText: Color {

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -46,28 +46,10 @@ extension Color {
         )
     }
 
-    static var posOverlayFillInverted: Color {
-        Color(
-            UIColor(
-                light: .black,
-                dark: .white
-            )
-        )
-    }
-
     // MARK: - Text
 
     static var posPrimaryText: Color {
         return Color.primary
-    }
-
-    static var posPrimaryTextInverted: Color {
-        return Color(
-            UIColor(
-                light: UIColor(.white),
-                dark: UIColor(.black)
-            )
-        )
     }
 
     static var posSecondaryText: Color {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13967

## Description
This PR tackles the design review on TfaZ4LUkEwEGrxfnEFzvJj-fi-4665_22771 by:
- Removed the success icon
- Updated the button colour to use white/black combination

## Testing
- In POS, process an order and complete the payment flow
- Observe the updated success view in light and dark modes:

| Before (light) | After (light) |
|--------|--------|
| ![before - light](https://github.com/user-attachments/assets/c50c80e6-4def-4404-8b5f-59be9064a785) | ![after - light](https://github.com/user-attachments/assets/efc8b773-126b-4797-9cf9-b782eace406a) | 

| Before (dark) | After (dark) |
|--------|--------|
| ![before - dark](https://github.com/user-attachments/assets/e5aaa204-37ff-4be3-929e-ee9a48577d47) | ![after - dark](https://github.com/user-attachments/assets/d5f5ac4f-5ac9-45f9-8aaf-617e6d286e4c) | 



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.