### PR TITLE
Orders: Show trash option in order status filter list

### DIFF
--- a/Networking/Networking/Model/OrderStatusEnum.swift
+++ b/Networking/Networking/Model/OrderStatusEnum.swift
@@ -15,6 +15,7 @@ public enum OrderStatusEnum: Codable, Hashable, Comparable, Sendable, GeneratedF
     case cancelled
     case refunded
     case failed
+    case trash
     case custom(String)
 }
 
@@ -71,6 +72,12 @@ public extension OrderStatusEnum {
                 value: "Refunded",
                 comment: "Display label for refunded order status."
             )
+        case .trash:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.trash",
+                value: "Trash",
+                comment: "Display label for trashed order status."
+            )
         case .custom(let payload):
             return payload // unable to localize at runtime.
         }
@@ -101,6 +108,8 @@ extension OrderStatusEnum: RawRepresentable {
             self = .completed
         case Keys.refunded:
             self = .refunded
+        case Keys.trash:
+            self = .trash
         default:
             self = .custom(rawValue)
         }
@@ -118,6 +127,7 @@ extension OrderStatusEnum: RawRepresentable {
         case .cancelled:            return Keys.cancelled
         case .completed:            return Keys.completed
         case .refunded:             return Keys.refunded
+        case .trash:                return Keys.trash
         case .custom(let payload):  return payload
         }
     }
@@ -135,4 +145,5 @@ private enum Keys {
     static let cancelled    = "cancelled"
     static let completed    = "completed"
     static let refunded     = "refunded"
+    static let trash        = "trash"
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 20.5
 -----
+- [*] Orders: Enabled viewing orders in trash. [https://github.com/woocommerce/woocommerce-ios/pull/13974]
 - [*] Blaze: Schedule a reminder local notification asking to continue abandoned campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13950]
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -230,7 +230,7 @@ private extension LastOrdersDashboardCardViewModel {
         let remoteStatuses = statusResultsController.fetchedObjects
             .map { OrderStatusEnum(rawValue: $0.slug) }
             .map { OrderStatusRow($0) }
-        allStatuses = [.any] + remoteStatuses
+        allStatuses = [.any] + remoteStatuses + [.trash]
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -17,6 +17,7 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
         case cancelled
         case refunded
         case failed
+        case trash
         case custom(String)
 
         init(_ status: OrderStatusEnum?) {
@@ -42,6 +43,8 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
                 self = .completed
             case .refunded:
                 self = .refunded
+            case .trash:
+                self = .trash
             case .custom(let value):
                 self = .custom(value)
             }
@@ -67,6 +70,8 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
                 return .completed
             case .refunded:
                 return .refunded
+            case .trash:
+                return .trash
             case .custom(let value):
                 return .custom(value)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -7,7 +7,7 @@ import protocol WooFoundation.Analytics
 ///
 @MainActor
 final class LastOrdersDashboardCardViewModel: ObservableObject {
-    enum OrderStatusRow: Identifiable {
+    enum OrderStatusRow: Identifiable, Equatable {
         case any
         case autoDraft
         case pending
@@ -230,7 +230,12 @@ private extension LastOrdersDashboardCardViewModel {
         let remoteStatuses = statusResultsController.fetchedObjects
             .map { OrderStatusEnum(rawValue: $0.slug) }
             .map { OrderStatusRow($0) }
-        allStatuses = [.any] + remoteStatuses + [.trash]
+        allStatuses = [.any] + remoteStatuses
+
+        /// manually add trash option if not present
+        if !allStatuses.contains(where: { $0 == .trash }) {
+            allStatuses.append(.trash)
+        }
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1109,7 +1109,7 @@ extension EditableOrderViewModel {
             title = orderStatus.name ?? orderStatus.slug
             color = {
                 switch orderStatus.status {
-                case .autoDraft, .pending, .cancelled, .refunded, .custom:
+                case .autoDraft, .pending, .cancelled, .refunded, .custom, .trash:
                     return .gray(.shade5)
                 case .onHold:
                     return .withColorStudio(.orange, shade: .shade5)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusEnum+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusEnum+UI.swift
@@ -4,7 +4,7 @@ import enum Yosemite.OrderStatusEnum
 extension OrderStatusEnum {
     var backgroundColor: UIColor {
         switch self {
-        case .autoDraft, .pending, .cancelled, .refunded, .custom:
+        case .autoDraft, .pending, .cancelled, .refunded, .custom, .trash:
                 .gray(.shade5)
         case .onHold:
                 .withColorStudio(.orange, shade: .shade5)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -92,7 +92,11 @@ private extension OrderStatusFilterViewController {
                 break
             }
         }
-        rows.append(.trash)
+
+        /// manually add trash option if not present
+        if !rows.contains(where: { $0 == .trash }) {
+            rows.append(.trash)
+        }
     }
 
     func selectOrDelesectRow(_ row: Row) {
@@ -149,7 +153,7 @@ extension OrderStatusFilterViewController: UITableViewDelegate {
 // MARK: - Cell configuration
 //
 private extension OrderStatusFilterViewController {
-    enum Row {
+    enum Row: Equatable {
 
         // The order of the statuses declaration is according to the Order's lifecycle
         // and it is used to determine the user facing display order using the synthesized allCases

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -92,6 +92,7 @@ private extension OrderStatusFilterViewController {
                 break
             }
         }
+        rows.append(.trash)
     }
 
     func selectOrDelesectRow(_ row: Row) {
@@ -160,6 +161,7 @@ private extension OrderStatusFilterViewController {
         case cancelled
         case refunded
         case failed
+        case trash
         case custom(OrderStatus)
 
         var status: OrderStatusEnum? {
@@ -180,6 +182,8 @@ private extension OrderStatusFilterViewController {
                 return .completed
             case .refunded:
                 return .refunded
+            case .trash:
+                return .trash
             case .custom(let value):
                 return value.status
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -107,7 +107,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
 
 
     @MainActor
-    func test_order_statuses_are_loaded_from_storage_when_available() async {
+    func test_order_statuses_are_loaded_from_storage_when_available_with_additional_any_and_trash_statuses() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
@@ -125,7 +125,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
             .sorted()
 
         // Then
-        XCTAssertEqual(viewModel.allStatuses.map { $0.id }, (["any"] + statusSlugs))
+        XCTAssertEqual(viewModel.allStatuses.map { $0.id }, (["any"] + statusSlugs + ["trash"]))
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13973 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the option to see orders in trash as per feature request from users.

Currently, we're fetching order statuses from `wc/v3/reports/totals/orders`. This endpoint returns all statuses of orders in a store, but doesn't include the trash status.

This PR adds the `trash` option manually to the order status filter list of the order list and last orders dashboard card. Orders with selected statuses including trash should be fetched as before from the `wc/v3/orders` endpoint.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a test store with more than 1 order of different statuses.
- Trash an order from wp-admin or from them app through the order detail screen.
- In the Orders tab, select Filter > Order statuses > Trash (and other options if necessary).
- Apply the filter(s) and confirm that the order list displays the correct orders matching the filter criteria.
- Navigate the My Store tab and enable the Most recent orders card.
- Tap on the filter icon and confirm that there's an option for Trash. Select that option.
- Confirm that the correct results are displayed for Trash option.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 15 Pro iOS 17.4:
- Confirmed that order list displays the correct results when selecting Trash status alone or together with other statuses/criteria. 
- Confirmed that clearing the filter showing the full order list without the trash orders.
- Confirmed that selecting Trash in the most recent orders dashboard card displays the correct results.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
\ | Order list | Last order dashboard card |
--- | --- | ---
Status options | <img src="https://github.com/user-attachments/assets/0b9b36d9-cb82-4a5a-90e0-7f304bce1efb" width=320 /> | <img src="https://github.com/user-attachments/assets/2275b3b2-8605-419a-a32a-f92ae4687c73" width=320 />
Results | <img src="https://github.com/user-attachments/assets/1893bd00-9d10-464f-8382-d26f01e77578" width=320 /> | <img src="https://github.com/user-attachments/assets/866d6fb5-0b30-4758-bcc5-b99c3b54c6b9" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
