### PR TITLE
[Woo POS] Cart view design updates 

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -153,7 +153,6 @@ private extension CartView {
     enum Constants {
         static let primaryFont: POSFontStyle = .posTitleEmphasized
         static let secondaryFont: POSFontStyle = .posBodyRegular
-        static let cartEmptyViewTextLineHeight: CGFloat = 12
         static let itemsFont: POSFontStyle = .posDetailRegular
         static let clearButtonFont: POSFontStyle = .posDetailEmphasized
         static let clearButtonCornerRadius: CGFloat = 4
@@ -227,7 +226,6 @@ private extension CartView {
             // avoids issues when the text size is changed through dynamic type.
             Text(Localization.addItemsToCartHint)
                 .font(Constants.secondaryFont)
-                .lineSpacing(Constants.cartEmptyViewTextLineHeight)
                 .foregroundColor(Color.posTertiaryText)
                 .multilineTextAlignment(.center)
                 .overlay(alignment: .top) {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -111,7 +111,7 @@ struct CartView: View {
                 } else {
                     checkoutButton
                         .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
-                        .padding(.top, Constants.checkoutButtonTopPadding)
+                        .padding(.vertical, Constants.checkoutButtonVerticalPadding)
                         .accessibilityAddTraits(.isHeader)
                 }
             case .finalizing:
@@ -167,7 +167,7 @@ private extension CartView {
         static let backButtonSymbol: String = "chevron.backward"
         static let cartHeaderElementSpacing: CGFloat = 16
         static let cartAnimation: Animation = .spring(duration: 0.2)
-        static let checkoutButtonTopPadding: CGFloat = 16
+        static let checkoutButtonVerticalPadding: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -91,6 +91,7 @@ struct PointOfSaleDashboardView: View {
                     cartView
                         .accessibilitySortPriority(1)
                         .frame(width: geometry.size.width * Constants.cartWidth)
+                        .ignoresSafeArea(edges: .bottom)
                 }
 
                 if viewModel.orderStage == .finalizing {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13970
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR addresses some of the design feedback items logged on https://github.com/woocommerce/woocommerce-ios/issues/13859 .

## Changes
- Removes the custom line height for the empty cart text (discussion here: TfaZ4LUkEwEGrxfnEFzvJj-fi-4650_22586#950216468 )
- Removes bottom cart item clipping while in `finalizing` mode.

I attempted to fix the feedback regarding the cart's view shadow transparency as well but I wasn't able to do so after much iteration, so I left these outside of this PR for the time being.

## Testing information
- In POS, observe that when the cart is empty, the text "Tap on a product to add it to the cart" appears with reduced line height compared with before (we just use the default one)

| Before | After |
|--------|--------|
| <img width="318" alt="Screenshot 2024-09-18 at 10 27 24" src="https://github.com/user-attachments/assets/f4c69787-28b6-4900-aaff-1f5af4a9c6a2"> | <img width="263" alt="Screenshot 2024-09-18 at 10 27 35" src="https://github.com/user-attachments/assets/6fadfe0b-d132-4aef-9524-c4f3dc158acf"> |

- Add enough items to the cart so they cannot fit without scrolling down ( ~8+ items )
- Tap on Checkout. Observe that items are not being clipped to the Cart's safe area, but are rendered behind and below the "Connect your reader" button.

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-09-16 at 16 35 06](https://github.com/user-attachments/assets/b8cd3542-461a-4e2b-b50f-db177162171e) | ![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-09-16 at 17 10 57](https://github.com/user-attachments/assets/cb1c803e-3a0f-4063-90bf-250d97a0b37c) | 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.