### PR TITLE
[Mobile Payments] Log Stripe error codes within the CardReaderService

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -1056,9 +1056,10 @@ private extension StripeCardReaderService {
             if let underlyingError = error as? UnderlyingError {
                 return underlyingError
             }
-        case is CardReaderConfigError, is CardReaderServiceError:
+        case is CardReaderServiceError:
             DDLogError("💳 Card Reader Service Error: \(error)")
-            break
+        case is CardReaderConfigError:
+            DDLogError("💳 Card Reader Config Error: \(error)")
         default:
             let nsError = error as NSError
             let errorCode = ErrorCode(_nsError: error as NSError)

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -1063,7 +1063,6 @@ private extension StripeCardReaderService {
         case is CardReaderConfigError:
             DDLogError("💳 Card Reader Config Error: \(error)")
         default:
-            let nsError = error as NSError
             let errorCode = ErrorCode(_nsError: error as NSError)
             DDLogError("💳 Stripe Error Code: \(errorCode.code)")
         }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -1053,6 +1053,8 @@ private extension StripeCardReaderService {
     static func logAndDecodeError(_ error: Error) -> UnderlyingError {
         switch error {
         case is UnderlyingError:
+            // It's possible for errors to pass through this function more than once.
+            // In that scenario, we don't want to log them a second time, so we can just return.
             if let underlyingError = error as? UnderlyingError {
                 return underlyingError
             }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.5
 -----
 - [*] Blaze: Schedule a reminder local notification asking to continue abandoned campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13950]
+- [internal] Mobile Payments: Log errors from Stripe Terminal [https://github.com/woocommerce/woocommerce-ios/pull/13976]
 
 
 20.4


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds logging for the error codes we get from Stripe, within the StripeCardReaderService, for a lower-level way to identify errors that are causing issues.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Turn off bluetooth on your device
3. Navigate to `Menu > Payments > Manage card reader`
4. Tap `Connect card reader` if needed
5. Observe the error is shown
6. Check the logs (Xcode console, or `Menu > Settings > Help & Support > View Application Log > Current`)
7. Observe that you see a log for `💳 Stripe Error Code: SCPError(rawValue: 2320)`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Some errors don't originate from Stripe. If they don't, they'll default to being tracked with code 1. I've written some pattern matching logic to try to avoid this, but it's not feasible to test every situation here.

No unit testing because the `StripeCardReaderService` is not structured for unit tests, due to the impracticality of mocking the Stripe Terminal.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.