### PR TITLE
[Tooling] Release Publishing fix

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,14 +1,19 @@
 #!/bin/bash -eu
 
-# BUILDKITE_RELEASE_VERSION is passed as an environment variable from fastlane to Buildkite
+# Note: BUILDKITE_RELEASE_VERSION is passed as an environment variable from fastlane to Buildkite
 # It must use the `BUILDKITE_` prefix to be passed to the agent due to how `hostmgr` works.
-if [[ -z "${BUILDKITE_RELEASE_VERSION}" ]]; then
-    echo "BUILDKITE_RELEASE_VERSION is not set."
+# This is considered legacy and we should eventually remove all custom BUILDKITE_ variables.
+
+# Use the provided RELEASE_VERSION if set, otherwise fall back to the legacy BUILDKITE_RELEASE_VERSION
+RELEASE_VERSION=${1:-$BUILDKITE_RELEASE_VERSION}
+
+if [[ -z "${RELEASE_VERSION}" ]]; then
+    echo "RELEASE_VERSION is not set and BUILDKITE_RELEASE_VERSION is not available."
     exit 1
 fi
 
 # Buildkite, by default, checks out a specific commit. For many release actions, we need to be
 # on a release branch instead.
-BRANCH_NAME="release/${BUILDKITE_RELEASE_VERSION}"
+BRANCH_NAME="release/${RELEASE_VERSION}"
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -eu
 
-# Note: BUILDKITE_RELEASE_VERSION is passed as an environment variable from fastlane to Buildkite
-# It must use the `BUILDKITE_` prefix to be passed to the agent due to how `hostmgr` works.
+# Note: BUILDKITE_RELEASE_VERSION is passed as an environment variable to Buildkite.
+# It must use the `BUILDKITE_` prefix to then be forwarded to the MacOS VM due to how `hostmgr` works.
 # This is considered legacy and we should eventually remove all custom BUILDKITE_ variables.
 
-# Use the provided RELEASE_VERSION if set, otherwise fall back to the legacy BUILDKITE_RELEASE_VERSION
+# Use the provided argument if there's one, otherwise fall back to the legacy BUILDKITE_RELEASE_VERSION
 RELEASE_VERSION=${1:-$BUILDKITE_RELEASE_VERSION}
 
 if [[ -z "${RELEASE_VERSION}" ]]; then

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -eu
 
-# Note: BUILDKITE_RELEASE_VERSION is passed as an environment variable to Buildkite.
-# It must use the `BUILDKITE_` prefix to then be forwarded to the MacOS VM due to how `hostmgr` works.
-# This is considered legacy and we should eventually remove all custom BUILDKITE_ variables.
+# Note: `BUILDKITE_RELEASE_VERSION` is the legacy environment variable passed to Buildkite by ReleaseV2.
+# It used the `BUILDKITE_` prefix so it was not filtered out when passed to the MacOS VMs, due to how `hostmgr` works.
+# This is considered legacy: we should eventually remove all use of custom `BUILDKITE_` variables, and instead
+# resolve the value of those sooner (i.e. in the YML pipeline) then pass it as parameter to the `.sh` calls instead.
 
 # Use the provided argument if there's one, otherwise fall back to the legacy BUILDKITE_RELEASE_VERSION
 RELEASE_VERSION=${1:-$BUILDKITE_RELEASE_VERSION}

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -14,7 +14,7 @@ steps:
       .buildkite/commands/configure-environment.sh
 
       echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -14,7 +14,7 @@ steps:
       .buildkite/commands/configure-environment.sh
 
       echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -14,7 +14,7 @@ steps:
       .buildkite/commands/configure-environment.sh
 
       echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -14,7 +14,7 @@ steps:
       .buildkite/commands/configure-environment.sh
 
       echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -14,7 +14,7 @@ steps:
       .buildkite/commands/configure-environment.sh
 
       echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply

--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -14,7 +14,7 @@ steps:
       .buildkite/commands/configure-environment.sh
 
       echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :closed_lock_with_key: Access Secrets'
       bundle exec fastlane run configure_apply

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -536,7 +536,7 @@ platform :ios do
   #
   lane :publish_release do |skip_confirm: false|
     ensure_git_status_clean
-    ensure_git_branch_is_release_branch
+    ensure_git_branch_is_release_branch!
 
     version_number = release_version_current
 
@@ -1480,9 +1480,7 @@ rescue StandardError => e
   error_message = <<-MESSAGE
     Error creating backmerge pull request:
 
-    ```
     #{e.message}
-    ```
 
     If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
     Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.


### PR DESCRIPTION
This PR fixes the issue on release publishing found / fixed by @mokagio in another project (typo in the lane) and the comment from @AliSoftware on D161538-code.

I haven't fully migrated to `RELEASE_VERSION` as this will require more changes in Rv2 (and might break for ongoing releases). Plus, it doesn't seem strictly necessary for now, so I'm proposing a transition period where we can have it either way.