### PR TITLE
Remove CardPresentPluginsDataProvider singleton when initializing `PaymentReceiptEmailParameterDeterminer`

### DIFF
--- a/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
@@ -32,8 +32,6 @@ struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
     private let stores: StoresManager
     private let configurationLoader: CardPresentConfigurationLoader
 
-    static let shared = CardPresentPluginsDataProvider(configurationLoader: CardPresentConfigurationLoader(stores: ServiceLocator.stores))
-
     init(
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -12,7 +12,12 @@ protocol ReceiptEmailParameterDeterminer {
 struct PaymentReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {
     private let cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol
 
-    init(cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol = CardPresentPluginsDataProvider.shared) {
+    private static var defaultDataProvider: CardPresentPluginsDataProviderProtocol {
+        let configurationLoader = CardPresentConfigurationLoader(stores: ServiceLocator.stores)
+        return CardPresentPluginsDataProvider(configurationLoader: configurationLoader)
+    }
+
+    init(cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol = Self.defaultDataProvider) {
         self.cardPresentPluginsDataProvider = cardPresentPluginsDataProvider
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to: #13897
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In a fix made in https://github.com/woocommerce/woocommerce-ios/pull/13897, I introduced a singleton for `CardPresentPluginsDataProvider` only for the purpose of default initializer for `PaymentReceiptEmailParameterDeterminer`. However, as @joshheald [correctly pointed out](https://github.com/woocommerce/woocommerce-ios/pull/13897#discussion_r1761334731), it can causes issues, especially if  `CardPresentPluginsDataProvider` starts holding any state.

For now, I tested `PaymentReceiptEmailParameterDeterminer` behavior and reviewed the code, and can confirm that there're no side effects for `CardPresentPluginsDataProvider` having a singleton.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

I tested the changes this way:
1. Logged into a site with a payment provider configured
2. Put a breakpoint in `PaymentReceiptEmailParameterDeterminer.receiptEmail`
3. Make a card reader payment
4. Note  the data `cardPresentPluginsDataProvider` provides
5. Switch to a different site with a payment provider configured
6. Make a card reader payment
7. Note the data `cardPresentPluginsDataProvider` provides and that is different from the first one

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Retested fixes made https://github.com/woocommerce/woocommerce-ios/pull/13897#issuecomment-2340013470, which resulted in this singleton being introduced
- Tested `PaymentReceiptEmailParameterDeterminer`, confirmed that switching sites produces different `paymentPluginsStatus` and consequentially a different `receiptEmail` 

No unit tests for this change 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.