### PR TITLE
[Woo POS] Simplify `TotalsViewModel` protocol. Update access control

### DIFF
--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -43,18 +43,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         startNewOrderActionSubject.eraseToAnyPublisher()
     }
 
-    var computedFormattedCartTotalPrice: String? {
-        formattedPrice(totalsCalculator?.itemsTotal.stringValue, currency: order?.currency)
-    }
-
-    var computedFormattedOrderTotalPrice: String? {
-        formattedPrice(order?.total, currency: order?.currency)
-    }
-
-    var computedFormattedOrderTotalTaxPrice: String? {
-        formattedPrice(order?.totalTax, currency: order?.currency)
-    }
-
     var isShimmering: Bool {
         orderState.isSyncing
     }
@@ -189,16 +177,20 @@ extension TotalsViewModel {
         }
     }
 
-    private func updateFormattedPrices() {
-        formattedCartTotalPrice = computedFormattedCartTotalPrice
-        formattedOrderTotalPrice = computedFormattedOrderTotalPrice
-        formattedOrderTotalTaxPrice = computedFormattedOrderTotalTaxPrice
-    }
-
     private func updateOrder(_ updatedOrder: Order) {
         self.order = updatedOrder
         totalsCalculator = OrderTotalsCalculator(for: updatedOrder, using: currencyFormatter)
         updateFormattedPrices()
+    }
+}
+
+// MARK: - Price formatters
+
+private extension TotalsViewModel {
+    func updateFormattedPrices() {
+        formattedCartTotalPrice = computedFormattedCartTotalPrice
+        formattedOrderTotalPrice = computedFormattedOrderTotalPrice
+        formattedOrderTotalTaxPrice = computedFormattedOrderTotalTaxPrice
     }
 
     func formattedPrice(_ price: String?, currency: String?) -> String? {
@@ -206,6 +198,18 @@ extension TotalsViewModel {
             return nil
         }
         return currencyFormatter.formatAmount(price, with: currency)
+    }
+
+    var computedFormattedCartTotalPrice: String? {
+        formattedPrice(totalsCalculator?.itemsTotal.stringValue, currency: order?.currency)
+    }
+
+    var computedFormattedOrderTotalPrice: String? {
+        formattedPrice(order?.total, currency: order?.currency)
+    }
+
+    var computedFormattedOrderTotalTaxPrice: String? {
+        formattedPrice(order?.totalTax, currency: order?.currency)
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -94,8 +94,8 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
 
     var orderStatePublisher: Published<OrderState>.Publisher { $orderState }
     var paymentStatePublisher: Published<PaymentState>.Publisher { $paymentState }
-    var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { $cardPresentPaymentAlertViewModel }
-    var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { $cardPresentPaymentEvent }
+    private var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { $cardPresentPaymentAlertViewModel }
+    private var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { $cardPresentPaymentEvent }
     var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { $connectionStatus }
     var formattedCartTotalPricePublisher: Published<String?>.Publisher { $formattedCartTotalPrice }
     var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -34,9 +34,9 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
 
     @Published private(set) var connectionStatus: CardReaderConnectionStatus = .disconnected
 
-    @Published var formattedCartTotalPrice: String?
-    @Published var formattedOrderTotalPrice: String?
-    @Published var formattedOrderTotalTaxPrice: String?
+    @Published private(set) var formattedCartTotalPrice: String?
+    @Published private(set) var formattedOrderTotalPrice: String?
+    @Published private(set) var formattedOrderTotalTaxPrice: String?
 
     private let startNewOrderActionSubject = PassthroughSubject<Void, Never>()
     var startNewOrderActionPublisher: AnyPublisher<Void, Never> {

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -96,10 +96,10 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     var paymentStatePublisher: Published<PaymentState>.Publisher { $paymentState }
     private var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { $cardPresentPaymentAlertViewModel }
     private var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { $cardPresentPaymentEvent }
-    var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { $connectionStatus }
-    var formattedCartTotalPricePublisher: Published<String?>.Publisher { $formattedCartTotalPrice }
-    var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }
-    var formattedOrderTotalTaxPricePublisher: Published<String?>.Publisher { $formattedOrderTotalTaxPrice }
+    private var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { $connectionStatus }
+    private var formattedCartTotalPricePublisher: Published<String?>.Publisher { $formattedCartTotalPrice }
+    private var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }
+    private var formattedOrderTotalTaxPricePublisher: Published<String?>.Publisher { $formattedOrderTotalTaxPrice }
 
     private var startPaymentOnReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -13,8 +13,6 @@ protocol TotalsViewModelProtocol {
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { get }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { get }
-    var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { get }
-    var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { get }
     var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { get }
     var formattedCartTotalPricePublisher: Published<String?>.Publisher { get }
     var formattedOrderTotalPricePublisher: Published<String?>.Publisher { get }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -4,7 +4,6 @@ import protocol Yosemite.POSItem
 
 protocol TotalsViewModelProtocol {
     var paymentState: TotalsViewModel.PaymentState { get }
-    var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType? { get }
     var cardPresentPaymentEvent: CardPresentPaymentEvent { get }
     var connectionStatus: CardReaderConnectionStatus { get }
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -17,8 +17,6 @@ protocol TotalsViewModelProtocol {
 
     func startNewOrder()
     func checkOutTapped(with cartItems: [CartItem], allItems: [POSItem])
-    func connectReaderTapped()
-    func onTotalsViewDisappearance()
 
     func startShowingTotalsView()
     func stopShowingTotalsView()

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -13,10 +13,6 @@ protocol TotalsViewModelProtocol {
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { get }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { get }
-    var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { get }
-    var formattedCartTotalPricePublisher: Published<String?>.Publisher { get }
-    var formattedOrderTotalPricePublisher: Published<String?>.Publisher { get }
-    var formattedOrderTotalTaxPricePublisher: Published<String?>.Publisher { get }
     var startNewOrderActionPublisher: AnyPublisher<Void, Never> { get }
 
     var isShimmering: Bool { get }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -12,7 +12,6 @@ protocol TotalsViewModelProtocol {
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { get }
     var startNewOrderActionPublisher: AnyPublisher<Void, Never> { get }
 
-    var isShimmering: Bool { get }
     var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType? { get }
     var order: Order? { get }
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -7,18 +7,12 @@ protocol TotalsViewModelProtocol {
     var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType? { get }
     var cardPresentPaymentEvent: CardPresentPaymentEvent { get }
     var connectionStatus: CardReaderConnectionStatus { get }
-    var formattedCartTotalPrice: String? { get }
-    var formattedOrderTotalPrice: String? { get }
-    var formattedOrderTotalTaxPrice: String? { get }
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { get }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { get }
     var startNewOrderActionPublisher: AnyPublisher<Void, Never> { get }
 
     var isShimmering: Bool { get }
-    var isTotalPriceFieldRedacted: Bool { get }
-    var isSubtotalFieldRedacted: Bool { get }
-    var isTaxFieldRedacted: Bool { get }
     var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType? { get }
     var order: Order? { get }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -36,14 +36,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
         orderState = .syncing
     }
 
-    func connectReaderTapped() {
-        // Provide a mock implementation if needed
-    }
-
-    func onTotalsViewDisappearance() {
-        // Provide a mock implementation if needed
-    }
-
     var spyStopShowingTotalsViewCalled = false
     func stopShowingTotalsView() {
         spyStopShowingTotalsViewCalled = true

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -20,8 +20,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { $orderState }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { $paymentState }
-    var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { $cardPresentPaymentAlertViewModel }
-    var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { $cardPresentPaymentEvent }
     var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { $connectionStatus }
     var formattedCartTotalPricePublisher: Published<String?>.Publisher { $formattedCartTotalPrice }
     var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -19,10 +19,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { $paymentState }
     var startNewOrderActionPublisher: AnyPublisher<Void, Never> { $startNewOrderAction.eraseToAnyPublisher() }
 
-    var isShimmering: Bool {
-        orderState.isSyncing
-    }
-
     var isSyncingOrder: Bool {
         return orderState.isSyncing
     }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -10,7 +10,7 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
 
     @Published var orderState: TotalsViewModel.OrderState = .loaded
     @Published var paymentState: TotalsViewModel.PaymentState = .idle
-    @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
+
     @Published var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
     @Published var connectionStatus: CardReaderConnectionStatus = .disconnected
     @Published var startNewOrderAction: Void = ()

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -20,10 +20,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { $orderState }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { $paymentState }
-    var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { $connectionStatus }
-    var formattedCartTotalPricePublisher: Published<String?>.Publisher { $formattedCartTotalPrice }
-    var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }
-    var formattedOrderTotalTaxPricePublisher: Published<String?>.Publisher { $formattedOrderTotalTaxPrice }
     var startNewOrderActionPublisher: AnyPublisher<Void, Never> { $startNewOrderAction.eraseToAnyPublisher() }
 
     var isShimmering: Bool {

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -13,9 +13,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
     @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
     @Published var connectionStatus: CardReaderConnectionStatus = .disconnected
-    @Published var formattedCartTotalPrice: String?
-    @Published var formattedOrderTotalPrice: String?
-    @Published var formattedOrderTotalTaxPrice: String?
     @Published var startNewOrderAction: Void = ()
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { $orderState }
@@ -28,18 +25,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
 
     var isSyncingOrder: Bool {
         return orderState.isSyncing
-    }
-
-    var isSubtotalFieldRedacted: Bool {
-        formattedCartTotalPrice == nil || isSyncingOrder
-    }
-
-    var isTaxFieldRedacted: Bool {
-        formattedOrderTotalTaxPrice == nil || isSyncingOrder
-    }
-
-    var isTotalPriceFieldRedacted: Bool {
-        formattedOrderTotalPrice == nil || isSyncingOrder
     }
 
     var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType? {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -25,20 +25,15 @@ final class TotalsViewModelTests: XCTestCase {
                               paymentState: .acceptingCard)
         cancellables = Set()
     }
-    func test_on_checkOutTapped_startSyncOrder() {}
-    func test_stopSyncOrder() {}
-    func test_order() {}
-    func test_formattedPrice() {}
-    func test_formattedOrderTotalPrice() {}
-    func test_formattedOrderTotalTaxPrice() {}
-    func test_clearOrder() {
+
+    func test_order_when_clearOrder_invoked_then_order_is_set_to_nil() {
         // When
         sut.clearOrder()
 
         // Then
         XCTAssertNil(sut.order)
     }
-    func test_setOrder() {}
+
     func test_startNewOrder_after_collecting_payment() async throws {
         // Given
         let paymentState: TotalsViewModel.PaymentState = .acceptingCard

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -25,26 +25,6 @@ final class TotalsViewModelTests: XCTestCase {
                               paymentState: .acceptingCard)
         cancellables = Set()
     }
-/*
- Since we're not exposing the publisher outside of the class, and it's public just for testing purposes
- (which we do not have tests for), we don't need these tests, simplifying the interface:
- */
-//    func test_order_cardPresentPaymentEvent_when_initial_state_then_state_is_idle() {
-//        // Given
-//        let expectation = XCTestExpectation(description: "Initial state")
-//
-//        // When
-//        sut.cardPresentPaymentEventPublisher
-//            .sink { event in
-//                if case .idle = event {
-//                    // Then
-//                    expectation.fulfill()
-//                } else {
-//                    XCTFail("Expected .idle event state, got \(event)")
-//                }
-//            }
-//            .store(in: &cancellables)
-//    }
 
     func test_order_when_clearOrder_invoked_then_order_is_set_to_nil() {
         // When

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -25,6 +25,26 @@ final class TotalsViewModelTests: XCTestCase {
                               paymentState: .acceptingCard)
         cancellables = Set()
     }
+/*
+ Since we're not exposing the publisher outside of the class, and it's public just for testing purposes
+ (which we do not have tests for), we don't need these tests, simplifying the interface:
+ */
+//    func test_order_cardPresentPaymentEvent_when_initial_state_then_state_is_idle() {
+//        // Given
+//        let expectation = XCTestExpectation(description: "Initial state")
+//
+//        // When
+//        sut.cardPresentPaymentEventPublisher
+//            .sink { event in
+//                if case .idle = event {
+//                    // Then
+//                    expectation.fulfill()
+//                } else {
+//                    XCTFail("Expected .idle event state, got \(event)")
+//                }
+//            }
+//            .store(in: &cancellables)
+//    }
 
     func test_order_when_clearOrder_invoked_then_order_is_set_to_nil() {
         // When


### PR DESCRIPTION
## Description
This PR attempts to simplify the existing `TotalsViewModelProtocol` and its implementations. By making private several properties and functions that were never accessed from the outside, we can make the design simpler. 

I left some comments below as there's still room for improvement, but this looks like a good first step.

## Changes
- Deleted empty placeholder tests from the initial states of the POC, most of them are no longer valid.
- Made properties and methods private when not being accessed from outside the class, this lead to deleting their signature from the protocol, and the associated mock implementation (if any).
- Moved currency formatter helpers to a private extension.

## Testing information

CI should pass. 

Consider smoke testing the payment flow, and the totals view, but there are no changes to the business logic: The computed properties that have been deleted from the view model weren't used anywhere except for protocol conformance, and the publicly-exposed properties that we've restricted remain gettable via `private(set)`.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.