### PR TITLE
`MetaDataStore` unit tests

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -218,6 +218,8 @@
 		453305FB245AEDCB00264E50 /* SitePostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305FA245AEDCB00264E50 /* SitePostStoreTests.swift */; };
 		453954D82C9197BE00A3E64A /* MetaDataAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453954D72C9197BE00A3E64A /* MetaDataAction.swift */; };
 		453954DA2C9197C900A3E64A /* MetaDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453954D92C9197C900A3E64A /* MetaDataStore.swift */; };
+		453954DC2C91F79B00A3E64A /* MetaDataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453954DB2C91F79B00A3E64A /* MetaDataStoreTests.swift */; };
+		454D606F2C9C5DF1004709AB /* MockMetaDataRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454D606E2C9C5DF1004709AB /* MockMetaDataRemote.swift */; };
 		4552073D25811B4E001CF873 /* ProductAttributeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4552073C25811B4E001CF873 /* ProductAttributeStoreTests.swift */; };
 		455A931D2747C19300259C7F /* AppSettingsStoreTests+OrdersSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455A931C2747C19300259C7F /* AppSettingsStoreTests+OrdersSettings.swift */; };
 		45739F372437680F00480C95 /* ProductSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45739F362437680F00480C95 /* ProductSettings.swift */; };
@@ -721,6 +723,8 @@
 		453305FA245AEDCB00264E50 /* SitePostStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePostStoreTests.swift; sourceTree = "<group>"; };
 		453954D72C9197BE00A3E64A /* MetaDataAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaDataAction.swift; sourceTree = "<group>"; };
 		453954D92C9197C900A3E64A /* MetaDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaDataStore.swift; sourceTree = "<group>"; };
+		453954DB2C91F79B00A3E64A /* MetaDataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaDataStoreTests.swift; sourceTree = "<group>"; };
+		454D606E2C9C5DF1004709AB /* MockMetaDataRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMetaDataRemote.swift; sourceTree = "<group>"; };
 		4552073C25811B4E001CF873 /* ProductAttributeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeStoreTests.swift; sourceTree = "<group>"; };
 		455A931C2747C19300259C7F /* AppSettingsStoreTests+OrdersSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettingsStoreTests+OrdersSettings.swift"; sourceTree = "<group>"; };
 		45739F362437680F00480C95 /* ProductSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductSettings.swift; sourceTree = "<group>"; };
@@ -1407,6 +1411,7 @@
 				02DF98082A136BFB0009E2EA /* MockSitePluginsRemote.swift */,
 				EE4D51B72ACD3C9800783D77 /* MockProductCategoriesRemote.swift */,
 				DEB387872C2C09FC0025256E /* MockGoogleListingsAndAdsRemote.swift */,
+				454D606E2C9C5DF1004709AB /* MockMetaDataRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1744,6 +1749,7 @@
 				0286A1BB2A0CC4120099EF94 /* FeatureFlagStoreTests.swift */,
 				DEDA8DB22B184B950076BF0F /* WordPressThemeStoreTests.swift */,
 				DEB387852C2C09A70025256E /* GoogleAdsStoreTests.swift */,
+				453954DB2C91F79B00A3E64A /* MetaDataStoreTests.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -2586,6 +2592,7 @@
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockAcountStore.swift in Sources */,
 				312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */,
+				453954DC2C91F79B00A3E64A /* MetaDataStoreTests.swift in Sources */,
 				EEB4E2CF29B04D7900371C3C /* StoreOnboardingTasksStoreTests.swift in Sources */,
 				687F83722C0EBF8900460AB3 /* POSProductProviderTests.swift in Sources */,
 				03EB99922907EBB300F06A39 /* JustInTimeMessageStoreTests.swift in Sources */,
@@ -2685,6 +2692,7 @@
 				020C907D24C729D6001E2BEB /* MockProductVariation.swift in Sources */,
 				7499936820EFC0ED00CF01CD /* OrderNoteStoreTests.swift in Sources */,
 				578CE7972475FD8200492EBF /* MockProductReview.swift in Sources */,
+				454D606F2C9C5DF1004709AB /* MockMetaDataRemote.swift in Sources */,
 				E18FDB0128F98376008519BA /* AppAccountTokenTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMetaDataRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMetaDataRemote.swift
@@ -1,0 +1,27 @@
+import XCTest
+import Networking
+
+/// Mock for `MetaDataRemote`.
+///
+final class MockMetaDataRemote {
+    private var updatingMetaDataResult: Result<[MetaData], Error>?
+
+    func whenUpdatingMetaData(thenReturn result: Result<[MetaData], Error>) {
+        updatingMetaDataResult = result
+    }
+}
+
+extension MockMetaDataRemote: MetaDataRemoteProtocol {
+    func updateMetaData(for siteID: Int64, for parentID: Int64, type: MetaDataType, metadata: [[String: Any]]) async throws -> [MetaData] {
+        guard let result = updatingMetaDataResult else {
+            XCTFail("Could not find result for updating metadata.")
+            throw NetworkError.notFound()
+        }
+        switch result {
+        case .success(let metaData):
+            return metaData
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import Networking
+@testable import Storage
+@testable import Yosemite
+
+final class MetaDataStoreTests: XCTestCase {
+    private var network: MockNetwork!
+    private var remote: MockMetaDataRemote!
+    private var storageManager: MockStorageManager!
+    private var storage: StorageType! {
+        storageManager.viewStorage
+    }
+    private var viewStorage: StorageType {
+        return storageManager.viewStorage
+    }
+    private let sampleSiteID: Int64 = 1234
+    private let sampleOrderID: Int64 = 1
+    private let sampleProductID: Int64 = 2
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+        storageManager = MockStorageManager()
+        remote = MockMetaDataRemote()
+    }
+
+    override func tearDown() {
+        network = nil
+        storageManager = nil
+        remote = nil
+        super.tearDown()
+    }
+
+    // MARK: - Update Order MetaData
+
+    func test_updateOrderMetaData_is_successful_when_updating_successfully() throws {
+        // Given
+        let newMetadataArray = [["id": 1234, "key": "newValue"]]
+        let returnMetaData = MetaData.fake().copy(metadataID: 1234, key: "key", value: "newValue")
+        remote.whenUpdatingMetaData(thenReturn: .success([returnMetaData]))
+        let store = MetaDataStore(dispatcher: Dispatcher(),
+                                  storageManager: storageManager,
+                                  network: network,
+                                  remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(MetaDataAction.updateOrderMetaData(siteID: self.sampleSiteID,
+                                                              orderID: self.sampleOrderID,
+                                                              metadata: newMetadataArray,
+                                                              onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        let updatedMetaData = try result.get()
+        XCTAssertEqual(updatedMetaData.count, 1)
+        XCTAssertEqual(updatedMetaData.first?.key, "key")
+        XCTAssertEqual(updatedMetaData.first?.value, "newValue")
+    }
+
+    func test_updateOrderMetaData_returns_error_on_failure() throws {
+        // Given
+        let metadata = [["key": "newValue"]]
+        remote.whenUpdatingMetaData(thenReturn: .failure(NetworkError.timeout()))
+        let store = MetaDataStore(dispatcher: Dispatcher(),
+                                  storageManager: storageManager,
+                                  network: network,
+                                  remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(MetaDataAction.updateOrderMetaData(siteID: self.sampleSiteID, orderID: self.sampleOrderID, metadata: metadata, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
+
+    // MARK: - Update Product MetaData
+
+    func test_updateProductMetaData_is_successful_when_updating_successfully() throws {
+        // Given
+        let newMetadataArray = [["id": 1234, "key": "newValue"]]
+        let returnMetaData = MetaData.fake().copy(metadataID: 1234, key: "key", value: "newValue")
+        remote.whenUpdatingMetaData(thenReturn: .success([returnMetaData]))
+        let store = MetaDataStore(dispatcher: Dispatcher(),
+                                  storageManager: storageManager,
+                                  network: network,
+                                  remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(MetaDataAction.updateProductMetaData(siteID: self.sampleSiteID,
+                                                                productID: self.sampleProductID,
+                                                                metadata: newMetadataArray,
+                                                                onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        let updatedMetaData = try result.get()
+        XCTAssertEqual(updatedMetaData.count, 1)
+        XCTAssertEqual(updatedMetaData.first?.key, "key")
+        XCTAssertEqual(updatedMetaData.first?.value, "newValue")
+    }
+
+    func test_updateProductMetaData_returns_error_on_failure() throws {
+        // Given
+        let metadata = [["key": "value"]]
+        remote.whenUpdatingMetaData(thenReturn: .failure(NetworkError.timeout()))
+        let store = MetaDataStore(dispatcher: Dispatcher(),
+                                  storageManager: storageManager,
+                                  network: network,
+                                  remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(MetaDataAction.updateProductMetaData(siteID: self.sampleSiteID,
+                                                                productID: self.sampleProductID,
+                                                                metadata: metadata,
+                                                                onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
@@ -47,7 +47,7 @@ final class MetaDataStoreTests: XCTestCase {
         let result = waitFor { promise in
             store.onAction(MetaDataAction.updateOrderMetaData(siteID: self.sampleSiteID,
                                                               orderID: self.sampleOrderID,
-                                                              metadata: newMetadataArray,
+                                                              metadata: self.newMetadataArray,
                                                               onCompletion: { result in
                 promise(result)
             }))
@@ -95,7 +95,7 @@ final class MetaDataStoreTests: XCTestCase {
         let result = waitFor { promise in
             store.onAction(MetaDataAction.updateProductMetaData(siteID: self.sampleSiteID,
                                                                 productID: self.sampleProductID,
-                                                                metadata: newMetadataArray,
+                                                                metadata: self.newMetadataArray,
                                                                 onCompletion: { result in
                 promise(result)
             }))

--- a/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
@@ -16,6 +16,8 @@ final class MetaDataStoreTests: XCTestCase {
     private let sampleSiteID: Int64 = 1234
     private let sampleOrderID: Int64 = 1
     private let sampleProductID: Int64 = 2
+    private let newMetadataArray = [["id": 1234, "key": "newValue"]]
+    private let returnMetaDataArray = [MetaData.fake().copy(metadataID: 1234, key: "key", value: "newValue")]
 
     override func setUp() {
         super.setUp()
@@ -35,9 +37,7 @@ final class MetaDataStoreTests: XCTestCase {
 
     func test_updateOrderMetaData_is_successful_when_updating_successfully() throws {
         // Given
-        let newMetadataArray = [["id": 1234, "key": "newValue"]]
-        let returnMetaData = MetaData.fake().copy(metadataID: 1234, key: "key", value: "newValue")
-        remote.whenUpdatingMetaData(thenReturn: .success([returnMetaData]))
+        remote.whenUpdatingMetaData(thenReturn: .success(returnMetaDataArray))
         let store = MetaDataStore(dispatcher: Dispatcher(),
                                   storageManager: storageManager,
                                   network: network,
@@ -85,9 +85,7 @@ final class MetaDataStoreTests: XCTestCase {
 
     func test_updateProductMetaData_is_successful_when_updating_successfully() throws {
         // Given
-        let newMetadataArray = [["id": 1234, "key": "newValue"]]
-        let returnMetaData = MetaData.fake().copy(metadataID: 1234, key: "key", value: "newValue")
-        remote.whenUpdatingMetaData(thenReturn: .success([returnMetaData]))
+        remote.whenUpdatingMetaData(thenReturn: .success(returnMetaDataArray))
         let store = MetaDataStore(dispatcher: Dispatcher(),
                                   storageManager: storageManager,
                                   network: network,


### PR DESCRIPTION

Closes: #13901


## Description
This set of changes follows the changes introduced in this PR https://github.com/woocommerce/woocommerce-ios/pull/13929  handling the test of `MetaDataStore` unit tests, and introduces a new mock class for `MetaDataRemote`.

## Steps to reproduce
- Ensure all unit tests in `MetaDataStoreTests.swift` run successfully.

## Testing information
Just CI should be ✅ 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
