### PR TITLE
[Woo POS] Skip flaky test

### DIFF
--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -211,7 +211,8 @@ final class TotalsViewModelTests: XCTestCase {
         XCTAssertEqual(orderStates, [.idle, .syncing, .error(.init(message: "", handler: {}))])
     }
 
-    func test_when_reader_reconnects_on_TotalsView_reader_is_prepared_for_payment() async {
+    func test_when_reader_reconnects_on_TotalsView_reader_is_prepared_for_payment() async throws {
+        try XCTSkipIf(true, "This test is flaky in CI and should be improved. See #14005")
         // Given a reader has been connected, with the order synced, on the TotalsView
         sut.startShowingTotalsView()
         cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

TotalsViewModelTest.test_when_reader_reconnects_on_TotalsView_reader_is_prepared_for_payment failed in CI without reporting the failure, during the 20.4 release.

As a result, we're skipping it for now. #14005 covers its removal or reinstatement.

This is likely due to using both async/await and waitForExpectations approaches in the same test, which has been known to be fragile especially on CI... changing it isn't trivial though!

Context: p1726823993370659-slack-C6H8C3G23

We should make this a 20.5 beta fix, but the branch isn't currently available, so don't merge until that's done.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Check unit tests pass on CI and locally.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.