### PR TITLE
[Shipping labels] Update item price label to display total price based on item quantity

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -61,8 +61,7 @@ private extension WooShippingItemsViewModel {
     /// This includes the total weight and total price of all items.
     ///
     func generateItemsDetailLabel() -> String {
-        let totalWeight = dataSource.orderItems.map { calculateWeight(for: $0) }.reduce(0, +)
-        let formattedWeight = weightFormatter.formatWeight(weight: totalWeight)
+        let formattedWeight = formatWeight(for: dataSource.orderItems)
 
         let itemsTotal = dataSource.orderItems.map { $0.price.decimalValue * $0.quantity }.reduce(0, +)
         let formattedPrice = currencyFormatter.formatAmount(itemsTotal) ?? itemsTotal.description
@@ -75,12 +74,11 @@ private extension WooShippingItemsViewModel {
     func generateItemRows() -> [WooShippingItemRowViewModel] {
         dataSource.orderItems.map { item in
             let (product, variation) = getProductAndVariation(for: item)
-            let itemWeight = calculateWeight(for: item)
             return WooShippingItemRowViewModel(imageUrl: variation?.imageURL ?? product?.imageURL,
                                                quantityLabel: item.quantity.description,
                                                name: item.name,
                                                detailsLabel: generateItemRowDetailsLabel(for: item),
-                                               weightLabel: weightFormatter.formatWeight(weight: itemWeight),
+                                               weightLabel: formatWeight(for: [item]),
                                                priceLabel: formatPrice(for: item))
         }
     }
@@ -112,6 +110,13 @@ private extension WooShippingItemsViewModel {
         }()
 
         return [formattedDimensions, attributes].compacted().joined(separator: " • ")
+    }
+
+    /// Calculates and formats the total weight of the given items.
+    ///
+    func formatWeight(for items: [OrderItem]) -> String {
+        let totalWeight = items.map { calculateWeight(for: $0) }.reduce(0, +)
+        return weightFormatter.formatWeight(weight: totalWeight)
     }
 
     /// Calculates the weight of the given item based on the item quantity and the product or variation weight.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -17,6 +17,7 @@ final class WooShippingItemsViewModel: ObservableObject {
     @Published var itemsCountLabel: String = ""
 
     /// Label with the details of the items to ship.
+    /// Include total weight and total price for all items in the shipment.
     @Published var itemsDetailLabel: String = ""
 
     /// View models for rows of items to ship.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -81,7 +81,7 @@ private extension WooShippingItemsViewModel {
                                                name: item.name,
                                                detailsLabel: generateItemRowDetailsLabel(for: item),
                                                weightLabel: weightFormatter.formatWeight(weight: itemWeight),
-                                               priceLabel: currencyFormatter.formatAmount(item.price.decimalValue) ?? item.price.description)
+                                               priceLabel: formatPrice(for: item))
         }
     }
 
@@ -127,6 +127,14 @@ private extension WooShippingItemsViewModel {
         }()
         let quantity = Double(truncating: item.quantity as NSDecimalNumber)
         return itemWeight * quantity
+    }
+
+    /// Calculates and formats the price of the given item based on the item quantity and unit price.
+    ///
+    func formatPrice(for item: OrderItem) -> String {
+        let totalPrice = item.price.decimalValue * item.quantity
+        let formattedPrice = currencyFormatter.formatAmount(totalPrice)
+        return formattedPrice ?? item.price.description
     }
 
     /// Finds the corresponding product and variation for the given item.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -86,6 +86,7 @@ private extension WooShippingItemsViewModel {
     }
 
     /// Generates a details label for an item row.
+    /// Includes item dimensions (height, weight, length) and variation attributes, if available.
     ///
     func generateItemRowDetailsLabel(for item: OrderItem) -> String {
         let dimensions: ProductDimensions? = {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -117,6 +117,21 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         assertEqual("Red, Small", firstItem.detailsLabel)
     }
 
+    func test_item_rows_handle_items_with_quantity_greater_than_one() throws {
+        // Given
+        let product = Product.fake().copy(productID: 1, weight: "3")
+        let orderItem = OrderItem.fake().copy(productID: product.productID, quantity: 2, price: 10)
+        let dataSource = MockDataSource(orderItems: [orderItem], products: [product])
+
+        // When
+        let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings, shippingSettingsService: shippingSettingsService)
+
+        // Then
+        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
+        assertEqual("6 oz", firstItem.weightLabel)
+        assertEqual("$20.00", firstItem.priceLabel)
+    }
+
 }
 
 private final class MockDataSource: WooShippingItemsDataSource {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13550
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the price displayed for each item in the items section in the new Woo Shipping label creation flow. Previously, we were showing the per-unit item price; now, we show the total price for the item based on the item quantity.

This also includes some small improvements to the view model documentation and refactors the weight calculations and formatting into a separate method.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product with a quantity greater than 1.
4. In the order details, select "Create Shipping Label."
5. In the shipping label flow, confirm the items section appears with the same details as before, except the price for each item is the per-unit item price times the item quantity.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Before](https://github.com/user-attachments/assets/0e629fa9-e25d-499c-ac1c-c4ac0c8c59ca)|![After](https://github.com/user-attachments/assets/a038667a-c2b5-43ea-874c-3d579913314f)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.