### PR TITLE
[Shipping labels] Use ShippingLabelPackageItem for Woo Shipping items

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
@@ -27,6 +27,9 @@ struct ShippingLabelPackageItem: Equatable {
 
     /// Attributes of the variation
     let attributes: [VariationAttributeViewModel]
+
+    /// Image URL of the product or variation
+    let imageURL: URL?
 }
 
 // MARK: Custom initializers
@@ -40,6 +43,7 @@ extension ShippingLabelPackageItem {
         self.dimensions = copy.dimensions
         self.attributes = copy.attributes
         self.value = copy.value
+        self.imageURL = copy.imageURL
     }
 
     init?(orderItem: OrderItem, products: [Product], productVariations: [ProductVariation]) {
@@ -56,10 +60,12 @@ extension ShippingLabelPackageItem {
             self.productOrVariationID = productVariation.productVariationID
             self.weight = Double(productVariation.weight ?? "0") ?? 0
             self.dimensions = productVariation.dimensions
+            self.imageURL = productVariation.imageURL
         } else if let product = product, !product.virtual {
             self.productOrVariationID = product.productID
             self.weight = Double(product.weight ?? "0") ?? 0
             self.dimensions = product.dimensions
+            self.imageURL = product.imageURL
         } else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRowViewModel.swift
@@ -1,4 +1,6 @@
 import Foundation
+import protocol Yosemite.ShippingSettingsService
+import WooFoundation
 
 /// Provides view data for `WooShippingItemRow`.
 ///
@@ -23,6 +25,77 @@ struct WooShippingItemRowViewModel: Identifiable {
 
     /// Label for item price
     let priceLabel: String
+
+    init(imageUrl: URL?,
+         quantityLabel: String,
+         name: String,
+         detailsLabel: String,
+         weightLabel: String,
+         priceLabel: String) {
+        self.imageUrl = imageUrl
+        self.quantityLabel = quantityLabel
+        self.name = name
+        self.detailsLabel = detailsLabel
+        self.weightLabel = weightLabel
+        self.priceLabel = priceLabel
+    }
+
+    init(item: ShippingLabelPackageItem,
+         shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        self.imageUrl = item.imageURL
+        self.quantityLabel = item.quantity.description
+        self.name = item.name
+
+        let dimensionUnit = shippingSettingsService.dimensionUnit ?? ""
+        self.detailsLabel = [item.formatDimensions(with: dimensionUnit), item.formattedAttributes].compacted().joined(separator: " • ")
+
+        let weightUnit = shippingSettingsService.weightUnit ?? ""
+        self.weightLabel = item.formatWeight(with: weightUnit)
+
+        self.priceLabel = item.formatPrice(with: currencySettings)
+    }
+}
+
+// MARK: Formatting helpers
+private extension ShippingLabelPackageItem {
+    /// Provides the item attributes formatted in a comma-separated list.
+    ///
+    var formattedAttributes: String? {
+        guard attributes.isNotEmpty else {
+            return nil
+        }
+        return attributes.map(\.nameOrValue).joined(separator: ", ")
+    }
+
+    /// Formats the item dimensions with the provided dimension unit.
+    ///
+    func formatDimensions(with unit: String) -> String {
+        String(format: Localization.dimensionsFormat, dimensions.length, dimensions.width, dimensions.height, unit)
+    }
+
+    /// Formats the total item weight (per-unit weight x quantity) with the provided weight unit.
+    ///
+    func formatWeight(with unit: String) -> String {
+        let weightFormatter = WeightFormatter(weightUnit: unit)
+        let totalWeight = weight * Double(truncating: quantity as NSDecimalNumber)
+        return weightFormatter.formatWeight(weight: totalWeight)
+    }
+
+    /// Formats the total item price (per-unit value x quantity) with the provided currency settings.
+    ///
+    func formatPrice(with settings: CurrencySettings) -> String {
+        let totalPrice = Decimal(value) * quantity
+        let currencyFormatter = CurrencyFormatter(currencySettings: settings)
+        return currencyFormatter.formatAmount(totalPrice) ?? totalPrice.description
+    }
+
+    enum Localization {
+        static let dimensionsFormat = NSLocalizedString("wooShipping.createLabels.items.dimensions",
+                                                        value: "%1$@ x %2$@ x %3$@ %4$@",
+                                                        comment: "Length, width, and height dimensions with the unit for an item to ship. "
+                                                        + "Reads like: '20 x 35 x 5 cm'")
+    }
 }
 
 /// Convenience extension to provide data to `WooShippingItemRow`

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsDataSource.swift
@@ -6,9 +6,6 @@ import protocol Storage.StorageManagerType
 ///
 protocol WooShippingItemsDataSource {
     var items: [ShippingLabelPackageItem] { get }
-    var orderItems: [OrderItem] { get }
-    var products: [Product] { get }
-    var productVariations: [ProductVariation] { get }
 }
 
 final class DefaultWooShippingItemsDataSource: WooShippingItemsDataSource {
@@ -24,20 +21,20 @@ final class DefaultWooShippingItemsDataSource: WooShippingItemsDataSource {
 
     /// Items in the order.
     ///
-    var orderItems: [OrderItem] {
+    private var orderItems: [OrderItem] {
         order.items
     }
 
     /// Stored products that match the items in the order.
     ///
-    var products: [Product] {
+    private var products: [Product] {
         try? productResultsController.performFetch()
         return productResultsController.fetchedObjects
     }
 
     /// Stored product variations that match the items in the order.
     ///
-    var productVariations: [ProductVariation] {
+    private var productVariations: [ProductVariation] {
         try? productVariationResultsController.performFetch()
         return productVariationResultsController.fetchedObjects
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsDataSource.swift
@@ -5,6 +5,7 @@ import protocol Storage.StorageManagerType
 /// Provides data about items to ship for an order with the Woo Shipping extension.
 ///
 protocol WooShippingItemsDataSource {
+    var items: [ShippingLabelPackageItem] { get }
     var orderItems: [OrderItem] { get }
     var products: [Product] { get }
     var productVariations: [ProductVariation] { get }
@@ -14,6 +15,12 @@ final class DefaultWooShippingItemsDataSource: WooShippingItemsDataSource {
     private let order: Order
     private let storageManager: StorageManagerType
     private let stores: StoresManager
+
+    /// Items to ship from an order.
+    ///
+    var items: [ShippingLabelPackageItem] {
+        order.items.compactMap { ShippingLabelPackageItem(orderItem: $0, products: products, productVariations: productVariations) }
+    }
 
     /// Items in the order.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -62,10 +62,7 @@ private extension WooShippingItemsViewModel {
     ///
     func generateItemsDetailLabel() -> String {
         let formattedWeight = formatWeight(for: dataSource.items)
-
-        let itemsTotal = dataSource.orderItems.map { $0.price.decimalValue * $0.quantity }.reduce(0, +)
-        let formattedPrice = currencyFormatter.formatAmount(itemsTotal) ?? itemsTotal.description
-
+        let formattedPrice = formatPrice(for: dataSource.items)
         return "\(formattedWeight) • \(formattedPrice)"
     }
 
@@ -143,6 +140,14 @@ private extension WooShippingItemsViewModel {
         }()
         let quantity = Double(truncating: item.quantity as NSDecimalNumber)
         return itemWeight * quantity
+    }
+
+    /// Calculates and formats the price of the given item based on the item quantity and unit price.
+    ///
+    func formatPrice(for items: [ShippingLabelPackageItem]) -> String {
+        let totalPrice = items.map { Decimal($0.value) * $0.quantity }.reduce(0, +)
+        let formattedPrice = currencyFormatter.formatAmount(totalPrice)
+        return formattedPrice ?? totalPrice.description
     }
 
     /// Calculates and formats the price of the given item based on the item quantity and unit price.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -61,7 +61,7 @@ private extension WooShippingItemsViewModel {
     /// This includes the total weight and total price of all items.
     ///
     func generateItemsDetailLabel() -> String {
-        let formattedWeight = formatWeight(for: dataSource.orderItems)
+        let formattedWeight = formatWeight(for: dataSource.items)
 
         let itemsTotal = dataSource.orderItems.map { $0.price.decimalValue * $0.quantity }.reduce(0, +)
         let formattedPrice = currencyFormatter.formatAmount(itemsTotal) ?? itemsTotal.description
@@ -110,6 +110,17 @@ private extension WooShippingItemsViewModel {
         }()
 
         return [formattedDimensions, attributes].compacted().joined(separator: " • ")
+    }
+
+    /// Calculates and formats the total weight of the given items based on each item's weight and quantity.
+    ///
+    func formatWeight(for items: [ShippingLabelPackageItem]) -> String {
+        let totalWeight = items
+            .map { item in
+                item.weight * Double(truncating: item.quantity as NSDecimalNumber)
+            }
+            .reduce(0, +)
+        return weightFormatter.formatWeight(weight: totalWeight)
     }
 
     /// Calculates and formats the total weight of the given items.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -46,7 +46,7 @@ private extension WooShippingItemsViewModel {
     ///
     func configureItemRows() {
         itemRows = dataSource.items.map { item in
-            WooShippingItemRowViewModel(item: item, shippingSettingsService: shippingSettingsService, currencySettings: currencySettings)
+            WooShippingItemRowViewModel(item: item)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -53,7 +53,7 @@ private extension WooShippingItemsViewModel {
     /// Generates a label with the total number of items to ship.
     ///
     func generateItemsCountLabel() -> String {
-        let itemsCount = dataSource.orderItems.map(\.quantity).reduce(0, +)
+        let itemsCount = dataSource.items.map(\.quantity).reduce(0, +)
         return Localization.itemsCount(itemsCount)
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2256,6 +2256,7 @@
 		CE6E110B2C91DA5D00563DD4 /* WooShippingItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */; };
 		CE6E110D2C91E5FF00563DD4 /* WooShippingItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */; };
 		CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */; };
+		CE7B4A582CA191FB00F764EB /* WooShippingItemRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
 		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
@@ -5312,6 +5313,7 @@
 		CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRow.swift; sourceTree = "<group>"; };
 		CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItems.swift; sourceTree = "<group>"; };
 		CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedBorder.swift"; sourceTree = "<group>"; };
+		CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModelTests.swift; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
@@ -11879,6 +11881,7 @@
 		CEC3CC722C9343BC00B93FBE /* WooShipping Create Shipping Labels */ = {
 			isa = PBXGroup;
 			children = (
+				CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */,
 				CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */,
 				CEC3CC7B2C94A06500B93FBE /* WooShippingItemsDataSourceTests.swift */,
 			);
@@ -16409,6 +16412,7 @@
 				D88100D3257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift in Sources */,
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
+				CE7B4A582CA191FB00F764EB /* WooShippingItemRowViewModelTests.swift in Sources */,
 				093B265727DF05270026F92D /* UnitInputViewModelTests.swift in Sources */,
 				4552085B25829091001CF873 /* AddAttributeViewModelTests.swift in Sources */,
 				02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
@@ -183,13 +183,15 @@ extension ShippingLabelPackageItem {
                      quantity: Decimal = 1,
                      value: Double = 10,
                      dimensions: Yosemite.ProductDimensions = .fake(),
-                     attributes: [VariationAttributeViewModel] = []) -> ShippingLabelPackageItem {
+                     attributes: [VariationAttributeViewModel] = [],
+                     imageURL: URL? = nil) -> ShippingLabelPackageItem {
         ShippingLabelPackageItem(productOrVariationID: id,
                                  name: name,
                                  weight: weight,
                                  quantity: quantity,
                                  value: value,
                                  dimensions: dimensions,
-                                 attributes: attributes)
+                                 attributes: attributes,
+                                 imageURL: imageURL)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -267,7 +267,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                         quantity: 1,
                                                         value: 10.0,
                                                         dimensions: expectedDimensions,
-                                                        attributes: [])
+                                                        attributes: [],
+                                                        imageURL: nil)
 
         let givenPackageAttributes = ShippingLabelPackageAttributes(packageID: expectedPackageID,
                                                                     totalWeight: expectedPackageWeight,
@@ -308,7 +309,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                         quantity: 1,
                                                         value: 10.0,
                                                         dimensions: expectedDimensions,
-                                                        attributes: [])
+                                                        attributes: [],
+                                                        imageURL: nil)
 
         let givenPackageAttributes = ShippingLabelPackageAttributes(packageID: expectedPackageID,
                                                                     totalWeight: expectedPackageWeight,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemRowViewModelTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import WooFoundation
+import Yosemite
+@testable import WooCommerce
+
+final class WooShippingItemRowViewModelTests: XCTestCase {
+
+    private var currencySettings: CurrencySettings!
+    private var shippingSettingsService: MockShippingSettingsService!
+
+    override func setUp() {
+        currencySettings = CurrencySettings()
+        shippingSettingsService = MockShippingSettingsService()
+    }
+
+    func test_inits_with_expected_values() {
+        // Given
+        let row = WooShippingItemRowViewModel(imageUrl: URL(string: "https://woocommerce.com/woo.jpg"),
+                                              quantityLabel: "3",
+                                              name: "Little Nap Brazil",
+                                              detailsLabel: "15 x 10 x 8 in • Espresso",
+                                              weightLabel: "30 oz",
+                                              priceLabel: "$60.00")
+
+        // Then
+        assertEqual(URL(string: "https://woocommerce.com/woo.jpg"), row.imageUrl)
+        assertEqual("3", row.quantityLabel)
+        assertEqual("Little Nap Brazil", row.name)
+        assertEqual("15 x 10 x 8 in • Espresso", row.detailsLabel)
+        assertEqual("30 oz", row.weightLabel)
+        assertEqual("$60.00", row.priceLabel)
+    }
+
+    func test_inits_from_ShippingLabelPackageItem_with_expected_values() {
+        // Given
+        let item = ShippingLabelPackageItem(productOrVariationID: 1,
+                                            name: "Little Nap Brazil",
+                                            weight: 10,
+                                            quantity: 3,
+                                            value: 20,
+                                            dimensions: ProductDimensions(length: "15", width: "10", height: "8"),
+                                            attributes: [VariationAttributeViewModel(name: "Roast", value: "Espresso"),
+                                                         VariationAttributeViewModel(name: "Size", value: "10 oz")],
+                                            imageURL: URL(string: "https://woocommerce.com/woo.jpg"))
+        let row = WooShippingItemRowViewModel(item: item, shippingSettingsService: shippingSettingsService, currencySettings: currencySettings)
+
+        // Then
+        assertEqual(URL(string: "https://woocommerce.com/woo.jpg"), row.imageUrl)
+        assertEqual("3", row.quantityLabel)
+        assertEqual("Little Nap Brazil", row.name)
+        assertEqual("15 x 10 x 8 in • Espresso, 10 oz", row.detailsLabel)
+        assertEqual("30 oz", row.weightLabel)
+        assertEqual("$60.00", row.priceLabel)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsDataSourceTests.swift
@@ -13,18 +13,7 @@ final class WooShippingItemsDataSourceTests: XCTestCase {
         stores = MockStoresManager(sessionManager: .testingInstance)
     }
 
-    func test_it_inits_with_expected_order_items() {
-        // Given
-        let order = Order.fake().copy(items: [OrderItem.fake(), OrderItem.fake()])
-
-        // When
-        let dataSource = DefaultWooShippingItemsDataSource(order: order)
-
-        // Then
-        assertEqual(2, dataSource.orderItems.count)
-    }
-
-    func test_it_inits_with_expected_stored_products_and_variations() {
+    func test_it_inits_with_expected_items_from_storage() {
         // Given
         let product = Product.fake().copy(productID: 11)
         let variation = ProductVariation.fake().copy(productVariationID: 12)
@@ -37,11 +26,10 @@ final class WooShippingItemsDataSourceTests: XCTestCase {
         let dataSource = DefaultWooShippingItemsDataSource(order: order, storageManager: storageManager)
 
         // Then
-        assertEqual(1, dataSource.products.count)
-        assertEqual(1, dataSource.productVariations.count)
+        assertEqual(2, dataSource.items.count)
     }
 
-    func test_it_inits_with_expected_products_and_variations_from_remote() {
+    func test_it_inits_with_expected_items_from_remote() {
         // Given
         let product = Product.fake().copy(productID: 13)
         let variation = ProductVariation.fake().copy(productVariationID: 14)
@@ -69,8 +57,7 @@ final class WooShippingItemsDataSourceTests: XCTestCase {
         let dataSource = DefaultWooShippingItemsDataSource(order: order, storageManager: storageManager, stores: stores)
 
         // Then
-        assertEqual(1, dataSource.products.count)
-        assertEqual(1, dataSource.productVariations.count)
+        assertEqual(2, dataSource.items.count)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -135,6 +135,8 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 }
 
 private final class MockDataSource: WooShippingItemsDataSource {
+    var items: [ShippingLabelPackageItem]
+
     var orderItems: [OrderItem]
 
     var products: [Product]
@@ -147,5 +149,6 @@ private final class MockDataSource: WooShippingItemsDataSource {
         self.orderItems = orderItems
         self.products = products
         self.productVariations = productVariations
+        self.items = orderItems.compactMap { ShippingLabelPackageItem(orderItem: $0, products: products, productVariations: productVariations)}
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -15,11 +15,9 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_inits_with_expected_values() throws {
         // Given
-        let product = Product.fake().copy(productID: 1, weight: "4")
-        let productVariation = ProductVariation.fake().copy(productVariationID: 2, weight: "3")
-        let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 1, price: 10),
-                          OrderItem.fake().copy(variationID: productVariation.productVariationID, quantity: 1, price: 2.5)]
-        let dataSource = MockDataSource(orderItems: orderItems, products: [product], productVariations: [productVariation])
+        let items = [sampleItem(id: 1, weight: 4, value: 10, quantity: 1),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+        let dataSource = MockDataSource(items: items)
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
@@ -34,9 +32,9 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_total_items_count_handles_items_with_quantity_greater_than_one() {
         // Given
-        let products = [Product.fake().copy(productID: 1), Product.fake().copy(productID: 2)]
-        let orderItems = [OrderItem.fake().copy(productID: 1, quantity: 2), OrderItem.fake().copy(productID: 2, quantity: 1)]
-        let dataSource = MockDataSource(orderItems: orderItems, products: products)
+        let items = [sampleItem(id: 1, weight: 1, value: 1, quantity: 1),
+                     sampleItem(id: 2, weight: 1, value: 1, quantity: 2)]
+        let dataSource = MockDataSource(items: items)
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings)
@@ -47,12 +45,9 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_total_items_details_handles_items_with_quantity_greater_than_one() {
         // Given
-        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
-        let product = Product.fake().copy(productID: 1, weight: "5", dimensions: dimensions)
-        let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, weight: "3", dimensions: dimensions)
-        let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 2, price: 10),
-                          OrderItem.fake().copy(productID: variation.productID, variationID: variation.productVariationID, quantity: 1, price: 2.5)]
-        let dataSource = MockDataSource(orderItems: orderItems, products: [product], productVariations: [variation])
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+        let dataSource = MockDataSource(items: items)
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
@@ -65,21 +60,23 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
 }
 
+private extension WooShippingItemsViewModelTests {
+    func sampleItem(id: Int64, weight: Double, value: Double, quantity: Decimal) -> ShippingLabelPackageItem {
+        ShippingLabelPackageItem(productOrVariationID: id,
+                                 name: "Item",
+                                 weight: weight,
+                                 quantity: quantity,
+                                 value: value,
+                                 dimensions: ProductDimensions(length: "20", width: "35", height: "5"),
+                                 attributes: [],
+                                 imageURL: nil)
+    }
+}
+
 private final class MockDataSource: WooShippingItemsDataSource {
     var items: [ShippingLabelPackageItem]
 
-    var orderItems: [OrderItem]
-
-    var products: [Product]
-
-    var productVariations: [ProductVariation]
-
-    init(orderItems: [OrderItem] = [],
-         products: [Product] = [],
-         productVariations: [ProductVariation] = []) {
-        self.orderItems = orderItems
-        self.products = products
-        self.productVariations = productVariations
-        self.items = orderItems.compactMap { ShippingLabelPackageItem(orderItem: $0, products: products, productVariations: productVariations)}
+    init(items: [ShippingLabelPackageItem]) {
+        self.items = items
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -13,18 +13,13 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         shippingSettingsService = MockShippingSettingsService()
     }
 
-    func test_inits_with_expected_values_from_order_items() throws {
+    func test_inits_with_expected_values() throws {
         // Given
-        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
-        let products = [Product.fake().copy(productID: 1)]
-        let productVariations = [ProductVariation.fake().copy(productVariationID: 2, dimensions: dimensions)]
-        let orderItems = [OrderItem.fake().copy(name: "Shirt",
-                                                variationID: 2,
-                                                quantity: 1,
-                                                price: 10,
-                                                attributes: [OrderItemAttribute.fake().copy(value: "Red")]),
-                          OrderItem.fake().copy(productID: 1, quantity: 1, price: 2.5)]
-        let dataSource = MockDataSource(orderItems: orderItems, products: products, productVariations: productVariations)
+        let product = Product.fake().copy(productID: 1, weight: "4")
+        let productVariation = ProductVariation.fake().copy(productVariationID: 2, weight: "3")
+        let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 1, price: 10),
+                          OrderItem.fake().copy(variationID: productVariation.productVariationID, quantity: 1, price: 2.5)]
+        let dataSource = MockDataSource(orderItems: orderItems, products: [product], productVariations: [productVariation])
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
@@ -32,49 +27,9 @@ final class WooShippingItemsViewModelTests: XCTestCase {
                                                   shippingSettingsService: shippingSettingsService)
 
         // Then
-        // Section header labels have expected values
         assertEqual("2 items", viewModel.itemsCountLabel)
-        assertEqual("0 oz • $12.50", viewModel.itemsDetailLabel)
-
-        // Section rows have expected values
+        assertEqual("7 oz • $12.50", viewModel.itemsDetailLabel)
         assertEqual(2, viewModel.itemRows.count)
-        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
-        assertEqual("Shirt", firstItem.name)
-        assertEqual("1", firstItem.quantityLabel)
-        assertEqual("$10.00", firstItem.priceLabel)
-        assertEqual("20 x 35 x 5 in • Red", firstItem.detailsLabel)
-    }
-
-    func test_populates_item_data_from_products_and_variations() {
-        // Given
-        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
-        let image = ProductImage.fake().copy(src: "http://woocommerce.com/image.jpg")
-        let product = Product.fake().copy(productID: 1, weight: "5", dimensions: dimensions, images: [image])
-        let variation = ProductVariation.fake().copy(productID: 2, productVariationID: 12, image: image, weight: "3", dimensions: dimensions)
-        let orderItems = [OrderItem.fake().copy(productID: product.productID, quantity: 1),
-                          OrderItem.fake().copy(productID: variation.productID,
-                                                variationID: variation.productVariationID,
-                                                quantity: 1,
-                                                attributes: [OrderItemAttribute.fake().copy(value: "Red")])]
-        let dataSource = MockDataSource(orderItems: orderItems, products: [product], productVariations: [variation])
-
-        // When
-        let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
-                                                  currencySettings: currencySettings,
-                                                  shippingSettingsService: shippingSettingsService)
-
-        // Then
-        assertEqual("8 oz • $0.00", viewModel.itemsDetailLabel)
-
-        let productRow = viewModel.itemRows[0]
-        XCTAssertNotNil(productRow.imageUrl)
-        assertEqual("5 oz", productRow.weightLabel)
-        assertEqual("20 x 35 x 5 in", productRow.detailsLabel)
-
-        let variationRow = viewModel.itemRows[1]
-        XCTAssertNotNil(variationRow.imageUrl)
-        assertEqual("3 oz", variationRow.weightLabel)
-        assertEqual("20 x 35 x 5 in • Red", variationRow.detailsLabel)
     }
 
     func test_total_items_count_handles_items_with_quantity_greater_than_one() {
@@ -106,38 +61,6 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
         // Then
         assertEqual("13 oz • $22.50", viewModel.itemsDetailLabel)
-    }
-
-    func test_item_row_details_label_handles_items_with_multiple_attributes() throws {
-        // Given
-        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
-        let productVariation = ProductVariation.fake().copy(productVariationID: 1, dimensions: dimensions)
-        let orderItems = [OrderItem.fake().copy(variationID: productVariation.productVariationID,
-                                                attributes: [OrderItemAttribute.fake().copy(value: "Red"),
-                                                             OrderItemAttribute.fake().copy(value: "Small")])]
-        let dataSource = MockDataSource(orderItems: orderItems, productVariations: [productVariation])
-
-        // When
-        let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings, shippingSettingsService: shippingSettingsService)
-
-        // Then
-        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
-        assertEqual("20 x 35 x 5 in • Red, Small", firstItem.detailsLabel)
-    }
-
-    func test_item_rows_handle_items_with_quantity_greater_than_one() throws {
-        // Given
-        let product = Product.fake().copy(productID: 1, weight: "3")
-        let orderItem = OrderItem.fake().copy(productID: product.productID, quantity: 2, price: 10)
-        let dataSource = MockDataSource(orderItems: [orderItem], products: [product])
-
-        // When
-        let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings, shippingSettingsService: shippingSettingsService)
-
-        // Then
-        let firstItem = try XCTUnwrap(viewModel.itemRows.first)
-        assertEqual("6 oz", firstItem.weightLabel)
-        assertEqual("$20.00", firstItem.priceLabel)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -15,12 +15,16 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_inits_with_expected_values_from_order_items() throws {
         // Given
+        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
+        let products = [Product.fake().copy(productID: 1)]
+        let productVariations = [ProductVariation.fake().copy(productVariationID: 2, dimensions: dimensions)]
         let orderItems = [OrderItem.fake().copy(name: "Shirt",
+                                                variationID: 2,
                                                 quantity: 1,
                                                 price: 10,
                                                 attributes: [OrderItemAttribute.fake().copy(value: "Red")]),
-                          OrderItem.fake().copy(quantity: 1, price: 2.5)]
-        let dataSource = MockDataSource(orderItems: orderItems)
+                          OrderItem.fake().copy(productID: 1, quantity: 1, price: 2.5)]
+        let dataSource = MockDataSource(orderItems: orderItems, products: products, productVariations: productVariations)
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
@@ -38,7 +42,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         assertEqual("Shirt", firstItem.name)
         assertEqual("1", firstItem.quantityLabel)
         assertEqual("$10.00", firstItem.priceLabel)
-        assertEqual("Red", firstItem.detailsLabel)
+        assertEqual("20 x 35 x 5 in • Red", firstItem.detailsLabel)
     }
 
     func test_populates_item_data_from_products_and_variations() {
@@ -75,8 +79,9 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_total_items_count_handles_items_with_quantity_greater_than_one() {
         // Given
-        let orderItems = [OrderItem.fake().copy(quantity: 2), OrderItem.fake().copy(quantity: 1)]
-        let dataSource = MockDataSource(orderItems: orderItems)
+        let products = [Product.fake().copy(productID: 1), Product.fake().copy(productID: 2)]
+        let orderItems = [OrderItem.fake().copy(productID: 1, quantity: 2), OrderItem.fake().copy(productID: 2, quantity: 1)]
+        let dataSource = MockDataSource(orderItems: orderItems, products: products)
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -110,16 +110,19 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
     func test_item_row_details_label_handles_items_with_multiple_attributes() throws {
         // Given
-        let orderItems = [OrderItem.fake().copy(attributes: [OrderItemAttribute.fake().copy(value: "Red"),
+        let dimensions = ProductDimensions(length: "20", width: "35", height: "5")
+        let productVariation = ProductVariation.fake().copy(productVariationID: 1, dimensions: dimensions)
+        let orderItems = [OrderItem.fake().copy(variationID: productVariation.productVariationID,
+                                                attributes: [OrderItemAttribute.fake().copy(value: "Red"),
                                                              OrderItemAttribute.fake().copy(value: "Small")])]
-        let dataSource = MockDataSource(orderItems: orderItems)
+        let dataSource = MockDataSource(orderItems: orderItems, productVariations: [productVariation])
 
         // When
-        let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings)
+        let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings, shippingSettingsService: shippingSettingsService)
 
         // Then
         let firstItem = try XCTUnwrap(viewModel.itemRows.first)
-        assertEqual("Red, Small", firstItem.detailsLabel)
+        assertEqual("20 x 35 x 5 in • Red, Small", firstItem.detailsLabel)
     }
 
     func test_item_rows_handle_items_with_quantity_greater_than_one() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13550
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR introduces `ShippingLabelPackageItem` into the new Woo Shipping label creation flow. This is a UI-level model we've been using in the existing (legacy) shipping label creation flow, and I decided to reuse it here for several reasons:

1. It consolidates the logic for matching product/variation data with order items to display during shipping label creation.
2. It filters out virtual products/variations (which can't be shipped).
3. It allows us to simplify the new view models for items in the new Woo Shipping flow.

### What

Introducing `ShippingLabelPackageItem` involved a few key changes:

* Added `imageURL` property to `ShippingLabelPackageItem` since we now show an image for the item being shipped.
* Added an `init` method to `WooShippingItemRowViewModel`, to initialize an item row with a `ShippingLabelPackageItem`.
   * Added the corresponding helpers to this view model, to handle formatting the item properties for display in the row.
   * Removed those helpers from `WooShippingItemsViewModel`.
* Simplified the `WooShippingItemsDataSource` protocol so it only provides `ShippingLabelPackageItem` items.
* Added/updated the corresponding unit tests.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The only visible change in the UI should be that an order with virtual products/variations will no longer include them in the new shipping label creation flow. Otherwise, the items should be displayed the same as before.

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the processing status and at least one physical product with a quantity greater than 1.
4. In the order details, select "Create Shipping Label."
5. In the shipping label flow, confirm the items section appears with the same details as before, except any virtual products/variations in the order are no longer displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Before](https://github.com/user-attachments/assets/096a0666-853f-4b85-9342-14767cf85702)|![After](https://github.com/user-attachments/assets/b0261161-faa2-4d7c-a52b-2c220b64fcf5)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.