### PR TITLE
[Mobile Payments] Prevent sleep during Card Reader software updates

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -2,6 +2,7 @@
 import Combine
 import StripeTerminal
 import CoreBluetooth
+import class UIKit.UIApplication
 
 /// The adapter wrapping the Stripe Terminal SDK
 public final class StripeCardReaderService: NSObject {
@@ -866,6 +867,7 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
     }
 
     public func reader(_ reader: Reader, didStartInstallingUpdate update: ReaderSoftwareUpdate, cancelable: StripeTerminal.Cancelable?) {
+        UIApplication.shared.isIdleTimerDisabled = true
         softwareUpdateSubject.send(.started(cancelable: cancelable.map(StripeCancelable.init(cancelable:))))
     }
 
@@ -874,6 +876,8 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
     }
 
     public func reader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
+        // Note that this function is called with an error when updates are cancelled, so this is enough to ensure we re-enable sleep.
+        UIApplication.shared.isIdleTimerDisabled = false
         if let error = error {
             let underlyingError = Self.logAndDecodeError(error)
             softwareUpdateSubject.send(.failed(

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Jetpack setup: fixed issue checking site info after activating Jetpack for sites with Jetpack connection package. [https://github.com/woocommerce/woocommerce-ios/pull/13993]
 - [*] Blaze: Campaign status is now updated immediately after being canceled. [https://github.com/woocommerce/woocommerce-ios/pull/13992]
 - [internal] Logging for app storage size added in Core Data crash logs [https://github.com/woocommerce/woocommerce-ios/pull/14008]
+- [*] Payments: Prevent phone from sleeping during card reader updates [https://github.com/woocommerce/woocommerce-ios/pull/14021]
 
 20.5
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR disables sleep on a user's device for the duration of any Card Reader software updates.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set Xcode to use the simulated reader, and set `Terminal.shared.simulatorConfiguration.availableReaderUpdate = .required` in the `StripeCardReaderService`
2. Add breakpoints in `StripeCardReaderService.reader(_:didStartInstallingUpdate:cancelable:)` and `StripeCardReaderService.reader(_:didFinishInstallingUpdate:error:)`
3. Launch the app and connect to a reader
4. Observe that the sleep timer is disabled and enabled as expected.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The shortest auto-lock is 30s – this is longer than it takes to complete a (simulated) reader update, but using a timer to trigger the connection allowed me to check that it doesn't autolock during a (real) update, and does after the update completes.

I added `DispatchQueue.main.asyncAfter(deadline: .now() + 22)` in a Task in `CardReaderConnectionController.onFoundReader()`. I used 22 seconds to give it time to connect and start the update before the sleep timer kicks in – we don't disable device sleep until the install actually starts.

It's important to note that the device won't sleep while connected to the Xcode debugger regardless of what you do, so timer-based testing should be done without a connection to Xcode. This means you need a reader which has a pending update to test in this way, as the Stripe simulated readers only work when you're connected to Xcode.

If you have such a reader, be sure to cancel any updates before they complete!

Also it's best to turn of `Settings > Face ID > Attention Aware Features` to ensure you're not keeping your phone awake by looking at it.

StripeCardReaderService isn't unit tested due to the difficulties presented by faking the Stripe SDK.

## Screenshots

### Before

https://github.com/user-attachments/assets/a7d7beed-b180-4633-b6b7-79fa167e1063

### After

https://github.com/user-attachments/assets/1c86de90-4a26-4bf2-86a0-1438a1e7f288

Note that after the reader update is cancelled, the phone is allowed to go to sleep again, so 30s after the cancellation, the display goes to sleep in this second video.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.