### PR TITLE
[Shipping labels] Add read-only hazmat section for Woo Shipping

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmat.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmat.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct WooShippingHazmat: View {
+    var body: some View {
+        AdaptiveStack {
+            Text(Localization.hazmatLabel)
+                .bodyStyle()
+            Spacer()
+            Text("No") // TODO: Replace with actual hazmat selection for package
+                .secondaryBodyStyle()
+            Image(uiImage: .chevronImage) // TODO: Replace with actual navigation to hazmat declaration screen
+                .secondaryBodyStyle()
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: Layout.backgroundRadius).fill(Color(.quaternarySystemFill)))
+    }
+}
+
+private extension WooShippingHazmat {
+    enum Layout {
+        static let backgroundRadius: CGFloat = 8
+    }
+
+    enum Localization {
+        static let hazmatLabel = NSLocalizedString("wooShipping.createLabel.hazmatLabel",
+                                                   value: "Are you shipping dangerous goods or hazardous materials?",
+                                                   comment: "Label for section in shipping label creation to declare when a package contains hazardous materials.")
+    }
+}
+
+#Preview {
+    WooShippingHazmat()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
@@ -17,6 +17,7 @@ struct WooShippingItems: View {
     var body: some View {
         CollapsibleView(isCollapsed: $isCollapsed,
                         shouldShowDividers: false,
+                        backgroundColor: .clear,
                         label: {
             AdaptiveStack {
                 Text(itemsCountLabel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -26,8 +26,10 @@ struct WooShippingCreateLabelsView: View {
         NavigationStack {
             ScrollView {
                 WooShippingItems(viewModel: viewModel.items)
-                    .padding()
+
+                WooShippingHazmat()
             }
+            .padding()
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2257,6 +2257,7 @@
 		CE6E110D2C91E5FF00563DD4 /* WooShippingItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */; };
 		CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */; };
 		CE7B4A582CA191FB00F764EB /* WooShippingItemRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */; };
+		CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
 		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
@@ -5314,6 +5315,7 @@
 		CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItems.swift; sourceTree = "<group>"; };
 		CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedBorder.swift"; sourceTree = "<group>"; };
 		CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModelTests.swift; sourceTree = "<group>"; };
+		CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingHazmat.swift; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
@@ -11776,6 +11778,14 @@
 			path = "WooShipping Items Section";
 			sourceTree = "<group>";
 		};
+		CE7B4A592CA1BF7800F764EB /* WooShipping Hazmat Section */ = {
+			isa = PBXGroup;
+			children = (
+				CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */,
+			);
+			path = "WooShipping Hazmat Section";
+			sourceTree = "<group>";
+		};
 		CE85535B209B5B6A00938BDC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -11872,6 +11882,7 @@
 			isa = PBXGroup;
 			children = (
 				CE6E11092C91DA3D00563DD4 /* WooShipping Items Section */,
+				CE7B4A592CA1BF7800F764EB /* WooShipping Hazmat Section */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
 				CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */,
 			);
@@ -15155,6 +15166,7 @@
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,
 				03B9E5272A14EA89005C77F5 /* CardReaderSupportDeterminer.swift in Sources */,
 				DEF8CF1629A8C2EB00800A60 /* AdminRoleRequiredView.swift in Sources */,
+				CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmat.swift in Sources */,
 				0258B4D82B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift in Sources */,
 				DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */,
 				DE69C54D27BB719A000BB888 /* CouponRestrictions.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13550
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a read-only hazmat section to the new Woo Shipping label creation flow.

This section includes:

* A question about whether the package contains hazardous materials
* A static response ("No")
* A chevron

For now, the section contains static data and is not interactive. In a future milestone, we will add navigation to a screen where the merchant can enter their package's hazardous material details.

This PR only changes the view, with no live data, so there is not a view model or unit tests for these changes.

Note: This PR also contains a small fix for the Items section in dark mode. Previously, there was a lighter background around the Items section header content in dark mode; this removes that background (which didn't align with the rounded border when the section was collapsed).

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. Ensure the hazmat section appears below the items section in the shipping label creation screen.

Additional scenarios to consider:

* Landscape orientation
* Dark mode
* Increased font size

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Design:

![image](https://github.com/user-attachments/assets/4c8c642a-06e4-4005-bd70-ee4490a06f7d)


Before|After
-|-
![Before-Collapsed-Light](https://github.com/user-attachments/assets/6862edd1-a09c-4a02-b41d-3170cd0112e5)|![After-Collapsed-Light](https://github.com/user-attachments/assets/5a67b7a4-68b1-4368-a8f8-50e57faf108f)
![Before-Expanded-Light](https://github.com/user-attachments/assets/cd792a0f-f0d7-45d1-bd87-35461c633928)|![After-Expanded-Light](https://github.com/user-attachments/assets/19232f89-8a3d-47d9-87a5-dfd2af672f61)
![Before-Collapsed-Dark](https://github.com/user-attachments/assets/62dd22f6-60db-4d20-a002-b3fb044cec6a)|![After-Collapsed-Dark](https://github.com/user-attachments/assets/ea90b8b6-d67a-4573-8707-39ada7d1e12e)
![Before-Expanded-Dark](https://github.com/user-attachments/assets/b5543ac0-4aca-4127-bb7d-29d7f3d45454)|![After-Expanded-Dark](https://github.com/user-attachments/assets/d3b1a478-d0fd-45bd-b91a-78aa5141e5b4)

Landscape:
![After-Landscape](https://github.com/user-attachments/assets/220728a2-2130-40c9-9f26-2303685aa228)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added. 