### PR TITLE
[Shipping labels] Add package selection button for Woo Shipping

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package Selection/WooShippingPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package Selection/WooShippingPackageSelection.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct WooShippingPackageSelection: View {
+    var body: some View {
+        Button {
+            // TODO-13551: Open package selection UI
+        } label: {
+            Text(Localization.addPackage)
+        }
+        .buttonStyle(PrimaryButtonStyle())
+    }
+}
+
+private extension WooShippingPackageSelection {
+    enum Localization {
+        static let addPackage = NSLocalizedString("wooShipping.createLabel.addPackage.button",
+                                                  value: "Add a Package",
+                                                  comment: "Button to select a package to use for a shipment in the shipping label creation flow.")
+    }
+}
+
+#Preview {
+    WooShippingPackageSelection()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -28,6 +28,9 @@ struct WooShippingCreateLabelsView: View {
                 WooShippingItems(viewModel: viewModel.items)
 
                 WooShippingHazmat()
+
+                WooShippingPackageSelection()
+                    .padding(.vertical, Layout.buttonPadding)
             }
             .padding()
             .navigationTitle(Localization.title)
@@ -44,6 +47,10 @@ struct WooShippingCreateLabelsView: View {
 }
 
 private extension WooShippingCreateLabelsView {
+    enum Layout {
+        static let buttonPadding: CGFloat = 16
+    }
+
     enum Localization {
         static let title = NSLocalizedString("wooShipping.createLabels.title",
                                              value: "Create Shipping Labels",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2258,6 +2258,7 @@
 		CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */; };
 		CE7B4A582CA191FB00F764EB /* WooShippingItemRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */; };
 		CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */; };
+		CE7B4A602CA1D05D00F764EB /* WooShippingPackageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A5F2CA1D05D00F764EB /* WooShippingPackageSelection.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
 		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
@@ -5316,6 +5317,7 @@
 		CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedBorder.swift"; sourceTree = "<group>"; };
 		CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModelTests.swift; sourceTree = "<group>"; };
 		CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingHazmat.swift; sourceTree = "<group>"; };
+		CE7B4A5F2CA1D05D00F764EB /* WooShippingPackageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackageSelection.swift; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
@@ -11786,6 +11788,14 @@
 			path = "WooShipping Hazmat Section";
 			sourceTree = "<group>";
 		};
+		CE7B4A5C2CA1D03C00F764EB /* WooShipping Package Selection */ = {
+			isa = PBXGroup;
+			children = (
+				CE7B4A5F2CA1D05D00F764EB /* WooShippingPackageSelection.swift */,
+			);
+			path = "WooShipping Package Selection";
+			sourceTree = "<group>";
+		};
 		CE85535B209B5B6A00938BDC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -11883,6 +11893,7 @@
 			children = (
 				CE6E11092C91DA3D00563DD4 /* WooShipping Items Section */,
 				CE7B4A592CA1BF7800F764EB /* WooShipping Hazmat Section */,
+				CE7B4A5C2CA1D03C00F764EB /* WooShipping Package Selection */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
 				CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */,
 			);
@@ -14980,6 +14991,7 @@
 				DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */,
 				02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */,
 				E138D4F4269ED9C3006EA5C6 /* CardPresentPaymentsOnboardingViewController.swift in Sources */,
+				CE7B4A602CA1D05D00F764EB /* WooShippingPackageSelection.swift in Sources */,
 				26838358296F9A1E00CCF60A /* GenerateAllVariationsUseCase.swift in Sources */,
 				EE3BC28C2BE3905400195AF0 /* InAppFeedbackCardView.swift in Sources */,
 				2004E2E32C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13550
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/14023 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a package selection button ("Add a Package") to the new Woo Shipping label creation flow.

The button is in its own `WooShippingPackageSelection` view, to support the additional package UI that will be added in #13551 (showing e.g. the selected package instead of the button after selecting a package). That issue will also add the button action, to open the package selection UI.

This PR only contains view changes, so there are no view models or unit tests.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. Ensure the "Add a Package" button appears below the hazmat section in the shipping label creation screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Design:

![image](https://github.com/user-attachments/assets/fb66819f-38eb-4fe3-b537-5656270ae67b)


Light|Dark
-|-
![Simulator Screenshot - iPhone 16 Pro - 2024-09-23 at 17 59 15](https://github.com/user-attachments/assets/22016635-46b6-4a61-a264-6287ea1cbe60)|![Simulator Screenshot - iPhone 16 Pro - 2024-09-23 at 17 59 26](https://github.com/user-attachments/assets/3d69d98c-b228-43d4-9e94-0a899ffc0834)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.