### PR TITLE
Custom Fields: Local editing logic

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -488,7 +488,7 @@ extension OrderDetailsViewModel {
             let customFieldsView = UIHostingController(
                 rootView: CustomFieldsListView(
                     isEditable: featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders),
-                    customFields: customFields))
+                    viewModel: CustomFieldsListViewModel(customFields: customFields)))
             viewController.present(customFieldsView, animated: true)
         case .seeReceipt:
             let countryCode = configurationLoader.configuration.countryCode

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -77,11 +77,11 @@ private extension CustomFieldsListViewModel {
     }
 
     func updateCombinedList() {
-            let editedList = originalCustomFields.map { field in
-                editedFields.first { $0.id == field.id } ?? CustomFieldUI(customField: field)
-            }
-            combinedList = editedList + addedFields
+        let editedList = originalCustomFields.map { field in
+            editedFields.first { $0.id == field.id } ?? CustomFieldUI(customField: field)
         }
+        combinedList = editedList + addedFields
+    }
 }
 
 extension CustomFieldsListViewModel {

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+final class CustomFieldsListViewModel: ObservableObject {
+    private let originalCustomFields: [CustomFieldViewModel]
+
+    var shouldShowErrorState: Bool {
+        savingError != nil
+    }
+
+    @Published private(set) var savingError: Error?
+    @Published private(set) var combinedList: [CustomFieldUI] = []
+
+    @Published private var editedFields: [CustomFieldUI] = []
+    @Published private var addedFields: [CustomFieldUI] = []
+    var hasChanges: Bool {
+        !editedFields.isEmpty || !addedFields.isEmpty
+    }
+
+    init(customFields: [CustomFieldViewModel]) {
+        self.originalCustomFields = customFields
+        updateCombinedList()
+    }
+}
+
+// MARK: - Items actions
+extension CustomFieldsListViewModel {
+    func editField(at index: Int, newField: CustomFieldUI) {
+        let oldField = combinedList[index]
+
+        if newField.id == nil {
+            // If there's no id, it means we're now editing a newly added field.
+            if let addedIndex = addedFields.firstIndex(where: { $0.key == oldField.key }) {
+                if newField.key == oldField.key {
+                    // If the key hasn't changed, update the existing added field
+                    addedFields[addedIndex] = newField
+                } else {
+                    // If the key has changed, remove the old field and add the new one
+                    addedFields.remove(at: addedIndex)
+                    addedFields.append(newField)
+                }
+            } else {
+                // This case should not happen in normal flow
+                DDLogError("⛔️ Error: Editing a newly updated field that doesn't exist in combinedList")
+
+            }
+        } else {
+            // For when editing an already edited field
+            if let editedIndex = editedFields.firstIndex(where: { $0.id == oldField.id }) {
+                editedFields[editedIndex] = newField
+            } else {
+                // For the first time a field is edited
+                editedFields.append(newField)
+            }
+        }
+
+        updateCombinedList()
+    }
+
+    func addField(_ field: CustomFieldUI) {
+        addedFields.append(field)
+        updateCombinedList()
+    }
+}
+
+private extension CustomFieldsListViewModel {
+    func updateCombinedList() {
+            let editedList = originalCustomFields.map { field in
+                editedFields.first { $0.id == field.id } ?? CustomFieldUI(customField: field)
+            }
+            combinedList = editedList + addedFields
+        }
+}
+
+extension CustomFieldsListViewModel {
+    struct CustomFieldUI: Identifiable {
+        let key: String
+        let value: String
+        let id: Int64?
+
+        init(key: String, value: String, id: Int64? = nil) {
+            self.key = key
+            self.value = value
+            self.id = id
+        }
+
+        init(customField: CustomFieldViewModel) {
+            self.key = customField.title
+            self.value = customField.content
+            self.id = customField.id
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -24,6 +24,9 @@ final class CustomFieldsListViewModel: ObservableObject {
 
 // MARK: - Items actions
 extension CustomFieldsListViewModel {
+    /// Params:
+    /// - index: The index of field to be edited, taken from the `combinedList` array
+    /// - newField: The new content for the custom field in question
     func editField(at index: Int, newField: CustomFieldUI) {
         guard index >= 0 && index < combinedList.count else {
             DDLogError("⛔️ Error: Invalid index for editing a custom field")
@@ -32,12 +35,13 @@ extension CustomFieldsListViewModel {
 
         let oldField = combinedList[index]
         if newField.id == nil {
+            // When editing a field that has no id yet, it means the field has only been added locally.
             editLocallyAddedField(oldField: oldField, newField: newField)
         } else {
             if let existingId = oldField.id {
                 editExistingField(idToEdit: existingId, newField: newField)
             } else {
-                DDLogError("⛔️ Error: Trying to edit existing field that has no id.")
+                DDLogError("⛔️ Error: Trying to edit an existing field but it has no id. It might be the wrong field to edit.")
             }
         }
 
@@ -53,14 +57,14 @@ extension CustomFieldsListViewModel {
 private extension CustomFieldsListViewModel {
     func editLocallyAddedField(oldField: CustomFieldUI, newField: CustomFieldUI) {
         if let index = addedFields.firstIndex(where: { $0.key == oldField.key }) {
-            // Found the matching field, update it
             addedFields[index] = newField
         } else {
-            // This shouldn't happen in normal flow, but log an error just in case
+            // This shouldn't happen in normal flow, but logging just in case
             DDLogError("⛔️ Error: Trying to edit a locally added field that doesn't exist in addedFields")
         }
     }
 
+    /// Checking by id when editing an existing field since existing fields will always have them.
     func editExistingField(idToEdit: Int64, newField: CustomFieldUI) {
         guard idToEdit == newField.id else {
             DDLogError("⛔️ Error: Trying to edit existing field but supplied new id is different.")
@@ -68,7 +72,7 @@ private extension CustomFieldsListViewModel {
         }
 
         if let index = editedFields.firstIndex(where: { $0.id == idToEdit }) {
-            // This field has been locally edited, let's update it again
+            // Existing field has been locally edited, let's update it again
             editedFields[index] = newField
         } else {
             // First time the field is locally edited

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -34,11 +34,11 @@ extension CustomFieldsListViewModel {
         }
 
         let oldField = combinedList[index]
-        if newField.id == nil {
+        if newField.fieldId == nil {
             // When editing a field that has no id yet, it means the field has only been added locally.
             editLocallyAddedField(oldField: oldField, newField: newField)
         } else {
-            if let existingId = oldField.id {
+            if let existingId = oldField.fieldId {
                 editExistingField(idToEdit: existingId, newField: newField)
             } else {
                 DDLogError("⛔️ Error: Trying to edit an existing field but it has no id. It might be the wrong field to edit.")
@@ -66,12 +66,12 @@ private extension CustomFieldsListViewModel {
 
     /// Checking by id when editing an existing field since existing fields will always have them.
     func editExistingField(idToEdit: Int64, newField: CustomFieldUI) {
-        guard idToEdit == newField.id else {
+        guard idToEdit == newField.fieldId else {
             DDLogError("⛔️ Error: Trying to edit existing field but supplied new id is different.")
             return
         }
 
-        if let index = editedFields.firstIndex(where: { $0.id == idToEdit }) {
+        if let index = editedFields.firstIndex(where: { $0.fieldId == idToEdit }) {
             // Existing field has been locally edited, let's update it again
             editedFields[index] = newField
         } else {
@@ -82,7 +82,7 @@ private extension CustomFieldsListViewModel {
 
     func updateCombinedList() {
         let editedList = originalCustomFields.map { field in
-            editedFields.first { $0.id == field.id } ?? CustomFieldUI(customField: field)
+            editedFields.first { $0.fieldId == field.id } ?? CustomFieldUI(customField: field)
         }
         combinedList = editedList + addedFields
     }
@@ -90,20 +90,21 @@ private extension CustomFieldsListViewModel {
 
 extension CustomFieldsListViewModel {
     struct CustomFieldUI: Identifiable {
+        let id = UUID()
         let key: String
         let value: String
-        let id: Int64?
+        let fieldId: Int64?
 
-        init(key: String, value: String, id: Int64? = nil) {
+        init(key: String, value: String, fieldId: Int64? = nil) {
             self.key = key
             self.value = value
-            self.id = id
+            self.fieldId = fieldId
         }
 
         init(customField: CustomFieldViewModel) {
             self.key = customField.title
             self.value = customField.content
-            self.id = customField.id
+            self.fieldId = customField.id
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -25,6 +25,11 @@ final class CustomFieldsListViewModel: ObservableObject {
 // MARK: - Items actions
 extension CustomFieldsListViewModel {
     func editField(at index: Int, newField: CustomFieldUI) {
+        guard index >= 0 && index < combinedList.count else {
+            DDLogError("⛔️ Error: Invalid index for editing a custom field")
+            return
+        }
+
         let oldField = combinedList[index]
 
         if newField.id == nil {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1712,6 +1712,7 @@
 		86DE68822B4BA47A00B437A6 /* BlazeAdDestinationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */; };
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
 		86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */; };
+		86F5FFE22CA302B300C767C4 /* CustomFieldsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */; };
 		86F9D3642C897FFE00B1835B /* CustomFieldEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
 		933A27372222354600C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27362222354600C2143A /* Logging.swift */; };
@@ -4736,6 +4737,7 @@
 		86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModel.swift; sourceTree = "<group>"; };
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
+		86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModel.swift; sourceTree = "<group>"; };
 		86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldEditorView.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
 		8CA4F6DD220B257000A47B5D /* WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.debug.xcconfig; path = ../config/WooCommerce.debug.xcconfig; sourceTree = "<group>"; };
@@ -10572,6 +10574,7 @@
 				B626C71A287659D60083820C /* CustomFieldsListView.swift */,
 				B6C838DD28793B3A003AB786 /* CustomFieldViewModel.swift */,
 				86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */,
+				86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */,
 			);
 			path = "Custom Fields";
 			sourceTree = "<group>";
@@ -16095,6 +16098,7 @@
 				B99B87A72AEFCF0A006B8AB1 /* Order+Empty.swift in Sources */,
 				CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */,
 				684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */,
+				86F5FFE22CA302B300C767C4 /* CustomFieldsListViewModel.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
 				0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */,
 				02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1713,6 +1713,7 @@
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
 		86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */; };
 		86F5FFE22CA302B300C767C4 /* CustomFieldsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */; };
+		86F5FFE42CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */; };
 		86F9D3642C897FFE00B1835B /* CustomFieldEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
 		933A27372222354600C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27362222354600C2143A /* Logging.swift */; };
@@ -4738,6 +4739,7 @@
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
 		86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModel.swift; sourceTree = "<group>"; };
+		86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModelTests.swift; sourceTree = "<group>"; };
 		86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldEditorView.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
 		8CA4F6DD220B257000A47B5D /* WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.debug.xcconfig; path = ../config/WooCommerce.debug.xcconfig; sourceTree = "<group>"; };
@@ -9771,6 +9773,7 @@
 			isa = PBXGroup;
 			children = (
 				CC5BA5F4287EDC900072F307 /* CustomFieldViewModelTests.swift */,
+				86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */,
 			);
 			path = "Custom Fields";
 			sourceTree = "<group>";
@@ -16421,6 +16424,7 @@
 				4552085B25829091001CF873 /* AddAttributeViewModelTests.swift in Sources */,
 				02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */,
 				CC33238C29CDF67D00CA9709 /* ComponentSettingsViewModelTests.swift in Sources */,
+				86F5FFE42CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift in Sources */,
 				0261F5A728D454CF00B7AC72 /* ProductSearchUICommandTests.swift in Sources */,
 				098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */,
 				DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -94,5 +94,32 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
         // Then: hasChanges should be true
         XCTAssertTrue(viewModel.hasChanges)
+
+    func test_given_invalidIndex_when_editFieldCalled_then_noChangesAreMade() {
+        // Given: An invalid index and a custom field UI
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+
+        // When: Trying to edit a field at an invalid index
+        viewModel.editField(at: -1, newField: editedField)
+
+        // Then: No changes should be made
+        XCTAssertEqual(viewModel.combinedList.count, 2)
+        XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
+        XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
+        XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
+    }
+
+    func test_given_duplicateKey_when_addFieldCalled_then_fieldIsAdded() {
+        // Given: A new custom field UI with a duplicate key
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "Key1", value: "NewValue")
+
+        // When: Adding the new field
+        viewModel.addField(newField)
+
+        // Then: The field should be added to the list
+        XCTAssertEqual(viewModel.combinedList.count, 3)
+        XCTAssertEqual(viewModel.combinedList.last?.key, "Key1")
+        XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import WooCommerce
+
+final class CustomFieldsListViewModelTests: XCTestCase {
+
+    private var viewModel: CustomFieldsListViewModel!
+
+    override func setUp() {
+        super.setUp()
+        let customFields = [
+            CustomFieldViewModel(id: 1, title: "Key1", content: "Value1"),
+            CustomFieldViewModel(id: 2, title: "Key2", content: "Value2")
+        ]
+        viewModel = CustomFieldsListViewModel(customFields: customFields)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_given_initializedViewModel_then_displayedItemsMatchInitialCustomFields() {
+        // Given: The viewModel is initialized with two custom fields (in setUp)
+
+        // When: No additional action needed, we're testing the initial state
+
+        // Then: The displayed items should match the initial custom fields
+        XCTAssertEqual(viewModel.combinedList.count, 2)
+        XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
+        XCTAssertEqual(viewModel.combinedList[0].id, 1)
+        XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
+        XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
+        XCTAssertEqual(viewModel.combinedList[1].id, 2)
+    }
+
+    func test_given_existingField_when_editFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
+        // Given: A custom field UI to edit an existing field
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+
+        // When: Editing the field
+        viewModel.editField(at: 0, newField: editedField)
+
+        // Then: The number of displayed items remains the same as before and the value is edited correctly
+        XCTAssertEqual(viewModel.combinedList.count, 2)
+        XCTAssertEqual(viewModel.combinedList[0].key, "EditedKey1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "EditedValue1")
+    }
+
+    func test_given_newField_when_addFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
+        // Given: A new custom field UI to add
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+
+        // When: Adding the new field
+        viewModel.addField(newField)
+
+        // Then: The pending changes and displayed items should be updated
+        XCTAssertEqual(viewModel.combinedList.count, 3)
+        XCTAssertEqual(viewModel.combinedList.last?.key, "NewKey")
+        XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
+    }
+
+    func test_given_editedAndNewFields_when_updatingDisplayedItems_then_changesAreReflected() {
+        // Given: An edited field and a new field
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+
+        // When: Editing and adding fields
+        viewModel.editField(at: 0, newField: editedField)
+        viewModel.addField(newField)
+
+        // Then: The displayed items should reflect both the edited and added fields
+        XCTAssertEqual(viewModel.combinedList.count, 3)
+        XCTAssertEqual(viewModel.combinedList[0].key, "EditedKey1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "EditedValue1")
+        XCTAssertEqual(viewModel.combinedList[2].key, "NewKey")
+        XCTAssertEqual(viewModel.combinedList[2].value, "NewValue")
+    }
+
+    func test_given_variousChanges_when_pendingChangesUpdated_then_hasChangesReflectsCorrectState() {
+        // Given: Initial state with no changes
+        XCTAssertFalse(viewModel.hasChanges)
+
+        // When: Editing a field
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        viewModel.editField(at: 0, newField: editedField)
+
+        // Then: hasChanges should be true
+        XCTAssertTrue(viewModel.hasChanges)
+
+        // When: Adding a new field
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+        viewModel.addField(newField)
+
+        // Then: hasChanges should be true
+        XCTAssertTrue(viewModel.hasChanges)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -36,7 +36,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_existingField_when_editFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
         // Given: A custom field UI to edit an existing field
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
 
         // When: Editing the field
         viewModel.editField(at: 0, newField: editedField)
@@ -62,7 +62,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_editedAndNewFields_when_updatingDisplayedItems_then_changesAreReflected() {
         // Given: An edited field and a new field
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
         let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
 
         // When: Editing and adding fields
@@ -82,7 +82,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasChanges)
 
         // When: Editing a field
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
         viewModel.editField(at: 0, newField: editedField)
 
         // Then: hasChanges should be true
@@ -97,7 +97,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
         func test_given_invalidIndex_when_editFieldCalled_then_noChangesAreMade() {
             // Given: An invalid index and a custom field UI
-            let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+            let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
 
             // When: Trying to edit a field at an invalid index
             viewModel.editField(at: -1, newField: editedField)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -28,10 +28,10 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.combinedList.count, 2)
         XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
         XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
-        XCTAssertEqual(viewModel.combinedList[0].id, 1)
+        XCTAssertEqual(viewModel.combinedList[0].fieldId, 1)
         XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
         XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
-        XCTAssertEqual(viewModel.combinedList[1].id, 2)
+        XCTAssertEqual(viewModel.combinedList[1].fieldId, 2)
     }
 
     func test_given_existingField_when_editFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
@@ -95,31 +95,32 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // Then: hasChanges should be true
         XCTAssertTrue(viewModel.hasChanges)
 
-    func test_given_invalidIndex_when_editFieldCalled_then_noChangesAreMade() {
-        // Given: An invalid index and a custom field UI
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        func test_given_invalidIndex_when_editFieldCalled_then_noChangesAreMade() {
+            // Given: An invalid index and a custom field UI
+            let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
 
-        // When: Trying to edit a field at an invalid index
-        viewModel.editField(at: -1, newField: editedField)
+            // When: Trying to edit a field at an invalid index
+            viewModel.editField(at: -1, newField: editedField)
 
-        // Then: No changes should be made
-        XCTAssertEqual(viewModel.combinedList.count, 2)
-        XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
-        XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
-        XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
-        XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
-    }
+            // Then: No changes should be made
+            XCTAssertEqual(viewModel.combinedList.count, 2)
+            XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
+            XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
+            XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
+            XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
+        }
 
-    func test_given_duplicateKey_when_addFieldCalled_then_fieldIsAdded() {
-        // Given: A new custom field UI with a duplicate key
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "Key1", value: "NewValue")
+        func test_given_duplicateKey_when_addFieldCalled_then_fieldIsAdded() {
+            // Given: A new custom field UI with a duplicate key
+            let newField = CustomFieldsListViewModel.CustomFieldUI(key: "Key1", value: "NewValue")
 
-        // When: Adding the new field
-        viewModel.addField(newField)
+            // When: Adding the new field
+            viewModel.addField(newField)
 
-        // Then: The field should be added to the list
-        XCTAssertEqual(viewModel.combinedList.count, 3)
-        XCTAssertEqual(viewModel.combinedList.last?.key, "Key1")
-        XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
+            // Then: The field should be added to the list
+            XCTAssertEqual(viewModel.combinedList.count, 3)
+            XCTAssertEqual(viewModel.combinedList.last?.key, "Key1")
+            XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: https://github.com/woocommerce/woocommerce-ios/issues/13493

Please do not merge until target is trunk
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The flow for editing/adding/deleting custom fields can be described as follows:


1. Each item in the **Custom Fields List** screen can open the **Custom Field Editor** screen to be edited. In the editor, merchants can change things and then tap "Done" when they're done editing. Doing so will return them to the list screen and the change will be shown.
2. Merchant can also delete a field from its Custom Field Editor screen. This removes the field from the list screen.
3. **Custom Fields List** also has an add button that opens the editor, then merchant can also tap "Done" to keep the change. This adds a field to the list screen.
4. All changes from edit/delete/add actions above are still pending, similar to making changes to various aspects of products in Product Details screen. The **Custom Fields List** has a "Save" button, which acts as the only way to do remote API call to save. It will save all existing changes at once, matching the behavior in core.

This PR handles the local editing behavior, by adding these:
1. `CustomFieldsListViewModel` which handles the business logic.
2. The viewmodel contains `editedFields` and `addedFields` arrays to store the pending edit and addition. It also has `combinedList` which is an array of the latest combined changes. These later can be used for making the API call.
3. The viewmodel has `editField()` and `addField()` functions that can later be used when editing or adding a field.
4. Unit tests for the viewmodel.

Not in this PR and will be added separately:
1. Handling for deletion.
2. UI functionality for editing or adding field.
3. UI functionality for remote saving

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The handling is not used anywhere in the app yet, so for now just check the code and ensure the unit tests also passes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.