### PR TITLE
Add focus functionality for title text field in Product Category

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 -----
 - [*] Jetpack setup: fixed issue checking site info after activating Jetpack for sites with Jetpack connection package. [https://github.com/woocommerce/woocommerce-ios/pull/13993]
 - [*] Blaze: Campaign status is now updated immediately after being canceled. [https://github.com/woocommerce/woocommerce-ios/pull/13992]
-- [*] Now the keyboard will be open automatically when creating a new Product Category.
+- [*] Now the keyboard will be open automatically when creating a new Product Category. [https://github.com/woocommerce/woocommerce-ios/pull/14031]
 - [internal] Logging for app storage size added in Core Data crash logs [https://github.com/woocommerce/woocommerce-ios/pull/14008]
 
 20.5

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] Jetpack setup: fixed issue checking site info after activating Jetpack for sites with Jetpack connection package. [https://github.com/woocommerce/woocommerce-ios/pull/13993]
 - [*] Blaze: Campaign status is now updated immediately after being canceled. [https://github.com/woocommerce/woocommerce-ios/pull/13992]
+- [*] Now the keyboard will be open automatically when creating a new Product Category.
 - [internal] Logging for app storage size added in Core Data crash logs [https://github.com/woocommerce/woocommerce-ios/pull/14008]
 
 20.5

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
@@ -173,7 +173,7 @@ extension AddEditProductCategoryViewController: UITableViewDelegate {
         }
     }
 
-    /// Update Title Category Text Field
+    /// Update Title Category Text Field focus
     ///
     private func updateTitleTextField(shouldFocus: Bool) {
         if let indexPath = sections.indexPathForRow(.title) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
@@ -38,6 +38,11 @@ final class AddEditProductCategoryViewController: UIViewController {
         configureTableView()
         startListeningToNotifications()
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        focusTitleTextField()
+    }
 }
 
 // MARK: - View Configuration
@@ -174,6 +179,15 @@ extension AddEditProductCategoryViewController: UITableViewDelegate {
         if let indexPath = sections.indexPathForRow(.title) {
             let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
             cell?.resignFirstResponder()
+        }
+    }
+
+    /// Focus on Title Category Text Field
+    ///
+    private func focusTitleTextField() {
+        if let indexPath = sections.indexPathForRow(.title) {
+            let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
+            cell?.becomeFirstResponder()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
@@ -41,7 +41,7 @@ final class AddEditProductCategoryViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        focusTitleTextField()
+        updateTitleTextField(shouldFocus: true)
     }
 }
 
@@ -115,7 +115,7 @@ extension AddEditProductCategoryViewController {
     @objc private func saveCategory() {
         ServiceLocator.analytics.track(.productCategorySettingsSaveNewCategoryTapped)
 
-        titleCategoryTextFieldResignFirstResponder()
+        updateTitleTextField(shouldFocus: false)
         configureRightButtonItemAsSpinner()
 
         Task { @MainActor in
@@ -173,21 +173,16 @@ extension AddEditProductCategoryViewController: UITableViewDelegate {
         }
     }
 
-    /// Dismiss keyboard on Title Category Text Field
+    /// Update Title Category Text Field
     ///
-    private func titleCategoryTextFieldResignFirstResponder() {
+    private func updateTitleTextField(shouldFocus: Bool) {
         if let indexPath = sections.indexPathForRow(.title) {
             let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
-            cell?.resignFirstResponder()
-        }
-    }
-
-    /// Focus on Title Category Text Field
-    ///
-    private func focusTitleTextField() {
-        if let indexPath = sections.indexPathForRow(.title) {
-            let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
-            cell?.becomeFirstResponder()
+            if shouldFocus {
+                cell?.becomeFirstResponder()
+            } else {
+                cell?.resignFirstResponder()
+            }
         }
     }
 }


### PR DESCRIPTION
Closes: #13860

## Description
This update adds functionality to automatically focus on the title text field when the Add/Edit Product Category view appears.

## Summary of changes
- Introduce `viewDidAppear` method to trigger `focusTitleTextField` when the view appears.
- Add `focusTitleTextField` method to focus the title text field programmatically.

## Steps to reproduce
Add or Edit an existing product category and verify that the title text field is focused automatically when the view appears.

## Testing information
Tested that the focus of the text field in the add product category now works as expected. Tried also to create/edit an existing category.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
