### PR TITLE
Add back `attributes` encoding to `Product` entity

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -746,6 +746,9 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         try container.encode(minAllowedQuantity, forKey: .minAllowedQuantity)
         try container.encode(groupOfQuantity, forKey: .groupOfQuantity)
 
+        // Attributes
+        try container.encode(attributes, forKey: .attributes)
+
         // Password
         try container.encode(password, forKey: .password)
 

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -515,7 +515,7 @@ final class ProductMapperTests: XCTestCase {
 
         // Given
         let product = try XCTUnwrap(mapLoadSubscriptionProductResponse())
-        let subscriptionSettings = try XCTUnwrap(product.subscription)
+        _ = try XCTUnwrap(product.subscription)
 
         // When
         let encoder = JSONEncoder()
@@ -548,6 +548,51 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(Int64(encodedMetadata?[9]["id"] as? String ?? ""), customFields[1].metadataID)
         XCTAssertEqual(encodedMetadata?[9]["key"] as? String, customFields[1].key)
         XCTAssertEqual(encodedMetadata?[9]["value"] as? String, customFields[1].value)
+    }
+
+    /// Test that attributes are properly encoded.
+    ///
+    func test_attributes_are_properly_encoded() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadProductResponse().first)
+
+
+        // When
+        let encoder = JSONEncoder()
+        let encodedData = try encoder.encode(product)
+        let encodedJSON = try JSONSerialization.jsonObject(with: encodedData, options: []) as? [String: Any]
+
+        // Then
+
+        let attribute1 = ProductAttribute(siteID: dummySiteID,
+                                          attributeID: 0,
+                                          name: "Color",
+                                          position: 1,
+                                          visible: true,
+                                          variation: true,
+                                          options: ["Purple", "Yellow", "Hot Pink", "Lime Green", "Teal"])
+
+        let attribute2 = ProductAttribute(siteID: dummySiteID,
+                                          attributeID: 0,
+                                          name: "Size",
+                                          position: 0,
+                                          visible: true,
+                                          variation: true,
+                                          options: ["Small", "Medium", "Large"])
+        let attributes = [attribute1, attribute2]
+
+        XCTAssertNotNil(encodedJSON)
+        let encodedAttributes = encodedJSON?["attributes"] as? [[String: Any]]
+        XCTAssertEqual(encodedAttributes?.count, attributes.count)
+
+        // Verify all attributes are properly encoded
+        for (index, attribute) in attributes.enumerated() {
+            XCTAssertEqual(encodedAttributes?[index]["name"] as? String, attribute.name)
+            XCTAssertEqual(encodedAttributes?[index]["position"] as? Int, attribute.position)
+            XCTAssertEqual(encodedAttributes?[index]["visible"] as? Bool, attribute.visible)
+            XCTAssertEqual(encodedAttributes?[index]["variation"] as? Bool, attribute.variation)
+            XCTAssertEqual(encodedAttributes?[index]["options"] as? [String], attribute.options)
+        }
     }
 }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Blaze: Schedule a reminder local notification asking to continue abandoned campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13950]
 - [**] Fixed formatting issues for discount and cash payment input values when the device and store currency settings are different. [https://github.com/woocommerce/woocommerce-ios/pull/13979]
 - [*] Blaze: Handle tap on local notifications to open campaign creation. [https://github.com/woocommerce/woocommerce-ios/pull/13968]
+- [**] Fixed an issue that prevented users from adding prices to product variations.
 - [internal] Mobile Payments: Log errors from Stripe Terminal [https://github.com/woocommerce/woocommerce-ios/pull/13976]
 
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 - [*] Blaze: Schedule a reminder local notification asking to continue abandoned campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13950]
 - [**] Fixed formatting issues for discount and cash payment input values when the device and store currency settings are different. [https://github.com/woocommerce/woocommerce-ios/pull/13979]
 - [*] Blaze: Handle tap on local notifications to open campaign creation. [https://github.com/woocommerce/woocommerce-ios/pull/13968]
-- [**] Fixed an issue that prevented users from adding prices to product variations.
+- [**] Fixed an issue that prevented users from adding prices to product variations. [https://github.com/woocommerce/woocommerce-ios/pull/14046]
 - [internal] Mobile Payments: Log errors from Stripe Terminal [https://github.com/woocommerce/woocommerce-ios/pull/13976]
 
 


### PR DESCRIPTION
## Description
This PR introduces the following changes:
1. Adds back the `attributes` encoding to the `Product` model, which was unintentionally removed in [this PR](https://github.com/woocommerce/woocommerce-ios/pull/13880).
2. Implemented unit tests to ensure the `attributes` are properly encoded, so next time this will not be missed.

## Steps to reproduce
When you select the attributes of a variable product, and generate the variations, you need to go to the variation to add the price and this should show so you can click on the variation and add the price. But instead you get the screen to generate the variation again. More info here C6H8C3G23/p1727271887123809

## Testing information
I tested if it's possible to click on the product variation and add the price.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
