### PR TITLE
[Watch] Improve when to send message updates to the watch app

### DIFF
--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -97,7 +97,10 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
         // Syncs the dependencies to the paired counterpart when the session becomes available.
         Publishers.CombineLatest3(watchDependencies, $isSessionActive, $syncTrigger)
             .sink { [watchSession] dependencies, isSessionActive, forceSync in
-                guard isSessionActive else { return }
+
+                // Do not update the context if the session is not active, the watch is not paired or the watch app is not installed.
+                guard isSessionActive, watchSession.isPaired, watchSession.isWatchAppInstalled else { return }
+
                 do {
 
                     // If dependencies is nil, send an empty dictionary. This is most likely a logged out state


### PR DESCRIPTION

# Why

To avoid potential connection issues and unnecessary error logs. This PR updates the watch app connectivity code not try to send messages to the watch app if there is no watch paired or if the watch app is not installed.

# How

Update `WatchDependenciesSynchronizer.swift` to consider the `watchSession.isPaired` and the `watchSession.isWatchAppInstalled` properties.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.