### PR TITLE
[Shipping labels] Remove label paper size from shipment details to match updated designs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -25,16 +25,6 @@ struct WooShippingCreateLabelsView: View {
     /// Whether the shipment details bottom sheet is expanded.
     @State private var isShipmentDetailsExpanded = false
 
-    // TODO: 14044 - Track the paper size selection in the view model
-    // TODO: 13558 - Set the default selection from the account settings
-    @State private var selectedPaperSize: String = "Label (4\"x6\")"
-
-    // TODO: 14044 - Replace this static list with real data from the store
-    private let paperSizes: [String] = [
-        "Letter (8.5\"x11\")",
-        "Label (4\"x6\")"
-    ]
-
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -55,32 +45,6 @@ struct WooShippingCreateLabelsView: View {
                         VStack(spacing: Layout.bottomSheetSpacing) {
                             Toggle(Localization.BottomSheet.markComplete, isOn: .constant(false)) // TODO: 14044 - Handle this toggle setting
                                 .font(.subheadline)
-
-                            Menu {
-                                ForEach(paperSizes, id: \.self) { paperSize in
-                                    Button {
-                                        selectedPaperSize = paperSize
-                                    } label: {
-                                        HStack {
-                                            Text(paperSize)
-                                            if selectedPaperSize == paperSize {
-                                                Image(uiImage: .checkmarkStyledImage)
-                                            }
-                                        }
-                                    }
-                                }
-                            } label: {
-                                HStack {
-                                    Text(selectedPaperSize)
-                                        .bodyStyle()
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                    Image(systemName: "chevron.up.chevron.down")
-                                        .bold()
-                                }
-                                .padding(insets: EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
-                            }
-                            .roundedBorder(cornerRadius: Layout.cornerRadius, lineColor: Color(.separator), lineWidth: 1)
-                            .accessibilityLabel(Localization.BottomSheet.paperSize)
 
                             Button {
                                 // TODO: 13556 - Trigger purchase action


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14044
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This removes the label paper size dropdown menu from the shipment details bottom sheet, in the new Woo Shipping label creation flow, per the design discussion in pe5pgL-5rm-p2#comment-4584.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. Confirm the bottom sheet appears and is collapsed with the "Shipment details" label.
6. Tap or drag the bottom sheet to expand it, and confirm the expected bottom sheet UI is visible.
7. Confirm the "Mark as complete" toggle and purchase button are at the bottom of the screen, and the label paper size menu is removed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screenshot - iPhone 16 Pro - 2024-09-26 at 17 36 27](https://github.com/user-attachments/assets/aa032ed9-1950-4d78-a567-09e06bd2014a)|![Simulator Screenshot - iPhone 16 Pro - 2024-09-27 at 09 39 36](https://github.com/user-attachments/assets/ab7d5ad8-fc43-4c4e-9d0b-0521040d7dfe)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.