### PR TITLE
Custom fields: Update list screen to be shown in Order Details as part of current navigation

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -488,8 +488,16 @@ extension OrderDetailsViewModel {
             let customFieldsView = UIHostingController(
                 rootView: CustomFieldsListView(
                     isEditable: featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders),
-                    viewModel: CustomFieldsListViewModel(customFields: customFields)))
-            viewController.present(customFieldsView, animated: true)
+                    viewModel: CustomFieldsListViewModel(customFields: customFields),
+                    onBackButtonTapped: {
+                    // Restore the hidden navigation bar
+                    viewController.navigationController?.setNavigationBarHidden(false, animated: true)
+                })
+            )
+
+            // Hide the navigation bar as `CustomFieldsListView` will create its own toolbar.
+            viewController.navigationController?.setNavigationBarHidden(true, animated: true)
+            viewController.navigationController?.pushViewController(customFieldsView, animated: true)
         case .seeReceipt:
             let countryCode = configurationLoader.configuration.countryCode
             ServiceLocator.analytics.track(event: .InPersonPayments.receiptViewTapped(countryCode: countryCode, source: .backend))

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -5,15 +5,18 @@ struct CustomFieldsListView: View {
     @ObservedObject private var viewModel: CustomFieldsListViewModel
 
     let isEditable: Bool
+    let onBackButtonTapped: () -> Void
 
     init(isEditable: Bool,
-         viewModel: CustomFieldsListViewModel) {
+         viewModel: CustomFieldsListViewModel,
+         onBackButtonTapped: @escaping () -> Void) {
         self.isEditable = isEditable
         self.viewModel = viewModel
+        self.onBackButtonTapped = onBackButtonTapped
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List(viewModel.combinedList) { customField in
                 if isEditable {
                     NavigationLink(destination: CustomFieldEditorView(key: customField.key, value: customField.value)) {
@@ -34,9 +37,10 @@ struct CustomFieldsListView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(action: {
+                        onBackButtonTapped()
                         presentationMode.wrappedValue.dismiss()
                     }, label: {
-                        Image(uiImage: .closeButton)
+                        Image(systemName: "chevron.backward")
                     })
                 }
 
@@ -149,7 +153,8 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
                 customFields: [
                     CustomFieldViewModel(id: 0, title: "First Title", content: "First Content"),
                     CustomFieldViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
-                ])
+                ]),
+            onBackButtonTapped: { }
             )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -32,6 +32,7 @@ struct CustomFieldsListView: View {
                                    contentURL: nil)
                 }
             }
+            .listStyle(.plain)
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -137,7 +138,6 @@ extension CustomFieldsListView {
 private extension CustomFieldRow {
     enum Constants {
         static let spacing: CGFloat = 8
-        static let vStackPadding: CGFloat = 16
         static let hStackPadding: CGFloat = 10
         static let height: CGFloat = 64
     }


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Please do not merge until target is `trunk`

This quick PR updates the Custom Fields List screen to no longer appear as a modal, but instead as part of the existing navigation controller. 

Check out this new behavior in iPhone and iPad:

https://github.com/user-attachments/assets/79a55a35-291a-47ad-be8b-5d62f5e6c424


https://github.com/user-attachments/assets/07442efd-9598-4d5d-8c60-2099bb31718e



## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Build and go to Order Details, then try the Custom Fields button there. Ensure the navigation matches the video above, and that the List screen is not shown in a modal.

Also smoke test the navigation between Order Details <-> Custom Fields List <-> Custom Fields Editor and ensure everything works fine.

## Testing notes
I tested the steps above in Simulator iPhone and iOS, as seen in the video.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
