### PR TITLE
Implement local Save functionality for existing Custom Fields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct CustomFieldEditorView: View {
+    @Environment(\.presentationMode) var presentationMode
     @State private var key: String
     @State private var value: String
     @State private var showRichTextEditor = false
@@ -9,6 +10,7 @@ struct CustomFieldEditorView: View {
     private let initialKey: String
     private let initialValue: String
     private let isReadOnlyValue: Bool
+    private let onSave: (String, String) -> Void
 
     private var hasUnsavedChanges: Bool {
         key != initialKey || value != initialValue
@@ -19,12 +21,14 @@ struct CustomFieldEditorView: View {
     ///  - key: The key for the custom field
     ///  - value: The value for the custom field
     ///  - isReadOnlyValue: Whether the value is read-only or not. To be used if the value is not string but JSON.
-    init(key: String, value: String, isReadOnlyValue: Bool = false) {
+    ///  - onSave: Closure to handle save action
+    init(key: String, value: String, isReadOnlyValue: Bool = false, onSave: @escaping (String, String) -> Void) {
         self._key = State(initialValue: key)
         self._value = State(initialValue: value)
         self.initialKey = key
         self.initialValue = value
         self.isReadOnlyValue = isReadOnlyValue
+        self.onSave = onSave
     }
 
     var body: some View {
@@ -100,6 +104,7 @@ struct CustomFieldEditorView: View {
                 HStack {
                     Button {
                         saveChanges()
+                        presentationMode.wrappedValue.dismiss()
                     } label: {
                         Text("Save") // todo-13493: set String to be translatable
                     }
@@ -137,7 +142,7 @@ struct CustomFieldEditorView: View {
     }
 
     private func saveChanges() {
-        // todo-13493: add save logic
+        onSave(key, value)
     }
 }
 
@@ -191,5 +196,5 @@ private extension CustomFieldEditorView {
 }
 
 #Preview {
-    CustomFieldEditorView(key: "title", value: "value")
+    CustomFieldEditorView(key: "title", value: "value", onSave: { _, _ in })
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -19,7 +19,9 @@ struct CustomFieldsListView: View {
         NavigationStack {
             List(viewModel.combinedList) { customField in
                 if isEditable {
-                    NavigationLink(destination: CustomFieldEditorView(key: customField.key, value: customField.value)) {
+                    NavigationLink(destination: CustomFieldEditorView(key: customField.key, value: customField.value, onSave: { updatedKey, updatedValue in
+                        viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: customField.fieldId)
+                    })) {
                         CustomFieldRow(isEditable: true,
                                        title: customField.key,
                                        content: customField.value.removedHTMLTags,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -52,6 +52,17 @@ extension CustomFieldsListViewModel {
         addedFields.append(field)
         updateCombinedList()
     }
+
+    func saveField(key: String, value: String, fieldId: Int64?) {
+        let newField = CustomFieldUI(key: key, value: value, fieldId: fieldId)
+        if let fieldId = fieldId {
+            if let index = combinedList.firstIndex(where: { $0.fieldId == fieldId }) {
+                editField(at: index, newField: newField)
+            }
+        } else {
+            addField(newField)
+        }
+    }
 }
 
 private extension CustomFieldsListViewModel {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -94,33 +94,65 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
         // Then: hasChanges should be true
         XCTAssertTrue(viewModel.hasChanges)
+    }
 
-        func test_given_invalidIndex_when_editFieldCalled_then_noChangesAreMade() {
-            // Given: An invalid index and a custom field UI
-            let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
+    func test_given_invalidIndex_when_editFieldCalled_then_noChangesAreMade() {
+        // Given: An invalid index and a custom field UI
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
 
-            // When: Trying to edit a field at an invalid index
-            viewModel.editField(at: -1, newField: editedField)
+        // When: Trying to edit a field at an invalid index
+        viewModel.editField(at: -1, newField: editedField)
 
-            // Then: No changes should be made
-            XCTAssertEqual(viewModel.combinedList.count, 2)
-            XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
-            XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
-            XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
-            XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
-        }
+        // Then: No changes should be made
+        XCTAssertEqual(viewModel.combinedList.count, 2)
+        XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
+        XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
+        XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
+    }
 
-        func test_given_duplicateKey_when_addFieldCalled_then_fieldIsAdded() {
-            // Given: A new custom field UI with a duplicate key
-            let newField = CustomFieldsListViewModel.CustomFieldUI(key: "Key1", value: "NewValue")
+    func test_given_duplicateKey_when_addFieldCalled_then_fieldIsAdded() {
+        // Given: A new custom field UI with a duplicate key
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "Key1", value: "NewValue")
 
-            // When: Adding the new field
-            viewModel.addField(newField)
+        // When: Adding the new field
+        viewModel.addField(newField)
 
-            // Then: The field should be added to the list
-            XCTAssertEqual(viewModel.combinedList.count, 3)
-            XCTAssertEqual(viewModel.combinedList.last?.key, "Key1")
-            XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
-        }
+        // Then: The field should be added to the list
+        XCTAssertEqual(viewModel.combinedList.count, 3)
+        XCTAssertEqual(viewModel.combinedList.last?.key, "Key1")
+        XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
+    }
+
+    func test_given_saveFieldCalled_when_fieldExists_then_fieldIsUpdated() {
+        // Given: An existing field to be updated
+        let key = "UpdatedKey1"
+        let value = "UpdatedValue1"
+        let fieldId: Int64 = 1
+
+        // When: Saving the field
+        viewModel.saveField(key: key, value: value, fieldId: fieldId)
+
+        // Then: The field should be updated in the list
+        XCTAssertEqual(viewModel.combinedList.count, 2)
+        XCTAssertEqual(viewModel.combinedList[0].key, "UpdatedKey1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "UpdatedValue1")
+        XCTAssertEqual(viewModel.combinedList[0].fieldId, 1)
+    }
+
+    func test_given_saveFieldCalled_when_fieldDoesNotExist_then_fieldIsAdded() {
+        // Given: A new field to be added
+        let key = "NewKey"
+        let value = "NewValue"
+        let fieldId: Int64? = nil
+
+        // When: Saving the field
+        viewModel.saveField(key: key, value: value, fieldId: fieldId)
+
+        // Then: The field should be added to the list
+        XCTAssertEqual(viewModel.combinedList.count, 3)
+        XCTAssertEqual(viewModel.combinedList.last?.key, "NewKey")
+        XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
+        XCTAssertNil(viewModel.combinedList.last?.fieldId)
     }
 }


### PR DESCRIPTION
Please, do not merge before this PR https://github.com/woocommerce/woocommerce-ios/pull/14059 has been merged.

Part of #13493 

## Description
This pull request implements the local save functionality for existing custom fields. Some tests were added to ensure coverage for various scenarios.

- **CustomFieldEditorView.swift**
  - Add `onSave` closure to handle saving changes.
  - Dismiss view after saving changes.
  - Update initializer to include `onSave` parameter.

- **CustomFieldsListView.swift**
  - Update to pass `onSave` closure to `CustomFieldEditorView`.

- **CustomFieldsListViewModel.swift**
  - Implement `saveField` method to handle saving custom fields.
  - Refactor `editField` method to handle both locally added and existing fields.

## Steps to reproduce
1. Open an existing custom field, and try to edit it.
2. The save button should be enabled after the editing.
3. Pressing "Save" should pop the view, and the changes should be reflected in the custom fields list.

## Testing information
I followed the steps to reproduce.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
