### PR TITLE
Move a release note from 20.6 to 20.7

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 20.7
 -----
-
+- [internal] Enhanced error logging in the `OrderDetailsDataSource` class to improve crash diagnostics. [https://github.com/woocommerce/woocommerce-ios/pull/14018]
 
 20.6
 -----
@@ -14,7 +14,6 @@
 - [*] Now the keyboard will be open automatically when creating a new Product Category. [https://github.com/woocommerce/woocommerce-ios/pull/14031]
 - [*] Payments: Prevent phone from sleeping during card reader updates [https://github.com/woocommerce/woocommerce-ios/pull/14021]
 - [internal] Logging for app storage size added in Core Data crash logs [https://github.com/woocommerce/woocommerce-ios/pull/14008]
-- [internal] Enhanced error logging in the `OrderDetailsDataSource` class to improve crash diagnostics. [https://github.com/woocommerce/woocommerce-ios/pull/14018]
 - [internal] Fixed concurrency issue with Blaze local notification scheduler.
 - [internal] Fixed concurrency issue with Blaze local notification scheduler. [https://github.com/woocommerce/woocommerce-ios/pull/14012]
 - [internal] We added ability to mark and filter favorite products. This feature isn't released yet. But please smoke test product filtering work as expected. [https://github.com/woocommerce/woocommerce-ios/pull/14001]


### PR DESCRIPTION
## Description
For unknown reason, the CI in this PR https://github.com/woocommerce/woocommerce-ios/pull/14018 was failing, so it was not merged in time in release 20.6, however, after rerunning them it was automatically merged, but the release notes are under 20.6 instead of 20.7. This PR move the release notes under 20.7.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
