### PR TITLE
Moved out label "Suggested by AI" in `BlazeCampaignCreationForm` layout

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -301,22 +301,6 @@ private extension BlazeCampaignCreationForm {
                         .background(Color(uiColor: .systemGray6))
                         .cornerRadius(Layout.adButtonCornerRadius)
                 }
-
-                // Label "Suggested by AI"
-                HStack {
-                    HStack(spacing: 0) {
-                        Image(uiImage: .sparklesImage)
-                            .renderingMode(.template)
-                            .resizable()
-                            .foregroundColor(Color(uiColor: .textSubtle))
-                            .frame(width: Layout.sparkleIconSize * scale, height: Layout.sparkleIconSize * scale)
-
-                        Text(Localization.suggestedByAI)
-                            .subheadlineStyle()
-                    }
-                    Spacer()
-                }
-                .renderedIf(viewModel.isUsingAISuggestions)
             }
             .padding(Layout.contentPadding)
             .background(Color(uiColor: .systemBackground))
@@ -326,19 +310,36 @@ private extension BlazeCampaignCreationForm {
                     x: 0,
                     y: Layout.shadowYOffset)
 
-            // Button to edit ad details
-            Button(action: {
-                viewModel.didTapEditAd()
-            }, label: {
-                Text(Localization.editAd)
-                    .fontWeight(.semibold)
-                    .font(.body)
-                    .foregroundColor(.accentColor)
-            })
-            .buttonStyle(.plain)
-            .disabled(!viewModel.canEditAd)
-            .redacted(reason: !viewModel.canEditAd ? .placeholder : [])
-            .shimmering(active: !viewModel.canEditAd)
+            VStack(spacing: Layout.contentPadding) {
+                // Label "Suggested by AI"
+                HStack(spacing: 0) {
+                    Image(uiImage: .sparklesImage)
+                        .renderingMode(.template)
+                        .resizable()
+                        .foregroundColor(Color(uiColor: .textSubtle))
+                        .frame(width: Layout.sparkleIconSize * scale, height: Layout.sparkleIconSize * scale)
+
+                    Text(Localization.suggestedByAI)
+                        .subheadlineStyle()
+
+                    Spacer()
+                }
+                .renderedIf(viewModel.isUsingAISuggestions)
+
+                // Button to edit ad details
+                Button(action: {
+                    viewModel.didTapEditAd()
+                }, label: {
+                    Text(Localization.editAd)
+                        .fontWeight(.semibold)
+                        .font(.body)
+                        .foregroundColor(.accentColor)
+                })
+                .buttonStyle(.plain)
+                .disabled(!viewModel.canEditAd)
+                .redacted(reason: !viewModel.canEditAd ? .placeholder : [])
+                .shimmering(active: !viewModel.canEditAd)
+            }
         }
         .environment(\.colorScheme, .light)
         .padding(Layout.contentPadding)


### PR DESCRIPTION
Related to #12671

## Description
This PR reverts the recent changes made to the `BlazeCampaignCreationForm` layout, specifically moving the "Suggested by AI" label and the edit ad button back to their original positions. This decision follows a discussion highlighting concerns about the label's placement within the Ad Preview section C03L1NF1EA3/p1727177421848799


## Steps to reproduce
- Ensure that the visual layout in the form matches the original design specifications.

## Testing information
Followed the same steps as `Steps to reproduce`.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 16 Pro - 2024-09-30 at 15 59 09](https://github.com/user-attachments/assets/658b1296-2e6e-4ecd-8a3f-15d0a4abe587) | ![Simulator Screenshot - iPhone 16 Pro - 2024-09-30 at 16 06 53](https://github.com/user-attachments/assets/425e18ec-c6da-4f29-8669-f4870349e039)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
