### PR TITLE
Update ListSelectorViewController to use safe index accessors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
@@ -89,11 +89,12 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(Cell.self, for: indexPath)
-        let model = command.data[indexPath.row]
-        // Configures the cell's `accessoryType` before calling `command.configureCell` so that the command could override the `accessoryType`.
-        cell.accessoryType = command.isSelected(model: model) ? .checkmark: .none
-        command.configureCell(cell: cell, model: model)
 
+        if let model = command.data[safe: indexPath.row] {
+            // Configures the cell's `accessoryType` before calling `command.configureCell` so that the command could override the `accessoryType`.
+            cell.accessoryType = command.isSelected(model: model) ? .checkmark: .none
+            command.configureCell(cell: cell, model: model)
+        }
         return cell
     }
 
@@ -102,8 +103,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        let selected = command.data[indexPath.row]
-        if !command.isSelected(model: selected) {
+        if let selected = command.data[safe: indexPath.row], !command.isSelected(model: selected) {
             command.handleSelectedChange(selected: selected, viewController: self)
             tableView.reloadData()
         }


### PR DESCRIPTION
Closes: #14070 
peaMlT-Vj-p2

# Context

`command.data[indexPath.row]` should never fail as the dataset does not mutate, but according to crash reports it does.
I assume that this happens when the view is used in a SwiftUI hosting environment and some variables could be updated or mutated due to the underlying view lifecycle, causing the command data to be inconsistent with the current index path.

# How

- Updates `ListSelectorViewController` to use safe index accessors to prevent any out of index crash.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.