### PR TITLE
[Barcode Scanner] Handle the empty SKU situation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeSKUScannerErrorNoticeFactory.swift
@@ -22,6 +22,8 @@ struct BarcodeSKUScannerErrorNoticeFactory {
             return String(format: Localization.productNotFoundMessage, code.payloadStringValue)
         case .notPurchasable:
             return String(format: Localization.productNotPurchasableMessage, code.payloadStringValue)
+        case .emptySKU:
+            return Localization.invalidSKU
         default:
             return Localization.defaultTitle
         }
@@ -32,6 +34,8 @@ private extension BarcodeSKUScannerErrorNoticeFactory {
     enum Localization {
         static let defaultTitle = NSLocalizedString("Cannot add Product to Order.",
                                                     comment: "Generic error when a product can't be added to an order after being scanned.")
+        static let invalidSKU = NSLocalizedString("Invalid SKU",
+                                                    comment: "Error when an empty SKU is returned from the barcode scanner")
         static let productNotFoundMessage = NSLocalizedString("Product with SKU \"%@\" not found.",
                                                             comment: "Error message when the scanner cannot find a matching product. %@ is the SKU code.")
         static let productNotPurchasableMessage = NSLocalizedString("Product with SKU \"%@\" is not purchasable.",

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -422,6 +422,11 @@ private extension ProductStore {
     /// Retrieves the first product associated with a given siteID and exact-matching SKU (if any)
     ///
     func retrieveFirstPurchasableItemMatchFromSKU(siteID: Int64, sku: String, onCompletion: @escaping (Result<SKUSearchResult, Error>) -> Void) {
+
+        guard !sku.isEmpty else {
+            return onCompletion(.failure(ProductLoadError.emptySKU))
+        }
+
         remote.searchProductsBySKU(for: siteID,
                                    keyword: sku,
                                    pageNumber: Remote.Default.firstPageNumber,
@@ -1358,6 +1363,7 @@ public enum ProductLoadError: Error, Equatable {
     case notFound
     case notFoundInStorage
     case notPurchasable
+    case emptySKU
     case unknown(error: AnyError)
 
     init(underlyingError error: Error) {

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -2411,6 +2411,27 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(error, ProductLoadError.notFound)
     }
 
+    func test_retrieveFirstPurchasableItemMatchFromSKU_errors_on_empty_SKU() throws {
+        // Given
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let emptySKU = ""
+        let result = waitFor { promise in
+            let action = ProductAction.retrieveFirstPurchasableItemMatchFromSKU(siteID: self.sampleSiteID,
+                                                                        sku: emptySKU,
+                                                                        onCompletion: { product in
+                promise(product)
+            })
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure as? ProductLoadError)
+        XCTAssertEqual(result.isFailure, true)
+        XCTAssertEqual(error, ProductLoadError.emptySKU)
+    }
+
     func test_retrieveFirstPurchasableItemMatchFromSKU_when_unsuccessful_SKU_match_then_does_not_upsert_product_to_storage() throws {
         // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)


### PR DESCRIPTION
closes https://github.com/woocommerce/woocommerce-ios/issues/14076

# Why

Prior to this PR, the app did not handle well the scenario of an empty SKU, resulting in any product without an SKU being returned/selected.

# How

- Update the `ProductStore` to return a proper error when an empty SKU is passed as a parameter

## Before

https://github.com/user-attachments/assets/6cef12a3-9a3f-4071-baa3-b3362dad0958

## After

https://github.com/user-attachments/assets/e2bd7dd5-292e-454a-b893-b078e2222f6a

# Testing Steps

- Go to the orders list
- Tap the scan barcode button at the top leading margins
- Scan the demo barcode image
- See that a proper error notice is presented

<img width="650" alt="Screenshot 2024-09-30 at 5 20 09 PM" src="https://github.com/user-attachments/assets/8711257b-f3f8-4358-ae79-501c0b1bf664">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.