### PR TITLE
[Shipping labels] Update bottom sheet layout for landscape orientation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -42,7 +42,7 @@ struct WooShippingCreateLabelsView: View {
                     isShipmentDetailsExpanded = isExpanded
                 }) {
                     if isShipmentDetailsExpanded {
-                        VStack(spacing: Layout.bottomSheetSpacing) {
+                        CollapsibleHStack(spacing: Layout.bottomSheetSpacing) {
                             Toggle(Localization.BottomSheet.markComplete, isOn: .constant(false)) // TODO: 14044 - Handle this toggle setting
                                 .font(.subheadline)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -21,6 +21,12 @@ struct WooShippingCreateLabelsView: View {
     @ObservedObject var viewModel: WooShippingCreateLabelsViewModel
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private var isiPhonePortrait: Bool {
+        verticalSizeClass == .regular && horizontalSizeClass == .compact
+    }
 
     /// Tracks the size of the "Ship from" label in the Shipment Details address section.
     @State private var shipmentDetailsShipFromSize: CGSize = .zero
@@ -65,9 +71,10 @@ struct WooShippingCreateLabelsView: View {
                     }
                 } expandableContent: {
                     VStack(alignment: .leading, spacing: Layout.bottomSheetSpacing) {
-                        Text(Localization.BottomSheet.orderDetails)
-                            .footnoteStyle()
-
+                        if isiPhonePortrait {
+                            Text(Localization.BottomSheet.orderDetails)
+                                .footnoteStyle()
+                        }
                         CollapsibleHStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: .zero) {
                             HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
                                 Text(Localization.BottomSheet.shipFrom)
@@ -94,46 +101,22 @@ struct WooShippingCreateLabelsView: View {
                         }
                         .font(.subheadline)
                         .roundedBorder(cornerRadius: Layout.cornerRadius, lineColor: Color(.separator), lineWidth: 0.5)
-                        Group {
-                            AdaptiveStack {
-                                Image(uiImage: .productIcon)
-                                    .frame(width: Layout.iconSize)
-                                Text(viewModel.items.itemsCountLabel)
-                                    .bold()
-                                Spacer()
-                                Text("$148.50") // TODO: 14044 - Show real item total
-                            }
-                            AdaptiveStack {
-                                Image(uiImage: .shippingIcon)
-                                    .frame(width: Layout.iconSize)
-                                Text("Flat rate shipping") // TODO: 14044 - Show real shipping name
-                                    .bold()
-                                Spacer()
-                                Text("$25.00") // TODO: 14044 - Show real shipping amount
-                            }
-                        }
 
-                        Divider()
-                            .padding(.trailing, -16)
-                        Text(Localization.BottomSheet.shipmentCosts)
-                            .footnoteStyle()
-                        Group {
-                            AdaptiveStack {
-                                Text(Localization.BottomSheet.subtotal)
-                                Spacer()
-                                Text("$0.00") // TODO: 13555 - Show real subtotal value
-                                    .if(true) { subtotal in // TODO: 14044 - Only show placeholder if subtotal is not available
-                                        subtotal.redacted(reason: .placeholder)
-                                    }
+                        // Always use a VStack in iPhone portrait orientation.
+                        // CollapsibleHStack will use an HStack even if some text is truncated.
+                        if isiPhonePortrait {
+                            VStack(spacing: Layout.bottomSheetPadding) {
+                                orderDetails
+                                Divider()
+                                    .padding(.trailing, Layout.bottomSheetPadding * -1)
+                                shipmentDetails
                             }
-                            AdaptiveStack {
-                                Text(Localization.BottomSheet.total)
-                                    .bold()
-                                Spacer()
-                                Text("$0.00") // TODO: 13555 - Show real total value
-                                    .if(true) { total in // TODO: 14044 - Only show placeholder if total is not available
-                                        total.redacted(reason: .placeholder)
-                                    }
+                        } else {
+                            HStack(spacing: Layout.bottomSheetPadding) {
+                                orderDetails
+                                Divider()
+                                    .padding(.trailing, Layout.bottomSheetPadding * -1)
+                                shipmentDetails
                             }
                         }
                     }
@@ -155,10 +138,69 @@ struct WooShippingCreateLabelsView: View {
 }
 
 private extension WooShippingCreateLabelsView {
+    /// View showing the order details, such as order items and shipping costs.
+    var orderDetails: some View {
+        VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+            if !(isiPhonePortrait) {
+                Text(Localization.BottomSheet.orderDetails)
+                    .footnoteStyle()
+            }
+            AdaptiveStack {
+                Image(uiImage: .productIcon)
+                    .frame(width: Layout.iconSize)
+                Text(viewModel.items.itemsCountLabel)
+                    .bold()
+                Spacer()
+                Text("$148.50") // TODO: 14044 - Show real item total
+            }
+            .frame(idealHeight: Layout.rowHeight)
+            AdaptiveStack {
+                Image(uiImage: .shippingIcon)
+                    .frame(width: Layout.iconSize)
+                Text("Flat rate shipping") // TODO: 14044 - Show real shipping name
+                    .bold()
+                    .lineLimit(nil)
+                Spacer()
+                Text("$25.00") // TODO: 14044 - Show real shipping amount
+            }
+            .frame(idealHeight: Layout.rowHeight)
+        }
+    }
+
+    /// View showing the shipment details, such as shipping rate and additional costs.
+    var shipmentDetails: some View {
+        VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+            Text(Localization.BottomSheet.shipmentCosts)
+                .footnoteStyle()
+            AdaptiveStack {
+                Text(Localization.BottomSheet.subtotal)
+                Spacer()
+                Text("$0.00") // TODO: 13555 - Show real subtotal value
+                    .if(true) { subtotal in // TODO: 14044 - Only show placeholder if subtotal is not available
+                        subtotal.redacted(reason: .placeholder)
+                    }
+            }
+            .frame(idealHeight: Layout.rowHeight)
+            AdaptiveStack {
+                Text(Localization.BottomSheet.total)
+                    .bold()
+                Spacer()
+                Text("$0.00") // TODO: 13555 - Show real total value
+                    .if(true) { total in // TODO: 14044 - Only show placeholder if total is not available
+                        total.redacted(reason: .placeholder)
+                    }
+            }
+            .frame(idealHeight: Layout.rowHeight)
+        }
+    }
+}
+
+private extension WooShippingCreateLabelsView {
     enum Layout {
         static let verticalSpacing: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let iconSize: CGFloat = 32
+        static let rowHeight: CGFloat = 32
         static let chevronSize: CGFloat = 30
         static let bottomSheetSpacing: CGFloat = 16
         static let bottomSheetPadding: CGFloat = 16

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -130,9 +130,9 @@ struct WooShippingCreateLabelsView: View {
                             }
                         }
                     }
-                    .padding(.bottom, Layout.bottomSheetPadding)
-                    .padding(.horizontal, Layout.bottomSheetPadding)
+                    .padding([.bottom, .horizontal], Layout.bottomSheetPadding)
                 }
+                .ignoresSafeArea(edges: .horizontal)
             }
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -22,6 +22,9 @@ struct WooShippingCreateLabelsView: View {
 
     @Environment(\.dismiss) private var dismiss
 
+    /// Tracks the size of the "Ship from" label in the Shipment Details address section.
+    @State private var shipmentDetailsShipFromSize: CGSize = .zero
+
     /// Whether the shipment details bottom sheet is expanded.
     @State private var isShipmentDetailsExpanded = false
 
@@ -65,25 +68,29 @@ struct WooShippingCreateLabelsView: View {
                         Text(Localization.BottomSheet.orderDetails)
                             .footnoteStyle()
 
-                        Grid(alignment: .leading, verticalSpacing: .zero) {
-                            GridRow(alignment: .top) {
+                        CollapsibleHStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: .zero) {
+                            HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
                                 Text(Localization.BottomSheet.shipFrom)
+                                    .trackSize(size: $shipmentDetailsShipFromSize)
                                 Text("417 MONTGOMERY ST, SAN FRANCISCO") // TODO: 14044 - Show real "ship from" address (store address)
                                     .lineLimit(1)
                                     .truncationMode(.tail)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                             }
-                            .padding()
+                            .padding(Layout.bottomSheetPadding)
                             Divider()
-                            GridRow(alignment: .top) {
+                            HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
                                 Text(Localization.BottomSheet.shipTo)
+                                    .frame(width: shipmentDetailsShipFromSize.width, alignment: .leading)
                                 VStack(alignment: .leading) {
                                     Text("1 Infinite Loop") // TODO: 14044 - Show real "ship to" address (customer address)
                                         .bold()
                                     Text("Cupertino, CA 95014")
                                     Text("USA")
                                 }
+                                .frame(maxWidth: .infinity, alignment: .leading)
                             }
-                            .padding()
+                            .padding(Layout.bottomSheetPadding)
                         }
                         .font(.subheadline)
                         .roundedBorder(cornerRadius: Layout.cornerRadius, lineColor: Color(.separator), lineWidth: 0.5)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14044
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the UI for the "Shipment details" bottom sheet in the new Woo Shipping label creation flow. It handles the layout according to the landscape designs.

### How

* Uses `CollapsibleHStack` instead of `VStack` or `Grid`. This allows the layout to use an `HStack` where it fits (i.e. iPad or landscape on iPhone) but otherwise uses a `VStack`.
* Because we're no longer using `Grid` for the address layout, this also introduces `shipmentDetailsShipFromSize` to make sure the "Ship from" and "Ship to" labels have the same width.
* However, in one case we handle the layout manually by checking the horizontal and vertical size class, and using an `HStack` or `VStack` as needed. I found that `CollapsibleHStack` (which relies on `ViewThatFits`) will continue to use an `HStack` even if some strings are truncated. The only workarounds I found for that were to handle the layout manually or introduce changes that break e.g. the dynamic type support.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. Tap the "Shipment details" bottom sheet to expand it.
6. Confirm you can view all the shipment details in portrait orientation as expected, according to the design.
7. Rotate the device to landscape orientation and confirm you can view all the shipment details in landscape as expected, according to the design.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Design:

![Create Order (2)](https://github.com/user-attachments/assets/f88bb5dc-ee06-440a-ae26-fd629aa50514)

Before|After
-|-
![Simulator Screenshot - iPhone 16 Pro - 2024-10-02 at 16 17 54](https://github.com/user-attachments/assets/42c221be-95f8-4040-b2ea-2b6717096174)|![Simulator Screenshot - iPhone 16 Pro - 2024-10-02 at 16 14 45](https://github.com/user-attachments/assets/41ea7a5f-9e4e-45c5-b974-44a5a86fc4bc)
![Simulator Screenshot - iPhone 16 Pro - 2024-10-02 at 16 17 51](https://github.com/user-attachments/assets/4e9ddf8f-52be-42a9-9de6-b6e880bad246)|![Simulator Screenshot - iPhone 16 Pro - 2024-10-02 at 16 14 49](https://github.com/user-attachments/assets/f8057948-366a-4c12-94ce-cfa9b968e24a)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.