### PR TITLE
[Crash] Fix crash when searching products in order product selector

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Payments: Fixed a bug preventing payments onboarding from being automatically hidden when complete [https://github.com/woocommerce/woocommerce-ios/pull/14017]
 - [*] Payments: Give a specific label to Tap to Pay trial payments [https://github.com/woocommerce/woocommerce-ios/pull/14022]
 - [*] Some error views were misaligned on iPad when the store was not a WordPress site or didn't have Jetpack installed. Now, everything is perfectly centered. [https://github.com/woocommerce/woocommerce-ios/pull/13991]
+- [*] Orders: Fixed a crash when searching for products to add to an order. [https://github.com/woocommerce/woocommerce-ios/pull/14095]
 
 20.6
 -----

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -267,9 +267,9 @@ private extension ProductStore {
         let sitePredicate = NSPredicate(format: "siteID == %lld", siteID)
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [namePredicate, sitePredicate])
 
-        let results = sharedDerivedStorage.allObjects(ofType: StorageProduct.self,
-                                                      matching: predicate,
-                                                      sortedBy: nil)
+        let results = storageManager.viewStorage.allObjects(ofType: StorageProduct.self,
+                                                            matching: predicate,
+                                                            sortedBy: nil)
 
         handleSearchResults(siteID: siteID,
                             keyword: keyword,

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -263,7 +263,7 @@ private extension ProductStore {
     }
 
     func searchInCache(siteID: Int64, keyword: String, pageSize: Int, onCompletion: @escaping (Bool) -> Void) {
-        let namePredicate = NSPredicate(format: "name LIKE[c] %@", keyword)
+        let namePredicate = NSPredicate(format: "name CONTAINS[c] %@", keyword)
         let sitePredicate = NSPredicate(format: "siteID == %lld", siteID)
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [namePredicate, sitePredicate])
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14085
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes a crash caused by fetching products from storage while updating them in the same context on a background thread. This happened while performing a product search in the order form product selector (while adding products to an order).

This also includes a small improvement to the local search, to return results with partial matches to the search term (similar to the remote search method) instead of only exact matches.

## How

* Instead of using `sharedDerivedStorage` (which is `storageManager.writerDerivedStorage`, meant for writing to storage and used for background updates) we now use `storageManager.viewStorage` to fetch the products.
* The local search predicate now uses `CONTAINS` instead of `LIKE` (to return partial matches).

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Note: I was only able to get the app to crash in the simulator. I couldn't reproduce this crash on a device, but as the simulator crash indicates this action is not thread safe.

1. Build and run the app.
2. Go to the Orders tab.
3. Tap "+" to create a new order.
4. Tap "Add Products".
5. Search for a product. Notice that it crashes on `_PFAssertSafeMultiThreadedAccess_impl`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test with the same steps as above in this branch and confirm it doesn't crash.

Additional testing:

1. Build and run the app with Xcode 16.
2. Go to the Orders tab.
3. Tap "+" to create a new order.
4. Tap "Add Products".
5. Search for a product using a partial match (e.g. `Card` when you have a product called `Gift Card` in the first page of results) and confirm the match is loaded from storage.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Screencast demonstrates the following search scenarios:

* Local results (full match to product name)
* Local results (partial match) + remote results added
* No local results + remote results added
* No local results & no remote results


https://github.com/user-attachments/assets/777a98b5-62a1-4876-9a14-6e84fab9a0fa



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.