### PR TITLE
[Shipping labels] Display actual shipment data in shipment details bottom sheet

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -508,7 +508,11 @@ private extension OrderDetailsViewController {
             return
         }
 
-        let shippingLabelCreationVM = WooShippingCreateLabelsViewModel(order: viewModel.order)
+        let shippingLabelCreationVM = WooShippingCreateLabelsViewModel(order: viewModel.order, onLabelPurchase: { [weak self] markOrderComplete in
+            if markOrderComplete {
+                self?.markOrderCompleteFromShippingLabels()
+            }
+        })
         let shippingLabelCreationVC = WooShippingCreateLabelsViewHostingController(viewModel: shippingLabelCreationVM)
         shippingLabelCreationVC.modalPresentationStyle = .overFullScreen
         navigationController?.present(shippingLabelCreationVC, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -16,7 +16,7 @@ final class WooShippingItemsViewModel: ObservableObject {
     @Published private(set) var itemsCountLabel: String = ""
 
     /// Label with the total price for all items in the shipment.
-    private(set) var itemsPriceLabel = ""
+    @Published private(set) var itemsPriceLabel = ""
 
     /// Label with the total weight for all items in the shipment.
     private var itemsWeightLabel = ""

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -15,9 +15,17 @@ final class WooShippingItemsViewModel: ObservableObject {
     /// Label with the total number of items to ship.
     @Published private(set) var itemsCountLabel: String = ""
 
+    /// Label with the total price for all items in the shipment.
+    private(set) var itemsPriceLabel = ""
+
+    /// Label with the total weight for all items in the shipment.
+    private var itemsWeightLabel = ""
+
     /// Label with the details of the items to ship.
-    /// Include total weight and total price for all items in the shipment.
-    @Published private(set) var itemsDetailLabel: String = ""
+    /// Includes total weight and total price for all items in the shipment.
+    var itemsDetailLabel: String {
+        "\(itemsWeightLabel) • \(itemsPriceLabel)"
+    }
 
     /// View models for rows of items to ship.
     @Published private(set) var itemRows: [WooShippingItemRowViewModel] = []
@@ -38,8 +46,10 @@ private extension WooShippingItemsViewModel {
     /// Configures the labels in the section header.
     ///
     func configureSectionHeader() {
-        itemsCountLabel = generateItemsCountLabel()
-        itemsDetailLabel = generateItemsDetailLabel()
+        let itemsCount = dataSource.items.map(\.quantity).reduce(0, +)
+        itemsCountLabel = Localization.itemsCount(itemsCount)
+        itemsWeightLabel = formatWeight(for: dataSource.items)
+        itemsPriceLabel = formatPrice(for: dataSource.items)
     }
 
     /// Configures the item rows.
@@ -48,22 +58,6 @@ private extension WooShippingItemsViewModel {
         itemRows = dataSource.items.map { item in
             WooShippingItemRowViewModel(item: item)
         }
-    }
-
-    /// Generates a label with the total number of items to ship.
-    ///
-    func generateItemsCountLabel() -> String {
-        let itemsCount = dataSource.items.map(\.quantity).reduce(0, +)
-        return Localization.itemsCount(itemsCount)
-    }
-
-    /// Generates a label with the details of the items to ship.
-    /// This includes the total weight and total price of all items.
-    ///
-    func generateItemsDetailLabel() -> String {
-        let formattedWeight = formatWeight(for: dataSource.items)
-        let formattedPrice = formatPrice(for: dataSource.items)
-        return "\(formattedWeight) • \(formattedPrice)"
     }
 
     /// Calculates and formats the total weight of the given items based on each item's weight and quantity.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -91,12 +91,14 @@ private extension WooShippingItemsViewModel {
 private extension WooShippingItemsViewModel {
     enum Localization {
         static func itemsCount(_ count: Decimal) -> String {
-            let formattedCount = NumberFormatter.localizedString(from: count as NSDecimalNumber, number: .decimal)
-            return String(format: Localization.itemsCountFormat, formattedCount)
+            return String.pluralize(count, singular: Localization.itemsCountSingularFormat, plural: Localization.itemsCountPluralFormat)
         }
-        static let itemsCountFormat = NSLocalizedString("wooShipping.createLabels.items.count",
-                                                        value: "%1$@ items",
-                                                        comment: "Total number of items to ship during shipping label creation. Reads like: '3 items'")
+        static let itemsCountSingularFormat = NSLocalizedString("wooShipping.createLabels.items.countSingular",
+                                                                value: "%1$@ item",
+                                                                comment: "Label for singular item to ship during shipping label creation. Reads like: '1 item'")
+        static let itemsCountPluralFormat = NSLocalizedString("wooShipping.createLabels.items.count",
+                                                              value: "%1$@ items",
+                                                              comment: "Label for plural items to ship during shipping label creation. Reads like: '3 items'")
         static let dimensionsFormat = NSLocalizedString("wooShipping.createLabels.items.dimensions",
                                                         value: "%1$@ x %2$@ x %3$@ %4$@",
                                                         comment: "Length, width, and height dimensions with the unit for an item to ship. "

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -13,14 +13,14 @@ final class WooShippingItemsViewModel: ObservableObject {
     private var dataSource: WooShippingItemsDataSource
 
     /// Label with the total number of items to ship.
-    @Published var itemsCountLabel: String = ""
+    @Published private(set) var itemsCountLabel: String = ""
 
     /// Label with the details of the items to ship.
     /// Include total weight and total price for all items in the shipment.
-    @Published var itemsDetailLabel: String = ""
+    @Published private(set) var itemsDetailLabel: String = ""
 
     /// View models for rows of items to ship.
-    @Published var itemRows: [WooShippingItemRowViewModel] = []
+    @Published private(set) var itemRows: [WooShippingItemRowViewModel] = []
 
     init(dataSource: WooShippingItemsDataSource,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -79,7 +79,7 @@ struct WooShippingCreateLabelsView: View {
                             HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
                                 Text(Localization.BottomSheet.shipFrom)
                                     .trackSize(size: $shipmentDetailsShipFromSize)
-                                Text("417 MONTGOMERY ST, SAN FRANCISCO") // TODO: 14044 - Show real "ship from" address (store address)
+                                Text(viewModel.originAddress)
                                     .lineLimit(1)
                                     .truncationMode(.tail)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -90,10 +90,12 @@ struct WooShippingCreateLabelsView: View {
                                 Text(Localization.BottomSheet.shipTo)
                                     .frame(width: shipmentDetailsShipFromSize.width, alignment: .leading)
                                 VStack(alignment: .leading) {
-                                    Text("1 Infinite Loop") // TODO: 14044 - Show real "ship to" address (customer address)
-                                        .bold()
-                                    Text("Cupertino, CA 95014")
-                                    Text("USA")
+                                    ForEach(viewModel.destinationAddressLines, id: \.self) { addressLine in
+                                        Text(addressLine)
+                                            .if(addressLine == viewModel.destinationAddressLines.first) { line in
+                                                line.bold()
+                                            }
+                                    }
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -52,11 +52,11 @@ struct WooShippingCreateLabelsView: View {
                 }) {
                     if isShipmentDetailsExpanded {
                         CollapsibleHStack(spacing: Layout.bottomSheetSpacing) {
-                            Toggle(Localization.BottomSheet.markComplete, isOn: .constant(false)) // TODO: 14044 - Handle this toggle setting
+                            Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
                                 .font(.subheadline)
 
                             Button {
-                                // TODO: 13556 - Trigger purchase action
+                                viewModel.purchaseLabel()
                             } label: {
                                 Text(Localization.BottomSheet.purchase)
                             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -156,16 +156,18 @@ private extension WooShippingCreateLabelsView {
                 Text(viewModel.items.itemsPriceLabel)
             }
             .frame(idealHeight: Layout.rowHeight)
-            AdaptiveStack {
-                Image(uiImage: .shippingIcon)
-                    .frame(width: Layout.iconSize)
-                Text("Flat rate shipping") // TODO: 14044 - Show real shipping name
-                    .bold()
-                    .lineLimit(nil)
-                Spacer()
-                Text("$25.00") // TODO: 14044 - Show real shipping amount
+            ForEach(viewModel.shippingLines) { shippingLine in
+                AdaptiveStack {
+                    Image(uiImage: .shippingIcon)
+                        .frame(width: Layout.iconSize)
+                    Text(shippingLine.title)
+                        .bold()
+                        .lineLimit(nil)
+                    Spacer()
+                    Text(shippingLine.formattedTotal)
+                }
+                .frame(idealHeight: Layout.rowHeight)
             }
-            .frame(idealHeight: Layout.rowHeight)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -153,7 +153,7 @@ private extension WooShippingCreateLabelsView {
                 Text(viewModel.items.itemsCountLabel)
                     .bold()
                 Spacer()
-                Text("$148.50") // TODO: 14044 - Show real item total
+                Text(viewModel.items.itemsPriceLabel)
             }
             .frame(idealHeight: Layout.rowHeight)
             AdaptiveStack {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -61,7 +61,7 @@ struct WooShippingCreateLabelsView: View {
                                 Text(Localization.BottomSheet.purchase)
                             }
                             .buttonStyle(PrimaryButtonStyle())
-                            .disabled(true) // TODO: 14044 - Enable button when shipping label is ready to purchase
+                            .disabled(true) // TODO: 13556 - Enable button when shipping label is ready to purchase
                         }
                         .padding(.horizontal, Layout.bottomSheetPadding)
                     } else {
@@ -179,8 +179,8 @@ private extension WooShippingCreateLabelsView {
             AdaptiveStack {
                 Text(Localization.BottomSheet.subtotal)
                 Spacer()
-                Text("$0.00") // TODO: 13555 - Show real subtotal value
-                    .if(true) { subtotal in // TODO: 14044 - Only show placeholder if subtotal is not available
+                Text("$0.00") // TODO: 13554 - Show subtotal value(s) for selected rate
+                    .if(true) { subtotal in // TODO: 13554 - Only show placeholder if subtotal is not available
                         subtotal.redacted(reason: .placeholder)
                     }
             }
@@ -189,8 +189,8 @@ private extension WooShippingCreateLabelsView {
                 Text(Localization.BottomSheet.total)
                     .bold()
                 Spacer()
-                Text("$0.00") // TODO: 13555 - Show real total value
-                    .if(true) { total in // TODO: 14044 - Only show placeholder if total is not available
+                Text("$0.00") // TODO: 13554 - Show total value for selected shipping rate
+                    .if(true) { total in // TODO: 13554 - Only show placeholder if total is not available
                         total.redacted(reason: .placeholder)
                     }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 /// Provides view data for `WooShippingCreateLabelsView`.
 ///
@@ -12,6 +13,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     let destinationAddressLines: [String]
+
+    /// Shipping lines for the order, with formatted amount.
+    let shippingLines: [WooShipping_ShippingLineViewModel]
 
     /// Whether to mark the order as complete after the label is purchased.
     @Published var markOrderComplete: Bool = false
@@ -26,6 +30,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.onLabelPurchase = onLabelPurchase
         self.originAddress = Self.formatOriginAddress(siteAddress: siteAddress)
         self.destinationAddressLines = (order.shippingAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
+        self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
     }
 
     /// Purchases a shipping label with the provided label details and settings.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -7,6 +7,12 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
+    /// Address to ship from (store address), formatted for display.
+    let originAddress: String
+
+    /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
+    let destinationAddressLines: [String]
+
     /// Whether to mark the order as complete after the label is purchased.
     @Published var markOrderComplete: Bool = false
 
@@ -14,14 +20,36 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
     init(order: Order,
+         siteAddress: SiteAddress = SiteAddress(),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
         self.onLabelPurchase = onLabelPurchase
+        self.originAddress = Self.formatOriginAddress(siteAddress: siteAddress)
+        self.destinationAddressLines = (order.shippingAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
     }
 
     /// Purchases a shipping label with the provided label details and settings.
     func purchaseLabel() {
         // TODO: 13556 - Add action to purchase label remotely
         onLabelPurchase?(markOrderComplete) // TODO: 13556 - Only call this closure if the remote purchase is successful
+    }
+}
+
+private extension WooShippingCreateLabelsViewModel {
+    /// Formats the origin address from the provided `SiteAddress`.
+    static func formatOriginAddress(siteAddress: SiteAddress) -> String {
+        let address = Address(firstName: "",
+                              lastName: "",
+                              company: nil,
+                              address1: siteAddress.address,
+                              address2: siteAddress.address2,
+                              city: siteAddress.city,
+                              state: siteAddress.state,
+                              postcode: siteAddress.postalCode,
+                              country: siteAddress.countryCode.rawValue,
+                              phone: nil,
+                              email: nil)
+        let formattedPostalAddress = address.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ")
+        return formattedPostalAddress ?? ""
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -7,7 +7,21 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
-    init(order: Order) {
+    /// Whether to mark the order as complete after the label is purchased.
+    @Published var markOrderComplete: Bool = false
+
+    /// Closure to execute after the label is successfully purchased.
+    let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
+
+    init(order: Order,
+         onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
+        self.onLabelPurchase = onLabelPurchase
+    }
+
+    /// Purchases a shipping label with the provided label details and settings.
+    func purchaseLabel() {
+        // TODO: 13556 - Add action to purchase label remotely
+        onLabelPurchase?(markOrderComplete) // TODO: 13556 - Only call this closure if the remote purchase is successful
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModel.swift
@@ -1,0 +1,21 @@
+import Yosemite
+import WooFoundation
+
+/// Represents a shipping line in the Woo Shipping label creation flow.
+struct WooShipping_ShippingLineViewModel: Identifiable {
+    /// Unique ID for the shipping line.
+    let id: Int64
+
+    /// Title for the shipping line.
+    let title: String
+
+    /// Formatted total amount for the shipping line.
+    let formattedTotal: String
+
+    init(shippingLine: ShippingLine,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        id = shippingLine.shippingID
+        title = shippingLine.methodTitle
+        formattedTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2179,6 +2179,7 @@
 		CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21B3DE20FFC59700A259D5 /* ProductDetailsTableViewCell.swift */; };
 		CE21B3E120FFC59700A259D5 /* ProductDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE21B3DF20FFC59700A259D5 /* ProductDetailsTableViewCell.xib */; };
 		CE21FB262C2DB3A900303832 /* GoogleAdsCampaignReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB252C2DB3A900303832 /* GoogleAdsCampaignReportCardViewModel.swift */; };
+		CE2207042CA5C55800E16D9B /* WooShippingCreateLabelsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2207032CA5C55100E16D9B /* WooShippingCreateLabelsViewModelTests.swift */; };
 		CE22571B20E16FBC0037F478 /* LeftImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1EC8EB20B8A3FF009762BF /* LeftImageTableViewCell.xib */; };
 		CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE227096228F152400C0626C /* WooBasicTableViewCell.swift */; };
 		CE227099228F180B00C0626C /* WooBasicTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE227098228F180B00C0626C /* WooBasicTableViewCell.xib */; };
@@ -5225,6 +5226,7 @@
 		CE21B3DE20FFC59700A259D5 /* ProductDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		CE21B3DF20FFC59700A259D5 /* ProductDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductDetailsTableViewCell.xib; sourceTree = "<group>"; };
 		CE21FB252C2DB3A900303832 /* GoogleAdsCampaignReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModel.swift; sourceTree = "<group>"; };
+		CE2207032CA5C55100E16D9B /* WooShippingCreateLabelsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsViewModelTests.swift; sourceTree = "<group>"; };
 		CE227096228F152400C0626C /* WooBasicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooBasicTableViewCell.swift; sourceTree = "<group>"; };
 		CE227098228F180B00C0626C /* WooBasicTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WooBasicTableViewCell.xib; sourceTree = "<group>"; };
 		CE22709E2293052700C0626C /* WebviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebviewHelper.swift; path = Classes/Tools/WebviewHelper.swift; sourceTree = SOURCE_ROOT; };
@@ -11849,6 +11851,7 @@
 		CEC3CC722C9343BC00B93FBE /* WooShipping Create Shipping Labels */ = {
 			isa = PBXGroup;
 			children = (
+				CE2207032CA5C55100E16D9B /* WooShippingCreateLabelsViewModelTests.swift */,
 				CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */,
 				CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */,
 				CEC3CC7B2C94A06500B93FBE /* WooShippingItemsDataSourceTests.swift */,
@@ -16825,6 +16828,7 @@
 				AEB6903729770B1D00872FE0 /* ProductListViewModelTests.swift in Sources */,
 				03B9E52B2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift in Sources */,
 				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStorageTests.swift in Sources */,
+				CE2207042CA5C55800E16D9B /* WooShippingCreateLabelsViewModelTests.swift in Sources */,
 				02D635792B58071C00B1CBF6 /* MockNote.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2214,6 +2214,8 @@
 		CE37C04422984E81008DCB39 /* PickListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE37C04222984E81008DCB39 /* PickListTableViewCell.swift */; };
 		CE37C04522984E81008DCB39 /* PickListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE37C04322984E81008DCB39 /* PickListTableViewCell.xib */; };
 		CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */; };
+		CE49C4752CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */; };
+		CE49C4772CBEC8C300EA5C84 /* WooShipping_ShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */; };
 		CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */; };
 		CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
 		CE4ECA582BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4ECA572BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift */; };
@@ -5260,6 +5262,8 @@
 		CE37C04222984E81008DCB39 /* PickListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PickListTableViewCell.swift; sourceTree = "<group>"; };
 		CE37C04322984E81008DCB39 /* PickListTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PickListTableViewCell.xib; sourceTree = "<group>"; };
 		CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CNContact+Helpers.swift"; sourceTree = "<group>"; };
+		CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShipping_ShippingLineViewModel.swift; sourceTree = "<group>"; };
+		CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShipping_ShippingLineViewModelTests.swift; sourceTree = "<group>"; };
 		CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatterTests.swift; sourceTree = "<group>"; };
 		CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		CE4ECA572BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCAnalyticsStatsTotals+UI.swift"; sourceTree = "<group>"; };
@@ -11844,6 +11848,7 @@
 				CECEFA6B2CA2CE990071C7DB /* WooShipping Package and Rate Selection */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
 				CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */,
+				CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -11855,6 +11860,7 @@
 				CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */,
 				CEC3CC732C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift */,
 				CEC3CC7B2C94A06500B93FBE /* WooShippingItemsDataSourceTests.swift */,
+				CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -16217,6 +16223,7 @@
 				039B7E6529F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift in Sources */,
 				03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */,
 				DEF657A62C895AE900ACD61E /* BlazeCampaignObjectivePickerView.swift in Sources */,
+				CE49C4752CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift in Sources */,
 				029D025A2C2319FA00CB1E75 /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift in Sources */,
 				D449C52626DFBBDB00D75B02 /* WhatsNewFactory.swift in Sources */,
 				028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */,
@@ -16675,6 +16682,7 @@
 				453904F523BB8BD5007C4956 /* ProductTaxClassListSelectorDataSourceTests.swift in Sources */,
 				D85DD1E1257F376200861AA8 /* NotWPAccountViewModelTests.swift in Sources */,
 				020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */,
+				CE49C4772CBEC8C300EA5C84 /* WooShipping_ShippingLineViewModelTests.swift in Sources */,
 				DEF13C542963ED4E0024A02B /* PostSiteCredentialLoginCheckerTests.swift in Sources */,
 				EEC2D281292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import WooCommerce
-import Yosemite
+@testable import Networking
 
 final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_inits_with_expected_values() {
@@ -12,6 +12,31 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.markOrderComplete)
+    }
+
+    func test_site_address_converted_to_formatted_originAddress() {
+        // Given
+        let siteSettings = mapLoadGeneralSiteSettingsResponse()
+        let siteAddress = SiteAddress(siteSettings: siteSettings)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), siteAddress: siteAddress)
+
+        // Then
+        XCTAssertEqual("60 29th Street #343, Auburn NY 13021, US", viewModel.originAddress)
+    }
+
+    func test_order_shipping_address_converted_to_formatted_desinationAddressLines() {
+        // Given
+        let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
+        let order = Order.fake().copy(shippingAddress: address)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order)
+
+        // Then
+        let expectedAddressLines = [address.address1, "\(address.city) \(address.state) \(address.postcode)", address.country]
+        XCTAssertEqual(expectedAddressLines, viewModel.destinationAddressLines)
     }
 
     func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() {
@@ -46,5 +71,23 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(markOrderComplete)
+    }
+}
+
+private extension WooShippingCreateLabelsViewModelTests {
+    /// Returns the SiteSettings output upon receiving `filename` (Data Encoded)
+    ///
+    func mapGeneralSettings(from filename: String) -> [SiteSetting] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try! SiteSettingsMapper(siteID: 123, settingsGroup: SiteSettingGroup.general).map(response: response)
+    }
+
+    /// Returns the SiteSetting array as output upon receiving `settings-general`
+    ///
+    func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
+        return mapGeneralSettings(from: "settings-general")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -39,6 +39,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(expectedAddressLines, viewModel.destinationAddressLines)
     }
 
+    func test_order_shipping_lines_converted_to_shippingLineViewModels() {
+        // Given
+        let order = Order.fake().copy(shippingLines: [ShippingLine.fake().copy(shippingID: 1),
+                                                      ShippingLine.fake().copy(shippingID: 2),
+                                                      ShippingLine.fake().copy(shippingID: 3)])
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order)
+
+        // Then
+        XCTAssertEqual(order.shippingLines.map({ $0.shippingID }), viewModel.shippingLines.map({ $0.id }))
+    }
+
     func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() {
         // Given
         let order = Order.fake()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class WooShippingCreateLabelsViewModelTests: XCTestCase {
+    func test_inits_with_expected_values() {
+        // Given
+        let order = Order.fake()
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order)
+
+        // Then
+        XCTAssertFalse(viewModel.markOrderComplete)
+    }
+
+    func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() {
+        // Given
+        let order = Order.fake()
+
+        // When
+        let markOrderComplete: Bool = waitFor { promise in
+            let viewModel = WooShippingCreateLabelsViewModel(order: order, onLabelPurchase: { complete in
+                promise(complete)
+            })
+            viewModel.markOrderComplete = false
+            viewModel.purchaseLabel()
+        }
+
+        // Then
+        XCTAssertFalse(markOrderComplete)
+    }
+
+    func test_onLabelPurchase_notifies_when_order_should_be_marked_complete() {
+        // Given
+        let order = Order.fake()
+
+        // When
+        let markOrderComplete: Bool = waitFor { promise in
+            let viewModel = WooShippingCreateLabelsViewModel(order: order, onLabelPurchase: { complete in
+                promise(complete)
+            })
+            viewModel.markOrderComplete = true
+            viewModel.purchaseLabel()
+        }
+
+        // Then
+        XCTAssertTrue(markOrderComplete)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -26,6 +26,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
         // Then
         assertEqual("2 items", viewModel.itemsCountLabel)
+        assertEqual("$12.50", viewModel.itemsPriceLabel)
         assertEqual("7 oz • $12.50", viewModel.itemsDetailLabel)
         assertEqual(2, viewModel.itemRows.count)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -30,7 +30,19 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         assertEqual(2, viewModel.itemRows.count)
     }
 
-    func test_total_items_count_handles_items_with_quantity_greater_than_one() {
+    func test_total_items_count_label_handles_single_item() {
+        // Given
+        let items = [sampleItem(id: 1, weight: 1, value: 1, quantity: 1)]
+        let dataSource = MockDataSource(items: items)
+
+        // When
+        let viewModel = WooShippingItemsViewModel(dataSource: dataSource, currencySettings: currencySettings)
+
+        // Then
+        assertEqual("1 item", viewModel.itemsCountLabel)
+    }
+
+    func test_total_items_count_label_handles_items_with_quantity_greater_than_one() {
         // Given
         let items = [sampleItem(id: 1, weight: 1, value: 1, quantity: 1),
                      sampleItem(id: 2, weight: 1, value: 1, quantity: 2)]
@@ -43,7 +55,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         assertEqual("3 items", viewModel.itemsCountLabel)
     }
 
-    func test_total_items_details_handles_items_with_quantity_greater_than_one() {
+    func test_total_items_detail_label_handles_items_with_quantity_greater_than_one() {
         // Given
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
                      sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModelTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+import WooFoundation
+
+final class WooShipping_ShippingLineViewModelTests: XCTestCase {
+
+    private let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+    func test_it_inits_with_expected_values() {
+        // Given
+        let shippingLine = ShippingLine.fake().copy(shippingID: 123, methodTitle: "Flat Rate Shipping", total: "2.50")
+
+        // When
+        let viewModel = WooShipping_ShippingLineViewModel(shippingLine: shippingLine, currencyFormatter: currencyFormatter)
+
+        // Then
+        assertEqual(shippingLine.shippingID, viewModel.id)
+        assertEqual(shippingLine.methodTitle, viewModel.title)
+        assertEqual("$2.50", viewModel.formattedTotal)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14044
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the main view and view model for the new Woo Shipping label creation flow, to display actual shipment details in the bottom sheet. We now display real data for the following fields:

* Origin ("Ship from") address
* Destination ("Ship to") address
* Items total value
* Shipping lines (names and amounts)
* "Mark order as complete" toggle

The following behavior will be added in a later PR when these parts of the flow are supported:
* Showing the subtotal/total values for the label when that data (shipping rates) is set
* Activating the purchase button when the label is ready to purchase

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the `processing` status, at least one physical product, and at least one shipping line.
5. In the order details, select "Create Shipping Label."
6. On the shipping label creation screen, tap the "Shipment details" bottom sheet to expand it.
7. Confirm the shipment details contain the expected (real) values for the ship to/from addresses, total number and value of the order items, and shipping lines.
8. Tap the "Mark order as complete" toggle and confirm it can be toggled.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screenshot - iPhone 16 Pro - 2024-10-15 at 17 19 28](https://github.com/user-attachments/assets/46fd14e6-8421-4bc8-ac17-5d754c6e8036)|![Simulator Screenshot - iPhone 16 Pro - 2024-10-15 at 17 13 56](https://github.com/user-attachments/assets/4eaffa33-1af4-4242-8bf5-041981069f7c)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.