### PR TITLE
Enhance rounded corner and background design in Support Form and Custom Fields Editor

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -44,6 +44,7 @@ struct CustomFieldEditorView: View {
                         .overlay(
                             RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
                         )
+                        .cornerRadius(Layout.cornerRadius)
                 }
 
                 // Value Input
@@ -74,6 +75,7 @@ struct CustomFieldEditorView: View {
                         .overlay(
                             RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
                         )
+                        .cornerRadius(Layout.cornerRadius)
                     } else {
                         TextEditor(text: isReadOnlyValue ? .constant(value) : $value)
                             .foregroundColor(Color(.text))
@@ -84,6 +86,7 @@ struct CustomFieldEditorView: View {
                             .overlay(
                                 RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
                             )
+                            .cornerRadius(Layout.cornerRadius)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -108,6 +108,7 @@ struct SupportForm: View {
                             .overlay(
                                 RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
                             )
+                            .cornerRadius(Layout.cornerRadius)
                     }
 
                     // Site Address Text Field
@@ -124,6 +125,7 @@ struct SupportForm: View {
                             .overlay(
                                 RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
                             )
+                            .cornerRadius(Layout.cornerRadius)
                     }
 
                     // Description Text Editor
@@ -138,6 +140,7 @@ struct SupportForm: View {
                             .overlay(
                                 RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
                             )
+                            .cornerRadius(Layout.cornerRadius)
                     }
                 }
                 .padding()


### PR DESCRIPTION
Closes: #14028

## Description
This update enhances the user interface of specific elements by adding corner radius adjustments to ensure visual consistency across UI components. The changes ensure that background views have rounded corners to match the overlays, improving the overall aesthetic and user experience.

## Steps to reproduce
Check there is no background views in text field in both `CustomFieldEditorView` and `SupportForm`.

## Testing information
Tested that there are no background views in text field in both `CustomFieldEditorView` and `SupportForm`, in iOS 18 simulator (compiled with Xcode 16).

## Screenshots
| CustomFieldEditorView before             |  CustomFieldEditorView after |
:-------------------------:|:-------------------------:
<img width="134" alt="370223200-bf99f566-b73a-45d5-8451-fd7432f3a9ce" src="https://github.com/user-attachments/assets/ff0cab94-2b80-4fa1-9f8e-a6b092feb1c4"> |  ![Custom field Editor view](https://github.com/user-attachments/assets/770c95a1-7b3d-4f86-891b-866ee239c6a2)



| SupportForm before            |  SupportForm after |
:-------------------------:|:-------------------------:
<img width="438" alt="370272127-38616410-8add-4381-a5de-5abc70a55e1d" src="https://github.com/user-attachments/assets/4d7ceb8b-88b6-4fa4-879d-c438dcdfe386"> | ![Support form](https://github.com/user-attachments/assets/29a54311-fabe-4933-9b22-dc67e1300b9d)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
