### PR TITLE
My Store: added missing divider line above "View All store analytics" button in Top performers card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -53,6 +53,9 @@ struct TopPerformersDashboardView: View {
                     .redacted(reason: viewModel.periodViewModel.redacted.rows ? [.placeholder] : [])
                     .shimmering(active: viewModel.periodViewModel.redacted.rows)
 
+                Divider()
+                    .padding(.leading, Layout.padding)
+                
                 viewAllAnalyticsButton
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.periodViewModel.redacted.actionButton ? [.placeholder] : [])

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -55,7 +55,7 @@ struct TopPerformersDashboardView: View {
 
                 Divider()
                     .padding(.leading, Layout.padding)
-                
+
                 viewAllAnalyticsButton
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.periodViewModel.redacted.actionButton ? [.placeholder] : [])


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14042
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
The top performers card was shown without a divider line above the "View all store analytics" button. In comparison, the "Performance" card above it does have the line, as do the other cards. Added the missing separator.

## Steps to reproduce
The separator should appear on top of  "View All store analytics" button in Top performers card.

## Testing information
Tested that the separator now appear on top of  "View All store analytics" button in Top performers card on iOS 18 simulator, Xcode 16.


## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![2024-09-25 17 59 50](https://github.com/user-attachments/assets/c257c2ec-85c8-4c01-805b-174caf3f9e26) | ![Simulator Screenshot - iPhone 16 Pro - 2024-10-04 at 17 36 36](https://github.com/user-attachments/assets/81f4a3bb-367c-4044-9b9f-4657adfa2d76)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
