### PR TITLE
Fix Custom Fields Handling in Storage for both Orders and Products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 20.6
 -----
+- [**] Users can experience orders not loading or loading slowly if they have a large number of custom fields. This has been fixed now. [https://github.com/woocommerce/woocommerce-ios/pull/14110]
 - [*] Dashboard: Cards are now displayed in 2 columns on large screen sizes. [https://github.com/woocommerce/woocommerce-ios/pull/13983]
 - [*] Jetpack setup: fixed issue checking site info after activating Jetpack for sites with Jetpack connection package. [https://github.com/woocommerce/woocommerce-ios/pull/13993]
 - [*] Blaze: Campaign status is now updated immediately after being canceled. [https://github.com/woocommerce/woocommerce-ios/pull/13992]

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -307,7 +307,7 @@ struct OrdersUpsertUseCase {
         // Create a set of metadata IDs from the read-only order for quick lookup
         let readOnlyMetadataIDs = Set(readOnlyOrder.customFields.map { $0.metadataID })
 
-        // Remove any objects that exist in `storageOrder.customFields` but not in `readOnlyOrder.customFields`
+        // Remove any objects that exist in `storageOrder.customFields` regarding a specific order.
         storageOrder.customFields?.forEach { storageCustomField in
             storageOrder.removeFromCustomFields(storageCustomField)
             storage.deleteObject(storageCustomField)

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -309,19 +309,15 @@ struct OrdersUpsertUseCase {
 
         // Remove any objects that exist in `storageOrder.customFields` but not in `readOnlyOrder.customFields`
         storageOrder.customFields?.forEach { storageCustomField in
-            if !readOnlyMetadataIDs.contains(storageCustomField.metadataID) {
-                storageOrder.removeFromCustomFields(storageCustomField)
-                storage.deleteObject(storageCustomField)
-            }
+            storageOrder.removeFromCustomFields(storageCustomField)
+            storage.deleteObject(storageCustomField)
         }
 
-        var newStorageMetaDataArray: [Storage.MetaData] = []
-
-        // Upsert the `customFields` from the `readOnlyOrder`
-        readOnlyOrder.customFields.forEach { readOnlyCustomField in
+        // Create `customFields` objects from the `readOnlyOrder`
+        let newStorageMetaDataArray = readOnlyOrder.customFields.map { readOnlyCustomField in
             let newStorageMetaData = storage.insertNewObject(ofType: Storage.MetaData.self)
             newStorageMetaData.update(with: readOnlyCustomField)
-            newStorageMetaDataArray.append(newStorageMetaData)
+            return newStorageMetaData
         }
 
         // Batch writing process of multiple custom fields

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -304,8 +304,6 @@ struct OrdersUpsertUseCase {
     /// Updates, inserts, or prunes the provided `storageOrder`'s custom fields using the provided `readOnlyOrder`'s custom fields
     ///
     private func handleOrderCustomFields(_ readOnlyOrder: Networking.Order, _ storageOrder: Storage.Order, _ storage: StorageType) {
-        // Create a set of metadata IDs from the read-only order for quick lookup
-        let readOnlyMetadataIDs = Set(readOnlyOrder.customFields.map { $0.metadataID })
 
         // Remove any objects that exist in `storageOrder.customFields` regarding a specific order.
         storageOrder.customFields?.forEach { storageCustomField in

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1165,32 +1165,27 @@ extension ProductStore {
         // Create a set of metadata IDs from the read-only product for quick lookup
         let readOnlyMetadataIDs = Set(readOnlyProduct.customFields.map { $0.metadataID })
 
+        // Remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`
+                storageProduct.customFields?.forEach { storageCustomField in
+                    if !readOnlyMetadataIDs.contains(storageCustomField.metadataID) {
+                        storageProduct.removeFromCustomFields(storageCustomField)
+                        storage.deleteObject(storageCustomField)
+                    }
+                }
+        
         var newStorageMetaDataArray: [Storage.MetaData] = []
 
         // Upsert the `customFields` from the `readOnlyProduct`
         readOnlyProduct.customFields.forEach { readOnlyCustomField in
-            if let existingStorageMetaData = storage.loadProductMetaData(siteID: readOnlyProduct.siteID,
-                                                                         productID: storageProduct.productID,
-                                                                         metadataID: readOnlyCustomField.metadataID) {
-                existingStorageMetaData.update(with: readOnlyCustomField)
-            } else {
                 let newStorageMetaData = storage.insertNewObject(ofType: Storage.MetaData.self)
                 newStorageMetaData.update(with: readOnlyCustomField)
                 newStorageMetaDataArray.append(newStorageMetaData)
-            }
+            
         }
 
         // Batch writing process of multiple custom fields
         if !newStorageMetaDataArray.isEmpty {
             storageProduct.addToCustomFields(NSSet(array: newStorageMetaDataArray))
-        }
-
-        // Remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`
-        storageProduct.customFields?.forEach { storageCustomField in
-            if !readOnlyMetadataIDs.contains(storageCustomField.metadataID) {
-                storageProduct.removeFromCustomFields(storageCustomField)
-                storage.deleteObject(storageCustomField)
-            }
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1167,20 +1167,15 @@ extension ProductStore {
 
         // Remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`
         storageProduct.customFields?.forEach { storageCustomField in
-            if !readOnlyMetadataIDs.contains(storageCustomField.metadataID) {
-                storageProduct.removeFromCustomFields(storageCustomField)
-                storage.deleteObject(storageCustomField)
-            }
+            storageProduct.removeFromCustomFields(storageCustomField)
+            storage.deleteObject(storageCustomField)
         }
 
-        var newStorageMetaDataArray: [Storage.MetaData] = []
-
-        // Upsert the `customFields` from the `readOnlyProduct`
-        readOnlyProduct.customFields.forEach { readOnlyCustomField in
+        // Create `customFields` objects from the `readOnlyProduct`
+        let newStorageMetaDataArray = readOnlyProduct.customFields.map { readOnlyCustomField in
             let newStorageMetaData = storage.insertNewObject(ofType: Storage.MetaData.self)
             newStorageMetaData.update(with: readOnlyCustomField)
-            newStorageMetaDataArray.append(newStorageMetaData)
-
+            return newStorageMetaData
         }
 
         // Batch writing process of multiple custom fields

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1165,6 +1165,8 @@ extension ProductStore {
         // Create a set of metadata IDs from the read-only product for quick lookup
         let readOnlyMetadataIDs = Set(readOnlyProduct.customFields.map { $0.metadataID })
 
+        var newStorageMetaDataArray: [Storage.MetaData] = []
+
         // Upsert the `customFields` from the `readOnlyProduct`
         readOnlyProduct.customFields.forEach { readOnlyCustomField in
             if let existingStorageMetaData = storage.loadProductMetaData(siteID: readOnlyProduct.siteID,
@@ -1174,8 +1176,13 @@ extension ProductStore {
             } else {
                 let newStorageMetaData = storage.insertNewObject(ofType: Storage.MetaData.self)
                 newStorageMetaData.update(with: readOnlyCustomField)
-                storageProduct.addToCustomFields(newStorageMetaData)
+                newStorageMetaDataArray.append(newStorageMetaData)
             }
+        }
+
+        // Batch writing process of multiple custom fields
+        if !newStorageMetaDataArray.isEmpty {
+            storageProduct.addToCustomFields(NSSet(array: newStorageMetaDataArray))
         }
 
         // Remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1165,7 +1165,7 @@ extension ProductStore {
         // Create a set of metadata IDs from the read-only product for quick lookup
         let readOnlyMetadataIDs = Set(readOnlyProduct.customFields.map { $0.metadataID })
 
-        // Remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`
+        // Remove any objects that exist in `storageProduct.customFields` regarding a specific product.
         storageProduct.customFields?.forEach { storageCustomField in
             storageProduct.removeFromCustomFields(storageCustomField)
             storage.deleteObject(storageCustomField)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1162,8 +1162,6 @@ extension ProductStore {
     /// Updates, inserts, or prunes the provided `storageProduct`'s custom fields using the provided `readOnlyProduct`'s custom fields
     ///
     private func handleProductCustomFields(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
-        // Create a set of metadata IDs from the read-only product for quick lookup
-        let readOnlyMetadataIDs = Set(readOnlyProduct.customFields.map { $0.metadataID })
 
         // Remove any objects that exist in `storageProduct.customFields` regarding a specific product.
         storageProduct.customFields?.forEach { storageCustomField in

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1166,21 +1166,21 @@ extension ProductStore {
         let readOnlyMetadataIDs = Set(readOnlyProduct.customFields.map { $0.metadataID })
 
         // Remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`
-                storageProduct.customFields?.forEach { storageCustomField in
-                    if !readOnlyMetadataIDs.contains(storageCustomField.metadataID) {
-                        storageProduct.removeFromCustomFields(storageCustomField)
-                        storage.deleteObject(storageCustomField)
-                    }
-                }
-        
+        storageProduct.customFields?.forEach { storageCustomField in
+            if !readOnlyMetadataIDs.contains(storageCustomField.metadataID) {
+                storageProduct.removeFromCustomFields(storageCustomField)
+                storage.deleteObject(storageCustomField)
+            }
+        }
+
         var newStorageMetaDataArray: [Storage.MetaData] = []
 
         // Upsert the `customFields` from the `readOnlyProduct`
         readOnlyProduct.customFields.forEach { readOnlyCustomField in
-                let newStorageMetaData = storage.insertNewObject(ofType: Storage.MetaData.self)
-                newStorageMetaData.update(with: readOnlyCustomField)
-                newStorageMetaDataArray.append(newStorageMetaData)
-            
+            let newStorageMetaData = storage.insertNewObject(ofType: Storage.MetaData.self)
+            newStorageMetaData.update(with: readOnlyCustomField)
+            newStorageMetaDataArray.append(newStorageMetaData)
+
         }
 
         // Batch writing process of multiple custom fields

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1162,6 +1162,9 @@ extension ProductStore {
     /// Updates, inserts, or prunes the provided `storageProduct`'s custom fields using the provided `readOnlyProduct`'s custom fields
     ///
     private func handleProductCustomFields(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
+        // Create a set of metadata IDs from the read-only product for quick lookup
+        let readOnlyMetadataIDs = Set(readOnlyProduct.customFields.map { $0.metadataID })
+
         // Upsert the `customFields` from the `readOnlyProduct`
         readOnlyProduct.customFields.forEach { readOnlyCustomField in
             if let existingStorageMetaData = storage.loadProductMetaData(siteID: readOnlyProduct.siteID,
@@ -1175,9 +1178,9 @@ extension ProductStore {
             }
         }
 
-        // Now, remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`
+        // Remove any objects that exist in `storageProduct.customFields` but not in `readOnlyProduct.customFields`
         storageProduct.customFields?.forEach { storageCustomField in
-            if readOnlyProduct.customFields.first(where: { $0.metadataID == storageCustomField.metadataID } ) == nil {
+            if !readOnlyMetadataIDs.contains(storageCustomField.metadataID) {
                 storageProduct.removeFromCustomFields(storageCustomField)
                 storage.deleteObject(storageCustomField)
             }

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -276,7 +276,7 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         DispatchQueue.global(qos: .background).async {
             orderUseCase.upsert([order])
             productStore.upsertStoredProducts(readOnlyProducts: [product], in: backgroundContext)
-        backgroundContext.saveIfNeeded()
+            backgroundContext.saveIfNeeded()
         }
 
         // Then

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -261,7 +261,6 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         XCTAssertEqual(storageCustomField.toReadOnly(), customField)
     }
 
-
     func test_it_handles_large_number_of_custom_fields_for_order_and_product_without_deadlock_in_small_amount_of_time() throws {
         // Given
         let customFields = (1...2500).map { MetaData(metadataID: $0, key: "Key\($0)", value: "Value\($0)") }
@@ -281,7 +280,6 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         }
 
         // Then
-
         self.waitUntil {
             self.viewStorage.countObjects(ofType: Storage.MetaData.self) == 5000
         }

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -2,8 +2,7 @@ import XCTest
 
 import Fakes
 import Storage
-import Networking
-
+@testable import Networking
 @testable import Yosemite
 
 final class OrdersUpsertUseCaseTests: XCTestCase {
@@ -260,6 +259,32 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         // Then
         let storageCustomField = try XCTUnwrap(viewStorage.loadOrderMetaData(siteID: 3, orderID: order.orderID, metadataID: 1))
         XCTAssertEqual(storageCustomField.toReadOnly(), customField)
+    }
+
+
+    func test_it_handles_large_number_of_custom_fields_for_order_and_product_without_deadlock_in_small_amount_of_time() throws {
+        // Given
+        let customFields = (1...2500).map { MetaData(metadataID: $0, key: "Key\($0)", value: "Value\($0)") }
+        let order = makeOrder().copy(siteID: 3, orderID: 98, customFields: customFields)
+        let product = Product.fake().copy(siteID: 3, productID: 99, customFields: customFields)
+        let backgroundContext = storageManager.writerDerivedStorage
+        let orderUseCase = OrdersUpsertUseCase(storage: backgroundContext)
+        let dispatcher = Dispatcher()
+        let network = MockNetwork()
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        DispatchQueue.global(qos: .background).async {
+            orderUseCase.upsert([order])
+            productStore.upsertStoredProducts(readOnlyProducts: [product], in: backgroundContext)
+        backgroundContext.saveIfNeeded()
+        }
+
+        // Then
+
+        self.waitUntil {
+            self.viewStorage.countObjects(ofType: Storage.MetaData.self) == 5000
+        }
     }
 
     func test_it_persists_order_gift_card_in_storage() throws {


### PR DESCRIPTION
Closes #14106

## Description
It has been reported that for some users orders does not load peaMlT-Wz. It seems that this can happen when a store has a lot of custom fields for products, so upserting custom fields creates a deadlock on the writer context, delaying the syncing of orders for around 2 minutes.
This update optimizes the handling of custom fields in both `OrdersUpsertUseCase` and `ProductStore`. The changes improve performance by streamlining the logic for managing custom fields, introducing batch processing, and eliminating redundant operations.

## Summary of changes
- **OrdersUpsertUseCase**
  - Removed checks for the existence of custom fields in `storageOrder` that are not present in `readOnlyOrder`, directly removing them to simplify the logic.
  - Converted the creation of new custom fields from a loop with appends to a map for efficiency.
  - Implemented batch writing for new custom fields to reduce database calls.

- **ProductStore**
  - Improved readability and indentation for better code maintenance.
  - Simplified the logic for removing custom fields that are not in `readOnlyProduct` by directly using a set lookup.
  - Removed redundant operations for managing custom fields.
  - Introduced batch processing for adding new custom fields, thereby optimizing database interactions.

## Steps to reproduce
1. Login to a store with a lot of products and orders, with a lot of custom fields for each one (more than 100).
2. Notice that Order List is not loading, if not after a lot of time.
3. Make sure that in the product detail, the list of custom fields will be loaded correctly (cc @hafizrahman).

## Testing information
Tested that in a store with a lot of custom fields for products and orders, and everything loads properly.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
