### PR TITLE
[Payments] Update `OrderAction.markOrderAsPaidLocally` return type

### DIFF
--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -121,7 +121,7 @@ public enum OrderAction: Action {
     /// app to prevent from multiple charging for the same order after subsequent failures (e.g. Interac in Canada).
     /// Internally, the order is marked with a paid date and the order status is changed to processing.
     ///
-    case markOrderAsPaidLocally(siteID: Int64, orderID: Int64, datePaid: Date, onCompletion: (Result<Order, Error>) -> Void)
+    case markOrderAsPaidLocally(siteID: Int64, orderID: Int64, datePaid: Date, onCompletion: (Result<Void, Error>) -> Void)
 
     /// Deletes a given order.
     ///

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -537,7 +537,7 @@ private extension OrderStore {
     /// Updates an order to be considered as paid locally, for use cases where the payment is captured in the
     /// app to prevent from multiple charging for the same order after subsequent failures (e.g. Interac in Canada).
     ///
-    func markOrderAsPaidLocally(siteID: Int64, orderID: Int64, datePaid: Date, onCompletion: (Result<Order, Error>) -> Void) {
+    func markOrderAsPaidLocally(siteID: Int64, orderID: Int64, datePaid: Date, onCompletion: (Result<Void, Error>) -> Void) {
         let storage = storageManager.viewStorage
         guard let order = storage.loadOrder(siteID: siteID, orderID: orderID) else {
             return onCompletion(.failure(MarkOrderAsPaidLocallyError.orderNotFoundInStorage))
@@ -545,7 +545,7 @@ private extension OrderStore {
         order.datePaid = datePaid
         order.statusKey = OrderStatusEnum.processing.rawValue
         storage.saveIfNeeded()
-        onCompletion(.success(order.toReadOnly()))
+        onCompletion(.success(()))
     }
 
     /// Deletes a given order.


### PR DESCRIPTION
## Description
This PR modifies the result type of `OrderAction.markOrderAsPaidLocally` to return Void on success, rather than a copy of the Order.

## Why?

This was prompted from the latest iteration on [updating storage access and usage](https://github.com/woocommerce/woocommerce-ios/pull/14099#issuecomment-2401191367), where we found a consistent crash when processing Interac card-payment orders when marking them as paid locally. 

I've tried different approaches to resolve the threading issue without success, ultimately it would seem that we do not need to return a copy of the order on this method completion, as this is not really used anywhere. This resolves the crash entirely as there's no longer multi-threading access to storage when marking it as paid locally and unblocks the changes.

## Testing information
We're testing that the existing behaviour when collecting an Interac payment hasn't changed:

- You'll need a Canadian store, with WooCommerce Payments onboarding completed, and an WisePad 3 reader with an Interac card.
- Create an order with products, or simple payment
- Process the payment using the WisePad 3 and an Interac card
- Observe the order is completed and marked as paid normally.
- Repeat the process simulating a server-side processing error, for example using these testing steps here: https://github.com/woocommerce/woocommerce-ios/pull/6818
- Observe that the order is still completed and marked as paid normally.

Updated existing tests, but I haven't added any new one. This is covered both in `OrderStoreTests` and `CollectOrderPaymentUseCaseTests`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.