### PR TITLE
Fix issue with JSON parsing in Product AI creation

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -633,6 +633,7 @@
 		93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */; };
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
 		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
+		95122E3E2CB82C0A0079FF0A /* generate-product-success-wrapped.json in Resources */ = {isa = PBXBuildFile; fileRef = 95122E3D2CB82C0A0079FF0A /* generate-product-success-wrapped.json */; };
 		A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */; };
 		AE1950F3296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1950F2296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift */; };
 		AE2D6623272A8F6E004A2C3A /* TelemetryRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D6622272A8F6E004A2C3A /* TelemetryRemoteTests.swift */; };
@@ -1786,6 +1787,7 @@
 		93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsMapper.swift; sourceTree = "<group>"; };
 		93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings.json"; sourceTree = "<group>"; };
 		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
+		95122E3D2CB82C0A0079FF0A /* generate-product-success-wrapped.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "generate-product-success-wrapped.json"; sourceTree = "<group>"; };
 		9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-deleted-refunds.json"; sourceTree = "<group>"; };
 		AE1950F2296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsBulkUpdateMapper.swift; sourceTree = "<group>"; };
@@ -3466,6 +3468,7 @@
 				45B79AC52C9355F800DCCB2C /* meta-data-products-and-orders_nested_in_data.json */,
 				453954D12C90D84200A3E64A /* meta-data-products-and-orders.json */,
 				453954D52C9193BC00A3E64A /* meta-data-products-orders-update.json */,
+				95122E3D2CB82C0A0079FF0A /* generate-product-success-wrapped.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4582,6 +4585,7 @@
 				D865CE5B278CA10B002C8520 /* stripe-payment-intent-requires-payment-method.json in Resources */,
 				CC9A254626442CA7005DE56E /* shipping-label-eligibility-failure.json in Resources */,
 				DE78DE4E2B2BF0EA002E58DE /* product-subscription-alternative-types.json in Resources */,
+				95122E3E2CB82C0A0079FF0A /* generate-product-success-wrapped.json in Resources */,
 				4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */,
 				020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */,
 				3158FE7826129DF300E566B9 /* wcpay-account-restricted.json in Resources */,

--- a/Networking/Networking/Mapper/AIProductMapper.swift
+++ b/Networking/Networking/Mapper/AIProductMapper.swift
@@ -8,6 +8,10 @@ struct AIProductMapper: Mapper {
     func map(response: Data) throws -> AIProduct {
         let decoder = JSONDecoder()
         let textCompletion = try decoder.decode(JetpackAIQueryResponse.self, from: response).aiResponse()
+            // OpenAI sometimes returns the JSON response wrapped in a code block Markdown syntax, we remove it
+            // see: https://community.openai.com/t/why-do-some-responses-message-content-start-with-json/573289
+            .removingPrefix("```json")
+            .removingSuffix("```")
         return try decoder.decode(AIProduct.self, from: Data(textCompletion.utf8))
     }
 }

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -513,6 +513,28 @@ final class GenerativeContentRemoteTests: XCTestCase {
         XCTAssertEqual(product.price, "250")
     }
 
+    func test_generateAIProduct_with_wrapped_json_returns_AIProduct() async throws {
+        // Given
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-openai-query/jwt", filename: "jwt-token-success")
+        network.simulateResponse(requestUrlSuffix: "jetpack-ai-query", filename: "generate-product-success-wrapped")
+
+        // When
+        let product = try await remote.generateAIProduct(siteID: sampleSiteID,
+                                                         productName: "Cookie",
+                                                         keywords: "Crunchy, Crispy",
+                                                         language: "en",
+                                                         tone: "Casual",
+                                                         currencySymbol: "INR",
+                                                         dimensionUnit: "cm",
+                                                         weightUnit: "kg",
+                                                         categories: [ProductCategory.fake(), ProductCategory.fake()],
+                                                         tags: [ProductTag.fake(), ProductTag.fake()])
+
+        // Then
+        XCTAssertNotNil(product)
+    }
+
     func test_generateAIProduct_with_failure_returns_error() async throws {
         // Given
         let remote = GenerativeContentRemote(network: network)

--- a/Networking/NetworkingTests/Responses/generate-product-success-wrapped.json
+++ b/Networking/NetworkingTests/Responses/generate-product-success-wrapped.json
@@ -1,0 +1,23 @@
+{
+  "id": "chatcmpl-adfada",
+  "object": "chat.completion",
+  "created": 1719307068,
+  "model": "gpt-4o-2024-05-13",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "```json\n{\"names\":[\"Cookie\", \"Biscuits\", \"Crunchy Cookies Delight\"], \n\"descriptions\":[\"Introducing Cookie, the ultimate crunchy and crispy treat that will satisfy your snacking cravings. Made with the finest ingredients, these irresistible cookies are baked to perfection, delivering a delightful texture with every bite. Whether you're enjoying them with a cup of tea or sharing them with friends, Cookie is the go-to snack for any casual occasion. Indulge in the mouthwatering flavors and experience a taste sensation that will leave you wanting more. Get your hands on Cookie today and discover why it's the ultimate snack companion.\", \"Experience the ultimate crunchy delight with our premium crispy cookies. Perfectly baked to ensure every bite is packed with a satisfying crunch that will keep you coming back for more. These cookies are a great treat for any time of the day, whether you're enjoying them with a cup of coffee or as an after-meal dessert\", \"Our crispy cookies are crafted with the finest ingredients to deliver a superior crunch and taste. Each cookie is baked to a golden perfection, providing a uniquely satisfying munch that’s sure to please. A delicious snack that’s perfect for sharing and savoring every moment of crispy goodness.\"], \n\"short_descriptions\":[\"The ultimate crunchy and crispy treat that will satisfy your snacking cravings\", \"Made with the finest ingredients, these irresistible cookies are baked to perfection, delivering a delightful texture with every bite.\", \"Indulge in the mouthwatering flavors of Cookie today!\"], \n\"virtual\": false, \n\"shipping\":{\"length\":\"15\", \"weight\":\"0.2\", \"width\":\"10\", \"height\":\"5\"},\n\"tags\":[\"Food\"], \n\"price\":\"250\", \n\"categories\":[\"Biscuits\"]\n}\n```"
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 44,
+    "completion_tokens": 1,
+    "total_tokens": 45
+  },
+  "system_fingerprint": "adefavacda"
+}

--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -101,14 +101,6 @@ extension String {
 
         return Set(arrayOfTags)
     }
-
-    func removingSuffix(_ suffix: String) -> String {
-        guard hasSuffix(suffix) else {
-            return self
-        }
-
-        return String(self.dropLast(suffix.count))
-    }
 }
 
 #if !os(watchOS)

--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -101,6 +101,14 @@ extension String {
 
         return Set(arrayOfTags)
     }
+
+    func removingSuffix(_ suffix: String) -> String {
+        guard hasSuffix(suffix) else {
+            return self
+        }
+
+        return String(self.dropLast(suffix.count))
+    }
 }
 
 #if !os(watchOS)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14115 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds a fix to make sure JSON is parsed correctly even when OpenAI decides to wrap it in a Markdown code block, it just trims the `"```json"` and `"```"` parts from the response.

## Steps to reproduce
1. Use an atomic website.
2. Navigate to the products tab.
3. Tap on Add product button.
4. Select AI product creation.

## Testing information
- Confirm product creation works without issues.
- Check the unit test and confirm it does what it's supposed to do.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.