### PR TITLE
Core Data: Move write operations in CardPresentPaymentStore to the background

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [internal] Updated storage usage in OrderStore [https://github.com/woocommerce/woocommerce-ios/pull/14093, https://github.com/woocommerce/woocommerce-ios/pull/14099]
 - [internal] Updated storage usage in RefundStore [https://github.com/woocommerce/woocommerce-ios/pull/14124]
 - [internal] Updated storage usage in OrderStatusStore [https://github.com/woocommerce/woocommerce-ios/pull/14125]
+- [internal] Updated storage usage in CardPresentPaymentStore [https://github.com/woocommerce/woocommerce-ios/pull/14131]
 - [internal] Fixed formatted amount field visibility in Custom Amounts, Shipping, and Cash Payments [https://github.com/woocommerce/woocommerce-ios/pull/14030]
 
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -579,10 +579,9 @@ private extension CardPresentPaymentStore {
             /// Delete any account present. There can be only one.
             deleteStaleAccount(siteID: readonlyAccount.siteID, gatewayID: readonlyAccount.gatewayID, in: storage)
 
-            let storageAccount = storage.loadPaymentGatewayAccount(siteID: readonlyAccount.siteID, gatewayID: readonlyAccount.gatewayID) ??
-                storage.insertNewObject(ofType: Storage.PaymentGatewayAccount.self)
-
+            let storageAccount = storage.insertNewObject(ofType: Storage.PaymentGatewayAccount.self)
             storageAccount.update(with: readonlyAccount)
+
         }, completion: onCompletion, on: .main)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14130 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the work to improve our Core Data usage in the app by moving write operations `CardPresentPaymentStore` to the background. 

For more context: we want to handle all write operations in the background context, and save the changes to its parent - the persistent container. The view context would get merges directly from the persistent container, and should be used only for reading data. Writing to the view context causes performances issues, and changes made are not merged back to the background context causing data discrepancy.

The changes in this PR include:
- Updated loading payment gateway accounts (both Stripe and WCPay):
  - Moved `upsertStoredAccountInBackground` and `deleteStaleAccount` implementation to be handled in the background.
  - Updated `upsertStoredAccountInBackground` to always delete existing accounts and insert new ones. Previously, we attempted to fetch an existing account and update it after deleting existing accounts, which is redundant. 
 - Updated `upsertCharge` and `deleteCharge` to be handled in the background.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Testing account fetching:
- Log in to a test store set up for card present payments (with WCPay or Stripe).
- Navigate to the Settings tab and confirm that there are no longer warning for write operations in the main thread like `⚠️ Write operations for PaymentGatewayAccount should only be done on a background context` or `⚠️ Saving data should only be done on a background context`.
- Select Payments and confirm that payment accounts are loaded successfully.

Testing charge fetching:
- Log in to a test store set up for card present payments (with WCPay or Stripe).
- Create an order and collect payment using a card reader.
- Open the order details on the app and select Issue Refund.
- Confirm that in Xcode consoles there are no warnings about write operations for WCPayCharge and WCPayCardPresentPaymentDetails.
- Select an order item and update the amount to 1 and submit the refund. Confirm that the refund works correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.1 and confirmed that payment account loading and refund both work as expected.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

TODO: @itsmeichigo to update the release notes before merging

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
