### PR TITLE
[Shipping labels] Basic UI for shipping service (rate) with static data

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -18,7 +18,7 @@ struct WooShippingServiceCardView: View {
     @State private var signatureSelection: SignatureSelection = .none
 
     var body: some View {
-        HStack(alignment: .top, spacing: 16) {
+        HStack(alignment: .firstTextBaseline, spacing: 16) {
             if let carrierLogo {
                 Image(uiImage: carrierLogo)
                     .resizable()
@@ -26,9 +26,9 @@ struct WooShippingServiceCardView: View {
                     .frame(width: 20)
             }
             VStack(alignment: .leading) {
-                AdaptiveStack {
+                AdaptiveStack(horizontalAlignment: .leading) {
                     Text(title)
-                    Spacer()
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     Text(rate)
                         .bold()
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -141,8 +141,9 @@ struct WooShippingServiceCardView: View {
                                freePickupLabel: nil,
                                signatureRequiredLabel: nil,
                                adultSignatureRequiredLabel: nil)
+}
 
-
+#Preview {
     WooShippingServiceCardView(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
                                title: "USPS - Media Mail",
                                rate: "$7.63",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct WooShippingServiceCardView: View {
+    let carrierLogo: UIImage?
+    let title: String
+    let rate: String
+    let daysToDelivery: String
+    let extraInfo: String
+
+    var body: some View {
+        HStack(alignment: .top) {
+            if let carrierLogo {
+                Image(uiImage: carrierLogo)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 20)
+            }
+            VStack(alignment: .leading) {
+                AdaptiveStack {
+                    Text(title)
+                    Spacer()
+                    Text(rate)
+                        .bold()
+                }
+                Group {
+                    Text(daysToDelivery).bold() + Text("  •  ") + Text(extraInfo)
+                }
+                .font(.footnote)
+            }
+        }
+        .padding()
+        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+    }
+}
+
+#Preview {
+    WooShippingServiceCardView(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
+                               title: "USPS - Media Mail",
+                               rate: "$7.63",
+                               daysToDelivery: "7 business days",
+                               extraInfo: "Includes tracking, insurance (up to $100.00), free pickup")
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -63,11 +63,27 @@ struct WooShippingServiceCardView: View {
                                     selectionCircle(selected: signatureSelection == .signatureRequired)
                                     Text(signatureRequiredLabel)
                                 }
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    if signatureSelection == .signatureRequired {
+                                        signatureSelection = .none
+                                    } else {
+                                        signatureSelection = .signatureRequired
+                                    }
+                                }
                             }
                             if let adultSignatureRequiredLabel {
                                 HStack {
                                     selectionCircle(selected: signatureSelection == .adultSignatureRequired)
                                     Text(adultSignatureRequiredLabel)
+                                }
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    if signatureSelection == .adultSignatureRequired {
+                                        signatureSelection = .none
+                                    } else {
+                                        signatureSelection = .adultSignatureRequired
+                                    }
                                 }
                             }
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -7,6 +7,16 @@ struct WooShippingServiceCardView: View {
     let daysToDelivery: String
     let extraInfo: String
 
+    let trackingLabel: String?
+    let insuranceLabel: String?
+    let freePickupLabel: String?
+    let signatureRequiredLabel: String?
+    let adultSignatureRequiredLabel: String?
+
+    @State var isSelected: Bool = false
+
+    @State private var signatureSelection: SignatureSelection = .none
+
     var body: some View {
         HStack(alignment: .top) {
             if let carrierLogo {
@@ -22,14 +32,85 @@ struct WooShippingServiceCardView: View {
                     Text(rate)
                         .bold()
                 }
-                Group {
-                    Text(daysToDelivery).bold() + Text("  •  ") + Text(extraInfo)
+                if isSelected {
+                    VStack(alignment: .leading) {
+                        Text(daysToDelivery)
+                            .bold()
+                            .font(.footnote)
+                        Group {
+                            VStack(alignment: .leading, spacing: 0) {
+                                if let trackingLabel {
+                                    HStack {
+                                        checkmark
+                                        Text(trackingLabel)
+                                    }
+                                }
+                                if let insuranceLabel {
+                                    HStack {
+                                        checkmark
+                                        Text(insuranceLabel)
+                                    }
+                                }
+                                if let freePickupLabel {
+                                    HStack {
+                                        checkmark
+                                        Text(freePickupLabel)
+                                    }
+                                }
+                            }
+                            if let signatureRequiredLabel {
+                                HStack {
+                                    selectionCircle(selected: signatureSelection == .signatureRequired)
+                                    Text(signatureRequiredLabel)
+                                }
+                            }
+                            if let adultSignatureRequiredLabel {
+                                HStack {
+                                    selectionCircle(selected: signatureSelection == .adultSignatureRequired)
+                                    Text(adultSignatureRequiredLabel)
+                                }
+                            }
+                        }
+                        .font(.subheadline)
+                    }
+                } else {
+                    Group {
+                        Text(daysToDelivery).bold() + Text("  •  ") + Text(extraInfo)
+                    }
+                    .font(.footnote)
                 }
-                .font(.footnote)
             }
         }
         .padding()
-        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+        .if(isSelected) { card in
+            card.background(Color(.wooCommercePurple(.shade0)))
+        }
+        .roundedBorder(cornerRadius: 8, lineColor: isSelected ? Color(.primary) : Color(.separator), lineWidth: isSelected ? 2 : 1)
+    }
+
+    @ViewBuilder
+    private var checkmark: some View {
+        Image(uiImage: .checkmarkStyledImage)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 24)
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private func selectionCircle(selected: Bool) -> some View {
+        if selected {
+            Image(uiImage: .checkCircleImage.withRenderingMode(.alwaysTemplate))
+                .foregroundStyle(Color(.primary))
+        } else {
+            Image(uiImage: .checkEmptyCircleImage)
+        }
+    }
+
+    private enum SignatureSelection {
+        case none
+        case signatureRequired
+        case adultSignatureRequired
     }
 }
 
@@ -38,5 +119,23 @@ struct WooShippingServiceCardView: View {
                                title: "USPS - Media Mail",
                                rate: "$7.63",
                                daysToDelivery: "7 business days",
-                               extraInfo: "Includes tracking, insurance (up to $100.00), free pickup")
+                               extraInfo: "Includes tracking, insurance (up to $100.00), free pickup",
+                               trackingLabel: nil,
+                               insuranceLabel: nil,
+                               freePickupLabel: nil,
+                               signatureRequiredLabel: nil,
+                               adultSignatureRequiredLabel: nil)
+
+
+    WooShippingServiceCardView(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
+                               title: "USPS - Media Mail",
+                               rate: "$7.63",
+                               daysToDelivery: "7 business days",
+                               extraInfo: "Includes tracking, insurance (up to $100.00), free pickup",
+                               trackingLabel: "Tracking",
+                               insuranceLabel: "Insurance (up to $100.00)",
+                               freePickupLabel: "Free pickup",
+                               signatureRequiredLabel: "Signature Required (+$3.70)",
+                               adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)",
+                               isSelected: true)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -99,7 +99,7 @@ struct WooShippingServiceCardView: View {
         }
         .padding(16)
         .if(isSelected) { card in
-            card.background(Color(.wooCommercePurple(.shade0)))
+            card.background { Color(.wooCommercePurple(.shade0)) }
         }
         .roundedBorder(cornerRadius: 8, lineColor: isSelected ? Color(.primary) : Color(.separator), lineWidth: isSelected ? 2 : 1)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -18,7 +18,7 @@ struct WooShippingServiceCardView: View {
     @State private var signatureSelection: SignatureSelection = .none
 
     var body: some View {
-        HStack(alignment: .top) {
+        HStack(alignment: .top, spacing: 16) {
             if let carrierLogo {
                 Image(uiImage: carrierLogo)
                     .resizable()
@@ -97,7 +97,7 @@ struct WooShippingServiceCardView: View {
                 }
             }
         }
-        .padding()
+        .padding(16)
         .if(isSelected) { card in
             card.background(Color(.wooCommercePurple(.shade0)))
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -2,8 +2,18 @@ import SwiftUI
 
 struct WooShippingServiceView: View {
     var body: some View {
-        Text(Localization.shippingService)
-            .headlineStyle()
+        VStack(alignment: .leading) {
+            HStack {
+                Text(Localization.shippingService)
+                    .headlineStyle()
+                Spacer()
+            }
+            WooShippingServiceCardView(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
+                                       title: "USPS - Media Mail",
+                                       rate: "$7.63",
+                                       daysToDelivery: "7 business days",
+                                       extraInfo: "Includes tracking, insurance (up to $100.00), free pickup")
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -12,7 +12,12 @@ struct WooShippingServiceView: View {
                                        title: "USPS - Media Mail",
                                        rate: "$7.63",
                                        daysToDelivery: "7 business days",
-                                       extraInfo: "Includes tracking, insurance (up to $100.00), free pickup")
+                                       extraInfo: "Includes tracking, insurance (up to $100.00), free pickup",
+                                       trackingLabel: "Tracking",
+                                       insuranceLabel: "Insurance (up to $100.00)",
+                                       freePickupLabel: "Free pickup",
+                                       signatureRequiredLabel: "Signature Required (+$3.70)",
+                                       adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct WooShippingServiceView: View {
+    var body: some View {
+        Text(Localization.shippingService)
+            .headlineStyle()
+    }
+}
+
+private extension WooShippingServiceView {
+    enum Localization {
+        static let shippingService = NSLocalizedString("wooShipping.createLabels.rates.shippingService",
+                                                       value: "Shipping service",
+                                                       comment: "Heading for the shipping service section in the shipping label creation screen.")
+    }
+}
+
+#Preview {
+    WooShippingServiceView()
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2204,6 +2204,7 @@
 		CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FC723C3D2D4002BEC1C /* RefundedProductsDataSource.swift */; };
 		CE2A9FCF23C4F2C8002BEC1C /* RefundedProductsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE2A9FCD23C4F2C8002BEC1C /* RefundedProductsViewController.xib */; };
 		CE2A9FD023C4F2C8002BEC1C /* RefundedProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */; };
+		CE2DF92C2CC162EB001AA394 /* WooShippingServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */; };
 		CE32B10B20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */; };
 		CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */; };
 		CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */; };
@@ -5252,6 +5253,7 @@
 		CE2A9FC723C3D2D4002BEC1C /* RefundedProductsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundedProductsDataSource.swift; sourceTree = "<group>"; };
 		CE2A9FCD23C4F2C8002BEC1C /* RefundedProductsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RefundedProductsViewController.xib; sourceTree = "<group>"; };
 		CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefundedProductsViewController.swift; sourceTree = "<group>"; };
+		CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceView.swift; sourceTree = "<group>"; };
 		CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnSectionHeaderView.xib; sourceTree = "<group>"; };
 		CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnSectionHeaderView.swift; sourceTree = "<group>"; };
 		CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
@@ -11905,6 +11907,7 @@
 			children = (
 				CECEFA6C2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift */,
 				DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */,
+				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
 			);
 			path = "WooShipping Package and Rate Selection";
 			sourceTree = "<group>";
@@ -15721,6 +15724,7 @@
 				DEC6C51C27477890006832D3 /* JCPJetpackInstallStepsView.swift in Sources */,
 				E15FC74526BC213500CF83E6 /* InPersonPaymentsLearnMore.swift in Sources */,
 				D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */,
+				CE2DF92C2CC162EB001AA394 /* WooShippingServiceView.swift in Sources */,
 				68D8FBD12BFEF9C700477C42 /* TotalsView.swift in Sources */,
 				E1ABAEF728479E0300F40BB2 /* InPersonPaymentsSelectPluginView.swift in Sources */,
 				207823E52C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2205,6 +2205,7 @@
 		CE2A9FCF23C4F2C8002BEC1C /* RefundedProductsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE2A9FCD23C4F2C8002BEC1C /* RefundedProductsViewController.xib */; };
 		CE2A9FD023C4F2C8002BEC1C /* RefundedProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */; };
 		CE2DF92C2CC162EB001AA394 /* WooShippingServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */; };
+		CE2DF92E2CC16C95001AA394 /* WooShippingServiceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */; };
 		CE32B10B20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */; };
 		CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */; };
 		CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */; };
@@ -5254,6 +5255,7 @@
 		CE2A9FCD23C4F2C8002BEC1C /* RefundedProductsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RefundedProductsViewController.xib; sourceTree = "<group>"; };
 		CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefundedProductsViewController.swift; sourceTree = "<group>"; };
 		CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceView.swift; sourceTree = "<group>"; };
+		CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceCardView.swift; sourceTree = "<group>"; };
 		CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnSectionHeaderView.xib; sourceTree = "<group>"; };
 		CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnSectionHeaderView.swift; sourceTree = "<group>"; };
 		CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
@@ -11908,6 +11910,7 @@
 				CECEFA6C2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift */,
 				DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */,
 				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
+				CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */,
 			);
 			path = "WooShipping Package and Rate Selection";
 			sourceTree = "<group>";
@@ -15465,6 +15468,7 @@
 				02C37B7B2967096800F0CF9E /* DomainSettingsView.swift in Sources */,
 				CC4B252B27CFCEE2008D2E6E /* OrderTotalsCalculator.swift in Sources */,
 				8625C5112BF20990007F1901 /* ReviewsDashboardCard.swift in Sources */,
+				CE2DF92E2CC16C95001AA394 /* WooShippingServiceCardView.swift in Sources */,
 				0247F512286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift in Sources */,
 				202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14140
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This is the basic UI for a shipping service (rate) in the new Woo Shipping label creation flow. It uses static data for now to introduce a shipping service section with a card showing the information for a single rate.

### How

* Adds `WooShippingServiceCardView` with the UI for an unselected and selected card.
* Adds `WooShippingServiceView`, which for now only includes a heading and a card with static data.

A future PR will add a view model to handle dynamic data for this new card, and unit testing for the view model logic. Note that for now these views aren't used in the app, so they can be previewed with the SwiftUI preview in Xcode.

## Testing information

The following UI scenarios have been tested to confirm the layout works as expected:

- [x] Dark mode
- [x] Landscape orientation
- [x] Dynamic text
- [x] RTL language

Since this UI isn't yet used in the app, the SwiftUI previews can be used for testing.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Design

![image](https://github.com/user-attachments/assets/dda1e9d0-8bfb-4461-b731-b292f378e74b)

### Actual

WooShippingServiceView with an unselected card:

![Screenshot 2024-10-17 at 18 23 54](https://github.com/user-attachments/assets/3ba5ca88-9c45-464a-9952-9f967f9245de)

WooShippingServiceCardView:

Unselected|Selected
-|-
![Screenshot 2024-10-18 at 12 05 09](https://github.com/user-attachments/assets/6b3b87fd-d272-4f14-b60b-135d8ec39847)|![Screenshot 2024-10-18 at 12 05 31](https://github.com/user-attachments/assets/b1e1f949-9a97-47a4-8357-c51d3875672c)
![Screenshot 2024-10-18 at 12 15 44](https://github.com/user-attachments/assets/0099a3b4-aca9-43b3-8499-ba31378bc272)|![Screenshot 2024-10-18 at 12 16 08](https://github.com/user-attachments/assets/fefb2afe-f370-48de-9c55-763f8974b377)
![Screenshot 2024-10-18 at 12 17 29](https://github.com/user-attachments/assets/93e758a7-903d-44b2-b9f6-a585c3452d06)|![Screenshot 2024-10-18 at 12 17 47](https://github.com/user-attachments/assets/879c1826-d427-4cd1-8c2f-1c92a355a26a)
![Screenshot 2024-10-18 at 12 22 53](https://github.com/user-attachments/assets/b9160267-307f-419f-8728-535e7cb0d1b2)|![Screenshot 2024-10-18 at 12 23 26](https://github.com/user-attachments/assets/2f49839c-a090-455e-a245-51ab3eb46361)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.