### PR TITLE
[Woo POS - payments onboarding] Enable POS for stores with incomplete payments onboarding

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -86,6 +86,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .favoriteProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .paymentsOnboardingInPointOfSale:
+            return buildConfig == .localDeveloper
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -188,4 +188,8 @@ public enum FeatureFlag: Int {
     /// Allows marking product as favorite
     ///
     case favoriteProducts
+
+    /// Supports Woo Payments onboarding in POS so that merchants who have not completed onboarding can access POS.
+    ///
+    case paymentsOnboardingInPointOfSale
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -311,7 +311,6 @@ private extension TotalsViewModel {
     }
 
     func observeCardPresentPaymentEvents() {
-
         cardPresentPaymentService.paymentEventPublisher
             .map { [weak self] event -> PointOfSaleCardPresentPaymentAlertType? in
                 guard let self else { return nil }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -20,7 +20,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         case cardPaymentSuccessful
     }
 
-    @Published private(set) var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
     @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
     @Published private(set) var isShowingCardReaderStatus: Bool = false
@@ -88,7 +87,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     var orderStatePublisher: Published<OrderState>.Publisher { $orderState }
     var paymentStatePublisher: Published<PaymentState>.Publisher { $paymentState }
     private var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { $cardPresentPaymentAlertViewModel }
-    private var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { $cardPresentPaymentEvent }
     private var connectionStatusPublisher: Published<CardPresentPaymentReaderConnectionStatus>.Publisher { $connectionStatus }
     private var formattedCartTotalPricePublisher: Published<String?>.Publisher { $formattedCartTotalPrice }
     private var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }
@@ -313,7 +311,6 @@ private extension TotalsViewModel {
     }
 
     func observeCardPresentPaymentEvents() {
-        cardPresentPaymentService.paymentEventPublisher.assign(to: &$cardPresentPaymentEvent)
 
         cardPresentPaymentService.paymentEventPublisher
             .map { [weak self] event -> PointOfSaleCardPresentPaymentAlertType? in

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -4,7 +4,6 @@ import protocol Yosemite.POSItem
 
 protocol TotalsViewModelProtocol {
     var paymentState: TotalsViewModel.PaymentState { get }
-    var cardPresentPaymentEvent: CardPresentPaymentEvent { get }
     var connectionStatus: CardPresentPaymentReaderConnectionStatus { get }
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { get }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
@@ -32,7 +32,6 @@ final class CardPresentPaymentsOnboardingViewController: UIHostingController<Car
 
 struct CardPresentPaymentsOnboardingView: View {
     @StateObject var viewModel: CardPresentPaymentsOnboardingViewModel
-    var shouldShowMenuOnCompletion: Bool = true
 
     var body: some View {
         Group {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -24,8 +24,13 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
                 .eraseToAnyPublisher()
         }
 
-        return Publishers.CombineLatest3(isOnboardingComplete, isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled)
-            .map { $0 && $1 && $2 }
+        guard featureFlagService.isFeatureFlagEnabled(.paymentsOnboardingInPointOfSale) else {
+            return Publishers.CombineLatest3(isOnboardingComplete, isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled)
+                .map { $0 && $1 && $2 }
+                .eraseToAnyPublisher()
+        }
+        return Publishers.CombineLatest(isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled)
+            .map { $0 && $1 }
             .eraseToAnyPublisher()
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,6 +22,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let revampedShippingLabelCreation: Bool
     private let viewEditCustomFieldsInProductsAndOrders: Bool
     private let favoriteProducts: Bool
+    private let paymentsOnboardingInPointOfSale: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -42,7 +43,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          blazeCampaignObjective: Bool = false,
          revampedShippingLabelCreation: Bool = false,
          viewEditCustomFieldsInProductsAndOrders: Bool = false,
-         favoriteProducts: Bool = false) {
+         favoriteProducts: Bool = false,
+         paymentsOnboardingInPointOfSale: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -63,6 +65,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.revampedShippingLabelCreation = revampedShippingLabelCreation
         self.viewEditCustomFieldsInProductsAndOrders = viewEditCustomFieldsInProductsAndOrders
         self.favoriteProducts = favoriteProducts
+        self.paymentsOnboardingInPointOfSale = paymentsOnboardingInPointOfSale
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -107,6 +110,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return viewEditCustomFieldsInProductsAndOrders
         case .favoriteProducts:
             return favoriteProducts
+        case .paymentsOnboardingInPointOfSale:
+            return paymentsOnboardingInPointOfSale
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -192,6 +192,26 @@ final class POSEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
+    func test_is_eligible_when_onboarding_state_is_not_completed_and_onboarding_feature_enabled_then_returns_true() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true, paymentsOnboardingInPointOfSale: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                            cardPresentPaymentsOnboarding: onboardingUseCase,
+                                            siteSettings: siteSettings,
+                                            currencySettings: Fixtures.usdCurrencySettings,
+                                            stores: stores,
+                                            featureFlagService: featureFlagService)
+        checker.isEligible.assign(to: &$isEligible)
+
+        // When
+        onboardingUseCase.state = .pluginNotInstalled
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
     func test_is_eligible_when_WooCommerce_version_is_below_6_6_then_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14147 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As in the project kickoff pdfdoF-5Bo-p2, I'm starting the project by adding a feature flag and enabling POS for stores with incomplete payments onboarding state behind the feature flag. I decided to add a feature flag so that it doesn't break the Installable Builds (used for Woo DM demo, if some people on the team try updating the app version) and the work is minimal.

## How

- A feature flag was added `paymentsOnboardingInPointOfSale`, this will be removed when the project is completed
- In `POSEligibilityChecker`, the onboarding completed state condition is removed when the onboardingfeature flag is enabled
- A test case was added for the `POSEligibilityChecker` changes

There are also two small commits at the beginning where I removed unused properties while I was looking into the code. Unused code could be confusing during code search and removing it would reduce the time spent searching for its usage.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Stores with onboarding completed

Prerequisite: the store is eligible for POS (US store, USD, WC v6.6+), and payments onboarding is completed (in Menu > Payments, no `Continue setup` banner is shown at the bottom)

* Launch app
* Go to Menu --> `Point of Sale Mode` row should appear as before
* Tap on `Point of Sale Mode`
* Tap `Connect your reader` --> connection flow should work as before

### Stores with incomplete onboarding

Prerequisite: the store is eligible for POS (US store, USD, WC v6.6+), but payments onboarding is not completed (in Menu > Payments, `Continue setup` banner is shown at the bottom, or not using Woo Payments)

* Launch app
* Go to Menu --> `Point of Sale Mode` row should appear (it shouldn't appear when the feature flag is off)
* Tap on `Point of Sale Mode`
* Tap `Connect your reader` --> no-op for now, onboarding UI will be integrated in https://github.com/woocommerce/woocommerce-ios/issues/14148

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested on iPad Pro 11in (M4) iOS 17.5 simulator with Xcode 16.
- [x] @jaclync tests when the feature flag is off, POS remains hidden for stores without completed onboarding

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/48bcaeaa-3976-4697-bdc4-2dcfd11581a6



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.