### PR TITLE
Custom Fields: Update navigation behavior for list and editor screens.

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -482,22 +482,19 @@ extension OrderDetailsViewModel {
             viewController.navigationController?.pushViewController(billingInformationViewController, animated: true)
         case .customFields:
             ServiceLocator.analytics.track(.orderViewCustomFieldsTapped)
+
             let customFields = order.customFields.map {
                 CustomFieldViewModel(metadata: $0)
             }
-            let customFieldsView = UIHostingController(
-                rootView: CustomFieldsListView(
-                    isEditable: featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders),
-                    viewModel: CustomFieldsListViewModel(customFields: customFields),
-                    onBackButtonTapped: {
-                    // Restore the hidden navigation bar
-                    viewController.navigationController?.setNavigationBarHidden(false, animated: false)
-                })
-            )
 
-            // Hide the navigation bar as `CustomFieldsListView` will create its own toolbar.
-            viewController.navigationController?.setNavigationBarHidden(true, animated: false)
-            viewController.navigationController?.pushViewController(customFieldsView, animated: true)
+            let isEditable = featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders)
+            let viewModel = CustomFieldsListViewModel(customFields: customFields)
+
+            let customFieldsListViewController = CustomFieldsListHostingController(isEditable: isEditable,
+                                                                                   viewModel: viewModel)
+
+            viewController.navigationController?.pushViewController(customFieldsListViewController, animated: true)
+
         case .seeReceipt:
             let countryCode = configurationLoader.configuration.countryCode
             ServiceLocator.analytics.track(event: .InPersonPayments.receiptViewTapped(countryCode: countryCode, source: .backend))

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -99,11 +99,11 @@ struct CustomFieldEditorView: View {
         }
         .background(Color(.listBackground))
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
+            ToolbarItem(placement: .cancellationAction) {
                 Button {
                     dismiss()
                 } label: {
-                    Text("Cancel") // todo-13493: set String to be translatable
+                    Text(Localization.cancelButton)
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -112,7 +112,7 @@ struct CustomFieldEditorView: View {
                         saveChanges()
                         dismiss()
                     } label: {
-                        Text("Save") // todo-13493: set String to be translatable
+                        Text(Localization.saveButton)
                     }
                     .disabled(!hasUnsavedChanges)
 
@@ -163,6 +163,18 @@ private extension CustomFieldEditorView {
     }
 
     enum Localization {
+        static let cancelButton = NSLocalizedString(
+            "customFieldEditorView.cancel",
+            value: "Cancel",
+            comment: "Label for the Cancel button to close the editor"
+        )
+
+        static let saveButton = NSLocalizedString(
+            "customFieldEditorView.save",
+            value: "Save",
+            comment: "Label for the Save button to save changes"
+        )
+
         static let keyLabel = NSLocalizedString(
             "customFieldEditorView.keyLabel",
             value: "Key",

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -98,6 +98,13 @@ struct CustomFieldEditorView: View {
         }
         .background(Color(.listBackground))
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Text("Cancel") // todo-13493: set String to be translatable
+                }
+            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack {
                     Button {

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct CustomFieldEditorView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) private var dismiss
+
     @State private var key: String
     @State private var value: String
     @State private var showRichTextEditor = false
@@ -100,7 +101,7 @@ struct CustomFieldEditorView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button {
-                    presentationMode.wrappedValue.dismiss()
+                    dismiss()
                 } label: {
                     Text("Cancel") // todo-13493: set String to be translatable
                 }
@@ -109,7 +110,7 @@ struct CustomFieldEditorView: View {
                 HStack {
                     Button {
                         saveChanges()
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                     } label: {
                         Text("Save") // todo-13493: set String to be translatable
                     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -83,10 +83,18 @@ struct CustomFieldsListView: View {
         }
         .listStyle(.plain)
         .sheet(item: $viewModel.selectedCustomField, content: { customField in
-            CustomFieldEditorView(key: customField.key, value: customField.value, onSave: { _,_ in })
+            CustomFieldEditorView(key: customField.key,
+                                  value: customField.value,
+                                  onSave: { updatedKey, updatedValue in
+                viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: customField.fieldId)
+            })
         })
         .sheet(isPresented: $viewModel.isAddingNewField) {
-            CustomFieldEditorView(key: "", value: "", onSave: { _,_ in })
+            CustomFieldEditorView(key: "",
+                                  value: "",
+                                  onSave: { updatedKey, updatedValue in
+                viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: nil)
+            })
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -187,7 +187,7 @@ private extension CustomFieldsListHostingController {
 
         static let accessibilityHintAddCustomField = NSLocalizedString(
             "customFieldsListHostingController.accessibilityHintAddCustomField",
-            value: "Add a new Custom FIeld to the list",
+            value: "Add a new custom field to the list",
             comment: "VoiceOver accessibility hint, informing the user the button can be used to add custom field.")
 
         static let save = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -83,18 +83,22 @@ struct CustomFieldsListView: View {
         }
         .listStyle(.plain)
         .sheet(item: $viewModel.selectedCustomField, content: { customField in
-            CustomFieldEditorView(key: customField.key,
-                                  value: customField.value,
-                                  onSave: { updatedKey, updatedValue in
-                viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: customField.fieldId)
-            })
+            NavigationView {
+                CustomFieldEditorView(key: customField.key,
+                                      value: customField.value,
+                                      onSave: { updatedKey, updatedValue in
+                    viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: customField.fieldId)
+                })
+            }
         })
         .sheet(isPresented: $viewModel.isAddingNewField) {
-            CustomFieldEditorView(key: "",
-                                  value: "",
-                                  onSave: { updatedKey, updatedValue in
-                viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: nil)
-            })
+            NavigationView {
+                CustomFieldEditorView(key: "",
+                                      value: "",
+                                      onSave: { updatedKey, updatedValue in
+                    viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: nil)
+                })
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -31,6 +31,14 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
         return button
     }()
 
+    /// Create a `UIBarButtonItem` to be used as the save custom field button on the top-right.
+    ///
+    private lazy var saveCustomFieldButtonItem =
+        UIBarButtonItem(title: Localization.save,
+                        style: .plain,
+                        target: self,
+                        action: #selector(saveCustomField))
+
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -39,11 +47,16 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
 private extension CustomFieldsListHostingController {
     func configureNavigation() {
         title = Localization.title
-        navigationItem.rightBarButtonItems = [addCustomFieldButtonItem]
+        navigationItem.rightBarButtonItems = [saveCustomFieldButtonItem, addCustomFieldButtonItem]
     }
 
     @objc func openAddCustomFieldScreen() {
         viewModel.isAddingNewField = true
+    }
+
+    @objc func saveCustomField() {
+        // todo: call viewmodel's save function
+        navigationController?.popViewController(animated: true)
     }
 }
 
@@ -154,6 +167,10 @@ private extension CustomFieldsListHostingController {
             value: "Add a new Custom FIeld to the list",
             comment: "VoiceOver accessibility hint, informing the user the button can be used to add custom field.")
 
+        static let save = NSLocalizedString(
+            "customFieldsListHostingController.save",
+            value: "Save",
+            comment: "Button to save the changes on Custom Fields list")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -7,8 +7,20 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
         )
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigation()
+    }
+
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension CustomFieldsListHostingController {
+    func configureNavigation() {
+        title = Localization.title
     }
 }
 
@@ -99,9 +111,12 @@ private struct CustomFieldRow: View {
 
 // MARK: - Constants
 //
-extension CustomFieldsListView {
+private extension CustomFieldsListHostingController {
     enum Localization {
-        static let title = NSLocalizedString("Custom Fields", comment: "Title for the order custom fields list")
+        static let title = NSLocalizedString(
+            "customFieldsListHostingController.title",
+            value: "Custom Fields",
+            comment: "Title for the order custom fields list")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -93,23 +93,11 @@ struct CustomFieldsListView: View {
             }
         }
         .listStyle(.plain)
-        .sheet(item: $viewModel.selectedCustomField, content: { customField in
-            NavigationView {
-                CustomFieldEditorView(key: customField.key,
-                                      value: customField.value,
-                                      onSave: { updatedKey, updatedValue in
-                    viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: customField.fieldId)
-                })
-            }
-        })
+        .sheet(item: $viewModel.selectedCustomField) { customField in
+            buildCustomFieldEditorView(customField: customField)
+        }
         .sheet(isPresented: $viewModel.isAddingNewField) {
-            NavigationView {
-                CustomFieldEditorView(key: "",
-                                      value: "",
-                                      onSave: { updatedKey, updatedValue in
-                    viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: nil)
-                })
-            }
+            buildCustomFieldEditorView(customField: nil)
         }
     }
 }
@@ -170,6 +158,28 @@ private struct CustomFieldRow: View {
     }
 }
 
+// MARK: - Helpers
+//
+private extension CustomFieldsListView {
+    /// Builds the Custom Field Editor View.
+    /// - When `customField` is provided, it configures the editor for editing an existing field
+    /// - When `customField` is nil, it configures the editor for creating a new field
+    func buildCustomFieldEditorView(customField: CustomFieldsListViewModel.CustomFieldUI?) -> some View {
+        NavigationView {
+            CustomFieldEditorView(
+                key: customField?.key ?? "",
+                value: customField?.value ?? "",
+                onSave: { updatedKey, updatedValue in
+                    viewModel.saveField(
+                        key: updatedKey,
+                        value: updatedValue,
+                        fieldId: customField?.fieldId
+                    )
+                }
+            )
+        }
+    }
+}
 
 // MARK: - Constants
 //

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -1,7 +1,9 @@
+import Combine
 import SwiftUI
 
 final class CustomFieldsListHostingController: UIHostingController<CustomFieldsListView> {
     private let viewModel: CustomFieldsListViewModel
+    private var subscriptions: Set<AnyCancellable> = []
 
     init(isEditable: Bool, viewModel: CustomFieldsListViewModel) {
         self.viewModel = viewModel
@@ -14,6 +16,7 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
         super.viewDidLoad()
 
         configureNavigation()
+        observeStateChange()
     }
 
     /// Create a `UIBarButtonItem` to be used as the add custom field button on the top-right.
@@ -57,6 +60,14 @@ private extension CustomFieldsListHostingController {
     @objc func saveCustomField() {
         // todo: call viewmodel's save function
         navigationController?.popViewController(animated: true)
+    }
+
+    func observeStateChange() {
+        viewModel.$hasChanges
+            .sink { [weak self] hasChanges in
+                self?.saveCustomFieldButtonItem.isEnabled = hasChanges
+            }
+            .store(in: &subscriptions)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -1,18 +1,27 @@
 import SwiftUI
 
+final class CustomFieldsListHostingController: UIHostingController<CustomFieldsListView> {
+    init(isEditable: Bool, viewModel: CustomFieldsListViewModel) {
+        super.init(rootView: CustomFieldsListView(isEditable: isEditable,
+                                                  viewModel: viewModel)
+        )
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 struct CustomFieldsListView: View {
     @Environment(\.presentationMode) var presentationMode
     @ObservedObject private var viewModel: CustomFieldsListViewModel
 
     let isEditable: Bool
-    let onBackButtonTapped: () -> Void
 
     init(isEditable: Bool,
-         viewModel: CustomFieldsListViewModel,
-         onBackButtonTapped: @escaping () -> Void) {
+         viewModel: CustomFieldsListViewModel) {
         self.isEditable = isEditable
         self.viewModel = viewModel
-        self.onBackButtonTapped = onBackButtonTapped
     }
 
     var body: some View {
@@ -114,9 +123,7 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
                 customFields: [
                     CustomFieldViewModel(id: 0, title: "First Title", content: "First Content"),
                     CustomFieldViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
-                ]),
-            onBackButtonTapped: { }
-            )
+                ]))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
 final class CustomFieldsListHostingController: UIHostingController<CustomFieldsListView> {
+    private let viewModel: CustomFieldsListViewModel
+
     init(isEditable: Bool, viewModel: CustomFieldsListViewModel) {
+        self.viewModel = viewModel
         super.init(rootView: CustomFieldsListView(isEditable: isEditable,
                                                   viewModel: viewModel)
         )
@@ -13,6 +16,21 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
         configureNavigation()
     }
 
+    /// Create a `UIBarButtonItem` to be used as the add custom field button on the top-right.
+    ///
+    private lazy var addCustomFieldButtonItem: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: .plusImage,
+                style: .plain,
+                target: self,
+                action: #selector(openAddCustomFieldScreen))
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = Localization.accessibilityLabelAddCustomField
+        button.accessibilityHint = Localization.accessibilityHintAddCustomField
+        button.accessibilityIdentifier = "add-custom-field-button"
+
+        return button
+    }()
+
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -21,6 +39,11 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
 private extension CustomFieldsListHostingController {
     func configureNavigation() {
         title = Localization.title
+        navigationItem.rightBarButtonItems = [addCustomFieldButtonItem]
+    }
+
+    @objc func openAddCustomFieldScreen() {
+        viewModel.isAddingNewField = true
     }
 }
 
@@ -49,6 +72,9 @@ struct CustomFieldsListView: View {
         .sheet(item: $viewModel.selectedCustomField, content: { customField in
             CustomFieldEditorView(key: customField.key, value: customField.value, onSave: { _,_ in })
         })
+        .sheet(isPresented: $viewModel.isAddingNewField) {
+            CustomFieldEditorView(key: "", value: "", onSave: { _,_ in })
+        }
     }
 }
 
@@ -117,6 +143,17 @@ private extension CustomFieldsListHostingController {
             "customFieldsListHostingController.title",
             value: "Custom Fields",
             comment: "Title for the order custom fields list")
+
+        static let accessibilityLabelAddCustomField = NSLocalizedString(
+            "customFieldsListHostingController.accessibilityLabelAddCustomField",
+            value: "Add custom field",
+            comment: "Accessibility label for the Add Custom Field button")
+
+        static let accessibilityHintAddCustomField = NSLocalizedString(
+            "customFieldsListHostingController.accessibilityHintAddCustomField",
+            value: "Add a new Custom FIeld to the list",
+            comment: "VoiceOver accessibility hint, informing the user the button can be used to add custom field.")
+
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -16,59 +16,18 @@ struct CustomFieldsListView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            List(viewModel.combinedList) { customField in
-                if isEditable {
-                    NavigationLink(destination: CustomFieldEditorView(key: customField.key, value: customField.value, onSave: { updatedKey, updatedValue in
-                        viewModel.saveField(key: updatedKey, value: updatedValue, fieldId: customField.fieldId)
-                    })) {
-                        CustomFieldRow(isEditable: true,
-                                       title: customField.key,
-                                       content: customField.value.removedHTMLTags,
-                                       contentURL: nil)
-                    }
-                } else {
-                    CustomFieldRow(isEditable: false,
-                                   title: customField.key,
-                                   content: customField.value.removedHTMLTags,
-                                   contentURL: nil)
-                }
+        List(viewModel.combinedList) { customField in
+            Button(action: { viewModel.selectedCustomField = customField }) {
+                CustomFieldRow(isEditable: isEditable,
+                               title: customField.key,
+                               content: customField.value.removedHTMLTags,
+                               contentURL: nil)
             }
-            .listStyle(.plain)
-            .navigationTitle(Localization.title)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(action: {
-                        onBackButtonTapped()
-                        presentationMode.wrappedValue.dismiss()
-                    }, label: {
-                        Image(systemName: "chevron.backward")
-                            .headlineLinkStyle()
-                    })
-                }
-
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    if isEditable {
-                        HStack {
-                            Button {
-                                // todo-13493: add save handling
-                            } label: {
-                                Text("Save") // todo-13493: set String to be translatable
-                            }
-                            .disabled(!viewModel.hasChanges)
-                            Button(action: {
-                                // todo-13493: add addition handling
-                            }, label: {
-                                Image(systemName: "plus")
-                                    .renderingMode(.template)
-                            })
-                        }
-                    }
-                }
-            }
-            .wooNavigationBarStyle()
         }
+        .listStyle(.plain)
+        .sheet(item: $viewModel.selectedCustomField, content: { customField in
+            CustomFieldEditorView(key: customField.key, value: customField.value, onSave: { _,_ in })
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -7,6 +7,7 @@ final class CustomFieldsListViewModel: ObservableObject {
         savingError != nil
     }
 
+    @Published var selectedCustomField: CustomFieldUI? = nil
     @Published private(set) var savingError: Error?
     @Published private(set) var combinedList: [CustomFieldUI] = []
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -8,6 +8,8 @@ final class CustomFieldsListViewModel: ObservableObject {
     }
 
     @Published var selectedCustomField: CustomFieldUI? = nil
+    @Published var isAddingNewField: Bool = false
+
     @Published private(set) var savingError: Error?
     @Published private(set) var combinedList: [CustomFieldUI] = []
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 final class CustomFieldsListViewModel: ObservableObject {
@@ -15,13 +16,12 @@ final class CustomFieldsListViewModel: ObservableObject {
 
     @Published private var editedFields: [CustomFieldUI] = []
     @Published private var addedFields: [CustomFieldUI] = []
-    var hasChanges: Bool {
-        !editedFields.isEmpty || !addedFields.isEmpty
-    }
+    @Published private(set) var hasChanges: Bool = false
 
     init(customFields: [CustomFieldViewModel]) {
         self.originalCustomFields = customFields
         updateCombinedList()
+        configureHasChanges()
     }
 }
 
@@ -99,6 +99,12 @@ private extension CustomFieldsListViewModel {
             editedFields.first { $0.fieldId == field.id } ?? CustomFieldUI(customField: field)
         }
         combinedList = editedList + addedFields
+    }
+
+    func configureHasChanges() {
+        $editedFields.combineLatest($addedFields)
+            .map { !$0.isEmpty || !$1.isEmpty }
+            .assign(to: &$hasChanges)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1494,19 +1494,12 @@ private extension ProductFormViewController {
             CustomFieldViewModel(metadata: $0)
         }
 
-        let customFieldsView = UIHostingController(
-            rootView: CustomFieldsListView(
-                isEditable: true,
-                viewModel: CustomFieldsListViewModel(customFields: customFields),
-                onBackButtonTapped: { [weak self] in
-                    // Restore the hidden navigation bar
-                    self?.navigationController?.setNavigationBarHidden(false, animated: false)
-            })
-        )
+        let viewModel = CustomFieldsListViewModel(customFields: customFields)
 
-        // Hide the navigation bar as `CustomFieldsListView` will create its own toolbar.
-        navigationController?.setNavigationBarHidden(true, animated: false)
-        navigationController?.pushViewController(customFieldsView, animated: true)
+        let customFieldsListViewController = CustomFieldsListHostingController(isEditable: true,
+                                                                               viewModel: viewModel)
+
+        navigationController?.pushViewController(customFieldsListViewController, animated: true)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13493

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the navigation behavior for Custom Fields List and Custom Field Editor screens, as follows:

- Previously, the List managed its toolbar using Swift UI for convenience. As it turned out, managing toolbar that way required some hacks as it is used by UI Kit-based screens (Order Details and Product Details), and it created some inconsistent design and behavior (more on that in this PR https://github.com/woocommerce/woocommerce-ios/pull/14068) 
With this PR, the List now has a hosting controller that also manages its toolbar. This way, the design and behavior consistency are preserved, and the hacks can be removed.
- Toolbar buttons functionality in the **List**  ("Save" and "+") is now handled by the hosting controller, and now involves the view model.
- Entering the Editor now uses `.sheet`, to present it modally. This is consistent with an existing flow in **Order Details** > **View Billing Information** > **Edit Billing Address.**, and with the suggestion proposed by @itsmeichigo [here](https://github.com/woocommerce/woocommerce-ios/pull/14068#pullrequestreview-2344850128).
- Navigation on "+" button is added, it will open the Editor in an empty state.
- Since it becomes a modal, the Editor screen how has a "Cancel" button for closing it.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Have a test Order that contains Custom Field, then open its details in the app,
2. Tap **View Custom Fields**. Ensure that the Custom Fields List screen is opened correctly
3. Go back and forth between **Order Details** and **Custom Fields List** screen. Ensure that navigation works and the toolbar on the List screen looks correct,
4. In the **Fields List** screen, tap an existing Custom Field. Ensure that the **Custom Field Editor** screen is shown correctly as a modal.
5. Go back and forth between  **Fields List** and **Editor** screens again. Ensure that navigation works and the toolbar on the Editor screen looks correct.
6. In the **Fields List** screen, tap the plus button on top right. Ensure that the **Custom Field Editor** screen is shown correctly as a modal, with empty values.
7. Test both in iPhone and iPad mode, as the Order Details layout differs. Check videos below for example.
8. Repeat the same test also from **Product Details**. "Custom Fields" option appear right away if the Product already has them, or under the **Add more details** option otherwise.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested this PR using simulator both iPhone and iPad version, following all the steps above.

## Video
<!-- Include before and after images or gifs when appropriate. -->

**Phone mode:**

https://github.com/user-attachments/assets/7ce70941-24cd-4d30-8cda-b1d9f52afc1f


**Tablet mode:**


https://github.com/user-attachments/assets/dbfaaab7-cf58-4f28-9655-93a930a100dc



---

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.