### PR TITLE
Adding a package UI - Custom Package Content updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -149,7 +149,7 @@ struct WooShippingAddPackageView: View {
                         .tint(Color.accentColor)
                         if customPackageViewModel.showSaveTemplate {
                             VStack {
-                                TextField("Enter a unique package name", text: $customPackageViewModel.packageTemplateName)
+                                TextField(Localization.savePackageTemplatePlaceholder, text: $customPackageViewModel.packageTemplateName)
                                     .font(.body)
                                     .focused($packageTemplateNameFieldFocused)
                                     .padding()
@@ -313,6 +313,9 @@ extension WooShippingAddPackageView {
         static let savePackageTemplate = NSLocalizedString("wooShipping.createLabel.addPackage.savePackageTemplate",
                                                            value: "Save package template",
                                                            comment: "Button for saving package as a new template")
+        static let savePackageTemplatePlaceholder = NSLocalizedString("wooShipping.createLabel.addPackage.savePackageTemplatePlaceholder",
+                                                           value: "Enter a unique package name",
+                                                           comment: "Placeholder text for package name field")
         static let keyboardDoneButton = NSLocalizedString(
             "wooShipping.createLabel.addPackage.keyboard.toolbar.done.button.title",
             value: "Done",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -17,7 +17,7 @@ struct WooShippingAddPackageView: View {
 
     enum Constants {
         static let defaultVerticalSpacing: CGFloat = 16.0
-        static let saveTemplateButtonID: String = "saveTemplateButtonID"
+        static let saveTemplateContentID: String = "saveTemplateContentID"
         static let scrollToDelay: Double = 0.5
     }
 
@@ -75,119 +75,127 @@ struct WooShippingAddPackageView: View {
 
     @ViewBuilder
     private var customPackageView: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: Constants.defaultVerticalSpacing) {
-                    HStack {
-                        Text(Localization.packageType)
-                            .font(.subheadline)
-                        Spacer()
-                    }
-                    Menu {
-                        // show selection
-                        ForEach(WooShippingPackageType.allCases, id: \.self) { option in
-                            Button {
-                                customPackageViewModel.packageType = option
-                            } label: {
-                                Text(option.name)
-                                    .bodyStyle()
-                                if customPackageViewModel.packageType == option {
-                                    Image(uiImage: .checkmarkStyledImage)
-                                }
-                            }
-                        }
-                    } label: {
+        GeometryReader { geometry in
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Constants.defaultVerticalSpacing) {
                         HStack {
-                            Text(customPackageViewModel.packageType.name)
-                                .bodyStyle()
+                            Text(Localization.packageType)
+                                .font(.subheadline)
                             Spacer()
-                            Image(systemName: "chevron.up.chevron.down")
                         }
-                        .padding()
-                    }
-                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
-                    AdaptiveStack(spacing: 8) {
-                        ForEach(WooShippingPackageDimensionType.allCases, id: \.self) { dimensionType in
-                            WooShippingAddPackageDimensionView(dimensionType: dimensionType, fieldValue: Binding(get: {
-                                return self.customPackageViewModel.fieldValues[dimensionType] ?? ""
-                            }, set: { value in
-                                self.customPackageViewModel.fieldValues[dimensionType] = value
-                            }), focusedField: _focusedField)
-                        }
-                    }
-                    .toolbar {
-                        ToolbarItemGroup(placement: .keyboard) {
-                            Group {
-                                Button(action: {
-                                    onBackwardButtonTapped()
-                                }, label: {
-                                    Image(systemName: "chevron.backward")
-                                })
-                                .disabled(focusedField == WooShippingPackageDimensionType.allCases.first)
-                                Button(action: {
-                                    onForwardButtonTapped()
-                                }, label: {
-                                    Image(systemName: "chevron.forward")
-                                })
-                                .disabled(focusedField == WooShippingPackageDimensionType.allCases.last)
-                                Spacer()
+                        Menu {
+                            // show selection
+                            ForEach(WooShippingPackageType.allCases, id: \.self) { option in
                                 Button {
-                                    dismissKeyboard()
+                                    customPackageViewModel.packageType = option
                                 } label: {
-                                    Text(Localization.keyboardDoneButton)
-                                        .bold()
+                                    Text(option.name)
+                                        .bodyStyle()
+                                    if customPackageViewModel.packageType == option {
+                                        Image(uiImage: .checkmarkStyledImage)
+                                    }
                                 }
                             }
-                            .renderedIf(focusedField != nil)
-                        }
-                    }
-                    Toggle(isOn: $customPackageViewModel.showSaveTemplate) {
-                        Text(Localization.saveNewPackageTemplate)
-                            .font(.subheadline)
-                    }
-                    .tint(Color.accentColor)
-                    if customPackageViewModel.showSaveTemplate {
-                        TextField("Enter a unique package name", text: $customPackageViewModel.packageTemplateName)
-                            .font(.body)
-                            .focused($packageTemplateNameFieldFocused)
-                            .padding()
-                            .roundedBorder(cornerRadius: 8,
-                                           lineColor: packageTemplateNameFieldFocused ? Color.accentColor : Color(.separator),
-                                           lineWidth: packageTemplateNameFieldFocused ? 2 : 1)
-                        Button(Localization.savePackageTemplate) {
-                            savePackageAsTemplateButtonTapped()
-                        }
-                        .disabled(!customPackageViewModel.validateCustomPackageInputFields())
-                        .buttonStyle(SecondaryButtonStyle())
-                        .padding(.bottom)
-                        .id(Constants.saveTemplateButtonID) // Set the id for the button so we can scroll to it
-                    }
-                }
-                .padding(.horizontal)
-                .onChange(of: customPackageViewModel.showSaveTemplate) { newValue in
-                    packageTemplateNameFieldFocused = newValue
-                }
-                .onChange(of: packageTemplateNameFieldFocused) { focused in
-                    if focused {
-                        // More info about why small delay is added:
-                        // - https://github.com/woocommerce/woocommerce-ios/pull/14086#discussion_r1806036901
-                        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.scrollToDelay, execute: {
-                            withAnimation {
-                                proxy.scrollTo(Constants.saveTemplateButtonID, anchor: .bottom)
+                        } label: {
+                            HStack {
+                                Text(customPackageViewModel.packageType.name)
+                                    .bodyStyle()
+                                Spacer()
+                                Image(systemName: "chevron.up.chevron.down")
                             }
-                        })
+                            .padding()
+                        }
+                        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+                        AdaptiveStack(spacing: 8) {
+                            ForEach(WooShippingPackageDimensionType.allCases, id: \.self) { dimensionType in
+                                WooShippingAddPackageDimensionView(dimensionType: dimensionType, fieldValue: Binding(get: {
+                                    return self.customPackageViewModel.fieldValues[dimensionType] ?? ""
+                                }, set: { value in
+                                    self.customPackageViewModel.fieldValues[dimensionType] = value
+                                }), focusedField: _focusedField)
+                            }
+                        }
+                        .toolbar {
+                            ToolbarItemGroup(placement: .keyboard) {
+                                Group {
+                                    Button(action: {
+                                        onBackwardButtonTapped()
+                                    }, label: {
+                                        Image(systemName: "chevron.backward")
+                                    })
+                                    .disabled(focusedField == WooShippingPackageDimensionType.allCases.first)
+                                    Button(action: {
+                                        onForwardButtonTapped()
+                                    }, label: {
+                                        Image(systemName: "chevron.forward")
+                                    })
+                                    .disabled(focusedField == WooShippingPackageDimensionType.allCases.last)
+                                    Spacer()
+                                    Button {
+                                        dismissKeyboard()
+                                    } label: {
+                                        Text(Localization.keyboardDoneButton)
+                                            .bold()
+                                    }
+                                }
+                                .renderedIf(focusedField != nil)
+                            }
+                        }
+                        Toggle(isOn: $customPackageViewModel.showSaveTemplate) {
+                            Text(Localization.saveNewPackageTemplate)
+                                .font(.subheadline)
+                        }
+                        .tint(Color.accentColor)
+                        if customPackageViewModel.showSaveTemplate {
+                            VStack {
+                                TextField("Enter a unique package name", text: $customPackageViewModel.packageTemplateName)
+                                    .font(.body)
+                                    .focused($packageTemplateNameFieldFocused)
+                                    .padding()
+                                    .roundedBorder(cornerRadius: 8,
+                                                   lineColor: packageTemplateNameFieldFocused ? Color.accentColor : Color(.separator),
+                                                   lineWidth: packageTemplateNameFieldFocused ? 2 : 1)
+                                Spacer()
+                                Button(Localization.savePackageTemplate) {
+                                    savePackageAsTemplateButtonTapped()
+                                }
+                                .disabled(!customPackageViewModel.validateCustomPackageInputFields())
+                                .buttonStyle(SecondaryButtonStyle())
+                                .padding(.bottom)
+                            }
+                            .id(Constants.saveTemplateContentID) // Set the id for the button so we can scroll to it
+                        }
+                        else {
+                            Spacer()
+                            Button(Localization.addPackage) {
+                                addPackageButtonTapped()
+                            }
+                            .disabled(!customPackageViewModel.validateCustomPackageInputFields())
+                            .buttonStyle(PrimaryButtonStyle())
+                            .padding(.bottom)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .frame(minHeight: geometry.size.height)
+                    .frame(width: geometry.size.width)
+                    .onChange(of: customPackageViewModel.showSaveTemplate) { newValue in
+                        packageTemplateNameFieldFocused = newValue
+                    }
+                    .onChange(of: packageTemplateNameFieldFocused) { focused in
+                        if focused {
+                            // More info about why small delay is added:
+                            // - https://github.com/woocommerce/woocommerce-ios/pull/14086#discussion_r1806036901
+                            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.scrollToDelay, execute: {
+                                withAnimation {
+                                    proxy.scrollTo(Constants.saveTemplateContentID, anchor: .top)
+                                }
+                            })
+                        }
                     }
                 }
+                .scrollDismissesKeyboard(.interactively)
             }
-        }
-        if !customPackageViewModel.showSaveTemplate {
-            Spacer()
-            Button(Localization.addPackage) {
-                addPackageButtonTapped()
-            }
-            .disabled(!customPackageViewModel.validateCustomPackageInputFields())
-            .buttonStyle(PrimaryButtonStyle())
-            .padding()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13551
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

During review of https://github.com/woocommerce/woocommerce-ios/pull/14086 we noticed a problem when using the app in landscape. Since Add Package button was not in ScrollView content and when keyboard was visible the content was not able to scroll and basically screen was not fully usable.
With this change the whole content is part of ScrollView and by using GeometryReader we are able to set VStack (content) height and there for properly use Spacer() when neeed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Test in both **portrait** and **landscape**:

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. Tap "Select a Package" button
6. Tap and type in Length, Width and Height fields and check that the content is visible and scrollable, and that "Add Package" is visible and tappable (it is enabled when all 3 fields have content)
7. Toggle new package template to ON
8. Check that the package name fields is focused and that content is still scrollable and "Save package template" is visible and part of scrolling content.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Portrait:

https://github.com/user-attachments/assets/3810d7ea-8f16-42de-bb04-872c322bbe4b

Landscape:

https://github.com/user-attachments/assets/90f0a49e-c094-40a7-9b04-59bc5bc15b43

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
