### PR TITLE
Address Stripe supportsReadersOfType crash by delaying the call to SDK

### DIFF
--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -38,7 +38,7 @@ final class MainTabViewModel {
 
     private var cancellables = Set<AnyCancellable>()
 
-    let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker = TapToPayBadgePromotionChecker()
+    private(set) lazy var tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker = TapToPayBadgePromotionChecker()
 
     init(storesManager: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {


### PR DESCRIPTION
More context: peaMlT-X6-p2

<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When `TapToPayBadgePromotionChecker` is initialized, it calls `checkTapToPayBadgeVisibility` which accesses `Terminal.shared.supportsReaders`. It occasionally causes crashes when the app launches. 

The hypothesis is that the crash happens due to resources being called too early. 

I made `tapToPayBadgePromotionChecker` initializer lazy to delay calls to it in `MainTabBarViewController` `viewDidLoad` instead of `init()`. At first, I built a solution to delay calls to check the tab to pay badge visibility when accessing `shouldShowTapToPayBadges`. However, it doesn't change much since `shouldShowTapToPayBadges` is accessed at the same time `TapToPayBadgePromotionChecker` is accessed for the first time. Another option would be to create an artificial delay to `checkTapToPayBadgeVisibility` call.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

I haven't found a way to reproduce this issue myself, no way to verify the fix works.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested that the functionality of the badge still works by editing `CardReaderSupportDeterminer`:
- `hasPreviousTapToPayUsage` -> `false`
- `siteSupportsLocalMobileReader` -> `true`
- `deviceSupportsLocalMobileReader` -> `true`

Otherwise, this PR doesn't change any functionality.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

![image](https://github.com/user-attachments/assets/0bfbf930-0b14-4a75-a253-b61c2a4cd2d7)

### After

![image](https://github.com/user-attachments/assets/8939ee5b-a969-4cd5-ad75-6ac278a327f4)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.