### PR TITLE
[Shipping Labels] Adding a package UI - WooShippingTabView UI component

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
@@ -9,14 +9,16 @@ struct WooShippingTabView: View {
 
     enum Layout {
         static let iconSize: CGFloat = 20.0
+        static let horizontalContentPadding: CGFloat = 16.0
+        static let verticalContentPadding: CGFloat = 9.0
         static let selectionIndicatorHeight: CGFloat = 3.0
     }
 
-    let items: [WooShippingTabView.TabItem]
+    let items: [TabItem]
     @Binding var selectedItem: Int?
 
     var body: some View {
-        ScrollView(.horizontal) {
+        ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 0) {
                 ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                     VStack(spacing: 0) {
@@ -32,7 +34,8 @@ struct WooShippingTabView: View {
                                 .bold()
                                 .foregroundColor(selectedItem == index ? Color.accentColor : Color.secondary)
                         }
-                        .padding()
+                        .padding(.horizontal, Layout.horizontalContentPadding)
+                        .padding(.vertical, Layout.verticalContentPadding)
                         .contentShape(Rectangle())
                         .onTapGesture {
                             selectedItem = index
@@ -42,28 +45,55 @@ struct WooShippingTabView: View {
                             .foregroundColor(selectedItem == index ? Color.accentColor : Color.clear)
                     }
                 }
-                Spacer()
             }
+            .padding(.horizontal)
         }
     }
 }
 
-#Preview {
-    struct Preview: View {
-        @State var selectedItem: Int? = 0
-        let items: [WooShippingTabView.TabItem] = [
-            WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
-            WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express")
-        ]
-        var body: some View {
+struct WooShippingTabViewPreviewWrapper: View {
+    @State var selectedItem: Int? = 0
+    let items: [WooShippingTabView.TabItem] = [
+        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
+        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express"),
+        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
+        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express")
+    ]
+
+    var contentView: some View {
+        VStack {
+            Spacer()
+            WooShippingTabView(items: items, selectedItem: $selectedItem)
+            Spacer()
+        }
+        .accentColor(Color.purple)
+    }
+
+    var groupContent: some View {
+        ScrollView {
             VStack {
-                Spacer()
-                WooShippingTabView(items: items, selectedItem: $selectedItem)
-                Spacer()
+                ForEach(ContentSizeCategory.allCases, id: \.self) { sizeCategory in
+                    contentView
+                        .environment(\.sizeCategory, sizeCategory)
+                }
             }
-            .accentColor(.purple)
         }
     }
 
-    return Preview()
+    var body: some View {
+        Group {
+            groupContent
+                .preferredColorScheme(.light)  // Light mode
+                .previewDisplayName("Light Mode")
+            groupContent
+                .preferredColorScheme(.dark)  // Dark mode
+                .previewDisplayName("Dark Mode")
+        }
+    }
+}
+
+struct WooShippingTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        WooShippingTabViewPreviewWrapper()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
@@ -15,25 +15,32 @@ struct WooShippingTabView: View {
     }
 
     let items: [TabItem]
+    let titleFont: Font
+    let selectedStateColor: Color
+    let unselectedStateColor: Color
+
     @Binding var selectedItem: Int?
+
+    private func itemContentView(_ item: TabItem, selected: Bool) -> some View {
+        HStack {
+            if let icon = item.icon {
+                Image(uiImage: icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: Layout.iconSize, height: Layout.iconSize)
+            }
+            Text(item.title)
+                .font(titleFont)
+                .foregroundColor(selected ? selectedStateColor : unselectedStateColor)
+        }
+    }
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 0) {
                 ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                     VStack(spacing: 0) {
-                        HStack {
-                            if let icon = item.icon {
-                                Image(uiImage: icon)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: Layout.iconSize, height: Layout.iconSize)
-                            }
-                            Text(item.title)
-                                .font(.subheadline)
-                                .bold()
-                                .foregroundColor(selectedItem == index ? Color.accentColor : Color.secondary)
-                        }
+                        itemContentView(item, selected: selectedItem == index)
                         .padding(.horizontal, Layout.horizontalContentPadding)
                         .padding(.vertical, Layout.verticalContentPadding)
                         .contentShape(Rectangle())
@@ -42,7 +49,7 @@ struct WooShippingTabView: View {
                         }
                         Rectangle()
                             .frame(height: Layout.selectionIndicatorHeight)
-                            .foregroundColor(selectedItem == index ? Color.accentColor : Color.clear)
+                            .foregroundColor(selectedItem == index ? selectedStateColor : Color.clear)
                     }
                 }
             }
@@ -61,11 +68,11 @@ struct WooShippingTabViewPreviewWrapper: View {
     ]
 
     var contentView: some View {
-        VStack {
-            Spacer()
-            WooShippingTabView(items: items, selectedItem: $selectedItem)
-            Spacer()
-        }
+        WooShippingTabView(items: items,
+                           titleFont: Font.subheadline.bold(),
+                           selectedStateColor: Color.accentColor,
+                           unselectedStateColor: Color.secondary,
+                           selectedItem: $selectedItem)
         .accentColor(Color.purple)
     }
 
@@ -83,10 +90,10 @@ struct WooShippingTabViewPreviewWrapper: View {
     var body: some View {
         Group {
             groupContent
-                .preferredColorScheme(.light)  // Light mode
+                .preferredColorScheme(.light)
                 .previewDisplayName("Light Mode")
             groupContent
-                .preferredColorScheme(.dark)  // Dark mode
+                .preferredColorScheme(.dark)
                 .previewDisplayName("Dark Mode")
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct WooShippingTabView: View {
+    struct TabItem: Identifiable {
+        let id = UUID()
+        let icon: UIImage?
+        let title: String
+    }
+
+    enum Layout {
+        static let iconSize: CGFloat = 20.0
+        static let selectionIndicatorHeight: CGFloat = 3.0
+    }
+
+    let items: [WooShippingTabView.TabItem]
+    @Binding var selectedItem: Int?
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 0) {
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    VStack(spacing: 0) {
+                        HStack {
+                            if let icon = item.icon {
+                                Image(uiImage: icon)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: Layout.iconSize, height: Layout.iconSize)
+                            }
+                            Text(item.title)
+                                .font(.subheadline)
+                                .bold()
+                                .foregroundColor(selectedItem == index ? Color.accentColor : Color.secondary)
+                        }
+                        .padding()
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            selectedItem = index
+                        }
+                        Rectangle()
+                            .frame(height: Layout.selectionIndicatorHeight)
+                            .foregroundColor(selectedItem == index ? Color.accentColor : Color.clear)
+                    }
+                }
+                Spacer()
+            }
+        }
+    }
+}
+
+#Preview {
+    struct Preview: View {
+        @State var selectedItem: Int? = 0
+        let items: [WooShippingTabView.TabItem] = [
+            WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
+            WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express")
+        ]
+        var body: some View {
+            VStack {
+                Spacer()
+                WooShippingTabView(items: items, selectedItem: $selectedItem)
+                Spacer()
+            }
+            .accentColor(.purple)
+        }
+    }
+
+    return Preview()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingTabView.swift
@@ -18,7 +18,6 @@ struct WooShippingTabView: View {
     let titleFont: Font
     let selectedStateColor: Color
     let unselectedStateColor: Color
-
     @Binding var selectedItem: Int?
 
     private func itemContentView(_ item: TabItem, selected: Bool) -> some View {
@@ -41,12 +40,10 @@ struct WooShippingTabView: View {
                 ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                     VStack(spacing: 0) {
                         itemContentView(item, selected: selectedItem == index)
-                        .padding(.horizontal, Layout.horizontalContentPadding)
-                        .padding(.vertical, Layout.verticalContentPadding)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            selectedItem = index
-                        }
+                            .padding(.horizontal, Layout.horizontalContentPadding)
+                            .padding(.vertical, Layout.verticalContentPadding)
+                            .contentShape(Rectangle())
+                            .onTapGesture { selectedItem = index }
                         Rectangle()
                             .frame(height: Layout.selectionIndicatorHeight)
                             .foregroundColor(selectedItem == index ? selectedStateColor : Color.clear)
@@ -59,12 +56,12 @@ struct WooShippingTabView: View {
 }
 
 struct WooShippingTabViewPreviewWrapper: View {
-    @State var selectedItem: Int? = 0
-    let items: [WooShippingTabView.TabItem] = [
-        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
-        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express"),
-        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
-        WooShippingTabView.TabItem(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express")
+    @State private var selectedItem: Int? = 0
+    private let items: [WooShippingTabView.TabItem] = [
+        .init(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
+        .init(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express"),
+        .init(icon: UIImage(named: "shipping-label-usps-logo"), title: "USPS"),
+        .init(icon: UIImage(named: "shipping-label-dhl-logo"), title: "DHL Express")
     ]
 
     var contentView: some View {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2450,6 +2450,7 @@
 		DA3F99BA2C92F6D30034BDA5 /* MarkOrderAsReadUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F99B92C92F6D30034BDA5 /* MarkOrderAsReadUseCaseTests.swift */; };
 		DA40806E2CC29650002A4577 /* WooShippingAddCustomPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA40806D2CC29650002A4577 /* WooShippingAddCustomPackageViewModelTests.swift */; };
 		DA4080722CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4080712CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift */; };
+		DA4080782CC68E75002A4577 /* WooShippingTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4080772CC68E21002A4577 /* WooShippingTabView.swift */; };
 		DA41043A2C247B6900E8456A /* POSOrderPreviewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4104392C247B6900E8456A /* POSOrderPreviewService.swift */; };
 		DA706BF92C8063B600E08A5B /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
 		DA706BFA2C80642800E08A5B /* Dictionary+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C5C9521B80E5400FF82B2 /* Dictionary+Woo.swift */; };
@@ -5511,6 +5512,7 @@
 		DA3F99B92C92F6D30034BDA5 /* MarkOrderAsReadUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkOrderAsReadUseCaseTests.swift; sourceTree = "<group>"; };
 		DA40806D2CC29650002A4577 /* WooShippingAddCustomPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddCustomPackageViewModelTests.swift; sourceTree = "<group>"; };
 		DA4080712CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddCustomPackageViewModel.swift; sourceTree = "<group>"; };
+		DA4080772CC68E21002A4577 /* WooShippingTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingTabView.swift; sourceTree = "<group>"; };
 		DA4104392C247B6900E8456A /* POSOrderPreviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSOrderPreviewService.swift; sourceTree = "<group>"; };
 		DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddPackageView.swift; sourceTree = "<group>"; };
 		DABF35262C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboardViewModelTests.swift; sourceTree = "<group>"; };
@@ -11928,6 +11930,7 @@
 				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
 				CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */,
 				DA4080712CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift */,
+				DA4080772CC68E21002A4577 /* WooShippingTabView.swift */,
 			);
 			path = "WooShipping Package and Rate Selection";
 			sourceTree = "<group>";
@@ -15245,6 +15248,7 @@
 				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */,
+				DA4080782CC68E75002A4577 /* WooShippingTabView.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSourceProtocol.swift in Sources */,
 				DE653EAF2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift in Sources */,
 				DED0392D2BC7DAFD005D0571 /* StatsTimeRangePicker.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13551
<!-- I

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Created a UI component `WooShippingTabView` that will be used in "Carrier" tab of Adding a package flow. The component itself is quite generic so if needed we can make it even more generic so it can be used in other parts of the app.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Preview of WooShippingTabView in various size categories:

| Light    | Dark |
| -------- | ------- |
| <img alt="Screenshot 2024-10-21 at 18 23 34" src="https://github.com/user-attachments/assets/fc902a26-3d2b-4572-acd5-ab34adfb985a">  | <img alt="Screenshot 2024-10-21 at 18 24 09" src="https://github.com/user-attachments/assets/2021dbd5-7284-46bc-90c5-eae388c5fd34">    |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
