### PR TITLE
[Shipping labels] Add view model for shipping service cards

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Card to display the rate details for a shipping service with the Woo Shipping extension.
 struct WooShippingServiceCardView: View {
     @ObservedObject var viewModel: WooShippingServiceCardViewModel
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -4,8 +4,8 @@ struct WooShippingServiceCardView: View {
     let carrierLogo: UIImage?
     let title: String
     let rate: String
-    let daysToDelivery: String
-    let extraInfo: String
+    let daysToDelivery: String?
+    let extraInfo: String?
 
     let trackingLabel: String?
     let insuranceLabel: String?
@@ -34,9 +34,11 @@ struct WooShippingServiceCardView: View {
                 }
                 if isSelected {
                     VStack(alignment: .leading) {
-                        Text(daysToDelivery)
-                            .bold()
-                            .font(.footnote)
+                        if let daysToDelivery {
+                            Text(daysToDelivery)
+                                .bold()
+                                .font(.footnote)
+                        }
                         Group {
                             VStack(alignment: .leading, spacing: 0) {
                                 if let trackingLabel {
@@ -91,7 +93,13 @@ struct WooShippingServiceCardView: View {
                     }
                 } else {
                     Group {
-                        Text(daysToDelivery).bold() + Text("  •  ") + Text(extraInfo)
+                        if let daysToDelivery, let extraInfo {
+                            Text(daysToDelivery).bold() + Text("  •  ") + Text(extraInfo)
+                        } else if let daysToDelivery {
+                            Text(daysToDelivery).bold()
+                        } else if let extraInfo {
+                            Text(extraInfo)
+                        }
                     }
                     .font(.footnote)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -119,9 +119,9 @@ struct WooShippingServiceCardView: View {
                                                                           rateLabel: "$7.63",
                                                                           daysToDeliveryLabel: "7 business days",
                                                                           extraInfoLabel: "Includes tracking, insurance (up to $100.00), free pickup",
-                                                                          trackingLabel: nil,
+                                                                          hasTracking: true,
                                                                           insuranceLabel: nil,
-                                                                          freePickupLabel: nil,
+                                                                          hasFreePickup: true,
                                                                           signatureRequiredLabel: nil,
                                                                           adultSignatureRequiredLabel: nil))
 }
@@ -134,9 +134,9 @@ struct WooShippingServiceCardView: View {
                                                                           rateLabel: "$7.63",
                                                                           daysToDeliveryLabel: "7 business days",
                                                                           extraInfoLabel: "Includes tracking, insurance (up to $100.00), free pickup",
-                                                                          trackingLabel: "Tracking",
+                                                                          hasTracking: true,
                                                                           insuranceLabel: "Insurance (up to $100.00)",
-                                                                          freePickupLabel: "Free pickup",
+                                                                          hasFreePickup: true,
                                                                           signatureRequiredLabel: "Signature Required (+$3.70)",
                                                                           adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)"))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -1,25 +1,11 @@
 import SwiftUI
 
 struct WooShippingServiceCardView: View {
-    let carrierLogo: UIImage?
-    let title: String
-    let rate: String
-    let daysToDelivery: String?
-    let extraInfo: String?
-
-    let trackingLabel: String?
-    let insuranceLabel: String?
-    let freePickupLabel: String?
-    let signatureRequiredLabel: String?
-    let adultSignatureRequiredLabel: String?
-
-    @State var isSelected: Bool = false
-
-    @State private var signatureSelection: SignatureSelection = .none
+    @ObservedObject var viewModel: WooShippingServiceCardViewModel
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 16) {
-            if let carrierLogo {
+            if let carrierLogo = viewModel.carrierLogo {
                 Image(uiImage: carrierLogo)
                     .resizable()
                     .scaledToFit()
@@ -27,65 +13,57 @@ struct WooShippingServiceCardView: View {
             }
             VStack(alignment: .leading) {
                 AdaptiveStack(horizontalAlignment: .leading) {
-                    Text(title)
+                    Text(viewModel.title)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Text(rate)
+                    Text(viewModel.rateLabel)
                         .bold()
                 }
-                if isSelected {
+                if viewModel.selected {
                     VStack(alignment: .leading) {
-                        if let daysToDelivery {
+                        if let daysToDelivery = viewModel.daysToDeliveryLabel {
                             Text(daysToDelivery)
                                 .bold()
                                 .font(.footnote)
                         }
                         Group {
                             VStack(alignment: .leading, spacing: 0) {
-                                if let trackingLabel {
+                                if let tracking = viewModel.trackingLabel {
                                     HStack {
                                         checkmark
-                                        Text(trackingLabel)
+                                        Text(tracking)
                                     }
                                 }
-                                if let insuranceLabel {
+                                if let insurance = viewModel.insuranceLabel {
                                     HStack {
                                         checkmark
-                                        Text(insuranceLabel)
+                                        Text(insurance)
                                     }
                                 }
-                                if let freePickupLabel {
+                                if let freePickup = viewModel.freePickupLabel {
                                     HStack {
                                         checkmark
-                                        Text(freePickupLabel)
+                                        Text(freePickup)
                                     }
                                 }
                             }
-                            if let signatureRequiredLabel {
+                            if let signatureRequired = viewModel.signatureRequiredLabel {
                                 HStack {
-                                    selectionCircle(selected: signatureSelection == .signatureRequired)
-                                    Text(signatureRequiredLabel)
+                                    selectionCircle(selected: viewModel.signatureRequirement == .signatureRequired)
+                                    Text(signatureRequired)
                                 }
                                 .contentShape(Rectangle())
                                 .onTapGesture {
-                                    if signatureSelection == .signatureRequired {
-                                        signatureSelection = .none
-                                    } else {
-                                        signatureSelection = .signatureRequired
-                                    }
+                                    viewModel.handleTap(on: .signatureRequired)
                                 }
                             }
-                            if let adultSignatureRequiredLabel {
+                            if let adultSignatureRequired = viewModel.adultSignatureRequiredLabel {
                                 HStack {
-                                    selectionCircle(selected: signatureSelection == .adultSignatureRequired)
-                                    Text(adultSignatureRequiredLabel)
+                                    selectionCircle(selected: viewModel.signatureRequirement == .adultSignatureRequired)
+                                    Text(adultSignatureRequired)
                                 }
                                 .contentShape(Rectangle())
                                 .onTapGesture {
-                                    if signatureSelection == .adultSignatureRequired {
-                                        signatureSelection = .none
-                                    } else {
-                                        signatureSelection = .adultSignatureRequired
-                                    }
+                                    viewModel.handleTap(on: .adultSignatureRequired)
                                 }
                             }
                         }
@@ -93,11 +71,12 @@ struct WooShippingServiceCardView: View {
                     }
                 } else {
                     Group {
-                        if let daysToDelivery, let extraInfo {
+                        if let daysToDelivery = viewModel.daysToDeliveryLabel,
+                           let extraInfo = viewModel.extraInfoLabel {
                             Text(daysToDelivery).bold() + Text("  •  ") + Text(extraInfo)
-                        } else if let daysToDelivery {
+                        } else if let daysToDelivery = viewModel.daysToDeliveryLabel {
                             Text(daysToDelivery).bold()
-                        } else if let extraInfo {
+                        } else if let extraInfo = viewModel.extraInfoLabel {
                             Text(extraInfo)
                         }
                     }
@@ -106,10 +85,12 @@ struct WooShippingServiceCardView: View {
             }
         }
         .padding(16)
-        .if(isSelected) { card in
+        .if(viewModel.selected) { card in
             card.background { Color(.wooCommercePurple(.shade0)) }
         }
-        .roundedBorder(cornerRadius: 8, lineColor: isSelected ? Color(.primary) : Color(.separator), lineWidth: isSelected ? 2 : 1)
+        .roundedBorder(cornerRadius: 8,
+                       lineColor: viewModel.selected ? Color(.primary) : Color(.separator),
+                       lineWidth: viewModel.selected ? 2 : 1)
     }
 
     @ViewBuilder
@@ -130,37 +111,32 @@ struct WooShippingServiceCardView: View {
             Image(uiImage: .checkEmptyCircleImage)
         }
     }
-
-    private enum SignatureSelection {
-        case none
-        case signatureRequired
-        case adultSignatureRequired
-    }
 }
 
 #Preview {
-    WooShippingServiceCardView(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
-                               title: "USPS - Media Mail",
-                               rate: "$7.63",
-                               daysToDelivery: "7 business days",
-                               extraInfo: "Includes tracking, insurance (up to $100.00), free pickup",
-                               trackingLabel: nil,
-                               insuranceLabel: nil,
-                               freePickupLabel: nil,
-                               signatureRequiredLabel: nil,
-                               adultSignatureRequiredLabel: nil)
+    WooShippingServiceCardView(viewModel: WooShippingServiceCardViewModel(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
+                                                                          title: "USPS - Media Mail",
+                                                                          rateLabel: "$7.63",
+                                                                          daysToDeliveryLabel: "7 business days",
+                                                                          extraInfoLabel: "Includes tracking, insurance (up to $100.00), free pickup",
+                                                                          trackingLabel: nil,
+                                                                          insuranceLabel: nil,
+                                                                          freePickupLabel: nil,
+                                                                          signatureRequiredLabel: nil,
+                                                                          adultSignatureRequiredLabel: nil))
 }
 
 #Preview {
-    WooShippingServiceCardView(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
-                               title: "USPS - Media Mail",
-                               rate: "$7.63",
-                               daysToDelivery: "7 business days",
-                               extraInfo: "Includes tracking, insurance (up to $100.00), free pickup",
-                               trackingLabel: "Tracking",
-                               insuranceLabel: "Insurance (up to $100.00)",
-                               freePickupLabel: "Free pickup",
-                               signatureRequiredLabel: "Signature Required (+$3.70)",
-                               adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)",
-                               isSelected: true)
+    WooShippingServiceCardView(viewModel: WooShippingServiceCardViewModel(selected: true,
+                                                                          signatureRequirement: .signatureRequired,
+                                                                          carrierLogo: UIImage(named: "shipping-label-usps-logo"),
+                                                                          title: "USPS - Media Mail",
+                                                                          rateLabel: "$7.63",
+                                                                          daysToDeliveryLabel: "7 business days",
+                                                                          extraInfoLabel: "Includes tracking, insurance (up to $100.00), free pickup",
+                                                                          trackingLabel: "Tracking",
+                                                                          insuranceLabel: "Insurance (up to $100.00)",
+                                                                          freePickupLabel: "Free pickup",
+                                                                          signatureRequiredLabel: "Signature Required (+$3.70)",
+                                                                          adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)"))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -141,6 +141,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
                   adultSignatureRequiredLabel: adultSignatureRequiredLabel)
     }
 
+    /// Sets `signatureRequirement` when a signature option is tapped.
     func handleTap(on signatureRequirement: SignatureRequirement) {
         if self.signatureRequirement == signatureRequirement {
             self.signatureRequirement = .none

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -97,13 +97,17 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
 
         let trackingLabel: String? = rate.hasTracking ? Localization.includesTracking.localizedLowercase : nil
         let insuranceLabel: String? = {
-            if let doubleInsurance = Double(rate.insurance), doubleInsurance > 0 {
+            guard rate.insurance.isNotEmpty else {
+                return nil
+            }
+            if let doubleInsurance = Double(rate.insurance) {
+                guard doubleInsurance > 0 else {
+                    return nil
+                }
                 let insuranceFormatted = currencyFormatter.formatAmount(Decimal(doubleInsurance)) ?? ""
                 return String(format: Localization.insuranceAmount, insuranceFormatted)
-            } else if rate.insurance.isNotEmpty {
-                return String(format: Localization.insuranceLiteral, rate.insurance)
             } else {
-                return nil
+                return String(format: Localization.insuranceLiteral, rate.insurance)
             }
         }()
         let freePickupLabel: String? = rate.isPickupFree ? Localization.freePickup.localizedLowercase : nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -177,22 +177,22 @@ private extension WooShippingServiceCardViewModel {
                                                 value: "Tracking",
                                                 comment: "Label when shipping rate includes tracking in Woo Shipping label creation flow.")
         static let insuranceLiteral = NSLocalizedString("wooShipping.createLabels.shippingService.insuranceLiteral",
-                                                        value: "insurance (%1$@)",
+                                                        value: "Insurance (%1$@)",
                                                         comment: "Label when shipping rate includes insurance in Woo Shipping label creation flow. " +
                                                         "Placeholder is a literal. Reads like: 'Insurance (limited)'")
         static let insuranceAmount = NSLocalizedString("wooShipping.createLabels.shippingService.insuranceAmount",
-                                                       value: "insurance (up to %1$@)",
+                                                       value: "Insurance (up to %1$@)",
                                                        comment: "Label when shipping rate includes insurance in Woo Shipping label creation flow. " +
                                                        "Placeholder is an amount. Reads like: 'Insurance (up to $100)'")
         static let freePickup = NSLocalizedString("wooShipping.createLabels.shippingService.freePickup",
-                                                  value: "free pickup",
-                                                  comment: "Carrier eligible for free pickup in Shipping Labels > Carrier and Rates")
+                                                  value: "Free pickup",
+                                                  comment: "Label when shipping rate includes free pickup in Woo Shipping label creation flow.")
         static let signatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.signatureRequired",
-                                                         value: "Signature required (+%1$@)",
+                                                         value: "Signature Required (+%1$@)",
                                                          comment: "Label when shipping rate has option to require a signature in " +
                                                          "Woo Shipping label creation flow. Reads like: 'Signature required (+$3.70)'")
         static let adultSignatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.adultSignatureRequired",
-                                                              value: "Adult signature required (+%1$@)",
+                                                              value: "Adult Signature Required (+%1$@)",
                                                               comment: "Label when shipping rate has option to require an adult signature in " +
                                                               "Woo Shipping label creation flow. Reads like: 'Adult signature required (+$9.35)'")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -1,0 +1,222 @@
+import Yosemite
+import WooFoundation
+
+final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
+    let id: String
+
+    /// Whether this service rate is selected.
+    @Published var selected: Bool
+
+    /// The selected signature requirement for this service rate.
+    @Published var signatureRequirement: SignatureRequirement = .none
+
+    /// Carrier logo for the service rate.
+    let carrierLogo: UIImage?
+
+    /// Title for the service rate.
+    let title: String
+
+    /// Rate (price) label for the service rate.
+    let rateLabel: String
+
+    /// Label showing the number of days to delivery for the service rate.
+    let daysToDeliveryLabel: String?
+
+    /// Additional information about the service rate.
+    let extraInfoLabel: String?
+
+    /// Label if the service rate has tracking.
+    let trackingLabel: String?
+
+    /// Label if the service rate has insurance.
+    let insuranceLabel: String?
+
+    /// Label if the service rate has free pickup.
+    let freePickupLabel: String?
+
+    /// Label if there is an option to require a signature.
+    let signatureRequiredLabel: String?
+
+    /// Label if there is an option to require an adult signature.
+    let adultSignatureRequiredLabel: String?
+
+    init(selected: Bool = false,
+         signatureRequirement: SignatureRequirement = .none,
+         carrierLogo: UIImage?,
+         title: String,
+         rateLabel: String,
+         daysToDeliveryLabel: String?,
+         extraInfoLabel: String?,
+         trackingLabel: String?,
+         insuranceLabel: String?,
+         freePickupLabel: String?,
+         signatureRequiredLabel: String?,
+         adultSignatureRequiredLabel: String?) {
+        self.id = UUID().uuidString
+        self.selected = selected
+        self.signatureRequirement = signatureRequirement
+        self.carrierLogo = carrierLogo
+        self.title = title
+        self.rateLabel = rateLabel
+        self.daysToDeliveryLabel = daysToDeliveryLabel
+        self.extraInfoLabel = extraInfoLabel
+        self.trackingLabel = trackingLabel
+        self.insuranceLabel = insuranceLabel
+        self.freePickupLabel = freePickupLabel
+        self.signatureRequiredLabel = signatureRequiredLabel
+        self.adultSignatureRequiredLabel = adultSignatureRequiredLabel
+    }
+
+    init(selected: Bool = false,
+         signatureRequirement: SignatureRequirement = .none,
+         rate: ShippingLabelCarrierRate,
+         signatureRate: ShippingLabelCarrierRate? = nil,
+         adultSignatureRate: ShippingLabelCarrierRate? = nil,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        id = rate.rateID
+        self.selected = selected
+        self.signatureRequirement = signatureRequirement
+
+        title = rate.title
+        let formatString = rate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
+        if let deliveryDays = rate.deliveryDays {
+            daysToDeliveryLabel = String(format: formatString, deliveryDays)
+        }
+        else {
+            daysToDeliveryLabel = nil
+        }
+
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+
+        rateLabel = {
+            switch (signatureRequirement, signatureRate, adultSignatureRate) {
+            case (.signatureRequired, .some(let signatureRate), _):
+                currencyFormatter.formatAmount(Decimal(signatureRate.rate)) ?? ""
+            case (.adultSignatureRequired, _, .some(let adultSignatureRate)):
+                currencyFormatter.formatAmount(Decimal(adultSignatureRate.rate)) ?? ""
+            default:
+                currencyFormatter.formatAmount(Decimal(rate.rate)) ?? ""
+            }
+        }()
+
+        carrierLogo = CarrierLogo(rawValue: rate.carrierID)?.image()
+
+        var extras: [String] = []
+        if rate.hasTracking {
+            trackingLabel = Localization.tracking
+            extras.append(Localization.includesTracking)
+        } else {
+            trackingLabel = nil
+        }
+
+        if let doubleInsurance = Double(rate.insurance), doubleInsurance > 0 {
+            let insuranceFormatted = currencyFormatter.formatAmount(Decimal(doubleInsurance)) ?? ""
+            let insuranceString = String(format: Localization.insuranceAmount, insuranceFormatted)
+            insuranceLabel = insuranceString
+            extras.append(insuranceString.localizedLowercase)
+        } else if rate.insurance.isNotEmpty {
+            let insuranceString = String(format: Localization.insuranceLiteral, rate.insurance)
+            insuranceLabel = insuranceString
+            extras.append(insuranceString.localizedLowercase)
+        } else {
+            insuranceLabel = nil
+        }
+
+        if rate.isPickupFree {
+            freePickupLabel = Localization.freePickup
+            extras.append(Localization.freePickup.localizedLowercase)
+        } else {
+            freePickupLabel = nil
+        }
+
+        extraInfoLabel = extras.isNotEmpty ? extras.joined(separator: ", ") : nil
+
+        if let signatureRate {
+            let amount = currencyFormatter.formatAmount(Decimal(signatureRate.rate - rate.rate)) ?? ""
+            signatureRequiredLabel = String(format: Localization.signatureRequired, amount)
+        } else {
+            signatureRequiredLabel = nil
+        }
+
+        if let adultSignatureRate {
+            let amount = currencyFormatter.formatAmount(Decimal(adultSignatureRate.rate - rate.rate)) ?? ""
+            adultSignatureRequiredLabel = String(format: Localization.adultSignatureRequired, amount)
+        } else {
+            adultSignatureRequiredLabel = nil
+        }
+    }
+
+    func handleTap(on signatureRequirement: SignatureRequirement) {
+        if self.signatureRequirement == signatureRequirement {
+            self.signatureRequirement = .none
+        } else {
+            self.signatureRequirement = signatureRequirement
+        }
+    }
+}
+
+extension WooShippingServiceCardViewModel {
+    /// Options for a required signature on delivery for a service rate.
+    enum SignatureRequirement {
+        case none
+        case signatureRequired
+        case adultSignatureRequired
+    }
+}
+
+private extension WooShippingServiceCardViewModel {
+    enum Localization {
+        static let businessDaySingular = NSLocalizedString("wooShipping.createLabels.shippingService.deliveryDaySingular",
+                                                           value: "%1$d business day",
+                                                           comment: "Singular format of number of business days in Woo Shipping label creation flow. " +
+                                                           "Reads like: '1 business day'")
+        static let businessDaysPlural = NSLocalizedString("wooShipping.createLabels.shippingService.deliveryDaysPlural",
+                                                          value: "%1$d business days",
+                                                          comment: "Plural format of number of business days in Woo Shipping label creation flow. " +
+                                                          "Reads like: '3 business days'")
+        static let includesTracking = NSLocalizedString("wooShipping.createLabels.shippingService.includesTracking",
+                                                        value: "Includes tracking",
+                                                        comment: "Label when shipping rate includes tracking in Woo Shipping label creation flow.")
+        static let tracking = NSLocalizedString("wooShipping.createLabels.shippingService.tracking",
+                                                value: "Tracking",
+                                                comment: "Label when shipping rate includes tracking in Woo Shipping label creation flow.")
+        static let insuranceLiteral = NSLocalizedString("wooShipping.createLabels.shippingService.insuranceLiteral",
+                                                        value: "insurance (%1$@)",
+                                                        comment: "Label when shipping rate includes insurance in Woo Shipping label creation flow. " +
+                                                        "Placeholder is a literal. Reads like: 'Insurance (limited)'")
+        static let insuranceAmount = NSLocalizedString("wooShipping.createLabels.shippingService.insuranceAmount",
+                                                       value: "insurance (up to %1$@)",
+                                                       comment: "Label when shipping rate includes insurance in Woo Shipping label creation flow. " +
+                                                       "Placeholder is an amount. Reads like: 'Insurance (up to $100)'")
+        static let freePickup = NSLocalizedString("wooShipping.createLabels.shippingService.freePickup",
+                                                  value: "free pickup",
+                                                  comment: "Carrier eligible for free pickup in Shipping Labels > Carrier and Rates")
+        static let signatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.signatureRequired",
+                                                         value: "Signature required (+%1$@)",
+                                                         comment: "Label when shipping rate has option to require a signature in " +
+                                                         "Woo Shipping label creation flow. Reads like: 'Signature required (+$3.70)'")
+        static let adultSignatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.adultSignatureRequired",
+                                                              value: "Adult signature required (+%1$@)",
+                                                              comment: "Label when shipping rate has option to require an adult signature in " +
+                                                              "Woo Shipping label creation flow. Reads like: 'Adult signature required (+$9.35)'")
+    }
+
+    enum CarrierLogo: String {
+        case ups
+        case usps
+        case dhlExpress = "dhlexpress"
+        case dhlEcommerce = "dhlecommerce"
+        case dhlEcommerceAsia = "dhlecommerceasia"
+
+        func image() -> UIImage? {
+            switch self {
+            case .ups:
+                return UIImage(named: "shipping-label-ups-logo")
+            case .usps:
+                return UIImage(named: "shipping-label-usps-logo")
+            case .dhlExpress, .dhlEcommerce, .dhlEcommerceAsia:
+                return UIImage(named: "shipping-label-dhl-logo")
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -95,7 +95,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
             return String(format: formatString, deliveryDays)
         }()
 
-        let trackingLabel: String? = rate.hasTracking ? Localization.includesTracking.localizedLowercase : nil
+        let trackingLabel: String? = rate.hasTracking ? Localization.includesTracking : nil
         let insuranceLabel: String? = {
             guard rate.insurance.isNotEmpty else {
                 return nil
@@ -111,8 +111,8 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
             }
         }()
         let freePickupLabel: String? = rate.isPickupFree ? Localization.freePickup.localizedLowercase : nil
-        let extras = [trackingLabel, insuranceLabel?.localizedLowercase, freePickupLabel]
-        let extraInfoLabel = extras.isNotEmpty ? extras.compacted().joined(separator: ", ") : nil
+        let extras = [trackingLabel, insuranceLabel?.localizedLowercase, freePickupLabel].compactMap { $0 }
+        let extraInfoLabel = extras.isNotEmpty ? extras.joined(separator: ", ") : nil
 
         let signatureRequiredLabel: String? = {
             guard let signatureRate else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -8,16 +8,16 @@ struct WooShippingServiceView: View {
                     .headlineStyle()
                 Spacer()
             }
-            WooShippingServiceCardView(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
-                                       title: "USPS - Media Mail",
-                                       rate: "$7.63",
-                                       daysToDelivery: "7 business days",
-                                       extraInfo: "Includes tracking, insurance (up to $100.00), free pickup",
-                                       trackingLabel: "Tracking",
-                                       insuranceLabel: "Insurance (up to $100.00)",
-                                       freePickupLabel: "Free pickup",
-                                       signatureRequiredLabel: "Signature Required (+$3.70)",
-                                       adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)")
+            WooShippingServiceCardView(viewModel: WooShippingServiceCardViewModel(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
+                                                                                  title: "USPS - Media Mail",
+                                                                                  rateLabel: "$7.63",
+                                                                                  daysToDeliveryLabel: "7 business days",
+                                                                                  extraInfoLabel: "Includes tracking, insurance (up to $100.00), free pickup",
+                                                                                  trackingLabel: "Tracking",
+                                                                                  insuranceLabel: "Insurance (up to $100.00)",
+                                                                                  freePickupLabel: "Free pickup",
+                                                                                  signatureRequiredLabel: "Signature Required (+$3.70)",
+                                                                                  adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)"))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -13,9 +13,9 @@ struct WooShippingServiceView: View {
                                                                                   rateLabel: "$7.63",
                                                                                   daysToDeliveryLabel: "7 business days",
                                                                                   extraInfoLabel: "Includes tracking, insurance (up to $100.00), free pickup",
-                                                                                  trackingLabel: "Tracking",
+                                                                                  hasTracking: true,
                                                                                   insuranceLabel: "Insurance (up to $100.00)",
-                                                                                  freePickupLabel: "Free pickup",
+                                                                                  hasFreePickup: true,
                                                                                   signatureRequiredLabel: "Signature Required (+$3.70)",
                                                                                   adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)"))
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2296,6 +2296,7 @@
 		CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEE006042077D1280079161F /* SummaryTableViewCell.xib */; };
 		CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006072077D14C0079161F /* OrderDetailsViewController.swift */; };
 		CEE02AF82C1859B400B0B6AB /* MessageComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */; };
+		CEE125512CC66C8700D3183D /* WooShippingServiceCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE125502CC66C8100D3183D /* WooShippingServiceCardViewModel.swift */; };
 		CEE482D52B83A9A300FAC8C5 /* AnalyticsCard+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */; };
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
@@ -5349,6 +5350,7 @@
 		CEE006042077D1280079161F /* SummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SummaryTableViewCell.xib; sourceTree = "<group>"; };
 		CEE006072077D14C0079161F /* OrderDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewController.swift; sourceTree = "<group>"; };
 		CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposeView.swift; sourceTree = "<group>"; };
+		CEE125502CC66C8100D3183D /* WooShippingServiceCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceCardViewModel.swift; sourceTree = "<group>"; };
 		CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsCard+UI.swift"; sourceTree = "<group>"; };
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
@@ -11916,6 +11918,7 @@
 				DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */,
 				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
 				CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */,
+				CEE125502CC66C8100D3183D /* WooShippingServiceCardViewModel.swift */,
 				DA4080712CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift */,
 			);
 			path = "WooShipping Package and Rate Selection";
@@ -14902,6 +14905,7 @@
 				205B7ED12C19FD8500D14A36 /* PointOfSaleCardPresentPaymentErrorMessageViewModel.swift in Sources */,
 				CECEFA6D2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift in Sources */,
 				02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */,
+				CEE125512CC66C8700D3183D /* WooShippingServiceCardViewModel.swift in Sources */,
 				CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */,
 				EE9D03122B89DF760077CED1 /* WooAnalyticsEvent+OrdersListFilter.swift in Sources */,
 				EEB703E82B20858200930C9F /* ProductCreationAISurveyUseCase.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2263,6 +2263,7 @@
 		CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */; };
 		CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85FD5920F7A7640080B73E /* TableFooterView.swift */; };
 		CE85FD5C20F7A7740080B73E /* TableFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE85FD5B20F7A7740080B73E /* TableFooterView.xib */; };
+		CE86C8332CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE86C8322CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift */; };
 		CE8CCD43239AC06E009DBD22 /* RefundDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */; };
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
@@ -5316,6 +5317,7 @@
 		CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoTableViewCell.swift; sourceTree = "<group>"; };
 		CE85FD5920F7A7640080B73E /* TableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableFooterView.swift; sourceTree = "<group>"; };
 		CE85FD5B20F7A7740080B73E /* TableFooterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TableFooterView.xib; sourceTree = "<group>"; };
+		CE86C8322CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewController.swift; sourceTree = "<group>"; };
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
@@ -11872,6 +11874,7 @@
 				CEC3CC7B2C94A06500B93FBE /* WooShippingItemsDataSourceTests.swift */,
 				CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */,
 				DA40806D2CC29650002A4577 /* WooShippingAddCustomPackageViewModelTests.swift */,
+				CE86C8322CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -16543,6 +16546,7 @@
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
 				0375799D2822F9040083F2E1 /* MockCardPresentPaymentsOnboardingPresenter.swift in Sources */,
 				455800CC24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift in Sources */,
+				CE86C8332CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift in Sources */,
 				26F92DBE2C7ECAB20074A208 /* EditOrderFormTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,
 				B958A7D828B5316A00823EEF /* MockURLOpener.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockShippingLabelCarrierRate.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockShippingLabelCarrierRate.swift
@@ -7,7 +7,9 @@ final class MockShippingLabelCarrierRate {
 
     static func makeRate(title: String = "USPS - Parcel Select Mail",
                          rate: Double = 40.060000000000002,
-                         insurance: String = "0") -> ShippingLabelCarrierRate {
+                         insurance: String = "0",
+                         hasTracking: Bool = true,
+                         isPickupFree: Bool = true) -> ShippingLabelCarrierRate {
         return ShippingLabelCarrierRate(title: title,
                                         insurance: insurance,
                                         retailRate: rate,
@@ -16,9 +18,9 @@ final class MockShippingLabelCarrierRate {
                                         serviceID: "ParcelSelect",
                                         carrierID: "usps",
                                         shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
-                                        hasTracking: true,
+                                        hasTracking: hasTracking,
                                         isSelected: false,
-                                        isPickupFree: true,
+                                        isPickupFree: isPickupFree,
                                         deliveryDays: 2,
                                         deliveryDateGuaranteed: false)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+import WooFoundation
+
+final class WooShippingServiceCardViewModelTests: XCTestCase {
+
+    func test_it_inits_with_expected_values() {
+        // Given
+        let viewModel = WooShippingServiceCardViewModel(selected: true,
+                                                        signatureRequirement: .signatureRequired,
+                                                        rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100"),
+                                                        signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                        adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
+                                                        currencySettings: CurrencySettings())
+
+        // Then
+        XCTAssertEqual(viewModel.selected, true)
+        XCTAssertEqual(viewModel.signatureRequirement, .signatureRequired)
+        XCTAssertEqual(viewModel.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(viewModel.daysToDeliveryLabel, "2 business days")
+        XCTAssertEqual(viewModel.rateLabel, "$45.99")
+        XCTAssertEqual(viewModel.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(viewModel.trackingLabel, "Tracking")
+        XCTAssertEqual(viewModel.insuranceLabel, "Insurance (up to $100.00)")
+        XCTAssertEqual(viewModel.freePickupLabel, "Free pickup")
+        XCTAssertEqual(viewModel.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
+        XCTAssertEqual(viewModel.signatureRequiredLabel, "Signature Required (+$5.66)")
+        XCTAssertEqual(viewModel.adultSignatureRequiredLabel, "Adult Signature Required (+$11.00)")
+    }
+
+    func test_it_inits_with_expected_values_with_no_extras() {
+        // Given
+        let viewModel = WooShippingServiceCardViewModel(rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, hasTracking: false, isPickupFree: false),
+                                                        currencySettings: CurrencySettings())
+
+        // Then
+        XCTAssertEqual(viewModel.selected, false)
+        XCTAssertEqual(viewModel.signatureRequirement, .none)
+        XCTAssertEqual(viewModel.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(viewModel.daysToDeliveryLabel, "2 business days")
+        XCTAssertEqual(viewModel.rateLabel, "$40.33")
+        XCTAssertEqual(viewModel.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertNil(viewModel.trackingLabel)
+        XCTAssertNil(viewModel.insuranceLabel)
+        XCTAssertNil(viewModel.freePickupLabel)
+        XCTAssertNil(viewModel.extraInfoLabel)
+        XCTAssertNil(viewModel.signatureRequiredLabel)
+        XCTAssertNil(viewModel.adultSignatureRequiredLabel)
+    }
+
+    func test_insuranceLabel_shows_expected_value_for_non_number_insurance() {
+        // Given
+        let viewModel = WooShippingServiceCardViewModel(rate: MockShippingLabelCarrierRate.makeRate(insurance: "limited"))
+
+        // Then
+        XCTAssertEqual(viewModel.insuranceLabel, "Insurance (limited)")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
@@ -57,4 +57,34 @@ final class WooShippingServiceCardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.insuranceLabel, "Insurance (limited)")
     }
 
+    func test_handleTap_enables_newly_selected_rate() {
+        // Given
+        let newSelection: WooShippingServiceCardViewModel.SignatureRequirement = .signatureRequired
+        let viewModel = WooShippingServiceCardViewModel(signatureRequirement: .none,
+                                                        rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100"),
+                                                        signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                        adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33))
+
+        // When
+        viewModel.handleTap(on: newSelection)
+
+        // Then
+        XCTAssertEqual(viewModel.signatureRequirement, newSelection)
+    }
+
+    func test_handleTap_disables_previously_selected_rate() {
+        // Given
+        let previousSelection: WooShippingServiceCardViewModel.SignatureRequirement = .adultSignatureRequired
+        let viewModel = WooShippingServiceCardViewModel(signatureRequirement: previousSelection,
+                                                        rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100"),
+                                                        signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                        adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33))
+
+        // When
+        viewModel.handleTap(on: previousSelection)
+
+        // Then
+        XCTAssertEqual(viewModel.signatureRequirement, .none)
+    }
+
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14140
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a view model for `WooShippingServiceView`, which displays a card with the rate details for a given shipping service.

### How

* Moves the properties for the view to the view model `WooShippingServiceCardViewModel`.
* Adds a convenience method to create the view model from provided `ShippingLabelCarrierRate` objects (rates fetched from the API).
* This borrows heavily from the existing `ShippingLabelCarrierRowViewModel`, which is used for rates in the legacy shipping label flow.
* Adds unit tests for view model properties/methods.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This view and view model aren't yet used in the app. Confirm unit tests cover all scenarios and tests pass, and confirm SwiftUI previews continue to show expected content.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Screenshot 2024-10-23 at 12 13 59](https://github.com/user-attachments/assets/a3cca0a9-e7c5-4d7f-97c1-4192580359b8)|![Screenshot 2024-10-23 at 12 09 48](https://github.com/user-attachments/assets/e1c7df9e-de79-4b53-a909-ff9833500f5b)
![Screenshot 2024-10-23 at 12 14 17](https://github.com/user-attachments/assets/2989cee0-50e4-4a23-a4ad-a457903e7575)|![Screenshot 2024-10-23 at 12 10 07](https://github.com/user-attachments/assets/658ff614-af31-44c6-b87d-359d3e68d5d2)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.