### PR TITLE
[Woo POS] Pagination support: Add `pageNumber ` to remote

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -196,10 +196,11 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     /// - Parameters:
     /// - siteID: Site for which we'll fetch remote products.
+    /// - pageNumber: Number of page that should be retrieved.
     ///
-    public func loadAllSimpleProductsForPointOfSale(for siteID: Int64) async throws -> [Product] {
+    public func loadSimpleProductsForPointOfSale(for siteID: Int64, pageNumber: Int = 1) async throws -> [Product] {
         let parameters = [
-            ParameterKey.page: POSConstants.page,
+            ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: POSConstants.productsPerPage,
             ParameterKey.productType: POSConstants.productType,
             ParameterKey.orderBy: OrderKey.name.value,
@@ -609,7 +610,6 @@ public extension ProductsRemote {
 
 private extension ProductsRemote {
     enum POSConstants {
-        static let page = "1"
         static let productsPerPage = "100"
         static let productType = "simple"
         static let productStatus = "publish"

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -899,7 +899,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
 
-        let products = try await remote.loadAllSimpleProductsForPointOfSale(for: sampleSiteID)
+        let products = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID)
 
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)
@@ -914,10 +914,43 @@ final class ProductsRemoteTests: XCTestCase {
 
         // When/Then
         await assertThrowsError({
-            let _ = try await remote.loadAllSimpleProductsForPointOfSale(for: sampleSiteID)
+            let _ = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID)
         }, errorAssert: {
             $0 as? NetworkError == .notFound()
         })
+    }
+    
+    func test_loadAllSimpleProductsForPointOfSale_when_page_has_products_then_loads_expected_products() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        let initialPageNumber = 1
+        let expectedProductsFromResponse = 6
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
+
+        let products = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID, pageNumber: initialPageNumber)
+
+        // Then
+        XCTAssertEqual(products.count, expectedProductsFromResponse)
+        for product in products {
+            XCTAssertEqual(try XCTUnwrap(product).productType, .simple)
+        }
+    }
+
+    func test_loadAllSimpleProductsForPointOfSale_when_page_has_no_products_then_loads_expected_products() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        let pageNumber = 2
+        let expectedProductsFromResponse = 0
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+
+        let products = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
+
+        // Then
+        XCTAssertEqual(products.count, expectedProductsFromResponse)
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -891,7 +891,7 @@ final class ProductsRemoteTests: XCTestCase {
         })
     }
 
-    func test_loadAllSimpleProductsForPointOfSale_loads_simple_products() async throws {
+    func test_loadSimpleProductsForPointOfSale_loads_simple_products() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let expectedProductsFromResponse = 6
@@ -908,7 +908,7 @@ final class ProductsRemoteTests: XCTestCase {
         }
     }
 
-    func test_loadAllSimpleProductsForPointOfSale_relays_networking_error() async throws {
+    func test_loadSimpleProductsForPointOfSale_relays_networking_error() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
@@ -920,7 +920,7 @@ final class ProductsRemoteTests: XCTestCase {
         })
     }
 
-    func test_loadAllSimpleProductsForPointOfSale_when_page_has_products_then_loads_expected_products() async throws {
+    func test_loadSimpleProductsForPointOfSale_when_page_has_products_then_loads_expected_products() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let initialPageNumber = 1
@@ -938,7 +938,7 @@ final class ProductsRemoteTests: XCTestCase {
         }
     }
 
-    func test_loadAllSimpleProductsForPointOfSale_when_page_has_no_products_then_loads_expected_products() async throws {
+    func test_loadSimpleProductsForPointOfSale_when_page_has_no_products_then_loads_expected_products() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let pageNumber = 2

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -919,7 +919,7 @@ final class ProductsRemoteTests: XCTestCase {
             $0 as? NetworkError == .notFound()
         })
     }
-    
+
     func test_loadAllSimpleProductsForPointOfSale_when_page_has_products_then_loads_expected_products() async throws {
         // Given
         let remote = ProductsRemote(network: network)

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -20,7 +20,7 @@ struct POSProductPreview: POSItem {
 }
 
 final class POSItemProviderPreview: POSItemProvider {
-    func providePointOfSaleItems() async throws -> [Yosemite.POSItem] {
+    func providePointOfSaleItems(pageNumber: Int) async throws -> [Yosemite.POSItem] {
         []
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -37,9 +37,10 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @MainActor
     func populatePointOfSaleItems() async {
+        let pageNumber: Int = 1
         do {
             state = .loading
-            items = try await itemProvider.providePointOfSaleItems()
+            items = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
             if items.count == 0 {
                 state = .empty
             } else {

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -37,10 +37,9 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @MainActor
     func populatePointOfSaleItems() async {
-        let pageNumber: Int = 1
         do {
             state = .loading
-            items = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
+            items = try await itemProvider.providePointOfSaleItems(pageNumber: Constants.firstPageNumber)
             if items.count == 0 {
                 state = .empty
             } else {
@@ -151,5 +150,6 @@ private extension ItemListViewModel {
             value: "Retry",
             comment: "Text for the button appearing on the item list screen when there's an error loading products."
         )
+        static let firstPageNumber: Int = 1
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -360,7 +360,7 @@ private extension ItemListViewModelTests {
         var shouldThrowError = false
         var shouldReturnZeroItems = false
 
-        func providePointOfSaleItems() async throws -> [Yosemite.POSItem] {
+        func providePointOfSaleItems(pageNumber: Int) async throws -> [Yosemite.POSItem] {
             if shouldThrowError {
                 throw NSError(domain: "Some error", code: 0)
             }

--- a/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
@@ -31,6 +31,6 @@ public protocol POSItemProvider {
 // if no pageNumber is given.
 extension POSItemProvider {
     func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSItem] {
-        try await providePointOfSaleItems(pageNumber: 1)
+        try await providePointOfSaleItems(pageNumber: pageNumber)
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
@@ -24,5 +24,13 @@ extension POSItem {
 }
 
 public protocol POSItemProvider {
-    func providePointOfSaleItems() async throws -> [POSItem]
+    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSItem]
+}
+
+// Default implementation for convenience, so we do not need to pass the first page explicitely
+// if no pageNumber is given.
+extension POSItemProvider {
+    func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSItem] {
+        try await providePointOfSaleItems(pageNumber: 1)
+    }
 }

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -28,7 +28,7 @@ public final class POSProductProvider: POSItemProvider {
 
     public func providePointOfSaleItems() async throws -> [POSItem] {
         do {
-            let products = try await productsRemote.loadAllSimpleProductsForPointOfSale(for: siteID)
+            let products = try await productsRemote.loadSimpleProductsForPointOfSale(for: siteID)
 
             let eligibilityCriteria: [(Product) -> Bool] = [
                 isNotVirtual,

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -26,7 +26,6 @@ public final class POSProductProvider: POSItemProvider {
                   network: AlamofireNetwork(credentials: credentials))
     }
 
-    
     /// Provides a list of products for the Point of Sale, by fetching simple products from the remote, applying any eligibility criteria,
     /// and maps them to POSItem type.
     ///

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -26,9 +26,15 @@ public final class POSProductProvider: POSItemProvider {
                   network: AlamofireNetwork(credentials: credentials))
     }
 
-    public func providePointOfSaleItems() async throws -> [POSItem] {
+    
+    /// Provides a list of products for the Point of Sale, by fetching simple products from the remote, applying any eligibility criteria,
+    /// and maps them to POSItem type.
+    ///
+    /// - pageNumber: Number of the page that should be retrieved. If none given, defaults to 1
+    ///
+    public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSItem] {
         do {
-            let products = try await productsRemote.loadSimpleProductsForPointOfSale(for: siteID)
+            let products = try await productsRemote.loadSimpleProductsForPointOfSale(for: siteID, pageNumber: pageNumber)
 
             let eligibilityCriteria: [(Product) -> Bool] = [
                 isNotVirtual,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-ios/issues/14186
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR gets the ball rolling on infinite scrolling and pagination for the Point of Sale by adding a `pageNumber` property to the remote and exposing this property to Yosemite, since we'll need these no matter which approach we ultimately take in the app layer.

We've also added a default implementation where if no page number is given, the first one will be used, so we do not have to declare this explicitly every time.

## Testing
No changes have been added to existing logic: The POS should work as always (still fetches only 1 page, up to 100 products). 

Tests and CI should pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
