### PR TITLE
[Crash fix] - removed unnecessary microphone device type

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [internal] Updated storage usage in ProductCategoryStore [https://github.com/woocommerce/woocommerce-ios/pull/14151]
 - [Internal] Updated storage usage in ProductReviewStore [https://github.com/woocommerce/woocommerce-ios/pull/14134]
+- [*] Product scanner: Fixed a crash when configuring camera swap button in code scanner. [https://github.com/woocommerce/woocommerce-ios/pull/14188]
 
 
 20.8

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -75,7 +75,9 @@ final class CodeScannerViewController: UIViewController {
     }
 
     private func configureSwapCameraButton() {
-        swapCameraButton.isHidden = captureDevice(with: .front) == nil || captureDevice(with: .back) == nil
+        let isFrontCameraAvailable = captureDevice(with: .front) != nil
+        let isBackCameraAvailable = captureDevice(with: .back) != nil
+        swapCameraButton.isHidden = !(isFrontCameraAvailable && isBackCameraAvailable)
         swapCameraButton.tintColor = UIColor.white
         swapCameraButton.addTarget(self, action: #selector(swapCamera), for: .touchUpInside)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -376,7 +376,6 @@ private extension CodeScannerViewController {
         do {
             deviceInput = try AVCaptureDeviceInput(device: validDevice)
         } catch let error {
-            print(error.localizedDescription)
             DDLogError("Error creating device input: \(error)")
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -365,12 +365,19 @@ private extension CodeScannerViewController {
             newDevice = captureDevice(with: .back)
         }
 
+        // Ensure newDevice is not nil
+        guard let validDevice = newDevice else {
+            DDLogError("Failed to find a new camera device.")
+            return
+        }
+
         // Create new capture input
         var deviceInput: AVCaptureDeviceInput!
         do {
-            deviceInput = try AVCaptureDeviceInput(device: newDevice!)
+            deviceInput = try AVCaptureDeviceInput(device: validDevice)
         } catch let error {
             print(error.localizedDescription)
+            DDLogError("Error creating device input: \(error)")
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -382,7 +382,6 @@ private extension CodeScannerViewController {
         let devices = AVCaptureDevice.DiscoverySession(deviceTypes:
                                                         [
                                                             .builtInWideAngleCamera,
-                                                            .builtInMicrophone,
                                                             .builtInDualCamera,
                                                             .builtInTelephotoCamera
                                                         ],


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14174
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There was an unnecessary `.builtInMicrophone` device type included in the capture device list for the code scanner, which caused crashes for some users.:
`NSMicrophoneUsageDescription > This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSMicrophoneUsageDescription key with a string value explaining to the user how the app uses this data.`

Since we do not need that device type, it is removed now.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Run the app on the physical device, iPhone or iPad
- Open Products tab
- Tap the scan button in top left
- Check that the swap camera button is shown in the code scanner
- Tap the swap camera button few times and make sure that the camera is actually being swapped and you are getting proper camera feed, without getting app to crash

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f7ab02b8-9c61-48a1-9961-5eb3369b2605

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
