### PR TITLE
Additions to TopTabView for customization options

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [internal] Updated storage usage in ProductCategoryStore [https://github.com/woocommerce/woocommerce-ios/pull/14151]
 - [Internal] Updated storage usage in ProductReviewStore [https://github.com/woocommerce/woocommerce-ios/pull/14134]
 - [internal] Replace unnecessary fetch requests for upserting orders and order search results [https://github.com/woocommerce/woocommerce-ios/pull/14128]
-
+- [internal] Additions to TopTabView for customization options [https://github.com/woocommerce/woocommerce-ios/pull/14192]
 
 20.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,8 +6,8 @@
 - [internal] Updated storage usage in ProductCategoryStore [https://github.com/woocommerce/woocommerce-ios/pull/14151]
 - [Internal] Updated storage usage in ProductReviewStore [https://github.com/woocommerce/woocommerce-ios/pull/14134]
 - [internal] Replace unnecessary fetch requests for upserting orders and order search results [https://github.com/woocommerce/woocommerce-ios/pull/14128]
-- [internal] Additions to TopTabView for customization options [https://github.com/woocommerce/woocommerce-ios/pull/14192]
 - [internal] Optimized storage usage in ProductStore [https://github.com/woocommerce/woocommerce-ios/pull/14139]
+- [internal] Additions to TopTabView for customization options [https://github.com/woocommerce/woocommerce-ios/pull/14192]
 
 
 20.8

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,8 +7,8 @@
 - [Internal] Updated storage usage in ProductReviewStore [https://github.com/woocommerce/woocommerce-ios/pull/14134]
 - [internal] Replace unnecessary fetch requests for upserting orders and order search results [https://github.com/woocommerce/woocommerce-ios/pull/14128]
 - [internal] Optimized storage usage in ProductStore [https://github.com/woocommerce/woocommerce-ios/pull/14139]
-- [internal] Additions to TopTabView for customization options [https://github.com/woocommerce/woocommerce-ios/pull/14192]
 - [internal] Optimized storage usage in ProductAttributeStore and ProductAttributeTermStore [https://github.com/woocommerce/woocommerce-ios/pull/14145]
+- [internal] Additions to TopTabView for customization options [https://github.com/woocommerce/woocommerce-ios/pull/14192]
 
 
 20.8

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -300,7 +300,12 @@ struct ContentView_Previews: PreviewProvider {
         ]
         TopTabView(tabs: tabs)
             .previewLayout(.sizeThatFits)
-            .previewDisplayName("Default Style")
+            .previewDisplayName("Default Light Style")
+            .preferredColorScheme(.light)
+        TopTabView(tabs: tabs)
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Default Dark Style")
+            .preferredColorScheme(.dark)
 
         let carrierTabs: [TopTabItem] = [
             TopTabItem(name: "USPS", icon: UIImage(named: "shipping-label-usps-logo"), content: {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -43,9 +43,8 @@ struct TopTabView<Content: View>: View {
     let selectedTabIndicatorHeight: CGFloat
     // Padding between tab items
     let tabPadding: CGFloat
-    //
-    let tabItemHorizontalPadding: CGFloat?
-    let tabItemVerticalPadding: CGFloat?
+    let tabItemContentHorizontalPadding: CGFloat?
+    let tabItemContentVerticalPadding: CGFloat?
 
     init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
@@ -56,8 +55,8 @@ struct TopTabView<Content: View>: View {
          unselectedStateColor: Color = .primary,
          selectedTabIndicatorHeight: CGFloat = Layout.selectedTabIndicatorHeight,
          tabPadding: CGFloat = Layout.tabPadding,
-         tabItemHorizontalPadding: CGFloat? = nil,
-         tabItemVerticalPadding: CGFloat? = nil) {
+         tabItemContentHorizontalPadding: CGFloat? = nil,
+         tabItemContentVerticalPadding: CGFloat? = nil) {
         self.tabs = tabs
         self._showTabs = showTabs
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
@@ -68,8 +67,8 @@ struct TopTabView<Content: View>: View {
         self.unselectedStateColor = unselectedStateColor
         self.selectedTabIndicatorHeight = selectedTabIndicatorHeight
         self.tabPadding = tabPadding
-        self.tabItemHorizontalPadding = tabItemHorizontalPadding
-        self.tabItemVerticalPadding = tabItemVerticalPadding
+        self.tabItemContentHorizontalPadding = tabItemContentHorizontalPadding
+        self.tabItemContentVerticalPadding = tabItemContentVerticalPadding
     }
 
     private func tabItemContentView(_ index: Int, selected: Bool) -> some View {
@@ -106,8 +105,8 @@ struct TopTabView<Content: View>: View {
                             HStack(spacing: tabPadding * 2) {
                                 ForEach(0..<tabs.count, id: \.self) { index in
                                     tabItemContentView(index, selected: selectedTab == index)
-                                        .padding(.vertical, tabItemVerticalPadding)
-                                        .padding(.horizontal, tabItemHorizontalPadding)
+                                        .padding(.vertical, tabItemContentVerticalPadding)
+                                        .padding(.horizontal, tabItemContentHorizontalPadding)
                                         .background(GeometryReader { geometry in
                                             Color.clear.onAppear {
                                                 if index < tabWidths.count {
@@ -339,8 +338,8 @@ struct ContentView_Previews: PreviewProvider {
                    unselectedStateColor: .secondary,
                    selectedTabIndicatorHeight: 3.0,
                    tabPadding: 0,
-                   tabItemHorizontalPadding: 16.0,
-                   tabItemVerticalPadding: 9.0)
+                   tabItemContentHorizontalPadding: 16.0,
+                   tabItemContentVerticalPadding: 9.0)
             .previewLayout(.sizeThatFits)
             .preferredColorScheme(.light)
             .previewDisplayName("Carrier Packages Light Style")
@@ -349,8 +348,8 @@ struct ContentView_Previews: PreviewProvider {
                    unselectedStateColor: .secondary,
                    selectedTabIndicatorHeight: 3.0,
                    tabPadding: 0,
-                   tabItemHorizontalPadding: 16.0,
-                   tabItemVerticalPadding: 9.0)
+                   tabItemContentHorizontalPadding: 16.0,
+                   tabItemContentVerticalPadding: 9.0)
             .previewLayout(.sizeThatFits)
             .preferredColorScheme(.dark)
             .previewDisplayName("Carrier Packages Dark Style")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -28,9 +28,9 @@ struct TopTabView<Content: View>: View {
 
     let tabs: [TopTabItem<Content>]
 
-    // // tabs container customization
+    // // Tabs container customization
     // Specifies horizontal padding for the entire container of tabs.
-    // - default value is 0
+    // - Default value is 0
     let tabsContainerHorizontalPadding: CGFloat?
     // Color used for tab name and underline selection indicator when selected
     let selectedStateColor: Color
@@ -42,10 +42,10 @@ struct TopTabView<Content: View>: View {
     // Padding between tab items
     let tabPadding: CGFloat
 
-    // // individual tab item customization
+    // // Individual tab item customization
     let tabsNameFont: Font
     // Specifies the height and width of the icon
-    // - applied with the conditional modifier
+    // - Applied with the conditional modifier
     let tabsIconSize: CGFloat?
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -27,12 +27,74 @@ struct TopTabView<Content: View>: View {
     @Binding var showTabs: Bool
 
     let tabs: [TopTabItem<Content>]
+    // Specifies horizontal padding for the entire container of tabs.
+    // - default value is 0
+    let tabsContainerHorizontalPadding: CGFloat?
+    let tabsNameFont: Font
+    // Specifies the height and width of the icon
+    // - applied with the conditional modifier
+    let tabsIconSize: CGFloat?
+    // Color used for tab name and underline selection indicator when selected
+    let selectedStateColor: Color
+    // Color used for tab name when not selected
+    let unselectedStateColor: Color
+    // Specifies the height of the selected tab indicator
+    // - Default value is Layout.selectedTabIndicatorHeight
+    let selectedTabIndicatorHeight: CGFloat
+    // Padding between tab items
+    let tabPadding: CGFloat
+    //
+    let tabItemHorizontalPadding: CGFloat?
+    let tabItemVerticalPadding: CGFloat?
 
     init(tabs: [TopTabItem<Content>],
-         showTabs: Binding<Bool> = .constant(true)) {
+         showTabs: Binding<Bool> = .constant(true),
+         tabsContainerHorizontalPadding: CGFloat? = 0.0,
+         tabsNameFont: Font = .headline,
+         tabsIconSize: CGFloat? = 20.0,
+         selectedStateColor: Color = Colors.selected,
+         unselectedStateColor: Color = .primary,
+         selectedTabIndicatorHeight: CGFloat = Layout.selectedTabIndicatorHeight,
+         tabPadding: CGFloat = Layout.tabPadding,
+         tabItemHorizontalPadding: CGFloat? = nil,
+         tabItemVerticalPadding: CGFloat? = nil) {
         self.tabs = tabs
         self._showTabs = showTabs
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
+        self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
+        self.tabsNameFont = tabsNameFont
+        self.tabsIconSize = tabsIconSize
+        self.selectedStateColor = selectedStateColor
+        self.unselectedStateColor = unselectedStateColor
+        self.selectedTabIndicatorHeight = selectedTabIndicatorHeight
+        self.tabPadding = tabPadding
+        self.tabItemHorizontalPadding = tabItemHorizontalPadding
+        self.tabItemVerticalPadding = tabItemVerticalPadding
+    }
+
+    private func tabItemContentView(_ index: Int, selected: Bool) -> some View {
+        HStack {
+            if let icon = tabs[index].icon {
+                Image(uiImage: icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .if(tabsIconSize != nil) {
+                        $0.frame(width: tabsIconSize, height: tabsIconSize)
+                    }
+            }
+            Text(tabs[index].name)
+                .font(tabsNameFont)
+                .foregroundColor(selected ? selectedStateColor : unselectedStateColor)
+                .id(index)
+                .onTapGesture {
+                    withAnimation {
+                        selectedTab = index
+                        tabs[selectedTab].onSelected?()
+                    }
+                }
+        }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(selected ? [.isSelected, .isHeader] : [])
     }
 
     var body: some View {
@@ -40,53 +102,44 @@ struct TopTabView<Content: View>: View {
             if tabs.count > 1 && showTabs {
                 ScrollView(.horizontal, showsIndicators: false) {
                     ScrollViewReader { scrollViewProxy in
-                        HStack(spacing: Layout.tabPadding * 2) {
-                            ForEach(0..<tabs.count, id: \.self) { index in
-                                VStack {
-                                    Text(tabs[index].name)
-                                        .font(.headline)
-                                        .foregroundColor(selectedTab == index ? Colors.selected : .primary)
-                                        .id(index)
-                                        .onTapGesture {
-                                            withAnimation {
-                                                selectedTab = index
-                                                tabs[selectedTab].onSelected?()
-                                            }
-                                        }
-                                        .onChange(of: selectedTab, perform: { newSelectedTab in
-                                            withAnimation {
-                                                scrollViewProxy.scrollTo(newSelectedTab, anchor: .center)
-                                                underlineOffset = calculateOffset(index: newSelectedTab)
+                        HStack {
+                            HStack(spacing: tabPadding * 2) {
+                                ForEach(0..<tabs.count, id: \.self) { index in
+                                    tabItemContentView(index, selected: selectedTab == index)
+                                        .padding(.vertical, tabItemVerticalPadding)
+                                        .padding(.horizontal, tabItemHorizontalPadding)
+                                        .background(GeometryReader { geometry in
+                                            Color.clear.onAppear {
+                                                if index < tabWidths.count {
+                                                    tabWidths[index] = geometry.size.width
+                                                }
                                             }
                                         })
-                                        .accessibilityAddTraits(.isButton)
-                                        .accessibilityAddTraits(selectedTab == index ? [.isSelected, .isHeader] : [])
                                 }
-                                .padding()
-                                .background(GeometryReader { geometry in
-                                    Color.clear.onAppear {
-                                        if index < tabWidths.count {
-                                            tabWidths[index] = geometry.size.width
-                                        }
+                                .onAppear {
+                                    withAnimation {
+                                        scrollViewProxy.scrollTo(selectedTab, anchor: .center)
+                                        underlineOffset = calculateOffset(index: selectedTab)
                                     }
-                                })
-                            }
-                            .onAppear {
-                                withAnimation {
-                                    scrollViewProxy.scrollTo(selectedTab, anchor: .center)
-                                    underlineOffset = calculateOffset(index: selectedTab)
                                 }
                             }
+                            .padding(.horizontal, tabPadding)
+                            .overlay(
+                                Rectangle()
+                                    .frame(width: selectedTabUnderlineWidth(),
+                                           height: selectedTabIndicatorHeight)
+                                    .foregroundColor(selectedStateColor)
+                                    .offset(x: underlineOffset),
+                                alignment: .bottomLeading
+                            )
+                            .onChange(of: selectedTab, perform: { newSelectedTab in
+                                withAnimation {
+                                    scrollViewProxy.scrollTo(newSelectedTab, anchor: .center)
+                                    underlineOffset = calculateOffset(index: newSelectedTab)
+                                }
+                            })
                         }
-                        .padding(.horizontal, Layout.tabPadding)
-                        .overlay(
-                            Rectangle()
-                                .frame(width: selectedTabUnderlineWidth(),
-                                       height: Layout.selectedTabIndicatorHeight)
-                                .foregroundColor(Colors.selected)
-                                .offset(x: underlineOffset),
-                            alignment: .bottomLeading
-                        )
+                        .padding(.horizontal, tabsContainerHorizontalPadding)
                     }
                 }
                 Divider()
@@ -166,12 +219,12 @@ struct TopTabView<Content: View>: View {
             DDLogError("Out of bounds tab selected at index \(selectedTab)")
             return 0
         }
-        return selectedTabWidth + (Layout.tabPadding * 2)
+        return selectedTabWidth + (tabPadding * 2)
     }
 
     private func calculateOffset(index: Int) -> CGFloat {
         // Takes all preceeding tab widths, and adds appropriate spacing to each side to get the overall offset
-        return tabWidths.prefix(index).reduce(0, +) + CGFloat(index) * (Layout.tabPadding * 2)
+        return tabWidths.prefix(index).reduce(0, +) + CGFloat(index) * (tabPadding * 2)
     }
 
     private func dragOffset(width: CGFloat) -> CGFloat {
@@ -224,7 +277,7 @@ struct ContentView_Previews: PreviewProvider {
                     .font(.largeTitle)
                     .padding()
             }),
-            TopTabItem(name: "A tab name", content: {
+            TopTabItem(name: "Tab with icon", content: {
                 Text("Content for Tab 2")
                     .font(.largeTitle)
                     .padding()
@@ -247,6 +300,55 @@ struct ContentView_Previews: PreviewProvider {
         ]
         TopTabView(tabs: tabs)
             .previewLayout(.sizeThatFits)
+            .previewDisplayName("Default Style")
+
+        let carrierTabs: [TopTabItem] = [
+            TopTabItem(name: "USPS", icon: UIImage(named: "shipping-label-usps-logo"), content: {
+                Text("Content for Tab 1")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "DHL Express", icon: UIImage(named: "shipping-label-dhl-logo"), content: {
+                Text("Content for Tab 2")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "USPS", icon: UIImage(named: "shipping-label-usps-logo"), content: {
+                Text("Content for Tab 3")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "DHL Express", icon: UIImage(named: "shipping-label-dhl-logo"), content: {
+                Text("Content for Tab 4")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "USPS", icon: UIImage(named: "shipping-label-usps-logo"), content: {
+                Text("Content for Tab 5")
+                    .font(.largeTitle)
+                    .padding()
+            })
+        ]
+        TopTabView(tabs: carrierTabs,
+                   tabsContainerHorizontalPadding: nil,
+                   unselectedStateColor: .secondary,
+                   selectedTabIndicatorHeight: 3.0,
+                   tabPadding: 0,
+                   tabItemHorizontalPadding: 16.0,
+                   tabItemVerticalPadding: 9.0)
+            .previewLayout(.sizeThatFits)
+            .preferredColorScheme(.light)
+            .previewDisplayName("Carrier Packages Light Style")
+        TopTabView(tabs: carrierTabs,
+                   tabsContainerHorizontalPadding: nil,
+                   unselectedStateColor: .secondary,
+                   selectedTabIndicatorHeight: 3.0,
+                   tabPadding: 0,
+                   tabItemHorizontalPadding: 16.0,
+                   tabItemVerticalPadding: 9.0)
+            .previewLayout(.sizeThatFits)
+            .preferredColorScheme(.dark)
+            .previewDisplayName("Carrier Packages Dark Style")
 
         let oneTab: [TopTabItem] = [
             TopTabItem(name: "A tab name", content: {
@@ -257,5 +359,6 @@ struct ContentView_Previews: PreviewProvider {
         ]
         TopTabView(tabs: oneTab)
             .previewLayout(.sizeThatFits)
+            .previewDisplayName("One Tab")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -342,6 +342,7 @@ struct ContentView_Previews: PreviewProvider {
                    unselectedStateColor: .secondary,
                    selectedTabIndicatorHeight: 3.0,
                    tabPadding: 0,
+                   tabsNameFont: Font.subheadline.bold(),
                    tabItemContentHorizontalPadding: 16.0,
                    tabItemContentVerticalPadding: 9.0)
             .previewLayout(.sizeThatFits)
@@ -352,6 +353,7 @@ struct ContentView_Previews: PreviewProvider {
                    unselectedStateColor: .secondary,
                    selectedTabIndicatorHeight: 3.0,
                    tabPadding: 0,
+                   tabsNameFont: Font.subheadline.bold(),
                    tabItemContentHorizontalPadding: 16.0,
                    tabItemContentVerticalPadding: 9.0)
             .previewLayout(.sizeThatFits)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -27,13 +27,11 @@ struct TopTabView<Content: View>: View {
     @Binding var showTabs: Bool
 
     let tabs: [TopTabItem<Content>]
+
+    // // tabs container customization
     // Specifies horizontal padding for the entire container of tabs.
     // - default value is 0
     let tabsContainerHorizontalPadding: CGFloat?
-    let tabsNameFont: Font
-    // Specifies the height and width of the icon
-    // - applied with the conditional modifier
-    let tabsIconSize: CGFloat?
     // Color used for tab name and underline selection indicator when selected
     let selectedStateColor: Color
     // Color used for tab name when not selected
@@ -43,30 +41,36 @@ struct TopTabView<Content: View>: View {
     let selectedTabIndicatorHeight: CGFloat
     // Padding between tab items
     let tabPadding: CGFloat
+
+    // // individual tab item customization
+    let tabsNameFont: Font
+    // Specifies the height and width of the icon
+    // - applied with the conditional modifier
+    let tabsIconSize: CGFloat?
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?
 
     init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
-         tabsNameFont: Font = .headline,
-         tabsIconSize: CGFloat? = 20.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
          selectedTabIndicatorHeight: CGFloat = Layout.selectedTabIndicatorHeight,
          tabPadding: CGFloat = Layout.tabPadding,
+         tabsNameFont: Font = .headline,
+         tabsIconSize: CGFloat? = 20.0,
          tabItemContentHorizontalPadding: CGFloat? = nil,
          tabItemContentVerticalPadding: CGFloat? = nil) {
         self.tabs = tabs
         self._showTabs = showTabs
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
-        self.tabsNameFont = tabsNameFont
-        self.tabsIconSize = tabsIconSize
         self.selectedStateColor = selectedStateColor
         self.unselectedStateColor = unselectedStateColor
         self.selectedTabIndicatorHeight = selectedTabIndicatorHeight
         self.tabPadding = tabPadding
+        self.tabsNameFont = tabsNameFont
+        self.tabsIconSize = tabsIconSize
         self.tabItemContentHorizontalPadding = tabItemContentHorizontalPadding
         self.tabItemContentVerticalPadding = tabItemContentVerticalPadding
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -2,13 +2,16 @@ import SwiftUI
 
 struct TopTabItem<Content: View> {
     let name: String
+    let icon: UIImage?
     let content: () -> Content
     let onSelected: (() -> Void)?
 
     init(name: String,
+         icon: UIImage? = nil,
          @ViewBuilder content: @escaping () -> Content,
          onSelected: (() -> Void)? = nil) {
         self.name = name
+        self.icon = icon
         self.content = content
         self.onSelected = onSelected
     }


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As discussed in https://github.com/woocommerce/woocommerce-ios/pull/14182#issuecomment-2429101146 we agreed that it would be better to add additions to `TopTabView` instead of having a new UI component, so that we can reuse that one in Carrier packages list (with some customizations).

This PR adds those options/additions but keeps the setup for code that currently uses `TopTabView`.

Small disclaimer: branch name has some parts from another nonrelated branch (copy-paste issue :) )

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Currently only `WooPaymentsDepositsOverviewView` uses `TopTabView` so only manual testing that should be done is to check if that component still works ok and looks the same.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

`TopTabView` previews:

| Default Light    | Default Dark |
| -------- | ------- |
| <img width="541" alt="Screenshot 2024-10-22 at 15 22 18" src="https://github.com/user-attachments/assets/277e1cfa-c739-4904-8183-287faa15fce2"> | <img width="544" alt="Screenshot 2024-10-22 at 15 22 42" src="https://github.com/user-attachments/assets/75d241b4-37a6-4ebe-87fc-057c4d03cdd4"> |

| Customized Light    | Customized Dark |
| -------- | ------- |
| <img width="543" alt="Screenshot 2024-10-22 at 15 23 03" src="https://github.com/user-attachments/assets/d31be84a-be51-45d3-b164-fcde3f12afd1"> | <img width="544" alt="Screenshot 2024-10-22 at 15 23 22" src="https://github.com/user-attachments/assets/c16af1a7-0c69-4891-ac3c-ca28df575457"> |

`WooPaymentsDepositsOverviewView` expanded preview (no change):

| Trunk    | This PR |
| -------- | ------- |
| <img width="546" alt="Screenshot 2024-10-22 at 15 29 08" src="https://github.com/user-attachments/assets/d9641e0d-829e-4857-96d0-711385384f0a"> | <img width="546" alt="Screenshot 2024-10-22 at 15 27 19" src="https://github.com/user-attachments/assets/a0f69f15-23b1-44e8-a2bf-c7d52824bf9b"> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
