### PR TITLE
[Custom Fields] Handle saving changes

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -222,7 +222,7 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
         let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? false
 
         // Filter out metadata if the key is prefixed with an underscore (internal meta keys) or the value is empty
-        let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") && !$0.value.isEmpty }) ?? []
+        let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") }) ?? []
 
         // Subscriptions extension
         let renewalSubscriptionID = allOrderMetaData?.first(where: { $0.key == "_subscription_renewal" })?.value

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -221,7 +221,7 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
         // https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-order.php#L1537-L1561
         let needsProcessing = try container.decodeIfPresent(Bool.self, forKey: .needsProcessing) ?? false
 
-        // Filter out metadata if the key is prefixed with an underscore (internal meta keys) or the value is empty
+        // Filter out metadata if the key is prefixed with an underscore (internal meta keys)
         let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") }) ?? []
 
         // Subscriptions extension

--- a/Networking/Networking/Remote/MetaDataRemote.swift
+++ b/Networking/Networking/Remote/MetaDataRemote.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Interface for remote requests to Product and Orders meta data.
 ///
 public protocol MetaDataRemoteProtocol {
-    func updateMetaData(for siteID: Int64, for parentID: Int64, type: MetaDataType, metadata: [[String: Any]]) async throws -> [MetaData]
+    func updateMetaData(for siteID: Int64, for parentID: Int64, type: MetaDataType, metadata: [[String: Any?]]) async throws -> [MetaData]
 }
 
 public final class MetaDataRemote: Remote, MetaDataRemoteProtocol {
@@ -19,7 +19,7 @@ public final class MetaDataRemote: Remote, MetaDataRemoteProtocol {
     ///     - metadata: The metadata to be updated.
     /// - Returns: An array of updated MetaData.
     ///
-    public func updateMetaData(for siteID: Int64, for parentID: Int64, type: MetaDataType, metadata: [[String: Any]]) async throws -> [MetaData] {
+    public func updateMetaData(for siteID: Int64, for parentID: Int64, type: MetaDataType, metadata: [[String: Any?]]) async throws -> [MetaData] {
 
         let parameters: [String: Any] = [ParameterKey.metaData: metadata, ParameterKey.fields: ParameterKey.metaData]
         let path: String

--- a/Networking/NetworkingTests/Remote/MetaDataRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MetaDataRemoteTests.swift
@@ -26,9 +26,10 @@ final class MetaDataRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/\(parentID)", filename: "meta-data-products-orders-update")
 
         // When
-        let metadata: [[String: Any]] = [
+        let metadata: [[String: Any?]] = [
             ["id": 1, "key": "lorem_key_1", "value": "Lorem ipsum"],
-            ["id": 2, "key": "ipsum_key_2", "value": "dolor sit amet"]
+            ["id": 2, "key": "ipsum_key_2", "value": "dolor sit amet"],
+            ["id": 3, "value": nil]
         ]
 
         let result = try await remote.updateMetaData(for: siteID, for: parentID, type: type, metadata: metadata)
@@ -53,9 +54,10 @@ final class MetaDataRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders/\(parentID)", filename: "meta-data-products-orders-update")
 
         // When
-        let metadata: [[String: Any]] = [
+        let metadata: [[String: Any?]] = [
             ["id": 1, "key": "lorem_key_1", "value": "Lorem ipsum"],
-            ["id": 2, "key": "ipsum_key_2", "value": "dolor sit amet"]
+            ["id": 2, "key": "ipsum_key_2", "value": "dolor sit amet"],
+            ["id": 3, "value": nil]
         ]
 
         let result = try await remote.updateMetaData(for: siteID, for: parentID, type: type, metadata: metadata)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -488,7 +488,7 @@ extension OrderDetailsViewModel {
             }
 
             let isEditable = featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders)
-            let viewModel = CustomFieldsListViewModel(customFields: customFields, customFieldType: .order)
+            let viewModel = CustomFieldsListViewModel(customFields: customFields, siteID: order.siteID, parentItemID: order.orderID, customFieldType: .order)
 
             let customFieldsListViewController = CustomFieldsListHostingController(isEditable: isEditable,
                                                                                    viewModel: viewModel)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -488,7 +488,7 @@ extension OrderDetailsViewModel {
             }
 
             let isEditable = featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders)
-            let viewModel = CustomFieldsListViewModel(customFields: customFields)
+            let viewModel = CustomFieldsListViewModel(customFields: customFields, customFieldType: .order)
 
             let customFieldsListViewController = CustomFieldsListHostingController(isEditable: isEditable,
                                                                                    viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -64,9 +64,9 @@ private extension CustomFieldsListHostingController {
     }
 
     func observeStateChange() {
-        viewModel.$pendingChanges
-            .sink { [weak self] pendingChanges in
-                self?.saveCustomFieldButtonItem.isEnabled = pendingChanges.hasChanges
+        viewModel.$hasChanges
+            .sink { [weak self] hasChanges in
+                self?.saveCustomFieldButtonItem.isEnabled = hasChanges
             }
             .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -63,9 +63,9 @@ private extension CustomFieldsListHostingController {
     }
 
     func observeStateChange() {
-        viewModel.$hasChanges
-            .sink { [weak self] hasChanges in
-                self?.saveCustomFieldButtonItem.isEnabled = hasChanges
+        viewModel.$pendingChanges
+            .sink { [weak self] pendingChanges in
+                self?.saveCustomFieldButtonItem.isEnabled = pendingChanges.hasChanges
             }
             .store(in: &subscriptions)
     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -243,6 +243,11 @@ extension CustomFieldsListHostingController {
             value: "Please wait while we save your changes",
             comment: "Message for the in progress view shown when saving changes"
         )
+        static let saveSuccessTitle = NSLocalizedString(
+            "customFieldsListHostingController.saveSuccessTitle",
+            value: "Changes saved",
+            comment: "Title for the success message when saving changes"
+        )
         static let saveErrorTitle = NSLocalizedString(
             "customFieldsListHostingController.saveErrorTitle",
             value: "Error saving changes",

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -243,6 +243,16 @@ extension CustomFieldsListHostingController {
             value: "Please wait while we save your changes",
             comment: "Message for the in progress view shown when saving changes"
         )
+        static let saveErrorTitle = NSLocalizedString(
+            "customFieldsListHostingController.saveErrorTitle",
+            value: "Error saving changes",
+            comment: "Title for the error message when saving changes"
+        )
+        static let saveErrorMessage = NSLocalizedString(
+            "customFieldsListHostingController.saveErrorMessage",
+            value: "There was an error saving your changes. Please try again.",
+            comment: "Message for the error message when saving changes"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -58,8 +58,9 @@ private extension CustomFieldsListHostingController {
     }
 
     @objc func saveCustomField() {
-        // todo: call viewmodel's save function
-        navigationController?.popViewController(animated: true)
+        Task {
+            await viewModel.saveChanges()
+        }
     }
 
     func observeStateChange() {
@@ -229,6 +230,8 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
                     CustomFieldViewModel(id: 0, title: "First Title", content: "First Content"),
                     CustomFieldViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
                 ],
+                siteID: 0,
+                parentItemID: 0,
                 customFieldType: .order
                 ))
     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -228,7 +228,9 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
                 customFields: [
                     CustomFieldViewModel(id: 0, title: "First Title", content: "First Content"),
                     CustomFieldViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
-                ]))
+                ],
+                customFieldType: .order
+                ))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -69,6 +69,31 @@ private extension CustomFieldsListHostingController {
                 self?.saveCustomFieldButtonItem.isEnabled = pendingChanges.hasChanges
             }
             .store(in: &subscriptions)
+
+        viewModel.$isSavingChanges
+            .sink { [weak self] isSavingChanges in
+                if isSavingChanges {
+                    self?.displayInProgressController()
+                } else {
+                    self?.dismissInProgressController()
+                }
+            }
+            .store(in: &subscriptions)
+    }
+
+    func displayInProgressController() {
+        let inProgressController = InProgressViewController(
+            viewProperties: InProgressViewProperties(
+                title: Localization.inProgressTitle,
+                message: Localization.inProgressMessage
+            )
+        )
+        inProgressController.modalPresentationStyle = .overFullScreen
+        present(inProgressController, animated: true)
+    }
+
+    func dismissInProgressController() {
+        dismiss(animated: true)
     }
 }
 
@@ -207,6 +232,16 @@ extension CustomFieldsListHostingController {
             "customFieldsListHostingController.deleteNoticeUndo",
             value: "Undo",
             comment: "Action to undo the deletion of a custom field"
+        )
+        static let inProgressTitle = NSLocalizedString(
+            "customFieldsListHostingController.inProgressTitle",
+            value: "Saving...",
+            comment: "Title for the in progress view shown when saving changes"
+        )
+        static let inProgressMessage = NSLocalizedString(
+            "customFieldsListHostingController.inProgressMessage",
+            value: "Please wait while we save your changes",
+            comment: "Message for the in progress view shown when saving changes"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -208,6 +208,16 @@ extension CustomFieldsListViewModel {
             self.value = customField.content
             self.fieldId = customField.id
         }
+
+        func asDictionary() -> [String: Any] {
+            var json: [String: Any] = [:]
+                if let fieldId = fieldId {
+                    json["id"] = fieldId
+                }
+                json["key"] = key
+                json["value"] = value
+            return json
+        }
     }
 
     struct PendingCustomFieldsChanges {
@@ -236,18 +246,8 @@ extension CustomFieldsListViewModel {
         }
 
         func asDictionary() -> [[String: Any?]] {
-            func metaDataAsDictionary(_ field: CustomFieldUI) -> [String: Any] {
-                var json: [String: Any] = [:]
-                if let fieldId = field.fieldId {
-                    json["id"] = fieldId
-                }
-                json["key"] = field.key
-                json["value"] = field.value
-                return json
-            }
-
-            return editedFields.map { metaDataAsDictionary($0) } +
-                addedFields.map { metaDataAsDictionary($0) } +
+            return editedFields.map { $0.asDictionary() } +
+                addedFields.map { $0.asDictionary() } +
                 deletedFieldIds.map { ["id": $0, "value": nil] }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -7,8 +7,8 @@ final class CustomFieldsListViewModel: ObservableObject {
     private let stores: StoresManager
     @Published private var originalCustomFields: [CustomFieldViewModel]
     private let customFieldsType: MetaDataType
-    private let siteId: Int64
-    private let parentItemId: Int64
+    private let siteID: Int64
+    private let parentItemID: Int64
 
     @Published var selectedCustomField: CustomFieldUI? = nil
     @Published var isAddingNewField: Bool = false
@@ -39,8 +39,8 @@ final class CustomFieldsListViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
         self.originalCustomFields = customFields
-        self.siteId = siteID
-        self.parentItemId = parentItemID
+        self.siteID = siteID
+        self.parentItemID = parentItemID
         self.customFieldsType = customFieldType
 
         observePendingChanges()
@@ -176,8 +176,8 @@ private extension CustomFieldsListViewModel {
     @MainActor
     func dispatchSavingChanges() async throws -> [MetaData] {
         return try await withCheckedThrowingContinuation { continuation in
-            let action = MetaDataAction.updateMetaData(siteID: siteId,
-                                                       parentItemID: parentItemId,
+            let action = MetaDataAction.updateMetaData(siteID: siteID,
+                                                       parentItemID: parentItemID,
                                                        metaDataType: customFieldsType,
                                                        metadata: pendingChanges.asJson()) { result in
                 continuation.resume(with: result)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -244,13 +244,9 @@ extension CustomFieldsListViewModel {
                 return json
             }
 
-            var json: [[String: Any?]] = []
-            json.append(contentsOf: editedFields.map { metaDataAsJson($0) })
-            json.append(contentsOf: addedFields.map { metaDataAsJson($0) })
-            json.append(contentsOf: deletedFieldIds.map {
-                ["id": $0, "value": nil]
-            })
-            return json
+            return editedFields.map { metaDataAsJson($0) } +
+                addedFields.map { metaDataAsJson($0) } +
+                deletedFieldIds.map { ["id": $0, "value": nil] }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -116,7 +116,7 @@ extension CustomFieldsListViewModel {
                             message: CustomFieldsListHostingController.Localization.saveErrorMessage,
                             feedbackType: .error)
         }
-      
+
         isSavingChanges = false
     }
 }
@@ -159,7 +159,7 @@ private extension CustomFieldsListViewModel {
         $pendingChanges
             .map { [weak self] pendingChanges in
                 guard let self = self else { return [] }
-                
+
                 return self.originalCustomFields
                     .filter { field in !pendingChanges.deletedFieldIds.contains(where: { $0 == field.id }) }
                     .map { field in pendingChanges.editedFields.first(where: { $0.fieldId == field.id }) ?? CustomFieldUI(customField: field) }
@@ -175,21 +175,11 @@ private extension CustomFieldsListViewModel {
     @MainActor
     func dispatchSavingChanges() async throws -> [MetaData] {
         return try await withCheckedThrowingContinuation { continuation in
-            let action = switch customFieldsType {
-            case .order:
-                MetaDataAction.updateOrderMetaData(siteID: siteId,
-                                                   orderID: parentItemId,
-                                                   metadata: pendingChanges.asJson(),
-                                                   onCompletion: { result in
-                                                        continuation.resume(with: result)
-                                                   })
-            case .product:
-                MetaDataAction.updateProductMetaData(siteID: siteId,
-                                                     productID: parentItemId,
-                                                     metadata: pendingChanges.asJson(),
-                                                     onCompletion: { result in
-                                                        continuation.resume(with: result)
-                                                     })
+            let action = MetaDataAction.updateMetaData(siteID: siteId,
+                                                       parentItemID: parentItemId,
+                                                       metaDataType: customFieldsType,
+                                                       metadata: pendingChanges.asJson()) { result in
+                continuation.resume(with: result)
             }
 
             stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -10,15 +10,10 @@ final class CustomFieldsListViewModel: ObservableObject {
     private let siteId: Int64
     private let parentItemId: Int64
 
-    var shouldShowErrorState: Bool {
-        savingError != nil
-    }
-
     @Published var selectedCustomField: CustomFieldUI? = nil
     @Published var isAddingNewField: Bool = false
     @Published var isSavingChanges: Bool = false
 
-    @Published private(set) var savingError: Error?
     @Published private(set) var combinedList: [CustomFieldUI] = []
     @Published var notice: Notice?
 
@@ -121,11 +116,13 @@ extension CustomFieldsListViewModel {
             originalCustomFields = result.map { CustomFieldViewModel(metadata: $0) }
             pendingChanges = PendingCustomFieldsChanges()
             updateCombinedList()
-            isSavingChanges = false
         } catch {
-            savingError = error
-            isSavingChanges = false
+            notice = Notice(title: CustomFieldsListHostingController.Localization.saveErrorTitle,
+                            message: CustomFieldsListHostingController.Localization.saveErrorMessage,
+                            feedbackType: .error)
         }
+      
+        isSavingChanges = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -106,6 +106,8 @@ extension CustomFieldsListViewModel {
     @MainActor
     func saveChanges() async {
         isSavingChanges = true
+        // Remove any existing notice before saving changes
+        notice = nil
 
         do {
             let result = try await dispatchSavingChanges()

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -113,6 +113,8 @@ extension CustomFieldsListViewModel {
             let result = try await dispatchSavingChanges()
             originalCustomFields = result.map { CustomFieldViewModel(metadata: $0) }
             pendingChanges = PendingCustomFieldsChanges()
+            notice = Notice(title: CustomFieldsListHostingController.Localization.saveSuccessTitle,
+                            feedbackType: .success)
         } catch {
             notice = Notice(title: CustomFieldsListHostingController.Localization.saveErrorTitle,
                             message: CustomFieldsListHostingController.Localization.saveErrorMessage,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -17,7 +17,7 @@ final class CustomFieldsListViewModel: ObservableObject {
     @Published private(set) var combinedList: [CustomFieldUI] = []
     @Published var notice: Notice?
 
-    @Published private(set) var pendingChanges = PendingCustomFieldsChanges()
+    @Published private var pendingChanges = PendingCustomFieldsChanges()
     private var editedFields: [CustomFieldUI] {
         get { pendingChanges.editedFields }
         set { pendingChanges = pendingChanges.copy(editedFields: newValue) }
@@ -30,6 +30,7 @@ final class CustomFieldsListViewModel: ObservableObject {
         get { pendingChanges.deletedFieldIds }
         set { pendingChanges = pendingChanges.copy(deletedFieldIds: newValue) }
     }
+    @Published private(set) var hasChanges: Bool = false
 
     init(customFields: [CustomFieldViewModel],
          siteID: Int64,
@@ -165,6 +166,10 @@ private extension CustomFieldsListViewModel {
                     + pendingChanges.addedFields
             }
             .assign(to: &$combinedList)
+
+        $pendingChanges
+            .map { $0.hasChanges }
+            .assign(to: &$hasChanges)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 final class CustomFieldsListViewModel: ObservableObject {
     private let stores: StoresManager
-    private var originalCustomFields: [CustomFieldViewModel]
+    @Published private var originalCustomFields: [CustomFieldViewModel]
     private let customFieldsType: MetaDataType
     private let siteId: Int64
     private let parentItemId: Int64
@@ -159,10 +159,9 @@ private extension CustomFieldsListViewModel {
 
     func observePendingChanges() {
         $pendingChanges
-            .map { [weak self] pendingChanges in
-                guard let self = self else { return [] }
-
-                return self.originalCustomFields
+            .combineLatest($originalCustomFields)
+            .map { (pendingChanges, originalFields) in
+                return originalFields
                     .filter { field in !pendingChanges.deletedFieldIds.contains(where: { $0 == field.id }) }
                     .map { field in pendingChanges.editedFields.first(where: { $0.fieldId == field.id }) ?? CustomFieldUI(customField: field) }
                     + pendingChanges.addedFields

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -179,7 +179,7 @@ private extension CustomFieldsListViewModel {
             let action = MetaDataAction.updateMetaData(siteID: siteID,
                                                        parentItemID: parentItemID,
                                                        metaDataType: customFieldsType,
-                                                       metadata: pendingChanges.asJson()) { result in
+                                                       metadata: pendingChanges.asDictionary()) { result in
                 continuation.resume(with: result)
             }
 
@@ -233,8 +233,8 @@ extension CustomFieldsListViewModel {
                                        deletedFieldIds: deletedFieldIds ?? self.deletedFieldIds)
         }
 
-        func asJson() -> [[String: Any?]] {
-            func metaDataAsJson(_ field: CustomFieldUI) -> [String: Any] {
+        func asDictionary() -> [[String: Any?]] {
+            func metaDataAsDictionary(_ field: CustomFieldUI) -> [String: Any] {
                 var json: [String: Any] = [:]
                 if let fieldId = field.fieldId {
                     json["id"] = fieldId
@@ -244,8 +244,8 @@ extension CustomFieldsListViewModel {
                 return json
             }
 
-            return editedFields.map { metaDataAsJson($0) } +
-                addedFields.map { metaDataAsJson($0) } +
+            return editedFields.map { metaDataAsDictionary($0) } +
+                addedFields.map { metaDataAsDictionary($0) } +
                 deletedFieldIds.map { ["id": $0, "value": nil] }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 
 final class CustomFieldsListViewModel: ObservableObject {
     private let originalCustomFields: [CustomFieldViewModel]
+    private let customFieldsType: MetaDataType
 
     var shouldShowErrorState: Bool {
         savingError != nil
@@ -20,8 +21,10 @@ final class CustomFieldsListViewModel: ObservableObject {
     @Published private var deletedFieldIds: [Int64] = []
     @Published private(set) var hasChanges: Bool = false
 
-    init(customFields: [CustomFieldViewModel]) {
+    init(customFields: [CustomFieldViewModel], customFieldType: MetaDataType) {
         self.originalCustomFields = customFields
+        self.customFieldsType = customFieldType
+
         updateCombinedList()
         configureHasChanges()
     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -1,6 +1,6 @@
 import Combine
 import Foundation
-import Networking
+import enum Networking.MetaDataType
 import Yosemite
 
 final class CustomFieldsListViewModel: ObservableObject {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1494,7 +1494,7 @@ private extension ProductFormViewController {
             CustomFieldViewModel(metadata: $0)
         }
 
-        let viewModel = CustomFieldsListViewModel(customFields: customFields)
+        let viewModel = CustomFieldsListViewModel(customFields: customFields, customFieldType: .product)
 
         let customFieldsListViewController = CustomFieldsListHostingController(isEditable: true,
                                                                                viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1494,7 +1494,7 @@ private extension ProductFormViewController {
             CustomFieldViewModel(metadata: $0)
         }
 
-        let viewModel = CustomFieldsListViewModel(customFields: customFields, customFieldType: .product)
+        let viewModel = CustomFieldsListViewModel(customFields: customFields, siteID: product.siteID, parentItemID: product.productID, customFieldType: .product)
 
         let customFieldsListViewController = CustomFieldsListHostingController(isEditable: true,
                                                                                viewModel: viewModel)

--- a/Yosemite/Yosemite/Actions/MetaDataAction.swift
+++ b/Yosemite/Yosemite/Actions/MetaDataAction.swift
@@ -14,7 +14,7 @@ public enum MetaDataAction: Action {
     ///
     case updateOrderMetaData(siteID: Int64,
                              orderID: Int64,
-                             metadata: [[String: Any]],
+                             metadata: [[String: Any?]],
                              onCompletion: (Result<[MetaData], Error>) -> Void)
 
     /// Updates product metadata both remotely and in the local database.
@@ -26,6 +26,6 @@ public enum MetaDataAction: Action {
     ///
     case updateProductMetaData(siteID: Int64,
                                productID: Int64,
-                               metadata: [[String: Any]],
+                               metadata: [[String: Any?]],
                                onCompletion: (Result<[MetaData], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/MetaDataAction.swift
+++ b/Yosemite/Yosemite/Actions/MetaDataAction.swift
@@ -5,27 +5,17 @@ import Networking
 ///
 public enum MetaDataAction: Action {
 
-    /// Updates order metadata both remotely and in the local database.
+    /// Updates metadata of a parent item both remotely and in the local database.
     ///
-    /// - Parameter siteID: Site id of the order.
-    /// - Parameter orderID: ID of the order.
+    /// - Parameter siteID: Site id of the item.
+    /// - Parameter parentItemID: ID of the parent item.
+    /// - Parameter metaDataType: Type of metadata.
     /// - Parameter metadata: Metadata to be updated.
     /// - Parameter onCompletion: Callback called when the action is finished, including the result of the update operation.
     ///
-    case updateOrderMetaData(siteID: Int64,
-                             orderID: Int64,
-                             metadata: [[String: Any?]],
-                             onCompletion: (Result<[MetaData], Error>) -> Void)
-
-    /// Updates product metadata both remotely and in the local database.
-    ///
-    /// - Parameter siteID: Site id of the product.
-    /// - Parameter productID: ID of the product.
-    /// - Parameter metadata: Metadata to be updated.
-    /// - Parameter onCompletion: Callback called when the action is finished, including the result of the update operation.
-    ///
-    case updateProductMetaData(siteID: Int64,
-                               productID: Int64,
-                               metadata: [[String: Any?]],
-                               onCompletion: (Result<[MetaData], Error>) -> Void)
+    case updateMetaData(siteID: Int64,
+                        parentItemID: Int64,
+                        metaDataType: MetaDataType,
+                        metadata: [[String: Any?]],
+                        onCompletion: (Result<[MetaData], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/MetaDataStore.swift
+++ b/Yosemite/Yosemite/Stores/MetaDataStore.swift
@@ -91,7 +91,7 @@ private extension MetaDataStore {
     ///
     func updateOrderMetaData(siteID: Int64,
                              orderID: Int64,
-                             metadata: [[String: Any]],
+                             metadata: [[String: Any?]],
                              onCompletion: @escaping (Result<[MetaData], Error>) -> Void) {
         Task { @MainActor in
             do {
@@ -162,7 +162,7 @@ private extension MetaDataStore {
     ///
     func updateProductMetaData(siteID: Int64,
                                productID: Int64,
-                               metadata: [[String: Any]],
+                               metadata: [[String: Any?]],
                                onCompletion: @escaping (Result<[MetaData], Error>) -> Void) {
         Task { @MainActor in
             do {

--- a/Yosemite/Yosemite/Stores/MetaDataStore.swift
+++ b/Yosemite/Yosemite/Stores/MetaDataStore.swift
@@ -54,10 +54,8 @@ public final class MetaDataStore: Store {
         }
 
         switch action {
-        case let .updateOrderMetaData(siteID, orderID, metadata, onCompletion):
-            updateOrderMetaData(siteID: siteID, orderID: orderID, metadata: metadata, onCompletion: onCompletion)
-        case let .updateProductMetaData(siteID, productID, metadata, onCompletion):
-            updateProductMetaData(siteID: siteID, productID: productID, metadata: metadata, onCompletion: onCompletion)
+        case let .updateMetaData(siteID, parentItemId, metaDataType, metadata, onCompletion):
+            updateMetaData(siteID: siteID, parentItemID: parentItemId, metaDataType: metaDataType, metadata: metadata, onCompletion: onCompletion)
         }
     }
 }
@@ -65,6 +63,25 @@ public final class MetaDataStore: Store {
 // MARK: - Upsert MetaData for Orders and Products
 //
 private extension MetaDataStore {
+    /// Updates metadata both remotely and in the local database.
+    /// - Parameters:
+    /// - siteID: Site id of the order.
+    /// - parentItemID: ID of the parent item.
+    /// - metaDataType: Type of metadata.
+    /// - metadata: Metadata to be updated.
+    func updateMetaData(siteID: Int64,
+                        parentItemID: Int64,
+                        metaDataType: MetaDataType,
+                        metadata: [[String: Any?]],
+                        onCompletion: @escaping (Result<[MetaData], Error>) -> Void) {
+        switch metaDataType {
+        case .order:
+            updateOrderMetaData(siteID: siteID, orderID: parentItemID, metadata: metadata, onCompletion: onCompletion)
+        case .product:
+            updateProductMetaData(siteID: siteID, productID: parentItemID, metadata: metadata, onCompletion: onCompletion)
+        }
+    }
+
     /// Updates order metadata both remotely and in the local database..
     /// - Parameters:
     ///   - siteID: Site id of the order.

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMetaDataRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMetaDataRemote.swift
@@ -12,7 +12,7 @@ final class MockMetaDataRemote {
 }
 
 extension MockMetaDataRemote: MetaDataRemoteProtocol {
-    func updateMetaData(for siteID: Int64, for parentID: Int64, type: MetaDataType, metadata: [[String: Any]]) async throws -> [MetaData] {
+    func updateMetaData(for siteID: Int64, for parentID: Int64, type: MetaDataType, metadata: [[String: Any?]]) async throws -> [MetaData] {
         guard let result = updatingMetaDataResult else {
             XCTFail("Could not find result for updating metadata.")
             throw NetworkError.notFound()

--- a/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
@@ -45,10 +45,11 @@ final class MetaDataStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(MetaDataAction.updateOrderMetaData(siteID: self.sampleSiteID,
-                                                              orderID: self.sampleOrderID,
-                                                              metadata: self.newMetadataArray,
-                                                              onCompletion: { result in
+            store.onAction(MetaDataAction.updateMetaData(siteID: self.sampleSiteID,
+                                                         parentItemID: self.sampleOrderID,
+                                                         metaDataType: .order,
+                                                         metadata: self.newMetadataArray,
+                                                         onCompletion: { result in
                 promise(result)
             }))
         }
@@ -71,9 +72,13 @@ final class MetaDataStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(MetaDataAction.updateOrderMetaData(siteID: self.sampleSiteID, orderID: self.sampleOrderID, metadata: metadata, onCompletion: { result in
-                promise(result)
-            }))
+            store.onAction(MetaDataAction.updateMetaData(siteID: self.sampleSiteID,
+                                                         parentItemID: self.sampleOrderID,
+                                                         metaDataType: .order,
+                                                         metadata: metadata,
+                                                         onCompletion: { result in
+                                                             promise(result)
+                                                         }))
         }
 
         // Then
@@ -93,12 +98,13 @@ final class MetaDataStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(MetaDataAction.updateProductMetaData(siteID: self.sampleSiteID,
-                                                                productID: self.sampleProductID,
-                                                                metadata: self.newMetadataArray,
-                                                                onCompletion: { result in
-                promise(result)
-            }))
+            store.onAction(MetaDataAction.updateMetaData(siteID: self.sampleSiteID,
+                                                         parentItemID: self.sampleOrderID,
+                                                         metaDataType: .order,
+                                                         metadata: self.newMetadataArray,
+                                                         onCompletion: { result in
+                                                             promise(result)
+                                                         }))
         }
 
         // Then
@@ -119,12 +125,13 @@ final class MetaDataStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            store.onAction(MetaDataAction.updateProductMetaData(siteID: self.sampleSiteID,
-                                                                productID: self.sampleProductID,
-                                                                metadata: metadata,
-                                                                onCompletion: { result in
-                promise(result)
-            }))
+            store.onAction(MetaDataAction.updateMetaData(siteID: self.sampleSiteID,
+                                                         parentItemID: self.sampleOrderID,
+                                                         metaDataType: .order,
+                                                         metadata: metadata,
+                                                         onCompletion: { result in
+                                                             promise(result)
+                                                         }))
         }
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14183
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds logic to handle saving the changes in the Custom Fields screen, the PR also added few changes to prepare for the saving, I'll post comments below on the rationale behind them.

This is my first big PR for iOS, so feel free to share any nitpicks 🙂.

## Steps to reproduce
1. Open an order or a product in the app.
2. Tap on the custom fields button (or row in products).
3. Make some changes.
4. Save.

## Testing information
- Test saving of different combinations of changes.
- Test error handling.

## Screenshots

https://github.com/user-attachments/assets/c2a3a6ad-9812-4768-8617-deb2f3ac1d5c

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.