### PR TITLE
[Woo POS] Pagination support: Initial infinite scrolling

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -23,7 +23,7 @@ struct ItemListView: View {
             }
             Button("Load more") {
                 Task { @MainActor in
-                    await viewModel.debug_forceNext()
+                    await viewModel.loadNextPage()
                 }
             }
         }
@@ -141,6 +141,20 @@ private extension ItemListView {
             }
             .padding(.bottom, floatingControlAreaSize.height)
             .padding(.horizontal, Constants.itemListPadding)
+            .background(GeometryReader { proxy in
+                Color.clear
+                    .onChange(of: proxy.frame(in: .global).maxY) { maxY in
+                        if viewModel.state == .loading {
+                            return
+                        }
+                        let viewHeight = UIScreen.main.bounds.height
+                        if maxY < viewHeight {
+                            Task {
+                                await viewModel.loadNextPage()
+                            }
+                        }
+                    }
+            })
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -21,11 +21,6 @@ struct ItemListView: View {
             case .loading, .loaded:
                 listView(viewModel.items)
             }
-            Button("Load more") {
-                Task { @MainActor in
-                    await viewModel.loadNextPage()
-                }
-            }
         }
         .refreshable {
             await viewModel.reload()
@@ -128,14 +123,11 @@ private extension ItemListView {
                 if dynamicTypeSize.isAccessibilitySize, viewModel.shouldShowHeaderBanner {
                     bannerCardView
                 }
-                ForEach(Array(items.enumerated()), id: \.element.productID) { index, item in
+                ForEach(items, id: \.productID) { item in
                     Button(action: {
                         viewModel.select(item)
                     }, label: {
                         ItemCardView(item: item)
-                            .onAppear {
-                                debugPrint("🍍 item: \(item.name) index: \(index) currentPage: \(viewModel.currentPage)")
-                            }
                     })
                 }
             }
@@ -150,7 +142,7 @@ private extension ItemListView {
                         let viewHeight = UIScreen.main.bounds.height
                         if maxY < viewHeight {
                             Task {
-                                await viewModel.loadNextPage()
+                                await viewModel.populatePointOfSaleItems()
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -21,6 +21,11 @@ struct ItemListView: View {
             case .loading, .loaded:
                 listView(viewModel.items)
             }
+            Button("Load more") {
+                Task { @MainActor in
+                    await viewModel.debug_forceNext()
+                }
+            }
         }
         .refreshable {
             await viewModel.reload()
@@ -123,11 +128,14 @@ private extension ItemListView {
                 if dynamicTypeSize.isAccessibilitySize, viewModel.shouldShowHeaderBanner {
                     bannerCardView
                 }
-                ForEach(items, id: \.productID) { item in
+                ForEach(Array(items.enumerated()), id: \.element.productID) { index, item in
                     Button(action: {
                         viewModel.select(item)
                     }, label: {
                         ItemCardView(item: item)
+                            .onAppear {
+                                debugPrint("🍍 item: \(item.name) index: \(index) currentPage: \(viewModel.currentPage)")
+                            }
                     })
                 }
             }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -73,10 +73,6 @@ final class ItemListViewModel: ItemListViewModelProtocol {
         }
     }
 
-    func loadNextPage() async {
-        await populatePointOfSaleItems()
-    }
-
     @MainActor
     func reload() async {
         await populatePointOfSaleItems()

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -66,6 +66,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     @MainActor
     func reload() async {
         currentPage = 0
+        items.removeAll()
         await populatePointOfSaleItems()
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -51,8 +51,8 @@ final class ItemListViewModel: ItemListViewModelProtocol {
                 // This is more of an issue if the `per_page` is low (ex: 5 when testing), but since we fetch 100 product on each call,
                 // we should be fine here and consider this edge case good for now, as we expect to find at least 1 eligible items in the
                 // subsequent 100 items.
-                debugPrint("🍍 next page \(nextPage) has no new items")
-                // If we hit it, it would stop as currentPage == lastPage, so for now let's assign the new page anyway for testing:
+                // If we hit it, we could would stop here as currentPage == lastPage, but for now let's assign the new page anyway to account
+                // for the temporary limitations.
                 currentPage = nextPage
                 return
             }
@@ -73,7 +73,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
         }
     }
 
-    func debug_forceNext() async {
+    func loadNextPage() async {
         await populatePointOfSaleItems()
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -57,7 +57,11 @@ final class ItemListViewModel: ItemListViewModelProtocol {
                 return
             }
 
-            items.append(contentsOf: newItems)
+            let uniqueNewItems = newItems.filter { newItem in
+                !items.contains(where: { $0.productID == newItem.productID })
+            }
+            items.append(contentsOf: uniqueNewItems)
+
             if items.count == 0 {
                 state = .empty
             } else {
@@ -75,6 +79,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @MainActor
     func reload() async {
+        currentPage = 0
         await populatePointOfSaleItems()
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -43,20 +43,6 @@ final class ItemListViewModel: ItemListViewModelProtocol {
         do {
             state = .loading
             let newItems = try await itemProvider.providePointOfSaleItems(pageNumber: nextPage)
-            if newItems.count == 0 {
-                // Current limitation:
-                // If newItems returns 0 here, that should mark the last page with items, so no further pagination would be needed.
-                // This doesn't work in our usecase, as we filter eligible products AFTER the remote call, this means there could be
-                // more eligible products in subsequent pages, so we cannot really stop paginating at this point.
-                // This is more of an issue if the `per_page` is low (ex: 5 when testing), but since we fetch 100 product on each call,
-                // we should be fine here and consider this edge case good for now, as we expect to find at least 1 eligible items in the
-                // subsequent 100 items.
-                // If we hit it, we could would stop here as currentPage == lastPage, but for now let's assign the new page anyway to account
-                // for the temporary limitations.
-                currentPage = nextPage
-                return
-            }
-
             let uniqueNewItems = newItems.filter { newItem in
                 !items.contains(where: { $0.productID == newItem.productID })
             }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -352,6 +352,30 @@ final class ItemListViewModelTests: XCTestCase {
 
         XCTAssertTrue(sut.showSimpleProductsModal)
     }
+
+    func test_currentPage_when_populatePointOfSaleItems_is_invoked_multiple_times_then_updates_to_next_page() async {
+        XCTAssertTrue(sut.currentPage == 0, "Initial state.")
+
+        // When/Then
+        await sut.populatePointOfSaleItems()
+        XCTAssertTrue(sut.currentPage == 1)
+
+        // When/Then
+        await sut.populatePointOfSaleItems()
+        XCTAssertTrue(sut.currentPage == 2)
+    }
+
+    func test_currentPage_when_reload_is_invoked_multiple_times_then_stays_on_first_page() async {
+        XCTAssertTrue(sut.currentPage == 0, "Initial state.")
+
+        // When/Then
+        await sut.reload()
+        XCTAssertTrue(sut.currentPage == 1)
+
+        // When/Then
+        await sut.reload()
+        XCTAssertTrue(sut.currentPage == 1)
+    }
 }
 
 private extension ItemListViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-ios/issues/14186
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds initial support for infinite scrolling to the Point of Sale, for this, we observe the changes on the view's height and attempt to fetch the next page of products.

If there are new products, we append them to the existing list and continue keeping track of the current page for subsequent pagination attempts.

We also update the pull-to-refresh to empty whatever is in memory and reset the page count to zero. There are still some improvements to be done, tracked in the [main issue](https://github.com/woocommerce/woocommerce-ios/issues/14186).

https://github.com/user-attachments/assets/f89c0757-bd1f-4a4a-a0f0-40e8a8c22125

## Testing information
- For easiness, update `POSConstants.productsPerPage` to a lower number of products that would still be larger than the available screen space, for example "10":
- In POS, observe that scrolling down keeps loading new products
- Without exiting POS, in the web, create a new eligible product and publish it, then in POS pull-to-refresh. Observe that items in memory are entirely cleared, and we're back to page 0 with the newest item at the top.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
