### PR TITLE
Adding a package UI - Add weight field to custom package creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -112,7 +112,7 @@ extension WooShippingPackageUnitType {
                                               value: "Height",
                                               comment: "Info label for height input field")
         static let packageWeight = NSLocalizedString("wooShipping.createLabel.addPackage.packageWeight",
-                                              value: "Package Weight",
+                                              value: "Package weight",
                                               comment: "Info label for weight input field")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -12,7 +12,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     @Published var packageTemplateName: String = ""
     // The dimension unit used in the store (e.g. "in")
     let dimensionUnit: String
-    // The weight unit used in the store (e.g. "lg")
+    // The weight unit used in the store (e.g. "kg")
     let weightUnit: String
 
     // MARK: Initialization

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -4,7 +4,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     // Holds values for all dimension input fields.
     // Using a dictionary so we can easily add/remove new types
     // if needed just by adding new case in enum
-    @Published var fieldValues: [WooShippingPackageDimensionType: String] = [:]
+    @Published var fieldValues: [WooShippingPackageUnitType: String] = [:]
     // Holds selected package type when custom package is selected, it can be `box` or `envelope`
     @Published var packageType: WooShippingPackageType = .box
     // Holds value for toggle that determines if we are showing button for saving the template
@@ -12,11 +12,15 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     @Published var packageTemplateName: String = ""
     // The dimension unit used in the store (e.g. "in")
     let dimensionUnit: String
+    // The weight unit used in the store (e.g. "lg")
+    let weightUnit: String
 
     // MARK: Initialization
 
-    init(dimensionUnit: String? = ServiceLocator.shippingSettingsService.dimensionUnit) {
+    init(dimensionUnit: String? = ServiceLocator.shippingSettingsService.dimensionUnit,
+         weightUnit: String? = ServiceLocator.shippingSettingsService.weightUnit) {
         self.dimensionUnit = dimensionUnit ?? ""
+        self.weightUnit = weightUnit ?? ""
     }
 
     // Field values are invalid if one of them is empty
@@ -26,7 +30,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
                 return true
             }
         }
-        return fieldValues.count != WooShippingPackageDimensionType.allCases.count
+        return fieldValues.count != WooShippingPackageUnitType.allCases.count
     }
 
     func clearFieldValues() {
@@ -67,8 +71,9 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     }
 }
 
-enum WooShippingPackageDimensionType: CaseIterable {
+enum WooShippingPackageUnitType: CaseIterable {
     case length, width, height
+    case weight
     var name: String {
         switch self {
         case .length:
@@ -77,11 +82,17 @@ enum WooShippingPackageDimensionType: CaseIterable {
             return Localization.width
         case .height:
             return Localization.height
+        case .weight:
+            return Localization.emptyPackageWeight
         }
+    }
+
+    static var dimensionUnits: [WooShippingPackageUnitType] {
+        return [.length, .width, .height]
     }
 }
 
-extension WooShippingPackageDimensionType {
+extension WooShippingPackageUnitType {
     enum Localization {
         static let length = NSLocalizedString("wooShipping.createLabel.addPackage.length",
                                               value: "Length",
@@ -92,6 +103,9 @@ extension WooShippingPackageDimensionType {
         static let height = NSLocalizedString("wooShipping.createLabel.addPackage.height",
                                               value: "Height",
                                               comment: "Info label for height input field")
+        static let emptyPackageWeight = NSLocalizedString("wooShipping.createLabel.addPackage.emptyPackageWeight",
+                                              value: "Empty Package Weight",
+                                              comment: "Info label for weight input field")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -24,13 +24,21 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     }
 
     // Field values are invalid if one of them is empty
+    // - if we are saving template we check all field values
+    // - if we are not saving template we check only dimensions
     var areFieldValuesInvalid: Bool {
-        for (_, value) in fieldValues {
+        let keysToCheck: [WooShippingPackageUnitType] = showSaveTemplate ? WooShippingPackageUnitType.allCases : WooShippingPackageUnitType.dimensionUnits
+
+        var validFieldsCount: Int = 0
+
+        for (key, value) in fieldValues {
+            guard keysToCheck.contains(key) else { continue }
             if value.isEmpty {
                 return true
             }
+            validFieldsCount += 1
         }
-        return fieldValues.count != WooShippingPackageUnitType.allCases.count
+        return validFieldsCount != keysToCheck.count
     }
 
     func clearFieldValues() {
@@ -83,7 +91,7 @@ enum WooShippingPackageUnitType: CaseIterable {
         case .height:
             return Localization.height
         case .weight:
-            return Localization.emptyPackageWeight
+            return Localization.packageWeight
         }
     }
 
@@ -103,8 +111,8 @@ extension WooShippingPackageUnitType {
         static let height = NSLocalizedString("wooShipping.createLabel.addPackage.height",
                                               value: "Height",
                                               comment: "Info label for height input field")
-        static let emptyPackageWeight = NSLocalizedString("wooShipping.createLabel.addPackage.emptyPackageWeight",
-                                              value: "Empty Package Weight",
+        static let packageWeight = NSLocalizedString("wooShipping.createLabel.addPackage.packageWeight",
+                                              value: "Package Weight",
                                               comment: "Info label for weight input field")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -113,7 +113,10 @@ struct WooShippingAddPackageView: View {
                                     unitInputView(for: dimensionUnit, unit: customPackageViewModel.dimensionUnit)
                                 }
                             }
-                            unitInputView(for: WooShippingPackageUnitType.weight, unit: customPackageViewModel.weightUnit)
+                            // showing weight input only if we are saving the template
+                            if customPackageViewModel.showSaveTemplate {
+                                unitInputView(for: WooShippingPackageUnitType.weight, unit: customPackageViewModel.weightUnit)
+                            }
                         }
                         .toolbar {
                             ToolbarItemGroup(placement: .keyboard) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -109,23 +109,11 @@ struct WooShippingAddPackageView: View {
                         .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
                         VStack {
                             AdaptiveStack(spacing: 8) {
-                                ForEach(WooShippingPackageUnitType.dimensionUnits, id: \.self) { dimensionType in
-                                    WooShippingAddPackageUnitInputView(unitType: dimensionType,
-                                                                       unit: customPackageViewModel.dimensionUnit,
-                                                                       fieldValue: Binding(get: {
-                                        return self.customPackageViewModel.fieldValues[dimensionType] ?? ""
-                                    }, set: { value in
-                                        self.customPackageViewModel.fieldValues[dimensionType] = value
-                                    }), focusedField: _focusedField)
+                                ForEach(WooShippingPackageUnitType.dimensionUnits, id: \.self) { dimensionUnit in
+                                    unitInputView(for: dimensionUnit, unit: customPackageViewModel.dimensionUnit)
                                 }
                             }
-                            WooShippingAddPackageUnitInputView(unitType: WooShippingPackageUnitType.weight,
-                                                               unit: customPackageViewModel.weightUnit,
-                                                               fieldValue: Binding(get: {
-                                return self.customPackageViewModel.fieldValues[WooShippingPackageUnitType.weight] ?? ""
-                            }, set: { value in
-                                self.customPackageViewModel.fieldValues[WooShippingPackageUnitType.weight] = value
-                            }), focusedField: _focusedField)
+                            unitInputView(for: WooShippingPackageUnitType.weight, unit: customPackageViewModel.weightUnit)
                         }
                         .toolbar {
                             ToolbarItemGroup(placement: .keyboard) {
@@ -208,6 +196,16 @@ struct WooShippingAddPackageView: View {
                 .scrollDismissesKeyboard(.interactively)
             }
         }
+    }
+
+    private func unitInputView(for unitType: WooShippingPackageUnitType, unit: String) -> some View {
+        WooShippingAddPackageUnitInputView(unitType: unitType,
+                                           unit: unit,
+                                           fieldValue: Binding(get: {
+            return self.customPackageViewModel.fieldValues[unitType] ?? ""
+        }, set: { value in
+            self.customPackageViewModel.fieldValues[unitType] = value
+        }), focusedField: _focusedField)
     }
 
     private func onBackwardButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -28,7 +28,7 @@ struct WooShippingAddPackageView: View {
     @State var selectedPackageType = PackageProviderType.custom
 
     @FocusState var packageTemplateNameFieldFocused: Bool
-    @FocusState var focusedField: WooShippingPackageDimensionType?
+    @FocusState var focusedField: WooShippingPackageUnitType?
 
     // MARK: - UI
 
@@ -107,16 +107,25 @@ struct WooShippingAddPackageView: View {
                             .padding()
                         }
                         .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
-                        AdaptiveStack(spacing: 8) {
-                            ForEach(WooShippingPackageDimensionType.allCases, id: \.self) { dimensionType in
-                                WooShippingAddPackageDimensionView(dimensionType: dimensionType,
-                                                                   dimensionUnit: customPackageViewModel.dimensionUnit,
-                                                                   fieldValue: Binding(get: {
-                                    return self.customPackageViewModel.fieldValues[dimensionType] ?? ""
-                                }, set: { value in
-                                    self.customPackageViewModel.fieldValues[dimensionType] = value
-                                }), focusedField: _focusedField)
+                        VStack {
+                            AdaptiveStack(spacing: 8) {
+                                ForEach(WooShippingPackageUnitType.dimensionUnits, id: \.self) { dimensionType in
+                                    WooShippingAddPackageUnitInputView(unitType: dimensionType,
+                                                                       unit: customPackageViewModel.dimensionUnit,
+                                                                       fieldValue: Binding(get: {
+                                        return self.customPackageViewModel.fieldValues[dimensionType] ?? ""
+                                    }, set: { value in
+                                        self.customPackageViewModel.fieldValues[dimensionType] = value
+                                    }), focusedField: _focusedField)
+                                }
                             }
+                            WooShippingAddPackageUnitInputView(unitType: WooShippingPackageUnitType.weight,
+                                                               unit: customPackageViewModel.weightUnit,
+                                                               fieldValue: Binding(get: {
+                                return self.customPackageViewModel.fieldValues[WooShippingPackageUnitType.weight] ?? ""
+                            }, set: { value in
+                                self.customPackageViewModel.fieldValues[WooShippingPackageUnitType.weight] = value
+                            }), focusedField: _focusedField)
                         }
                         .toolbar {
                             ToolbarItemGroup(placement: .keyboard) {
@@ -126,13 +135,13 @@ struct WooShippingAddPackageView: View {
                                     }, label: {
                                         Image(systemName: "chevron.backward")
                                     })
-                                    .disabled(focusedField == WooShippingPackageDimensionType.allCases.first)
+                                    .disabled(focusedField == WooShippingPackageUnitType.allCases.first)
                                     Button(action: {
                                         onForwardButtonTapped()
                                     }, label: {
                                         Image(systemName: "chevron.forward")
                                     })
-                                    .disabled(focusedField == WooShippingPackageDimensionType.allCases.last)
+                                    .disabled(focusedField == WooShippingPackageUnitType.allCases.last)
                                     Spacer()
                                     Button {
                                         dismissKeyboard()
@@ -209,6 +218,8 @@ struct WooShippingAddPackageView: View {
             focusedField = .length
         case .height:
             focusedField = .width
+        case .weight:
+            focusedField = .height
         case nil:
             return
         }
@@ -221,6 +232,8 @@ struct WooShippingAddPackageView: View {
         case .width:
             focusedField = .height
         case .height:
+            focusedField = .weight
+        case .weight:
             return
         case nil:
             return
@@ -255,16 +268,20 @@ struct WooShippingAddPackageView: View {
     }
 }
 
-struct WooShippingAddPackageDimensionView: View {
-    let dimensionType: WooShippingPackageDimensionType
-    let dimensionUnit: String
+struct WooShippingAddPackageUnitInputView: View {
+    let unitType: WooShippingPackageUnitType
+    let unit: String
     @Binding var fieldValue: String
-    @FocusState var focusedField: WooShippingPackageDimensionType?
+    @FocusState var focusedField: WooShippingPackageUnitType?
+
+    private var isFocused: Bool {
+        return focusedField == unitType
+    }
 
     var body: some View {
         VStack {
             HStack {
-                Text(dimensionType.name)
+                Text(unitType.name)
                     .font(.subheadline)
                 Spacer()
             }
@@ -272,15 +289,15 @@ struct WooShippingAddPackageDimensionView: View {
                 TextField("", text: $fieldValue)
                     .keyboardType(.decimalPad)
                     .bodyStyle()
-                    .focused($focusedField, equals: dimensionType)
-                Text(dimensionUnit)
+                    .focused($focusedField, equals: unitType)
+                Text(unit)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
             .padding()
             .roundedBorder(cornerRadius: 8,
-                           lineColor: focusedField == dimensionType ? Color.accentColor : Color(.separator),
-                           lineWidth: focusedField == dimensionType ? 2 : 1)
+                           lineColor: isFocused ? Color.accentColor : Color(.separator),
+                           lineWidth: isFocused ? 2 : 1)
         }
         .frame(minHeight: 48)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -12,15 +12,18 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         viewModel.checkDefaultInitProperties()
     }
 
-    func test_it_inits_with_dimension_unit() {
+    func test_it_inits_with_dimension_weight_unit() {
         // Given/When
         let expectedDimensionUnit = "in"
-        let viewModel = WooShippingAddCustomPackageViewModel(dimensionUnit: expectedDimensionUnit)
+        let expectedWeightUnit = "in"
+        let viewModel = WooShippingAddCustomPackageViewModel(dimensionUnit: expectedDimensionUnit,
+                                                             weightUnit: expectedWeightUnit)
 
         // Then
         XCTAssertNotNil(viewModel)
         viewModel.checkDefaultInitProperties()
         XCTAssertEqual(viewModel.dimensionUnit, expectedDimensionUnit)
+        XCTAssertEqual(viewModel.weightUnit, expectedWeightUnit)
     }
 
     func test_clear_field_values() {
@@ -149,7 +152,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
 extension WooShippingAddCustomPackageViewModel {
     func fillWithDummyFieldValues() {
-        for dimensionType in WooShippingPackageDimensionType.allCases {
+        for dimensionType in WooShippingPackageUnitType.allCases {
             fieldValues[dimensionType] = "1"
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -82,6 +82,45 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.areFieldValuesInvalid, false)
     }
 
+    func test_it_with_all_dimension_field_values_set_not_saving_template() {
+        // Given
+        let viewModel = WooShippingAddCustomPackageViewModel()
+
+        // When
+        viewModel.fillWithDummyDimensionFieldValues()
+        viewModel.showSaveTemplate = false
+
+        // Then
+        XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
+        XCTAssertEqual(viewModel.areFieldValuesInvalid, false)
+    }
+
+    func test_it_with_all_dimension_field_values_set_saving_template() {
+        // Given
+        let viewModel = WooShippingAddCustomPackageViewModel()
+
+        // When
+        viewModel.fillWithDummyDimensionFieldValues()
+        viewModel.showSaveTemplate = true
+
+        // Then
+        XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
+        XCTAssertEqual(viewModel.areFieldValuesInvalid, true)
+    }
+
+    func test_it_with_all_dimension_weight_field_values_set() {
+        // Given
+        let viewModel = WooShippingAddCustomPackageViewModel()
+
+        // When
+        viewModel.fillWithDummyDimensionFieldValues()
+        viewModel.showSaveTemplate = true
+        viewModel.fieldValues[.weight] = "1"
+        // Then
+        XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
+        XCTAssertEqual(viewModel.areFieldValuesInvalid, false)
+    }
+
     func test_validate_custom_package_input_fields_when_init() {
         // Given/When
         let viewModel = WooShippingAddCustomPackageViewModel()
@@ -153,6 +192,12 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 extension WooShippingAddCustomPackageViewModel {
     func fillWithDummyFieldValues() {
         for dimensionType in WooShippingPackageUnitType.allCases {
+            fieldValues[dimensionType] = "1"
+        }
+    }
+
+    func fillWithDummyDimensionFieldValues() {
+        for dimensionType in WooShippingPackageUnitType.dimensionUnits {
             fieldValues[dimensionType] = "1"
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13551
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Added a weight field in the custom package creation UI with "Empty Package Weight" field description.

In one of next PRs I will add visual indicators when fields are not valid.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. Tap "Select a Package" button
6. Tap on the package type button to change the type
7. Make sure that save template toggle is OFF
8. Check that the Add Package button is disabled
9. Tap in length, width, height fields to input values and check that the "Add Package" button is enabled when all 3 values are entered
10. Toggle save template toggle to ON
11. Check that the Save package template button is disabled
12. Type in package name
11. Check that the Save package template button is enabled

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Not saving template

| Empty    | Valid Fields |
| -------- | ------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-10-23 at 11 20 31](https://github.com/user-attachments/assets/a8b2e9e6-59d6-42e7-b984-c921ff7d4745) | ![Simulator Screenshot - iPhone 16 Pro - 2024-10-23 at 11 20 38](https://github.com/user-attachments/assets/78295f19-dbf4-44d5-b270-d051271bde15) |

Saving template

| Empty    | Valid Fields |
| -------- | ------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-10-23 at 14 10 41](https://github.com/user-attachments/assets/f46b7e6c-4404-4dd4-89ec-780b501464f5) | ![Simulator Screenshot - iPhone 16 Pro - 2024-10-23 at 14 10 55](https://github.com/user-attachments/assets/39ee2ad1-fbab-4bb0-99ba-ce3b26f27d2e) |

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
