### PR TITLE
Stripe Terminal SDK update 3.9.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ def cocoa_lumberjack
 end
 
 def stripe_terminal
-  pod 'StripeTerminal', '~> 3.3.1'
+  pod 'StripeTerminal', '~> 3.9.1'
 end
 
 def networking_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
   - Sentry/Core (8.36.0)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (3.3.1)
+  - StripeTerminal (3.9.1)
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
@@ -64,7 +64,7 @@ DEPENDENCIES:
   - Kingfisher (~> 7.6.2)
   - Sentry (~> 8.36.0)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 3.3.1)
+  - StripeTerminal (~> 3.9.1)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19)
   - WordPressAuthenticator (~> 9.10.0)
@@ -121,7 +121,7 @@ SPEC CHECKSUMS:
   Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: 369ef0cf0b90d838f42be1a0b371475986f4b79f
+  StripeTerminal: f7f5e176979224ed76edb3724f41138fbb28053c
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
@@ -142,6 +142,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2fbd2a9597af5d69760088bfb5e0e595e942f218
   ZendeskSupportSDK: 22156384d20d30b0aeb263c03f49bef44e1364b2
 
-PODFILE CHECKSUM: 13befb9700509f9984ff13fdd5d92ad6d71346f8
+PODFILE CHECKSUM: a6a6f05f8cb06ff4e707e8ed623df352e7d47ff5
 
 COCOAPODS: 1.15.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 - [Internal] Updated storage usage in ProductReviewStore [https://github.com/woocommerce/woocommerce-ios/pull/14134]
 - [internal] Replace unnecessary fetch requests for upserting orders and order search results [https://github.com/woocommerce/woocommerce-ios/pull/14128]
 - [internal] Optimized storage usage in ProductStore [https://github.com/woocommerce/woocommerce-ios/pull/14139]
-
+- [Internal] Update Stripe Terminal SDK to 3.9.1 [https://github.com/woocommerce/woocommerce-ios/pull/14198]
 
 20.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Context: peaMlT-Xd-p2#comment-2432
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updating Stripe Terminal SDK update 3.9.1. We've seen a few weird crashes within the SDK related to logging which had improvements in newer versions of the SDK. Moreover, the lowest supported version for TPP increased to 16.7 which is also being handled by a newer SDK.

## Changes in SDK 3.3.1 -> 3.9.1

Last update was made in this PR [Stripe Terminal SDK update 3.3.1](https://github.com/woocommerce/woocommerce-ios/pull/12078)

I marked the ones that look to be more relevant to us:
- Now 👇 
- Future TPP expansion 👉 

# 3.9.1 2024-09-05
* Built with Xcode 15.2, Swift version 5.9.
* Fix [#325](https://github.com/stripe/stripe-terminal-ios/issues/325): Corrects the status of `Terminal.shared.paymentStatus` and `Terminal.shared.connectionStatus` after [automatically reconnecting](https://docs.stripe.com/terminal/payments/connect-reader?terminal-sdk-platform=ios&reader-type=bluetooth#handle-disconnects) to mobile readers during unexpected disconnects.

# 3.9.0 2024-09-03
* Built with Xcode 15.2, Swift version 5.9.
* Beta: WeChat Pay support for smart readers is now available in private beta.
  * If you are interested in joining this beta, please email [stripe-terminal-betas@stripe.com](mailto:stripe-terminal-betas@stripe.com).
* 👉 New: Adds support for [Interac refunds](https://docs.stripe.com/terminal/payments/regional?integration-country=CA#refund-an-interac-payment) on the Tap to Pay simulated reader.
* Update: For mobile readers with [`auto reconnection`](https://docs.stripe.com/terminal/payments/connect-reader?terminal-sdk-platform=ios&reader-type=bluetooth#handle-disconnects) enabled, the SDK now installs required updates upon reconnection after a [reboot](https://docs.stripe.com/terminal/payments/connect-reader?terminal-sdk-platform=ios&reader-type=bluetooth#reboot-the-connected-reader). Your application will continue to receive notifications about updates via the [`BluetoothReaderDelegate`](https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPBluetoothReaderDelegate.html) and should handle updating its UI to inform the user of the update accordingly.
* Update: Improved handling of [`SCPErrorReaderMissingEncryptionKeys`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorReaderMissingEncryptionKeys) error for mobile readers with auto-reconnection enabled. Previously, the SDK would disconnect from the reader without auto-reconnecting when this error occurred. Now, if auto-reconnection is enabled, the SDK will automatically reconnect and recover from this error.
* 👉 Fix [#595](https://github.com/stripe/stripe-terminal-react-native/issues/595): Addresses the issue where backgrounding the app while the Tap to Pay PIN collection screen is displayed causes the SDK to become unresponsive until the app is relaunched.
* Fix: Resolves a race condition that occurs when a card is inserted simultaneously as [`collectPaymentMethod`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:completion:) is being canceled. Previously, this resulted in a [`SCPErrorReaderBusy`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorReaderBusy) error. Now, the collection will complete by returning a [`SCPErrorCanceled`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorCanceled) error instead.

# 3.8.3 2024-08-12
*  👇 Fix the root cause of the deadlocks, further reducing the risk of SDK crashes.

# 3.8.2 2024-08-08
* 👇  Fix another path that could result in a logger deadlock, further reducing the risk of SDK crashes.

# 3.8.1 2024-08-06
* 👇 Fix a deadlock in the logger that can cause the SDK to crash

# 3.8.0 2024-07-31
* Built with Xcode 15.2, Swift version 5.9.
* Fix an issue running on iOS 18 where the SDK fails [`collectPaymentMethod`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:completion:) with [`SCPErrorUnexpectedSdkError`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorUnexpectedSdkError) when collecting amounts greater than 99999.
* Fix an issue where the SDK can report a reader as connected if it had disconnected while installing a required update.
* Fix a rare race condition where [`confirmPaymentIntent`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)confirmPaymentIntent:completion:) could incorrectly fail with [`SCPErrorReaderBusy`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorReaderBusy).
* 👇 Fix `supportsReadersOfType` returning `true` for `SCPDeviceTypeAppleBuiltIn` on iOS versions below 16.7 (minimum supported version).

# 3.7.0 2024-06-24
* Built with Xcode 15.2, Swift version 5.9.
* Beta: Surcharging is now available in private beta.
  * added a `surchargeNotice` parameter to [`SCPCollectConfiguration`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPCollectConfiguration.html) to display a surcharge notice on the payment collection screen.
  * added a `SCPSurcharge` field to the [`SCPCardPresentParameters`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPCardPresentParameters.html) object.
  * added a [`SCPConfirmConfiguration`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPConfirmConfiguration.html) class to allow per-transaction overrides for [`confirmPaymentIntent`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)confirmPaymentIntent:completion:).
  * added an `amountSurcharge` parameter to [`SCPConfirmConfiguration`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPConfirmConfiguration.html) to surcharge when confirming a payment.
  * If you are interested in joining this beta, please email stripe-terminal-betas@stripe.com.
* Beta: Added a `collectData` method to collect eligible magstripe data, such as gift cards.
  * If you are interested in joining this beta, please email stripe-terminal-betas@stripe.com.
* Update: Added [`SCPSimulateReaderUpdateLowBatterySucceedConnect`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPSimulateReaderUpdate.html#/c:@E@SCPSimulateReaderUpdate@SCPSimulateReaderUpdateLowBatterySucceedConnect) to simulate an error scenario where a required update fails on a mobile reader due to low battery, but the SDK still successfully connects to the reader.
  * see [Simulated reader updates](https://docs.stripe.com/terminal/references/testing?terminal-sdk-platform=ios#simulated-reader-updates) for details.
* Update: if a mobile reader receives the [`SCPErrorReaderMissingEncryptionKeys`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorReaderMissingEncryptionKeys) error during payment collection, the SDK will disconnect from the reader. Note that auto reconnection will not work in this scenario. The error will automatically recover once the reader is reconnected.
* 👇 Fix: Fixed a crash that occurred when canceling [`collectPaymentMethod`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:completion:) after [`confirmPaymentIntent`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)confirmPaymentIntent:completion:) had already been called on the `PaymentIntent`.

# 3.6.0 2024-05-13
* Built with Xcode 15.2, Swift version 5.9.
* Update: Using [`SCPOfflineBehaviorRequireOnline`](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPOfflineBehavior.html#/c:@E@SCPOfflineBehavior@SCPOfflineBehaviorRequireOnline) will attempt online network calls regardless of the current network status. This may cause requests while the network is offline to take longer as requests will always be attempted online first.
* Update: Tapping or inserting an unsupported card will now report `SCPReaderDisplayMessageTryAnotherCard` instead of `SCPReaderDisplayMessageTryAnotherReadMethod`.
* Update: [`paymentStatus`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(py)paymentStatus) now stays `ready` while API-only commands are in-progress. This includes `createPaymentIntent`, `createSetupIntent`, `cancelPaymentIntent`, and `cancelSetupIntent`.
* Update: [`paymentStatus`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(py)paymentStatus) now updates to `waitingForInput` while [`collectInputs`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectInputs:completion:) is running.
* Update: If a reader receives the `SCPErrorReaderMissingEncryptionKeys` error when collecting a payment the SDK now also reboots the reader in addition to the existing behavior of disconnecting from the reader. Reconnecting to the reader should re-install the keys and allow the reader to collect payments again.

# 3.5.0 2024-04-12
* Built with Xcode 15.2, Swift version 5.9.
* Beta: [`CollectInputs`](https://stripe.com/docs/terminal/features/collect-inputs?terminal-sdk-platform=ios) can now display optional `toggles` in each input type.
  * If you are interested in joining this beta, please email stripe-terminal-betas@stripe.com.
* New: Support for connecting to mPOS readers over USB-C on iPads with M-series chips.
  * This feature is in private beta. Please [contact us](mailto:stripe-terminal-betas@stripe.com) if you are interested in joining this beta.
* New: Added an xcprivacy file to the framework listing our data use and [required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc) usage.
* Update: Added [`SetupIntentParameters.paymentMethodTypes`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPSetupIntentParameters.html#/c:objc(cs)SCPSetupIntentParameters(py)paymentMethodTypes).
  - _Note for internet reader integrations, this feature requires [reader software version](https://stripe.com/docs/terminal/readers/bbpos-wisepos-e#reader-software-version) `2.22` or later to be installed on your internet reader._
* Update: [`supportsReadersOfType`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)supportsReadersOfType:discoveryMethod:simulated:error:) now returns NO with error `SCPErrorInvalidDiscoveryConfiguration` if the device type and discovery method are incompatible.
* Update: When a Bluetooth reader has an error installing a required update the SDK will allow connecting to the reader if the reader is running a recent version. The error installing the update will still be communicated in the [`reader:didFinishInstallingUpdate:error:`](https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPBluetoothReaderDelegate.html#/c:objc(pl)SCPBluetoothReaderDelegate(im)reader:didFinishInstallingUpdate:error:) callback. The update will be available to be retried using [`installAvailableUpdate`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)installAvailableUpdate). If the update isn't installed with `installAvailableUpdate` the installation will be retried the next time connecting to the reader.
* Fixes [#291](https://github.com/stripe/stripe-terminal-ios/issues/291): Fixes a bug where the cancelable returned by [`collectPaymentMethod`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:completion:) was not responsive in certain conditions when a card was left in the reader or inserted before calling `collectPaymentMethod`.
* Fixes a bug where `rebootReader` would return `SCPErrorUnexpectedSdkError` if called after the reader received a firmware update.

# 3.4.0 2024-03-04
* Built with Xcode 15.2, Swift version 5.9.
* 👉 New: For Tap to Pay on iPhone, added `autoReconnectOnUnexpectedDisconnect` and `autoReconnectionDelegate` to the [`SCPLocalMobileConnectionConfiguration`](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPLocalMobileConnectionConfiguration.html). When `autoReconnectOnUnexpectedDisconnect` is enabled, the SDK will attempt to restore connection upon any unexpected disconnect to your local mobile reader. See [Stripe documentation](https://stripe.com/docs/terminal/payments/connect-reader?terminal-sdk-platform=ios&reader-type=tap-to-pay#handle-disconnects) for details.
* Update: Formatting on certain fields exposed in `SCPOfflineCardPresentDetails` is now consistent with `SCPCardPresentDetails`
  * `expYear` is a four-digit number
  * `receiptDetails.accountType` is no longer a number, and is one of `default`, `savings`, `checking`, or `credit`
* Update: The SDK now requires that a `NSBluetoothAlwaysUsageDescription` key be present in your app's Info.plist instead of a `NSBluetoothPeripheralUsageDescription` key.
* Update: Allow `SCPCollectConfiguration.updatePaymentIntent` to be true for offline enabled readers when `SCPCreateConfiguration` has `offlineBehavior` set to `SCPOfflineBehaviorRequireOnline`.
* Update: Added new `SCPErrorReaderMissingEncryptionKeys`. Returned in a rare condition where the reader is missing the required keys to encrypt payment method data. The reader will disconnect if this error is hit. Reconnecting to the reader should re-install the keys.
* Update: More descriptive error messages in `SCPErrorKeyMessage` for operations that fail due to network-related errors.
* Fixes a bug where `SCPPaymentIntent.stripeId` was not `nil` in the response to `confirmPaymentIntent` when operating offline with a smart reader.
* Fixes a rare bug where Bluetooth readers could get into a state where they would no longer accept payments and needed to be replaced.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested taking the M2 Reader payment and TPP reader payment and it all works fine. The project was compiled without any issues as well. However, we need to perform as many different payments as possible in different environments to bring the confidence up.

- [x] Connection from Order payment flow
- [x] Connection from Payments menu
- [x] Connection of a reader with a mandatory update
- [x] Connection of M2 reader
- [ ] Connection from switched off state
- [x] Connection of Chipper reader
- [ ] Take Interac payment
- [ ] Refund Interac payment
- [ ] Connection of WisePad 3 reader
- [x] Take payment after in-line connection process
- [x] Take payment with a previously-connected reader
- [x] Take TPP payment
- [ ] Take card-inserted payment
- [x] Reader update: error message when attempted with low battery
- [x] Reader update: successfully updates software and starts payment (in that flow) when completed

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.Con