### PR TITLE
[Shipping label] Add tabs for shipping carriers to Shipping Service view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
@@ -19,6 +19,21 @@ enum WooShippingCarrier: String, Comparable, CaseIterable {
         }
     }
 
+    var name: String {
+        switch self {
+        case .ups:
+            "UPS"
+        case .usps:
+            "USPS"
+        case .dhlExpress:
+            "DHL Express"
+        case .dhlEcommerce:
+            "DHL eCommerce"
+        case .dhlEcommerceAsia:
+            "DHL eCommerce Asia"
+        }
+    }
+
     static func < (lhs: WooShippingCarrier, rhs: WooShippingCarrier) -> Bool {
         guard let lhsIndex = allCases.firstIndex(of: lhs),
               let rhsIndex = allCases.firstIndex(of: rhs) else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+/// Represents a shipping carrier in the Woo Shipping extension.
+enum WooShippingCarrier: String, Comparable, CaseIterable {
+    case ups
+    case usps
+    case dhlExpress = "dhlexpress"
+    case dhlEcommerce = "dhlecommerce"
+    case dhlEcommerceAsia = "dhlecommerceasia"
+
+    var logo: UIImage? {
+        switch self {
+        case .ups:
+            return UIImage(named: "shipping-label-ups-logo")
+        case .usps:
+            return UIImage(named: "shipping-label-usps-logo")
+        case .dhlExpress, .dhlEcommerce, .dhlEcommerceAsia:
+            return UIImage(named: "shipping-label-dhl-logo")
+        }
+    }
+
+    static func < (lhs: WooShippingCarrier, rhs: WooShippingCarrier) -> Bool {
+        guard let lhsIndex = allCases.firstIndex(of: lhs),
+              let rhsIndex = allCases.firstIndex(of: rhs) else {
+            return false
+        }
+        return lhsIndex < rhsIndex
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -5,7 +5,7 @@ struct WooShippingServiceCardView: View {
     @ObservedObject var viewModel: WooShippingServiceCardViewModel
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 16) {
+        HStack(alignment: .top, spacing: 16) {
             if let carrierLogo = viewModel.carrierLogo {
                 Image(uiImage: carrierLogo)
                     .resizable()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -133,7 +133,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
         self.init(id: rate.rateID,
                   selected: selected,
                   signatureRequirement: signatureRequirement,
-                  carrierLogo: CarrierLogo(rawValue: rate.carrierID)?.image(),
+                  carrierLogo: WooShippingCarrier(rawValue: rate.carrierID)?.logo,
                   title: rate.title,
                   rateLabel: rateLabel,
                   daysToDeliveryLabel: daysToDeliveryLabel,
@@ -199,24 +199,5 @@ private extension WooShippingServiceCardViewModel {
                                                               value: "Adult Signature Required (+%1$@)",
                                                               comment: "Label when shipping rate has option to require an adult signature in " +
                                                               "Woo Shipping label creation flow. Reads like: 'Adult signature required (+$9.35)'")
-    }
-
-    enum CarrierLogo: String {
-        case ups
-        case usps
-        case dhlExpress = "dhlexpress"
-        case dhlEcommerce = "dhlecommerce"
-        case dhlEcommerceAsia = "dhlecommerceasia"
-
-        func image() -> UIImage? {
-            switch self {
-            case .ups:
-                return UIImage(named: "shipping-label-ups-logo")
-            case .usps:
-                return UIImage(named: "shipping-label-usps-logo")
-            case .dhlExpress, .dhlEcommerce, .dhlEcommerceAsia:
-                return UIImage(named: "shipping-label-dhl-logo")
-            }
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -37,7 +37,9 @@ private struct WooShippingServiceCardListView: View {
         VStack {
             ForEach(cards) { card in
                 WooShippingServiceCardView(viewModel: card)
+                    .fixedSize(horizontal: false, vertical: true) // Prevents card text from being truncated
             }
+            Spacer()
         }
         .padding(.vertical)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -20,7 +20,11 @@ struct WooShippingServiceView: View {
                     .headlineStyle()
                 Spacer()
             }
-            TopTabView(tabs: carriers)
+            TopTabView(tabs: carriers,
+                       unselectedStateColor: .secondary,
+                       tabsNameFont: .subheadline.bold(),
+                       tabItemContentHorizontalPadding: 16,
+                       tabItemContentVerticalPadding: 12)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -5,9 +5,10 @@ struct WooShippingServiceView: View {
     @ObservedObject var viewModel: WooShippingServiceViewModel
 
     private var carriers: [TopTabItem<WooShippingServiceCardListView>] {
-        viewModel.carrierRates.map { (carrierID, cards) in
-            TopTabItem(name: carrierID) {
-                WooShippingServiceCardListView(cards: cards)
+        viewModel.serviceTabs.map { tab in
+            TopTabItem(name: tab.id.name,
+                       icon: tab.id.logo) {
+                WooShippingServiceCardListView(cards: tab.cards)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -1,7 +1,16 @@
 import SwiftUI
 
+/// View to display the available shipping services (carriers and rates) with the Woo Shipping extension.
 struct WooShippingServiceView: View {
     @ObservedObject var viewModel: WooShippingServiceViewModel
+
+    private var carriers: [TopTabItem<WooShippingServiceCardListView>] {
+        viewModel.carrierRates.map { (carrierID, cards) in
+            TopTabItem(name: carrierID) {
+                WooShippingServiceCardListView(cards: cards)
+            }
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -10,12 +19,22 @@ struct WooShippingServiceView: View {
                     .headlineStyle()
                 Spacer()
             }
-            VStack {
-                ForEach(viewModel.rates) { rate in
-                    WooShippingServiceCardView(viewModel: rate)
-                }
+            TopTabView(tabs: carriers)
+        }
+    }
+}
+
+/// View to display a provided list of shipping rate cards with the Woo Shipping extension.
+private struct WooShippingServiceCardListView: View {
+    var cards: [WooShippingServiceCardViewModel]
+
+    var body: some View {
+        VStack {
+            ForEach(cards) { card in
+                WooShippingServiceCardView(viewModel: card)
             }
         }
+        .padding(.vertical)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct WooShippingServiceView: View {
+    @ObservedObject var viewModel: WooShippingServiceViewModel
+
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
@@ -8,16 +10,11 @@ struct WooShippingServiceView: View {
                     .headlineStyle()
                 Spacer()
             }
-            WooShippingServiceCardView(viewModel: WooShippingServiceCardViewModel(carrierLogo: UIImage(named: "shipping-label-usps-logo"),
-                                                                                  title: "USPS - Media Mail",
-                                                                                  rateLabel: "$7.63",
-                                                                                  daysToDeliveryLabel: "7 business days",
-                                                                                  extraInfoLabel: "Includes tracking, insurance (up to $100.00), free pickup",
-                                                                                  hasTracking: true,
-                                                                                  insuranceLabel: "Insurance (up to $100.00)",
-                                                                                  hasFreePickup: true,
-                                                                                  signatureRequiredLabel: "Signature Required (+$3.70)",
-                                                                                  adultSignatureRequiredLabel: "Adult Signature Required (+$9.35)"))
+            VStack {
+                ForEach(viewModel.rates) { rate in
+                    WooShippingServiceCardView(viewModel: rate)
+                }
+            }
         }
     }
 }
@@ -31,5 +28,5 @@ private extension WooShippingServiceView {
 }
 
 #Preview {
-    WooShippingServiceView()
+    WooShippingServiceView(viewModel: .init())
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -1,8 +1,8 @@
 import Yosemite
 
 final class WooShippingServiceViewModel: ObservableObject {
-    /// View models to display available shipping rates.
-    @Published private(set) var rates: [WooShippingServiceCardViewModel] = []
+    /// View models to display available shipping rates, grouped by carrier ID.
+    @Published private(set) var carrierRates: [String: [WooShippingServiceCardViewModel]] = [:]
 
     init() {
         // TODO: Replace with real data from remote
@@ -11,6 +11,19 @@ final class WooShippingServiceViewModel: ObservableObject {
                                               retailRate: 8,
                                               rate: 7.53,
                                               rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                              serviceID: "",
+                                              carrierID: "usps",
+                                              shipmentID: "",
+                                              hasTracking: true,
+                                              isSelected: false,
+                                              isPickupFree: true,
+                                              deliveryDays: 7,
+                                              deliveryDateGuaranteed: false),
+                     ShippingLabelCarrierRate(title: "USPS - Ground Advantage",
+                                              insurance: "100",
+                                              retailRate: 8,
+                                              rate: 7.53,
+                                              rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
                                               serviceID: "",
                                               carrierID: "usps",
                                               shipmentID: "",
@@ -32,11 +45,14 @@ final class WooShippingServiceViewModel: ObservableObject {
                                               isPickupFree: true,
                                               deliveryDays: 1,
                                               deliveryDateGuaranteed: false)]
-        generateRates(for: rates)
+        generateCarrierRates(from: rates)
     }
 
-    /// Generates the view models to display available shipping rates.
-    func generateRates(for rates: [ShippingLabelCarrierRate]) {
-        self.rates = rates.map { WooShippingServiceCardViewModel(rate: $0 )}
+    /// Generates the data to display available shipping rates, grouped by carrier ID.
+    private func generateCarrierRates(from rates: [ShippingLabelCarrierRate]) {
+        let groupedRates = rates.grouped(by: { $0.carrierID })
+        carrierRates = groupedRates.mapValues { rates in
+            rates.map({ WooShippingServiceCardViewModel(rate: $0) })
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -1,8 +1,9 @@
 import Yosemite
 
 final class WooShippingServiceViewModel: ObservableObject {
-    /// View models to display available shipping rates, grouped by carrier ID.
-    @Published private(set) var carrierRates: [String: [WooShippingServiceCardViewModel]] = [:]
+    /// List of tabs to display for the shipping services.
+    /// Contains the data about available shipping rates, grouped by carrier.
+    @Published private(set) var serviceTabs: [WooShippingServiceTab] = []
 
     init() {
         // TODO: Replace with real data from remote
@@ -71,20 +72,31 @@ final class WooShippingServiceViewModel: ObservableObject {
                                                             isPickupFree: true,
                                                             deliveryDays: 2,
                                                             deliveryDateGuaranteed: false)]
-        generateCarrierRates(from: standardRates, signatureRates: signatureRates, adultSignatureRates: adultSignatureRates)
+        generateServiceTabs(from: standardRates, signatureRates: signatureRates, adultSignatureRates: adultSignatureRates)
     }
 
     /// Generates the data to display available shipping rates, grouped by carrier ID.
-    private func generateCarrierRates(from standardRates: [ShippingLabelCarrierRate],
-                                      signatureRates: [ShippingLabelCarrierRate],
-                                      adultSignatureRates: [ShippingLabelCarrierRate]) {
-        carrierRates = standardRates.grouped(by: { $0.carrierID })
-            .mapValues { rates in
-                rates.map({ rate in
+    private func generateServiceTabs(from standardRates: [ShippingLabelCarrierRate],
+                                     signatureRates: [ShippingLabelCarrierRate],
+                                     adultSignatureRates: [ShippingLabelCarrierRate]) {
+        serviceTabs = standardRates.grouped(by: { $0.carrierID })
+            .compactMap { (carrierID, rates) -> WooShippingServiceTab? in
+                guard let carrier = WooShippingCarrier(rawValue: carrierID) else {
+                    return nil
+                }
+                let cards = rates.map { rate in
                     let signature = signatureRates.first { rate.title == $0.title }
                     let adultSignature = adultSignatureRates.first { rate.title == $0.title }
                     return WooShippingServiceCardViewModel(rate: rate, signatureRate: signature, adultSignatureRate: adultSignature)
-                })
+                }
+                return WooShippingServiceTab(id: carrier, cards: cards)
             }
+            .sorted(by: { $0.id < $1.id })
+    }
+
+    /// Holds the data needed to display a tab in `WooShippingServiceViewModel`.
+    struct WooShippingServiceTab: Identifiable {
+        let id: WooShippingCarrier
+        let cards: [WooShippingServiceCardViewModel]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -6,7 +6,7 @@ final class WooShippingServiceViewModel: ObservableObject {
 
     init() {
         // TODO: Replace with real data from remote
-        let rates = [ShippingLabelCarrierRate(title: "USPS - Media Mail",
+        let standardRates = [ShippingLabelCarrierRate(title: "USPS - Media Mail",
                                               insurance: "100",
                                               retailRate: 8,
                                               rate: 7.53,
@@ -19,10 +19,10 @@ final class WooShippingServiceViewModel: ObservableObject {
                                               isPickupFree: true,
                                               deliveryDays: 7,
                                               deliveryDateGuaranteed: false),
-                     ShippingLabelCarrierRate(title: "USPS - Ground Advantage",
+                     ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
                                               insurance: "100",
-                                              retailRate: 8,
-                                              rate: 7.53,
+                                              retailRate: 40.06,
+                                              rate: 40.06,
                                               rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
                                               serviceID: "",
                                               carrierID: "usps",
@@ -30,7 +30,7 @@ final class WooShippingServiceViewModel: ObservableObject {
                                               hasTracking: true,
                                               isSelected: false,
                                               isPickupFree: true,
-                                              deliveryDays: 7,
+                                              deliveryDays: 2,
                                               deliveryDateGuaranteed: false),
                      ShippingLabelCarrierRate(title: "DHL - Next Day",
                                               insurance: "100",
@@ -45,14 +45,46 @@ final class WooShippingServiceViewModel: ObservableObject {
                                               isPickupFree: true,
                                               deliveryDays: 1,
                                               deliveryDateGuaranteed: false)]
-        generateCarrierRates(from: rates)
+        let signatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                       insurance: "100",
+                                                       retailRate: 42.76,
+                                                       rate: 42.76,
+                                                       rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
+                                                       serviceID: "",
+                                                       carrierID: "usps",
+                                                       shipmentID: "",
+                                                       hasTracking: true,
+                                                       isSelected: false,
+                                                       isPickupFree: true,
+                                                       deliveryDays: 2,
+                                                       deliveryDateGuaranteed: false)]
+        let adultSignatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                            insurance: "100",
+                                                            retailRate: 46.96,
+                                                            rate: 46.96,
+                                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
+                                                            serviceID: "",
+                                                            carrierID: "usps",
+                                                            shipmentID: "",
+                                                            hasTracking: true,
+                                                            isSelected: false,
+                                                            isPickupFree: true,
+                                                            deliveryDays: 2,
+                                                            deliveryDateGuaranteed: false)]
+        generateCarrierRates(from: standardRates, signatureRates: signatureRates, adultSignatureRates: adultSignatureRates)
     }
 
     /// Generates the data to display available shipping rates, grouped by carrier ID.
-    private func generateCarrierRates(from rates: [ShippingLabelCarrierRate]) {
-        let groupedRates = rates.grouped(by: { $0.carrierID })
-        carrierRates = groupedRates.mapValues { rates in
-            rates.map({ WooShippingServiceCardViewModel(rate: $0) })
-        }
+    private func generateCarrierRates(from standardRates: [ShippingLabelCarrierRate],
+                                      signatureRates: [ShippingLabelCarrierRate],
+                                      adultSignatureRates: [ShippingLabelCarrierRate]) {
+        carrierRates = standardRates.grouped(by: { $0.carrierID })
+            .mapValues { rates in
+                rates.map({ rate in
+                    let signature = signatureRates.first { rate.title == $0.title }
+                    let adultSignature = adultSignatureRates.first { rate.title == $0.title }
+                    return WooShippingServiceCardViewModel(rate: rate, signatureRate: signature, adultSignatureRate: adultSignature)
+                })
+            }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -1,0 +1,42 @@
+import Yosemite
+
+final class WooShippingServiceViewModel: ObservableObject {
+    /// View models to display available shipping rates.
+    @Published private(set) var rates: [WooShippingServiceCardViewModel] = []
+
+    init() {
+        // TODO: Replace with real data from remote
+        let rates = [ShippingLabelCarrierRate(title: "USPS - Media Mail",
+                                              insurance: "100",
+                                              retailRate: 8,
+                                              rate: 7.53,
+                                              rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                              serviceID: "",
+                                              carrierID: "usps",
+                                              shipmentID: "",
+                                              hasTracking: true,
+                                              isSelected: false,
+                                              isPickupFree: true,
+                                              deliveryDays: 7,
+                                              deliveryDateGuaranteed: false),
+                     ShippingLabelCarrierRate(title: "DHL - Next Day",
+                                              insurance: "100",
+                                              retailRate: 15,
+                                              rate: 14.22,
+                                              rateID: "rate_a8a29d5f34984722942f466c30ea27eg",
+                                              serviceID: "",
+                                              carrierID: "dhlexpress",
+                                              shipmentID: "",
+                                              hasTracking: true,
+                                              isSelected: false,
+                                              isPickupFree: true,
+                                              deliveryDays: 1,
+                                              deliveryDateGuaranteed: false)]
+        generateRates(for: rates)
+    }
+
+    /// Generates the view models to display available shipping rates.
+    func generateRates(for rates: [ShippingLabelCarrierRate]) {
+        self.rates = rates.map { WooShippingServiceCardViewModel(rate: $0 )}
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2209,6 +2209,7 @@
 		CE2DF92C2CC162EB001AA394 /* WooShippingServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */; };
 		CE2DF92E2CC16C95001AA394 /* WooShippingServiceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */; };
 		CE315DC42CC91A4A00A06748 /* WooShippingServiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE315DC32CC91A4500A06748 /* WooShippingServiceViewModel.swift */; };
+		CE315DC62CC93CCE00A06748 /* WooShippingCarrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE315DC52CC93CCE00A06748 /* WooShippingCarrier.swift */; };
 		CE32B10B20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */; };
 		CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */; };
 		CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */; };
@@ -5265,6 +5266,7 @@
 		CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceView.swift; sourceTree = "<group>"; };
 		CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceCardView.swift; sourceTree = "<group>"; };
 		CE315DC32CC91A4500A06748 /* WooShippingServiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceViewModel.swift; sourceTree = "<group>"; };
+		CE315DC52CC93CCE00A06748 /* WooShippingCarrier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCarrier.swift; sourceTree = "<group>"; };
 		CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnSectionHeaderView.xib; sourceTree = "<group>"; };
 		CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnSectionHeaderView.swift; sourceTree = "<group>"; };
 		CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
@@ -11930,6 +11932,7 @@
 		CECEFA6B2CA2CE990071C7DB /* WooShipping Package and Rate Selection */ = {
 			isa = PBXGroup;
 			children = (
+				CE315DC52CC93CCE00A06748 /* WooShippingCarrier.swift */,
 				CECEFA6C2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift */,
 				DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */,
 				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
@@ -15576,6 +15579,7 @@
 				B97C6E562B15E51A008A2BF2 /* UpdateProductInventoryView.swift in Sources */,
 				268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */,
 				DE7E5E862B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift in Sources */,
+				CE315DC62CC93CCE00A06748 /* WooShippingCarrier.swift in Sources */,
 				4535EE7E281BE04A004212B4 /* CouponAmountInputFormatter.swift in Sources */,
 				209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */,
 				CE35F11B2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2210,6 +2210,7 @@
 		CE2DF92E2CC16C95001AA394 /* WooShippingServiceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */; };
 		CE315DC42CC91A4A00A06748 /* WooShippingServiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE315DC32CC91A4500A06748 /* WooShippingServiceViewModel.swift */; };
 		CE315DC62CC93CCE00A06748 /* WooShippingCarrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE315DC52CC93CCE00A06748 /* WooShippingCarrier.swift */; };
+		CE315DC82CC942A200A06748 /* WooShippingServiceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE315DC72CC942A200A06748 /* WooShippingServiceViewModelTests.swift */; };
 		CE32B10B20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */; };
 		CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */; };
 		CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */; };
@@ -5267,6 +5268,7 @@
 		CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceCardView.swift; sourceTree = "<group>"; };
 		CE315DC32CC91A4500A06748 /* WooShippingServiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceViewModel.swift; sourceTree = "<group>"; };
 		CE315DC52CC93CCE00A06748 /* WooShippingCarrier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCarrier.swift; sourceTree = "<group>"; };
+		CE315DC72CC942A200A06748 /* WooShippingServiceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceViewModelTests.swift; sourceTree = "<group>"; };
 		CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnSectionHeaderView.xib; sourceTree = "<group>"; };
 		CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnSectionHeaderView.swift; sourceTree = "<group>"; };
 		CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
@@ -11890,6 +11892,7 @@
 				CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */,
 				DA40806D2CC29650002A4577 /* WooShippingAddCustomPackageViewModelTests.swift */,
 				CE86C8322CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift */,
+				CE315DC72CC942A200A06748 /* WooShippingServiceViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -16539,6 +16542,7 @@
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
 				023BD5862BFDCECF00A10D7B /* BetaFeaturesConfigurationViewModelTests.swift in Sources */,
+				CE315DC82CC942A200A06748 /* WooShippingServiceViewModelTests.swift in Sources */,
 				DEC51AA0274F9922009F3DF4 /* JCPJetpackInstallStepsViewModelTests.swift in Sources */,
 				E1068058285C787100668B46 /* BetaFeaturesTests.swift in Sources */,
 				EE570A8D2BF5EE78006BA026 /* MostActiveCouponsCardViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2208,6 +2208,7 @@
 		CE2A9FD023C4F2C8002BEC1C /* RefundedProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */; };
 		CE2DF92C2CC162EB001AA394 /* WooShippingServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */; };
 		CE2DF92E2CC16C95001AA394 /* WooShippingServiceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */; };
+		CE315DC42CC91A4A00A06748 /* WooShippingServiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE315DC32CC91A4500A06748 /* WooShippingServiceViewModel.swift */; };
 		CE32B10B20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */; };
 		CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */; };
 		CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */; };
@@ -5263,6 +5264,7 @@
 		CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefundedProductsViewController.swift; sourceTree = "<group>"; };
 		CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceView.swift; sourceTree = "<group>"; };
 		CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceCardView.swift; sourceTree = "<group>"; };
+		CE315DC32CC91A4500A06748 /* WooShippingServiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceViewModel.swift; sourceTree = "<group>"; };
 		CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnSectionHeaderView.xib; sourceTree = "<group>"; };
 		CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnSectionHeaderView.swift; sourceTree = "<group>"; };
 		CE32B11320BF8779006FBCF4 /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
@@ -11931,6 +11933,7 @@
 				CECEFA6C2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift */,
 				DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */,
 				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
+				CE315DC32CC91A4500A06748 /* WooShippingServiceViewModel.swift */,
 				CE2DF92D2CC16C95001AA394 /* WooShippingServiceCardView.swift */,
 				CEE125502CC66C8100D3183D /* WooShippingServiceCardViewModel.swift */,
 				DA4080712CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift */,
@@ -15199,6 +15202,7 @@
 				DE4D23A629B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift in Sources */,
 				EEA3C21F2CA543D9000E82EC /* FavoriteProductsUseCase.swift in Sources */,
 				E1E636BB26FB467A00C9D0D7 /* Comparable+Woo.swift in Sources */,
+				CE315DC42CC91A4A00A06748 /* WooShippingServiceViewModel.swift in Sources */,
 				450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */,
 				DEB3879E2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift in Sources */,
 				EE45E2BA2A409BA40085F227 /* TooltipPresenter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import WooCommerce
+
+final class WooShippingServiceViewModelTests: XCTestCase {
+
+    func test_generateCarrierRates_returns_expected_data() throws {
+        // Given
+        let viewModel = WooShippingServiceViewModel()
+
+        // Then
+        XCTAssertEqual(viewModel.carrierRates.count, 2)
+        XCTAssertEqual(viewModel.carrierRates["usps"]?.count, 2)
+        XCTAssertEqual(viewModel.carrierRates["dhlexpress"]?.count, 1)
+
+        let rate = try XCTUnwrap(viewModel.carrierRates["usps"]?.first)
+        XCTAssertEqual(rate.selected, false)
+        XCTAssertEqual(rate.signatureRequirement, .none)
+        XCTAssertEqual(rate.title, "USPS - Media Mail")
+        XCTAssertEqual(rate.daysToDeliveryLabel, "7 business days")
+        XCTAssertEqual(rate.rateLabel, "$7.53")
+        XCTAssertEqual(rate.carrierLogo, WooShippingCarrier.usps.logo)
+        XCTAssertEqual(rate.trackingLabel, "Tracking")
+        XCTAssertEqual(rate.insuranceLabel, "Insurance (up to $100.00)")
+        XCTAssertEqual(rate.freePickupLabel, "Free pickup")
+        XCTAssertEqual(rate.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
+        XCTAssertNil(rate.signatureRequiredLabel)
+        XCTAssertNil(rate.adultSignatureRequiredLabel)
+
+        let rate2 = try XCTUnwrap(viewModel.carrierRates["usps"]?[1])
+        XCTAssertEqual(rate2.selected, false)
+        XCTAssertEqual(rate2.signatureRequirement, .none)
+        XCTAssertEqual(rate2.title, "USPS - Ground Advantage")
+        XCTAssertEqual(rate2.daysToDeliveryLabel, "7 business days")
+        XCTAssertEqual(rate2.rateLabel, "$7.53")
+        XCTAssertEqual(rate2.carrierLogo, WooShippingCarrier.usps.logo)
+        XCTAssertEqual(rate2.trackingLabel, "Tracking")
+        XCTAssertEqual(rate2.insuranceLabel, "Insurance (up to $100.00)")
+        XCTAssertEqual(rate2.freePickupLabel, "Free pickup")
+        XCTAssertEqual(rate2.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
+        XCTAssertNil(rate.signatureRequiredLabel)
+        XCTAssertNil(rate.adultSignatureRequiredLabel)
+
+        let rate3 = try XCTUnwrap(viewModel.carrierRates["dhlexpress"]?.first)
+        XCTAssertEqual(rate3.selected, false)
+        XCTAssertEqual(rate3.signatureRequirement, .none)
+        XCTAssertEqual(rate3.title, "DHL - Next Day")
+        XCTAssertEqual(rate3.daysToDeliveryLabel, "1 business day")
+        XCTAssertEqual(rate3.rateLabel, "$14.22")
+        XCTAssertEqual(rate3.carrierLogo, WooShippingCarrier.dhlExpress.logo)
+        XCTAssertEqual(rate3.trackingLabel, "Tracking")
+        XCTAssertEqual(rate3.insuranceLabel, "Insurance (up to $100.00)")
+        XCTAssertEqual(rate3.freePickupLabel, "Free pickup")
+        XCTAssertEqual(rate3.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
+        XCTAssertNil(rate.signatureRequiredLabel)
+        XCTAssertNil(rate.adultSignatureRequiredLabel)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -3,16 +3,16 @@ import XCTest
 
 final class WooShippingServiceViewModelTests: XCTestCase {
 
-    func test_generateCarrierRates_returns_expected_data() throws {
+    func test_generateServiceTabs_returns_expected_data() throws {
         // Given
         let viewModel = WooShippingServiceViewModel()
 
         // Then
-        XCTAssertEqual(viewModel.carrierRates.count, 2)
-        XCTAssertEqual(viewModel.carrierRates["usps"]?.count, 2)
-        XCTAssertEqual(viewModel.carrierRates["dhlexpress"]?.count, 1)
+        XCTAssertEqual(viewModel.serviceTabs.count, 2)
+        XCTAssertEqual(viewModel.serviceTabs[0].cards.count, 2)
+        XCTAssertEqual(viewModel.serviceTabs[1].cards.count, 1)
 
-        let rate = try XCTUnwrap(viewModel.carrierRates["usps"]?.first)
+        let rate = try XCTUnwrap(viewModel.serviceTabs[0].cards[0])
         XCTAssertEqual(rate.selected, false)
         XCTAssertEqual(rate.signatureRequirement, .none)
         XCTAssertEqual(rate.title, "USPS - Media Mail")
@@ -26,7 +26,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertNil(rate.signatureRequiredLabel)
         XCTAssertNil(rate.adultSignatureRequiredLabel)
 
-        let rate2 = try XCTUnwrap(viewModel.carrierRates["usps"]?[1])
+        let rate2 = try XCTUnwrap(viewModel.serviceTabs[0].cards[1])
         XCTAssertEqual(rate2.selected, false)
         XCTAssertEqual(rate2.signatureRequirement, .none)
         XCTAssertEqual(rate2.title, "USPS - Parcel Select Mail")
@@ -40,7 +40,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(rate2.signatureRequiredLabel, "Signature Required (+$2.70)")
         XCTAssertEqual(rate2.adultSignatureRequiredLabel, "Adult Signature Required (+$6.90)")
 
-        let rate3 = try XCTUnwrap(viewModel.carrierRates["dhlexpress"]?.first)
+        let rate3 = try XCTUnwrap(viewModel.serviceTabs[1].cards[0])
         XCTAssertEqual(rate3.selected, false)
         XCTAssertEqual(rate3.signatureRequirement, .none)
         XCTAssertEqual(rate3.title, "DHL - Next Day")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -29,16 +29,16 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let rate2 = try XCTUnwrap(viewModel.carrierRates["usps"]?[1])
         XCTAssertEqual(rate2.selected, false)
         XCTAssertEqual(rate2.signatureRequirement, .none)
-        XCTAssertEqual(rate2.title, "USPS - Ground Advantage")
-        XCTAssertEqual(rate2.daysToDeliveryLabel, "7 business days")
-        XCTAssertEqual(rate2.rateLabel, "$7.53")
+        XCTAssertEqual(rate2.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(rate2.daysToDeliveryLabel, "2 business days")
+        XCTAssertEqual(rate2.rateLabel, "$40.06")
         XCTAssertEqual(rate2.carrierLogo, WooShippingCarrier.usps.logo)
         XCTAssertEqual(rate2.trackingLabel, "Tracking")
         XCTAssertEqual(rate2.insuranceLabel, "Insurance (up to $100.00)")
         XCTAssertEqual(rate2.freePickupLabel, "Free pickup")
         XCTAssertEqual(rate2.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
-        XCTAssertNil(rate.signatureRequiredLabel)
-        XCTAssertNil(rate.adultSignatureRequiredLabel)
+        XCTAssertEqual(rate2.signatureRequiredLabel, "Signature Required (+$2.70)")
+        XCTAssertEqual(rate2.adultSignatureRequiredLabel, "Adult Signature Required (+$6.90)")
 
         let rate3 = try XCTUnwrap(viewModel.carrierRates["dhlexpress"]?.first)
         XCTAssertEqual(rate3.selected, false)
@@ -51,8 +51,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(rate3.insuranceLabel, "Insurance (up to $100.00)")
         XCTAssertEqual(rate3.freePickupLabel, "Free pickup")
         XCTAssertEqual(rate3.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
-        XCTAssertNil(rate.signatureRequiredLabel)
-        XCTAssertNil(rate.adultSignatureRequiredLabel)
+        XCTAssertNil(rate3.signatureRequiredLabel)
+        XCTAssertNil(rate3.adultSignatureRequiredLabel)
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14141
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This introduces a tab view to the Shipping service section of the new Woo Shipping label creation flow. Each tab corresponds to a shipping carrier, and selecting a tab shows that carrier's list of available rates.

Note: For now this shows a static list of cards with no interaction available. Future PRs will introduce dynamic data (fetched from remote) and interactivity e.g. to expand and select rates.

### How

* Introduces a new `WooShippingCarrier` model. This consolidates data about a given carrier, e.g. the logo and display name, and makes it easier to consistently sort carriers for display.
* Introduces a view model for `WooShippingServiceView`. For now this inits with a static set of rates and provides the data to display in each tab.
* Updates `WooShippingServiceView` to show a tab view with the provided service (carrier and rate) data.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This view is not yet used in the app, so for now confirm the SwiftUI preview works as expected:

* Each carrier has its logo and name on the tab.
* Selecting a tab highlights the selected tab and shows that carrier's list of rates.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

First tab|Second tab
-|-
![Screenshot 2024-10-23 at 17 48 43](https://github.com/user-attachments/assets/84da46e9-c53a-4810-930e-70436bdeb88c)|![Screenshot 2024-10-23 at 17 48 53](https://github.com/user-attachments/assets/3df54e0e-0848-4f6f-a4dc-c164d3876288)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.