### PR TITLE
[Custom Fields] Fix issue of not updating the parent item after saving changes

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -766,6 +766,13 @@ public extension StorageType {
         return firstObject(ofType: MetaData.self, matching: predicate)
     }
 
+    /// Retrieves all stored MetaData of a given Order
+    /// 
+    func loadOrderMetaData(siteID: Int64, orderID: Int64) -> [MetaData] {
+        let predicate = \MetaData.order?.siteID == siteID && \MetaData.order?.orderID == orderID
+        return allObjects(ofType: MetaData.self, matching: predicate, sortedBy: nil)
+    }
+
     /// Retrieves the Stored Metadata for a Product.
     ///
     func loadProductMetaData(siteID: Int64, productID: Int64, metadataID: Int64) -> MetaData? {
@@ -773,4 +780,10 @@ public extension StorageType {
         return firstObject(ofType: MetaData.self, matching: predicate)
     }
 
+    /// Retrieves all stored MetaData of a given Product
+    /// 
+    func loadProductMetaData(siteID: Int64, productID: Int64) -> [MetaData] {
+        let predicate = \MetaData.product?.siteID == siteID && \MetaData.product?.productID == productID
+        return allObjects(ofType: MetaData.self, matching: predicate, sortedBy: nil)
+    }
 }

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -767,7 +767,7 @@ public extension StorageType {
     }
 
     /// Retrieves all stored MetaData of a given Order
-    /// 
+    ///
     func loadOrderMetaData(siteID: Int64, orderID: Int64) -> [MetaData] {
         let predicate = \MetaData.order?.siteID == siteID && \MetaData.order?.orderID == orderID
         return allObjects(ofType: MetaData.self, matching: predicate, sortedBy: nil)
@@ -781,7 +781,7 @@ public extension StorageType {
     }
 
     /// Retrieves all stored MetaData of a given Product
-    /// 
+    ///
     func loadProductMetaData(siteID: Int64, productID: Int64) -> [MetaData] {
         let predicate = \MetaData.product?.siteID == siteID && \MetaData.product?.productID == productID
         return allObjects(ofType: MetaData.self, matching: predicate, sortedBy: nil)

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -273,6 +273,21 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(metadata, storedMetaData)
     }
 
+    func test_loadOrderMetaData_by_siteID_orderID() throws {
+        // Given
+        let metadata = storage.insertNewObject(ofType: MetaData.self)
+
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.siteID = sampleSiteID
+        order.addToCustomFields(metadata)
+
+        // When
+        let storedMetaData = try XCTUnwrap(storage.loadOrderMetaData(siteID: sampleSiteID, orderID: order.orderID))
+
+        // Then
+        XCTAssertEqual([metadata], storedMetaData)
+    }
+
     func test_loadProductMetaData_by_siteID_productID_metadataID() throws {
         // Given
         let metadataID: Int64 = 123
@@ -288,6 +303,21 @@ final class StorageTypeExtensionsTests: XCTestCase {
 
         // Then
         XCTAssertEqual(metadata, storedMetaData)
+    }
+
+    func test_loadProductMetaData_by_siteID_productID() throws {
+        // Given
+        let metadata = storage.insertNewObject(ofType: MetaData.self)
+
+        let product = storage.insertNewObject(ofType: Product.self)
+        product.siteID = sampleSiteID
+        product.addToCustomFields(metadata)
+
+        // When
+        let storedMetaData = try XCTUnwrap(storage.loadProductMetaData(siteID: sampleSiteID, productID: product.productID))
+
+        // Then
+        XCTAssertEqual([metadata], storedMetaData)
     }
 
     func test_loadTopEarnerStats_by_date_granularity() throws {

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -9,6 +9,7 @@ final class CustomFieldsListViewModel: ObservableObject {
     private let customFieldsType: MetaDataType
     private let siteID: Int64
     private let parentItemID: Int64
+    private let onChangesSaved: (([MetaData]) -> Void)?
 
     @Published var selectedCustomField: CustomFieldUI? = nil
     @Published var isAddingNewField: Bool = false
@@ -36,12 +37,14 @@ final class CustomFieldsListViewModel: ObservableObject {
          siteID: Int64,
          parentItemID: Int64,
          customFieldType: MetaDataType,
+         onChangesSaved: (([MetaData]) -> Void)? = nil,
          stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
         self.originalCustomFields = customFields
         self.siteID = siteID
         self.parentItemID = parentItemID
         self.customFieldsType = customFieldType
+        self.onChangesSaved = onChangesSaved
 
         observePendingChanges()
     }
@@ -115,6 +118,7 @@ extension CustomFieldsListViewModel {
             pendingChanges = PendingCustomFieldsChanges()
             notice = Notice(title: CustomFieldsListHostingController.Localization.saveSuccessTitle,
                             feedbackType: .success)
+            onChangesSaved?(result)
         } catch {
             notice = Notice(title: CustomFieldsListHostingController.Localization.saveErrorTitle,
                             message: CustomFieldsListHostingController.Localization.saveErrorMessage,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1494,7 +1494,14 @@ private extension ProductFormViewController {
             CustomFieldViewModel(metadata: $0)
         }
 
-        let viewModel = CustomFieldsListViewModel(customFields: customFields, siteID: product.siteID, parentItemID: product.productID, customFieldType: .product)
+        let viewModel = CustomFieldsListViewModel(customFields: customFields,
+                                                  siteID: product.siteID,
+                                                  parentItemID: product.productID,
+                                                  customFieldType: .product,
+                                                  onChangesSaved: { [weak self] customFields in
+            guard let self else { return }
+            self.viewModel.updateProductCustomFields(customFields: customFields)
+        })
 
         let customFieldsListViewController = CustomFieldsListHostingController(isEditable: true,
                                                                                viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -230,10 +230,6 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let featureFlagService: FeatureFlagService
 
-    private lazy var entityListener: EntityListener<Product> = {
-        return EntityListener(storageManager: ServiceLocator.storageManager, readOnlyEntity: originalProduct.product)
-    }()
-
     init(product: EditableProductModel,
          formType: ProductFormType,
          productImageActionHandler: ProductImageActionHandler,
@@ -266,7 +262,6 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         updateVariationsPriceState()
         configureResultsController()
         updateBlazeEligibility()
-        configureEntityListener()
     }
 
     deinit {
@@ -562,6 +557,14 @@ extension ProductFormViewModel {
     func updateQuantityRules(minQuantity: String, maxQuantity: String, groupOf: String) {
         product = EditableProductModel(product: product.product.copy(minAllowedQuantity: minQuantity, maxAllowedQuantity: maxQuantity, groupOfQuantity: groupOf))
     }
+
+    func updateProductCustomFields(customFields: [MetaData]) {
+        // Keep a reference to the edited product
+        let productWithChanges = product.product.copy(customFields: customFields)
+
+        resetProduct(EditableProductModel(product: originalProduct.product.copy(customFields: customFields)))
+        product = EditableProductModel(product: productWithChanges)
+    }
 }
 
 // MARK: Remote actions
@@ -775,18 +778,6 @@ private extension ProductFormViewModel {
     ///
     private func isNewTemplateProduct() -> Bool {
         originalProduct.productID == .zero && !originalProduct.isEmpty()
-    }
-
-    /// Listen to storage changes and update the product when needed
-    /// Only needed for updates that are saved remotely on other screens
-    ///
-    private func configureEntityListener() {
-        entityListener.onUpsert = { [weak self] product in
-            guard let self = self else { return }
-            // Custom fields are updated on a different screen, update the product to reflect the last changes
-            resetProduct(EditableProductModel(product: originalProduct.product.copy(customFields: product.customFields)))
-            self.product = EditableProductModel(product: product.copy(customFields: product.customFields))
-        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -155,6 +155,8 @@ protocol ProductFormViewModelProtocol {
 
     func updateQuantityRules(minQuantity: String, maxQuantity: String, groupOf: String)
 
+    func updateProductCustomFields(customFields: [MetaData])
+
     // Remote action
 
     /// Creates/updates a product remotely given an optional product status to override.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -389,6 +389,10 @@ extension ProductVariationFormViewModel {
                                                          parentProductSKU: parentProductSKU,
                                                          parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
+
+    func updateProductCustomFields(customFields: [MetaData]) {
+        // no-op
+    }
 }
 
 // MARK: Remote actions

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -253,4 +253,25 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // Then: An error should be thrown
         XCTAssertNotNil(viewModel.notice)
     }
+
+    func test_given_savingSucceeds_when_saveChangesCalled_then_callListener() async {
+        // Given: successfully saving the changes
+        stores.whenReceivingAction(ofType: MetaDataAction.self) { [self] action in
+            switch action {
+                case let .updateMetaData(_, _, _, _, onCompletion):
+                    onCompletion(.success(originalMetadata))
+            }
+        }
+        var listenerReceivedItems: [MetaData]? = nil
+        viewModel = CustomFieldsListViewModel(customFields: originalFields,
+                                              siteID: sampleSiteID,
+                                              parentItemID: sampleParentItemID,
+                                              customFieldType: sampleCustomFieldType,
+                                              onChangesSaved: { listenerReceivedItems = $0 },
+                                              stores: stores)
+        // When: Saving the changes
+        await viewModel.saveChanges()
+        // Then: The listener should be called
+        XCTAssertEqual(listenerReceivedItems, originalMetadata)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -799,6 +799,18 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.productModel.downloadable)
     }
 
+    func test_updateCustomFields_updated_originalProduct_and_productModel() {
+        // Given
+        let product = Product.fake().copy(customFields: [])
+        let viewModel = createViewModel(product: product, formType: .edit)
+        // When
+        let customFields = [MetaData(metadataID: 0, key: "key", value: "value")]
+        viewModel.updateProductCustomFields(customFields: customFields)
+        // Then
+        XCTAssertEqual(viewModel.productModel.product.customFields, customFields)
+        XCTAssertEqual(viewModel.originalProductModel.product.customFields, customFields)
+    }
+
 
     // MARK: Subscription Free trial
 

--- a/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MetaDataStoreTests.swift
@@ -86,6 +86,36 @@ final class MetaDataStoreTests: XCTestCase {
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
 
+    func test_updateOrderMetaData_removes_deleted_items() {
+        // Given
+        let metaData = [MetaData.fake().copy(metadataID: 1, key: "key", value: "value"),
+                        MetaData.fake().copy(metadataID: 2, key: "key", value: "value")]
+        let order = Yosemite.Order.fake().copy(siteID: sampleSiteID, orderID: sampleOrderID, customFields: metaData)
+        // Insert order with metadata
+        let orderUpsertUseCase = OrdersUpsertUseCase(storage: storage)
+        orderUpsertUseCase.upsert([order])
+
+        remote.whenUpdatingMetaData(thenReturn: .success([metaData.last!]))
+        let store = MetaDataStore(dispatcher: Dispatcher(),
+                                  storageManager: storageManager,
+                                  network: network,
+                                  remote: remote)
+
+        // When
+        waitFor { promise in
+            store.onAction(MetaDataAction.updateMetaData(siteID: self.sampleSiteID,
+                                                         parentItemID: self.sampleOrderID,
+                                                         metaDataType: .order,
+                                                         metadata: [["id": 1, "value": nil]],
+                                                         onCompletion: { _ in promise(()) }))
+        }
+
+        // Then
+        let updatedOrder = storageManager.viewStorage.loadOrder(siteID: order.siteID, orderID: order.orderID)?.toReadOnly()
+        XCTAssertEqual(updatedOrder?.customFields.count, 1)
+        XCTAssertEqual(updatedOrder?.customFields.first?.key, metaData.last!.key)
+    }
+
     // MARK: - Update Product MetaData
 
     func test_updateProductMetaData_is_successful_when_updating_successfully() throws {
@@ -137,5 +167,12 @@ final class MetaDataStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
+}
+
+private extension MockStorageManager {
+    func insertSampleMetaData(_ metaData: Networking.MetaData) {
+        let storageObj = viewStorage.insertNewObject(ofType: MetaData.self)
+        storageObj.update(with: metaData)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14199 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds a fix to the linked issue, the issue was that after saving changes (#14194), then the new changes weren't reflected in some cases:
- ~~In OrderDetails, after going back, the changes were loading asynchronously, meaning that if we open the custom fields later quickly, we could see the state before saving.~~ As discussed below, the issue for order details was just that deleted custom fields weren't deleted from storage.
- In ProductDetails, the changes were never elected.

These issues were caused by two issues:
- For Order Details, the issue was that the logic of `MetaDataStore` was broken, and wasn't cleaning up deleted custom fields.
- For Product Details, the parent screen was holding a reference to the outdated object, and wasn't updated when the custom fields list changes.

## Steps to reproduce
1. Open a product or an order in the app.
2. Tap on Custom Fields button (or row)
3. Make some changes.
4. Save changes.
5. Navigate back.
6. Re-open custom fields.

## Testing information
- Confirm that the changes are reflected immediately.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.