### PR TITLE
[Mobile Payments] Update error message for Tap to Pay support

### DIFF
--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -493,10 +493,10 @@ extension UnderlyingError: LocalizedError {
                                      "there is an issue with the merchant account or device.")
 
         case .unsupportedMobileDeviceConfiguration:
-            /// Strictly, 16.0 is required in the US, 16.4 in the UK... but it's overly complicated to make this country specific.
-            /// Any device running 16.0 can run 16.4, so this seems clear enough.
+            /// Sometimes there are different requirements in different countries but it's overly complicated to make this country specific.
+            /// Use the highest version number required by a country in this message.
             return NSLocalizedString("Please check that your phone meets these requirements: " +
-                                     "iPhone XS or newer running iOS 16.4 or above. Contact support if this error " +
+                                     "iPhone XS or newer running iOS 16.7 or above. Contact support if this error " +
                                      "shows on a supported device.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device does not meet minimum requirements.")

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 - [Internal] Update Stripe Terminal SDK to 3.9.1 [https://github.com/woocommerce/woocommerce-ios/pull/14198]
 - [internal] Optimized storage usage in ProductAttributeStore and ProductAttributeTermStore [https://github.com/woocommerce/woocommerce-ios/pull/14145]
 - [internal] Additions to TopTabView for customization options [https://github.com/woocommerce/woocommerce-ios/pull/14192]
-
+- [*] Payments: Tap to Pay now requires iOS 16.7 as a minimum [https://github.com/woocommerce/woocommerce-ios/pull/14205]
 
 20.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The minimum requirements for TTP support have increased to iOS 16.7.

This changes the error message shown when using an older version to tell merchants about the need to update.

We still show the old requirements elsewhere in the app with this change, but this avoids hiding TTP from merchants who’ve previously used it, without giving them any explanation for why it’s gone.

In a future PR we can update the app's requirements, potentially also adding a disabled/explainer version back to the app for merchants with an older version of tap to pay.


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This can only be tested on an iPhone running iOS 16.0-16.6, and I don't have one. It's just a string change though.

The simulated card reader doesn't produce the error when using an older version of iOS, it only shows iPads as not supporting TTP.

Launch the app on an iPhone running iOS 16.6 or earlier

1. Go to `Menu > Payments > Set up Tap to Pay on iPhone`
2. Complete the flow
3. Observe you're shown an error message mentioning iOS 16.7

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There will be places in the app which still reference iOS 16.0 or 16.4 – these can't be easily updated without also hiding tap to pay from merchants who may already use it, with no explanation.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Can't provide these


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.