### PR TITLE
[Woo POS - payments onboarding] Support actions in onboarding: support form and showing URL in webview

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -128,9 +128,16 @@ private extension PointOfSaleDashboardView {
         .navigationViewStyle(.stack)
     }
 
-    func paymentsOnboardingView(from viewModel: CardPresentPaymentsOnboardingViewModel) -> some View {
-        NavigationStack {
-            CardPresentPaymentsOnboardingView(viewModel: viewModel)
+    func paymentsOnboardingView(from onboardingViewModel: CardPresentPaymentsOnboardingViewModel) -> some View {
+        onboardingViewModel.showSupport = {
+            totalsViewModel.cardPresentPaymentOnboardingViewModel = nil
+            viewModel.showSupport = true
+        }
+        onboardingViewModel.showURL = { url in
+            totalsViewModel.cardPresentPaymentOnboardingURL = url
+        }
+        return NavigationStack {
+            CardPresentPaymentsOnboardingView(viewModel: onboardingViewModel)
                 .navigationBarTitleDisplayMode(.inline)
                 .interactiveDismissDisabled()
                 .toolbar {
@@ -140,6 +147,7 @@ private extension PointOfSaleDashboardView {
                         Text(Localization.cancelOnboarding)
                     }
                 }
+                .safariSheet(url: $totalsViewModel.cardPresentPaymentOnboardingURL)
                 .onDisappear {
                     totalsViewModel.cancelOnboarding()
                 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -21,6 +21,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     }
 
     @Published var cardPresentPaymentOnboardingViewModel: CardPresentPaymentsOnboardingViewModel?
+    @Published var cardPresentPaymentOnboardingURL: URL?
     private var onOnboardingCancellation: (() -> Void)?
     @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14176 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In the onboarding view model `CardPresentPaymentsOnboardingViewModel`, there are two actions that need to be handled by setting a closure:

- `showSupport`: show the support form
- `showURL`: show a URL, usually to learn more about an error, in a webview

This PR handles these actions in POS.

## How

`showSupport` and `showURL` are handled in `PointOfSaleDashboardView`.

For `showURL`, I originally handled it within `TotalsViewModel` when assigning `cardPresentPaymentOnboardingViewModel` like:

```swift
viewModel.showURL = { [weak self] url in
    self?.cardPresentPaymentOnboardingURL = url
}
```
but I noticed that the webview isn't shown after the dismissing the onboarding modal once. With some debugging, it was because `TotalsViewModel` gets reset every time the onboarding view is shown/hidden (probably due to its `cardPresentPaymentOnboardingViewModel`'s changes, since the totals view model is an `@ObservedObject`) and thus `self` is deallocated. Setting the closures in `PointOfSaleDashboardView` guarantees the totals view model is the current one. I still kept `cardPresentPaymentOnboardingURL` variable in `TotalsViewModel` to be with other onboarding properties, but I'm open to move it somewhere else like `PointOfSaleDashboardViewModel`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: store is eligible for POS, and onboarding isn't completed (missing some requirements, or plugin not activated with a Shop Manager role). Alternatively, you can hard code the state by returning `.stripeAccountOverdueRequirement(plugin: .wcPay)` in `CardPresentPaymentsOnboardingUseCase.checkOnboardingState`.

- Switch to store/user in the prerequisite, if needed
- Go to Menu > POS Mode
- Tap `Connect your reader` --> an onboarding modal should be shown shortly, with a `Learn more` CTA and `Contact us` CTA
- Tap `Learn more` --> a Safari sheet should be shown about the onboarding error
- Dismiss the webview
- Tap `Contact us` --> the onboarding modal should be dismissed, then support form is presented
- Tap `Connect your reader` again
- Repeat the steps above to tap on the 2 CTAs

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I tested in iPad Pro 11in iOS 17.5 with Xcode 16, in several stores with different states.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/b9228a3e-7d04-4468-acec-81174b1b3720



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
