### PR TITLE
[Woo POS] Separation between item’s first fetch from next fetch

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -142,7 +142,7 @@ private extension ItemListView {
                         let viewHeight = UIScreen.main.bounds.height
                         if maxY < viewHeight {
                             Task {
-                                await viewModel.populatePointOfSaleItems()
+                                await viewModel.loadNextItems()
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -80,7 +80,7 @@ struct PointOfSaleDashboardView: View {
             supportForm
         }
         .task {
-            await viewModel.itemListViewModel.populatePointOfSaleItems()
+            await viewModel.itemListViewModel.loadInitialItems()
         }
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -10,7 +10,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     @Published private(set) var isHeaderBannerDismissed: Bool = false
     @Published var showSimpleProductsModal: Bool = false
 
-    @Published private(set) var currentPage: Int = 0
+    @Published private(set) var currentPage: Int = Constants.initialPage
 
     var shouldShowHeaderBanner: Bool {
         // The banner it's shown as long as it hasn't already been dismissed once:
@@ -38,11 +38,33 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     }
 
     @MainActor
-    func populatePointOfSaleItems() async {
-        let nextPage = currentPage + 1
+    func loadInitialItems() async {
         do {
             state = .loading
-            let newItems = try await itemProvider.providePointOfSaleItems(pageNumber: nextPage)
+            items = try await itemProvider.providePointOfSaleItems(pageNumber: Constants.initialPage)
+            if items.count == 0 {
+                state = .empty
+            } else {
+                state = .loaded(items)
+            }
+        } catch {
+            state = .error(ErrorModel.errorOnLoadingProducts())
+        }
+    }
+
+    @MainActor
+    func loadNextItems() async {
+        // TODO:
+        // Optimize API calls. gh-14186
+        let nextPage = currentPage + 1
+        await fetchPage(pageNumber: nextPage)
+    }
+
+    @MainActor
+    private func fetchPage(pageNumber: Int) async {
+        do {
+            state = .loading
+            let newItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
             let uniqueNewItems = newItems.filter { newItem in
                 !items.contains(where: { $0.productID == newItem.productID })
             }
@@ -52,22 +74,18 @@ final class ItemListViewModel: ItemListViewModelProtocol {
                 state = .empty
             } else {
                 state = .loaded(items)
-                currentPage = nextPage
+                currentPage = pageNumber
             }
         } catch {
-            DDLogError("Error on load while fetching product data: \(error)")
-            let itemListError = ErrorModel(title: Constants.failedToLoadTitle,
-                                      subtitle: Constants.failedToLoadSubtitle,
-                                      buttonText: Constants.failedToLoadButtonTitle)
-            state = .error(itemListError)
+            state = .error(ErrorModel.errorOnLoadingProducts())
         }
     }
 
     @MainActor
     func reload() async {
-        currentPage = 0
+        currentPage = Constants.initialPage
         items.removeAll()
-        await populatePointOfSaleItems()
+        await loadInitialItems()
     }
 
     func dismissBanner() {
@@ -137,6 +155,12 @@ extension ItemListViewModel {
         let title: String
         let subtitle: String
         let buttonText: String
+
+        static func errorOnLoadingProducts() -> Self {
+            ErrorModel(title: Constants.failedToLoadTitle,
+                       subtitle: Constants.failedToLoadSubtitle,
+                       buttonText: Constants.failedToLoadButtonTitle)
+        }
     }
 
     struct BannerState {
@@ -161,5 +185,6 @@ private extension ItemListViewModel {
             value: "Retry",
             comment: "Text for the button appearing on the item list screen when there's an error loading products."
         )
+        static let initialPage: Int = 1
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -10,7 +10,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     @Published private(set) var isHeaderBannerDismissed: Bool = false
     @Published var showSimpleProductsModal: Bool = false
 
-    @Published private(set) var currentPage: Int = Constants.initialPage
+    @Published private var currentPage: Int = Constants.initialPage
 
     var shouldShowHeaderBanner: Bool {
         // The banner it's shown as long as it hasn't already been dismissed once:
@@ -54,8 +54,8 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @MainActor
     func loadNextItems() async {
-        // TODO:
-        // Optimize API calls. gh-14186
+        // TODO: Optimize API calls. gh-14186
+        // If there are no more pages to fetch, we can avoid the next call.
         let nextPage = currentPage + 1
         await fetchPage(pageNumber: nextPage)
     }
@@ -68,11 +68,11 @@ final class ItemListViewModel: ItemListViewModelProtocol {
             let uniqueNewItems = newItems.filter { newItem in
                 !items.contains(where: { $0.productID == newItem.productID })
             }
-            items.append(contentsOf: uniqueNewItems)
-
-            if items.count == 0 {
-                state = .empty
+            // If there are no new items, we just return what was already in memory
+            if (currentPage == pageNumber) && uniqueNewItems.count == 0 {
+                state = .loaded(items)
             } else {
+                items.append(contentsOf: uniqueNewItems)
                 state = .loaded(items)
                 currentPage = pageNumber
             }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -39,9 +39,10 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @MainActor
     func loadInitialItems() async {
+        currentPage = Constants.initialPage
         do {
             state = .loading
-            items = try await itemProvider.providePointOfSaleItems(pageNumber: Constants.initialPage)
+            items = try await itemProvider.providePointOfSaleItems(pageNumber: currentPage)
             if items.count == 0 {
                 state = .empty
             } else {
@@ -83,7 +84,6 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @MainActor
     func reload() async {
-        currentPage = Constants.initialPage
         items.removeAll()
         await loadInitialItems()
     }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -70,7 +70,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
                 !items.contains(where: { $0.productID == newItem.productID })
             }
             // If there are no new items, we just return what was already in memory
-            if (currentPage == pageNumber) && uniqueNewItems.count == 0 {
+            if uniqueNewItems.count == 0 {
                 state = .loaded(items)
             } else {
                 items.append(contentsOf: uniqueNewItems)

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
@@ -13,7 +13,8 @@ protocol ItemListViewModelProtocol: ObservableObject {
     var statePublisher: Published<ItemListViewModel.ItemListState>.Publisher { get }
 
     func select(_ item: POSItem)
-    func populatePointOfSaleItems() async
+    func loadInitialItems() async
+    func loadNextItems() async
     func reload() async
     func dismissBanner()
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
@@ -20,7 +20,10 @@ class MockItemListViewModel: ItemListViewModelProtocol {
     func select(_ item: any Yosemite.POSItem) {
     }
 
-    func populatePointOfSaleItems() async {
+    func loadInitialItems() async {
+    }
+
+    func loadNextItems() async {
     }
 
     func reload() async {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -24,27 +24,27 @@ final class ItemListViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_itemListViewModel_when_populatePointOfSaleItems_is_called_then_items_are_populated() async {
+    func test_itemListViewModel_when_loadInitialItems_then_items_are_populated() async {
         // Given
         XCTAssertEqual(sut.items.count, 0)
         let expectedItems = Self.makeItems()
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.items.count, expectedItems.count)
     }
 
-    func test_itemListViewModel_when_populatePointOfSaleItems_is_called_multiple_times_then_items_are_not_aggregated() async {
+    func test_itemListViewModel_when_loadInitialItems_is_called_multiple_times_then_items_are_not_aggregated() async {
         // Given
         XCTAssertEqual(sut.items.count, 0)
         let expectedItems = Self.makeItems()
 
         // When
-        await sut.populatePointOfSaleItems()
-        await sut.populatePointOfSaleItems()
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
+        await sut.loadInitialItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.items.count, expectedItems.count)
@@ -103,20 +103,20 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .loading)
     }
 
-    func test_itemListViewModel_when_populatePointOfSaleItems_then_state_is_loaded() async {
+    func test_itemListViewModel_when_loadInitialItems_then_state_is_loaded() async {
         // Given
         let expectedItems = Self.makeItems()
 
         XCTAssertEqual(sut.state, .loading)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.state, .loaded(expectedItems))
     }
 
-    func test_itemListViewModel_when_populatePointOfSaleItems_has_no_items_then_state_is_loaded_empty() async {
+    func test_itemListViewModel_when_loadInitialItems_has_no_items_then_state_is_loaded_empty() async {
         // Given
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldReturnZeroItems = true
@@ -125,13 +125,13 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .loading)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.state, .empty)
     }
 
-    func test_itemListViewModel_when_populatePointOfSaleItems_throws_error_then_state_is_error() async {
+    func test_itemListViewModel_when_loadInitialItems_throws_error_then_state_is_error() async {
         // Given
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
@@ -143,7 +143,7 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .loading)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.state, .error(expectedError))
@@ -198,7 +198,7 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_shouldShowHeaderBanner_when_itemListViewModel_is_loading_has_items_then_returns_true() async {
         // Given the list is already populated with items
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
         XCTAssertTrue(sut.items.isNotEmpty)
 
         // When we refresh the list again
@@ -210,7 +210,7 @@ final class ItemListViewModelTests: XCTestCase {
             }
         }
         .store(in: &cancellables)
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then banner shoud be shown
         await fulfillment(of: [expectation], timeout: 1)
@@ -226,7 +226,7 @@ final class ItemListViewModelTests: XCTestCase {
                                                          buttonText: "Retry")
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.state, .error(expectedError))
@@ -235,7 +235,7 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_state_when_itemListViewModel_loaded_normally_then_returns_isLoaded_true() async {
         // Given/When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.state.isLoaded, true)
@@ -248,13 +248,13 @@ final class ItemListViewModelTests: XCTestCase {
         let sut = ItemListViewModel(itemProvider: itemProvider)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(sut.state.isLoaded, false)
     }
 
-    func test_populatePointOfSaleItems_when_no_items_are_loaded_then_itemsPublisher_emits_no_items() async throws {
+    func test_loadInitialItems_when_no_items_are_loaded_then_itemsPublisher_emits_no_items() async throws {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldReturnZeroItems = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
@@ -268,14 +268,14 @@ final class ItemListViewModelTests: XCTestCase {
         .store(in: &cancellables)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertTrue(sut.state == .empty)
         XCTAssertTrue(receivedItems.isEmpty)
     }
 
-    func test_populatePointOfSaleItems_when_items_are_loaded_then_itemsPublisher_emits_items() async throws {
+    func test_loadInitialItems_when_items_are_loaded_then_itemsPublisher_emits_items() async throws {
         // Given
         let items = Self.makeItems()
         let expectation = XCTestExpectation(description: "Publisher should emit populated items")
@@ -287,7 +287,7 @@ final class ItemListViewModelTests: XCTestCase {
         .store(in: &cancellables)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
         guard let firstItem = items.first, let lastItem = items.last else {
             return XCTFail("Expected two items, got \(receivedItems).")
         }
@@ -298,7 +298,7 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(receivedItems.last?.productID, lastItem.productID)
     }
 
-    func test_populatePointOfSaleItems_when_no_items_are_loaded_then_statePublisher_emits_expected_empty_state() async throws {
+    func test_loadInitialItems_when_no_items_are_loaded_then_statePublisher_emits_expected_empty_state() async throws {
         // Given
         XCTAssertEqual(sut.state, .loading, "Initial state")
 
@@ -317,13 +317,13 @@ final class ItemListViewModelTests: XCTestCase {
         .store(in: &cancellables)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(receivedStates, [.loading, .empty])
     }
 
-    func test_populatePointOfSaleItems_when_items_are_loaded_then_statePublisher_emits_expected_loaded_state() async throws {
+    func test_loadInitialItems_when_items_are_loaded_then_statePublisher_emits_expected_loaded_state() async throws {
         // Given
         XCTAssertEqual(sut.state, .loading, "Initial state")
         let expectation = XCTestExpectation(description: "Publisher should emit state changes")
@@ -339,7 +339,7 @@ final class ItemListViewModelTests: XCTestCase {
         .store(in: &cancellables)
 
         // When
-        await sut.populatePointOfSaleItems()
+        await sut.loadInitialItems()
 
         // Then
         XCTAssertEqual(receivedStates, [.loading, .loaded(items)])
@@ -353,20 +353,20 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertTrue(sut.showSimpleProductsModal)
     }
 
-    func test_currentPage_when_populatePointOfSaleItems_is_invoked_multiple_times_then_updates_to_next_page() async {
-        XCTAssertTrue(sut.currentPage == 0, "Initial state.")
+    func test_currentPage_when_loadNextItems_is_invoked_then_updates_to_next_page() async {
+        XCTAssertTrue(sut.currentPage == 1, "Initial state.")
 
         // When/Then
-        await sut.populatePointOfSaleItems()
-        XCTAssertTrue(sut.currentPage == 1)
+        await sut.loadInitialItems()
+        XCTAssertTrue(sut.currentPage == 1, "Loading initial items does not update pagination.")
 
         // When/Then
-        await sut.populatePointOfSaleItems()
-        XCTAssertTrue(sut.currentPage == 2)
+        await sut.loadNextItems()
+        XCTAssertTrue(sut.currentPage == 2, "Loading subsequent items updates pagination.")
     }
 
     func test_currentPage_when_reload_is_invoked_multiple_times_then_stays_on_first_page() async {
-        XCTAssertTrue(sut.currentPage == 0, "Initial state.")
+        XCTAssertTrue(sut.currentPage == 1, "Initial state.")
 
         // When/Then
         await sut.reload()

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -27,7 +27,7 @@ final class ItemListViewModelTests: XCTestCase {
     func test_itemListViewModel_when_loadInitialItems_then_items_are_populated() async {
         // Given
         XCTAssertEqual(sut.items.count, 0)
-        let expectedItems = Self.makeItems()
+        let expectedItems = Self.makeInitialItems()
 
         // When
         await sut.loadInitialItems()
@@ -39,7 +39,7 @@ final class ItemListViewModelTests: XCTestCase {
     func test_itemListViewModel_when_loadInitialItems_is_called_multiple_times_then_items_are_not_aggregated() async {
         // Given
         XCTAssertEqual(sut.items.count, 0)
-        let expectedItems = Self.makeItems()
+        let expectedItems = Self.makeInitialItems()
 
         // When
         await sut.loadInitialItems()
@@ -53,7 +53,7 @@ final class ItemListViewModelTests: XCTestCase {
     func test_itemListViewModel_when_reload_is_called_then_items_are_populated() async {
         // Given
         XCTAssertEqual(sut.items.count, 0)
-        let expectedItems = Self.makeItems()
+        let expectedItems = Self.makeInitialItems()
 
         // When
         await sut.reload()
@@ -65,7 +65,7 @@ final class ItemListViewModelTests: XCTestCase {
     func test_itemListViewModel_when_reload_is_called_multiple_times_then_items_are_not_aggregated() async {
         // Given
         XCTAssertEqual(sut.items.count, 0)
-        let expectedItems = Self.makeItems()
+        let expectedItems = Self.makeInitialItems()
 
         // When
         await sut.reload()
@@ -78,7 +78,7 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_itemListViewModel_when_select_item_then_sends_item_to_publisher() {
         // Given
-        let items = Self.makeItems()
+        let items = Self.makeInitialItems()
         let expectation = XCTestExpectation(description: "Publisher should emit the selected item")
 
         var receivedItem: POSItem?
@@ -105,7 +105,7 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_itemListViewModel_when_loadInitialItems_then_state_is_loaded() async {
         // Given
-        let expectedItems = Self.makeItems()
+        let expectedItems = Self.makeInitialItems()
 
         XCTAssertEqual(sut.state, .loading)
 
@@ -114,6 +114,53 @@ final class ItemListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sut.state, .loaded(expectedItems))
+    }
+
+    func test_loadNextItems_when_initial_items_empty_then_state_is_loaded_with_empty_items() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldReturnZeroItems = true
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+
+        XCTAssertEqual(sut.state, .loading)
+
+        // When
+        await sut.loadNextItems()
+
+        // Then
+        XCTAssertEqual(sut.state, .loaded([]))
+    }
+
+    func test_loadNextItems_when_initial_items_has_items_then_state_is_loaded_with_initial_items() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        let initialItems = Self.makeInitialItems()
+        itemProvider.items = initialItems
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+
+        XCTAssertEqual(sut.state, .loading)
+
+        // When
+        await sut.loadNextItems()
+
+        // Then
+        XCTAssertEqual(sut.state, .loaded(initialItems))
+    }
+
+    func test_loadNextItems_when_simulateFetchNextPage_then_returns_expected_items() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        let initialItems = Self.makeInitialItems()
+        itemProvider.items = initialItems
+        itemProvider.shouldSimulateFetchNextPage = true
+
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+
+        // When
+        await sut.loadNextItems()
+
+        // Then
+        XCTAssertEqual(sut.items.count, 4)
     }
 
     func test_itemListViewModel_when_loadInitialItems_has_no_items_then_state_is_loaded_empty() async {
@@ -149,10 +196,28 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .error(expectedError))
     }
 
+    func test_itemListViewModel_when_loadNextItems_throws_error_then_state_is_error() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
+                                                         subtitle: "Give it another go?",
+                                                         buttonText: "Retry")
+
+        XCTAssertEqual(sut.state, .loading)
+
+        // When
+        await sut.loadNextItems()
+
+        // Then
+        XCTAssertEqual(sut.state, .error(expectedError))
+    }
+
     func test_itemListViewModel_when_reload_then_state_is_loaded_with_expected_items() async {
         // Given
         XCTAssertEqual(sut.state, .loading)
-        let expectedItems = Self.makeItems()
+        let expectedItems = Self.makeInitialItems()
 
         // When
         await sut.reload()
@@ -277,7 +342,7 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_loadInitialItems_when_items_are_loaded_then_itemsPublisher_emits_items() async throws {
         // Given
-        let items = Self.makeItems()
+        let items = Self.makeInitialItems()
         let expectation = XCTestExpectation(description: "Publisher should emit populated items")
         var receivedItems: [POSItem] = []
         sut.itemsPublisher.sink { items in
@@ -327,7 +392,7 @@ final class ItemListViewModelTests: XCTestCase {
         // Given
         XCTAssertEqual(sut.state, .loading, "Initial state")
         let expectation = XCTestExpectation(description: "Publisher should emit state changes")
-        let items = Self.makeItems()
+        let items = Self.makeInitialItems()
 
         var receivedStates: [ItemListViewModel.ItemListState] = []
         sut.statePublisher
@@ -352,30 +417,6 @@ final class ItemListViewModelTests: XCTestCase {
 
         XCTAssertTrue(sut.showSimpleProductsModal)
     }
-
-    func test_currentPage_when_loadNextItems_is_invoked_then_updates_to_next_page() async {
-        XCTAssertTrue(sut.currentPage == 1, "Initial state.")
-
-        // When/Then
-        await sut.loadInitialItems()
-        XCTAssertTrue(sut.currentPage == 1, "Loading initial items does not update pagination.")
-
-        // When/Then
-        await sut.loadNextItems()
-        XCTAssertTrue(sut.currentPage == 2, "Loading subsequent items updates pagination.")
-    }
-
-    func test_currentPage_when_reload_is_invoked_multiple_times_then_stays_on_first_page() async {
-        XCTAssertTrue(sut.currentPage == 1, "Initial state.")
-
-        // When/Then
-        await sut.reload()
-        XCTAssertTrue(sut.currentPage == 1)
-
-        // When/Then
-        await sut.reload()
-        XCTAssertTrue(sut.currentPage == 1)
-    }
 }
 
 private extension ItemListViewModelTests {
@@ -383,6 +424,7 @@ private extension ItemListViewModelTests {
         var items: [POSItem] = []
         var shouldThrowError = false
         var shouldReturnZeroItems = false
+        var shouldSimulateFetchNextPage = false
 
         func providePointOfSaleItems(pageNumber: Int) async throws -> [Yosemite.POSItem] {
             if shouldThrowError {
@@ -391,11 +433,40 @@ private extension ItemListViewModelTests {
             if shouldReturnZeroItems {
                 return []
             }
-            return makeItems()
+            if shouldSimulateFetchNextPage {
+                simulateFetchNextPage()
+                return items
+            }
+            return makeInitialItems()
+        }
+
+        func simulateFetchNextPage() {
+            let fakeUUID1 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E86D") ?? UUID()
+            let fakeUUID2 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E86F") ?? UUID()
+
+            let product1 = POSProduct(itemID: fakeUUID1,
+                                      productID: 0,
+                                      name: "Strawberry",
+                                      price: "2",
+                                      formattedPrice: "$2.00",
+                                      itemCategories: [],
+                                      productImageSource: nil,
+                                      productType: .simple)
+            items.append(product1)
+
+            let product2 = POSProduct(itemID: fakeUUID2,
+                                      productID: 1,
+                                      name: "Pistachio",
+                                      price: "3",
+                                      formattedPrice: "$3.00",
+                                      itemCategories: [],
+                                      productImageSource: nil,
+                                      productType: .simple)
+            items.append(product2)
         }
     }
 
-    static func makeItems() -> [POSItem] {
+    static func makeInitialItems() -> [POSItem] {
         let fakeUUID1 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E84E") ?? UUID()
         let fakeUUID2 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E84A") ?? UUID()
 


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/14203
Part of https://github.com/woocommerce/woocommerce-ios/issues/14186

## Description
In this PR we perform a separation between fetching the first page for POS products versus fetching subsequent pages. Pagination/infinite scrolling still should work as before:

https://github.com/user-attachments/assets/d05e5cc5-ccf5-4d99-b5e1-e5c2afd4f084

## Changes
- We delete `populatePointOfSaleItems()` in favour of two separate functions: `loadInitialItems()` and `loadNextItems()`
- We keep pagination state outside of the view, this is managed internally by the ViewModel
- Addressed marking `currentPage` private, following the feedback on https://github.com/woocommerce/woocommerce-ios/pull/14195#discussion_r1812168427
- Addressed marking the first page as a constant, following the feedback on https://github.com/woocommerce/woocommerce-ios/pull/14195#discussion_r1812160372
- Fixed a bug where if the next page returns 0 products, then we switch the view state to `.empty`. This is the case for the initial page fetch, but not for subsequent ones, in this case it will be just `.loaded(items)`.

I'd like some advice about passing/not passing the current page as a parameter into the publicly exposed function. At the moment we keep the page track completely private, as I think this approach keeps things decoupled and responsibilities to each own: The view just knows it has to fetch next page, and the viewmodel has to tackle which one. However, I had a hard time trying to unit test this, since most of the time I found myself actually testing the Mock's behaviour, rather than the actual implementation. Exposing `fetchPage(pageNumber: Int)` as internal would make tests easier, but yet again we would be changing the implementation just for the sake of testing, perhaps binding the variable between view and viewmodel would be adequate here 🤔

## Testing information
- For easiness, update `POSConstants.productsPerPage` to a lower number of products that would still be larger than the available screen space, for example "10":
- In POS, observe that scrolling down keeps loading new products
- Without exiting POS, in the web, create a new eligible product and publish it, then in POS pull-to-refresh. Observe that items in memory are entirely cleared, and we're back to page 0 with the newest item at the top.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
