### PR TITLE
Google Ads: Fix issue decoding campaigns when country is not available

### DIFF
--- a/Networking/Networking/Model/GoogleAds/GoogleAdsCampaign.swift
+++ b/Networking/Networking/Model/GoogleAds/GoogleAdsCampaign.swift
@@ -15,7 +15,7 @@ public struct GoogleAdsCampaign: Decodable, Equatable, GeneratedFakeable, Genera
 
     public let amount: Double
 
-    public let country: String
+    public let country: String?
 
     public let targetedLocations: [String]
 
@@ -28,7 +28,7 @@ public struct GoogleAdsCampaign: Decodable, Equatable, GeneratedFakeable, Genera
                 rawStatus: String,
                 rawType: String,
                 amount: Double,
-                country: String,
+                country: String?,
                 targetedLocations: [String]) {
         self.id = id
         self.name = name

--- a/Networking/NetworkingTests/Mapper/GoogleAdsCampaignListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/GoogleAdsCampaignListMapperTests.swift
@@ -25,7 +25,7 @@ final class GoogleAdsCampaignListMapperTests: XCTestCase {
         XCTAssertEqual(secondItem.rawStatus, "disabled")
         XCTAssertEqual(secondItem.rawType, "performance_max")
         XCTAssertEqual(secondItem.amount, 30)
-        XCTAssertEqual(secondItem.country, "US")
+        XCTAssertNil(secondItem.country)
         XCTAssertEqual(secondItem.targetedLocations, ["US"])
         XCTAssertEqual(secondItem.status, .disabled)
     }
@@ -52,7 +52,7 @@ final class GoogleAdsCampaignListMapperTests: XCTestCase {
         XCTAssertEqual(secondItem.rawStatus, "disabled")
         XCTAssertEqual(secondItem.rawType, "performance_max")
         XCTAssertEqual(secondItem.amount, 30)
-        XCTAssertEqual(secondItem.country, "US")
+        XCTAssertNil(secondItem.country)
         XCTAssertEqual(secondItem.targetedLocations, ["US"])
         XCTAssertEqual(secondItem.status, .disabled)
     }

--- a/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
@@ -83,7 +83,7 @@ final class GoogleListingsAndAdsRemoteTests: XCTestCase {
                               rawStatus: "disabled",
                               rawType: "performance_max",
                               amount: 30,
-                              country: "US",
+                              country: nil,
                               targetedLocations: ["US"])
         ]
         XCTAssertEqual(results, expectedCampaigns)

--- a/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
@@ -17,8 +17,10 @@
             "status": "disabled",
             "type": "performance_max",
             "amount": 30,
-            "country": nil,
-            "targeted_locations": []
+            "country": null,
+            "targeted_locations": [
+                "US"
+            ]
         }
     ]
 }

--- a/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
@@ -18,9 +18,7 @@
             "type": "performance_max",
             "amount": 30,
             "country": nil,
-            "targeted_locations": [
-                "US"
-            ]
+            "targeted_locations": []
         }
     ]
 }

--- a/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
@@ -17,7 +17,7 @@
             "status": "disabled",
             "type": "performance_max",
             "amount": 30,
-            "country": "US",
+            "country": nil,
             "targeted_locations": [
                 "US"
             ]

--- a/Networking/NetworkingTests/Responses/gla-campaign-list-without-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-campaign-list-without-data-envelope.json
@@ -16,9 +16,7 @@
         "status": "disabled",
         "type": "performance_max",
         "amount": 30,
-        "country": "US",
-        "targeted_locations": [
-            "US"
-        ]
+        "country": nil,
+        "targeted_locations": []
     }
 ]

--- a/Networking/NetworkingTests/Responses/gla-campaign-list-without-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-campaign-list-without-data-envelope.json
@@ -16,7 +16,9 @@
         "status": "disabled",
         "type": "performance_max",
         "amount": 30,
-        "country": nil,
-        "targeted_locations": []
+        "country": null,
+        "targeted_locations": [
+            "US"
+        ]
     }
 ]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [internal] Additions to TopTabView for customization options [https://github.com/woocommerce/woocommerce-ios/pull/14192]
 - [internal] Shipping Labels: Updated design to use responsive DHL logo [https://github.com/woocommerce/woocommerce-ios/pull/14206]
 - [*] Payments: Tap to Pay now requires iOS 16.7 as a minimum [https://github.com/woocommerce/woocommerce-ios/pull/14205]
+- [**] Fixed issue loading Google Ads dashboard card [https://github.com/woocommerce/woocommerce-ios/pull/14214]
 
 20.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14212 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the decoding issue for the Google Ads dashboard card when there are campaigns without country set.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- You can log in to a store eligible for GoogleAnds and use ProxyMan to update the response to `wc/gla/ads/campaigns%26_method%3Dget` endpoint to return campaign items with `country` being `nil`, or SSP to the site in ticket 8933727-zen.
- Enable the Google Ads card on the dashboard screen and confirm that the card is loaded successfully.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.0 and confirm that the dashboard card is loaded successfully on the user's site.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
