### PR TITLE
[Shipping label] Handle selecting a card in the shipping services tabs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -92,6 +92,9 @@ struct WooShippingServiceCardView: View {
         .roundedBorder(cornerRadius: 8,
                        lineColor: viewModel.selected ? Color(.primary) : Color(.separator),
                        lineWidth: viewModel.selected ? 2 : 1)
+        .onTapGesture {
+            viewModel.selectRate()
+        }
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -69,13 +69,24 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
     }
 
     convenience init(selected: Bool = false,
-                     signatureRequirement: SignatureRequirement = .none,
+                     signatureRequired: Bool = false,
+                     adultSignatureRequired: Bool = false,
                      rate: ShippingLabelCarrierRate,
                      signatureRate: ShippingLabelCarrierRate? = nil,
                      adultSignatureRate: ShippingLabelCarrierRate? = nil,
                      currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
 
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let signatureRequirement: SignatureRequirement = {
+            if signatureRequired {
+                return .signatureRequired
+            } else if adultSignatureRequired {
+                return .adultSignatureRequired
+            } else {
+                return .none
+            }
+        }()
+
         let rateLabel = {
             switch (signatureRequirement, signatureRate, adultSignatureRate) {
             case (.signatureRequired, .some(let signatureRate), _):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -40,6 +40,11 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
     /// Label if there is an option to require an adult signature.
     let adultSignatureRequiredLabel: String?
 
+    /// Completion callback
+    typealias Completion = (_ rateTitle: String,
+                            _ signatureRequirement: SignatureRequirement) -> Void
+    private let onCompletion: Completion?
+
     init(id: String = UUID().uuidString,
          selected: Bool = false,
          signatureRequirement: SignatureRequirement = .none,
@@ -52,7 +57,8 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
          insuranceLabel: String?,
          hasFreePickup: Bool,
          signatureRequiredLabel: String?,
-         adultSignatureRequiredLabel: String?) {
+         adultSignatureRequiredLabel: String?,
+         completion: Completion? = nil) {
         self.id = id
         self.selected = selected
         self.signatureRequirement = signatureRequirement
@@ -66,6 +72,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
         self.freePickupLabel = hasFreePickup ? Localization.freePickup : nil
         self.signatureRequiredLabel = signatureRequiredLabel
         self.adultSignatureRequiredLabel = adultSignatureRequiredLabel
+        self.onCompletion = completion
     }
 
     convenience init(selected: Bool = false,
@@ -74,7 +81,8 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
                      rate: ShippingLabelCarrierRate,
                      signatureRate: ShippingLabelCarrierRate? = nil,
                      adultSignatureRate: ShippingLabelCarrierRate? = nil,
-                     currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+                     currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+                     completion: Completion? = nil) {
 
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let signatureRequirement: SignatureRequirement = {
@@ -141,8 +149,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
             return String(format: Localization.adultSignatureRequired, amount)
         }()
 
-        self.init(id: rate.rateID,
-                  selected: selected,
+        self.init(selected: selected,
                   signatureRequirement: signatureRequirement,
                   carrierLogo: WooShippingCarrier(rawValue: rate.carrierID)?.logo,
                   title: rate.title,
@@ -153,7 +160,13 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
                   insuranceLabel: insuranceLabel,
                   hasFreePickup: rate.isPickupFree,
                   signatureRequiredLabel: signatureRequiredLabel,
-                  adultSignatureRequiredLabel: adultSignatureRequiredLabel)
+                  adultSignatureRequiredLabel: adultSignatureRequiredLabel,
+                  completion: completion)
+    }
+
+    /// Calls the completion callback with the rate title and signature requirement.
+    func selectRate() {
+        onCompletion?(title, signatureRequirement)
     }
 
     /// Sets `signatureRequirement` when a signature option is tapped.
@@ -163,6 +176,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
         } else {
             self.signatureRequirement = signatureRequirement
         }
+        selectRate()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -18,12 +18,14 @@ struct WooShippingServiceView: View {
             HStack {
                 Text(Localization.shippingService)
                     .headlineStyle()
-                Spacer()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
             }
             TopTabView(tabs: carriers,
+                       tabsContainerHorizontalPadding: 16,
                        unselectedStateColor: .secondary,
                        tabsNameFont: .subheadline.bold(),
-                       tabItemContentHorizontalPadding: 16,
+                       tabItemContentHorizontalPadding: 6,
                        tabItemContentVerticalPadding: 12)
         }
     }
@@ -39,9 +41,9 @@ private struct WooShippingServiceCardListView: View {
                 WooShippingServiceCardView(viewModel: card)
                     .fixedSize(horizontal: false, vertical: true) // Prevents card text from being truncated
             }
-            Spacer()
         }
-        .padding(.vertical)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .padding()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -5,9 +5,19 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Contains the data about available shipping rates, grouped by carrier.
     @Published private(set) var serviceTabs: [WooShippingServiceTab] = []
 
+    /// Selected shipping service rate.
+    @Published private(set) var selectedRate: ShippingLabelCarrierRate?
+
+    /// Available standard shipping rates.
+    private let standardRates: [ShippingLabelCarrierRate]
+    /// Available shipping rates with signature required.
+    private let signatureRates: [ShippingLabelCarrierRate]
+    /// Available shipping rates with adult signature required.
+    private let adultSignatureRates: [ShippingLabelCarrierRate]
+
     init() {
         // TODO: Replace with real data from remote
-        let standardRates = [ShippingLabelCarrierRate(title: "USPS - Media Mail",
+        standardRates = [ShippingLabelCarrierRate(title: "USPS - Media Mail",
                                               insurance: "100",
                                               retailRate: 8,
                                               rate: 7.53,
@@ -46,7 +56,7 @@ final class WooShippingServiceViewModel: ObservableObject {
                                               isPickupFree: true,
                                               deliveryDays: 1,
                                               deliveryDateGuaranteed: false)]
-        let signatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+        signatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
                                                        insurance: "100",
                                                        retailRate: 42.76,
                                                        rate: 42.76,
@@ -59,7 +69,7 @@ final class WooShippingServiceViewModel: ObservableObject {
                                                        isPickupFree: true,
                                                        deliveryDays: 2,
                                                        deliveryDateGuaranteed: false)]
-        let adultSignatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+        adultSignatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
                                                             insurance: "100",
                                                             retailRate: 46.96,
                                                             rate: 46.96,
@@ -72,13 +82,11 @@ final class WooShippingServiceViewModel: ObservableObject {
                                                             isPickupFree: true,
                                                             deliveryDays: 2,
                                                             deliveryDateGuaranteed: false)]
-        generateServiceTabs(from: standardRates, signatureRates: signatureRates, adultSignatureRates: adultSignatureRates)
+        generateServiceTabs()
     }
 
     /// Generates the data to display available shipping rates, grouped by carrier ID.
-    private func generateServiceTabs(from standardRates: [ShippingLabelCarrierRate],
-                                     signatureRates: [ShippingLabelCarrierRate],
-                                     adultSignatureRates: [ShippingLabelCarrierRate]) {
+    private func generateServiceTabs() {
         serviceTabs = standardRates.grouped(by: { $0.carrierID })
             .compactMap { (carrierID, rates) -> WooShippingServiceTab? in
                 guard let carrier = WooShippingCarrier(rawValue: carrierID) else {
@@ -87,7 +95,23 @@ final class WooShippingServiceViewModel: ObservableObject {
                 let cards = rates.map { rate in
                     let signature = signatureRates.first { rate.title == $0.title }
                     let adultSignature = adultSignatureRates.first { rate.title == $0.title }
-                    return WooShippingServiceCardViewModel(rate: rate, signatureRate: signature, adultSignatureRate: adultSignature)
+                    return WooShippingServiceCardViewModel(selected: selectedRate?.title == rate.title,
+                                                           signatureRequired: signature != nil && selectedRate == signature,
+                                                           adultSignatureRequired: adultSignature != nil && selectedRate == adultSignature,
+                                                           rate: rate,
+                                                           signatureRate: signature,
+                                                           adultSignatureRate: adultSignature) { [weak self] rateTitle, signatureRequirement in
+                        guard let self else { return }
+                        switch signatureRequirement {
+                        case .none:
+                            selectedRate = standardRates.first(where: { $0.title == rateTitle })
+                        case .signatureRequired:
+                            selectedRate = signatureRates.first(where: { $0.title == rateTitle })
+                        case .adultSignatureRequired:
+                            selectedRate = adultSignatureRates.first(where: { $0.title == rateTitle })
+                        }
+                        self.generateServiceTabs()
+                    }
                 }
                 return WooShippingServiceTab(id: carrier, cards: cards)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -5,8 +5,12 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Contains the data about available shipping rates, grouped by carrier.
     @Published private(set) var serviceTabs: [WooShippingServiceTab] = []
 
-    /// Selected shipping service rate.
-    @Published private(set) var selectedRate: ShippingLabelCarrierRate?
+    /// Selected standard shipping service rate.
+    private(set) var selectedStandardRate: ShippingLabelCarrierRate?
+    /// Selected signature shipping service rate (if signature is required).
+    private(set) var selectedSignatureRate: ShippingLabelCarrierRate?
+    /// Selected adult signature shipping service rate (if adult signature is required).
+    private(set) var selectedAdultSignatureRate: ShippingLabelCarrierRate?
 
     /// Available standard shipping rates.
     private let standardRates: [ShippingLabelCarrierRate]
@@ -95,20 +99,29 @@ final class WooShippingServiceViewModel: ObservableObject {
                 let cards = rates.map { rate in
                     let signature = signatureRates.first { rate.title == $0.title }
                     let adultSignature = adultSignatureRates.first { rate.title == $0.title }
-                    return WooShippingServiceCardViewModel(selected: selectedRate?.title == rate.title,
-                                                           signatureRequired: signature != nil && selectedRate == signature,
-                                                           adultSignatureRequired: adultSignature != nil && selectedRate == adultSignature,
+                    return WooShippingServiceCardViewModel(selected: selectedStandardRate?.title == rate.title,
+                                                           signatureRequired: signature != nil && selectedSignatureRate == signature,
+                                                           adultSignatureRequired: adultSignature != nil && selectedAdultSignatureRate == adultSignature,
                                                            rate: rate,
                                                            signatureRate: signature,
                                                            adultSignatureRate: adultSignature) { [weak self] rateTitle, signatureRequirement in
                         guard let self else { return }
+                        let standardRate = standardRates.first(where: { $0.title == rateTitle })
+                        let signatureRate = signatureRates.first(where: { $0.title == rateTitle })
+                        let adultSignatureRate = adultSignatureRates.first(where: { $0.title == rateTitle })
                         switch signatureRequirement {
                         case .none:
-                            selectedRate = standardRates.first(where: { $0.title == rateTitle })
+                            selectedStandardRate = standardRate
+                            selectedSignatureRate = nil
+                            selectedAdultSignatureRate = nil
                         case .signatureRequired:
-                            selectedRate = signatureRates.first(where: { $0.title == rateTitle })
+                            selectedStandardRate = standardRate
+                            selectedSignatureRate = signatureRate
+                            selectedAdultSignatureRate = nil
                         case .adultSignatureRequired:
-                            selectedRate = adultSignatureRates.first(where: { $0.title == rateTitle })
+                            selectedStandardRate = standardRate
+                            selectedSignatureRate = nil
+                            selectedAdultSignatureRate = adultSignatureRate
                         }
                         self.generateServiceTabs()
                     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
@@ -8,7 +8,7 @@ final class WooShippingServiceCardViewModelTests: XCTestCase {
     func test_it_inits_with_expected_values() {
         // Given
         let viewModel = WooShippingServiceCardViewModel(selected: true,
-                                                        signatureRequirement: .signatureRequired,
+                                                        signatureRequired: true,
                                                         rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100"),
                                                         signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                         adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
@@ -60,8 +60,7 @@ final class WooShippingServiceCardViewModelTests: XCTestCase {
     func test_handleTap_enables_newly_selected_rate() {
         // Given
         let newSelection: WooShippingServiceCardViewModel.SignatureRequirement = .signatureRequired
-        let viewModel = WooShippingServiceCardViewModel(signatureRequirement: .none,
-                                                        rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100"),
+        let viewModel = WooShippingServiceCardViewModel(rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100"),
                                                         signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                         adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33))
 
@@ -74,14 +73,13 @@ final class WooShippingServiceCardViewModelTests: XCTestCase {
 
     func test_handleTap_disables_previously_selected_rate() {
         // Given
-        let previousSelection: WooShippingServiceCardViewModel.SignatureRequirement = .adultSignatureRequired
-        let viewModel = WooShippingServiceCardViewModel(signatureRequirement: previousSelection,
+        let viewModel = WooShippingServiceCardViewModel(adultSignatureRequired: true,
                                                         rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100"),
                                                         signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                         adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33))
 
         // When
-        viewModel.handleTap(on: previousSelection)
+        viewModel.handleTap(on: .adultSignatureRequired)
 
         // Then
         XCTAssertEqual(viewModel.signatureRequirement, .none)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
@@ -85,4 +85,25 @@ final class WooShippingServiceCardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.signatureRequirement, .none)
     }
 
+    func test_selectRate_calls_completion_block_with_rate_title_and_signature_requirement() {
+        // Given
+        let rate = MockShippingLabelCarrierRate.makeRate(rate: 40.33, insurance: "100")
+        var completionRateTitle: String? = nil
+        var completionSignatureRequirement: WooShippingServiceCardViewModel.SignatureRequirement? = nil
+        let viewModel = WooShippingServiceCardViewModel(adultSignatureRequired: true,
+                                                        rate: rate,
+                                                        signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                        adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33)) { title, signature in
+            completionRateTitle = title
+            completionSignatureRequirement = signature
+        }
+
+        // When
+        viewModel.selectRate()
+
+        // Then
+        XCTAssertEqual(completionRateTitle, rate.title)
+        XCTAssertEqual(completionSignatureRequirement, .adultSignatureRequired)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -3,6 +3,14 @@ import XCTest
 
 final class WooShippingServiceViewModelTests: XCTestCase {
 
+    func test_init_sets_expected_values() {
+        // Given
+        let viewModel = WooShippingServiceViewModel()
+
+        // Then
+        XCTAssertNil(viewModel.selectedRate)
+    }
+
     func test_generateServiceTabs_returns_expected_data() throws {
         // Given
         let viewModel = WooShippingServiceViewModel()
@@ -53,6 +61,21 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(rate3.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
         XCTAssertNil(rate3.signatureRequiredLabel)
         XCTAssertNil(rate3.adultSignatureRequiredLabel)
+    }
+
+    func test_selecting_service_card_rate_updates_expected_values() throws {
+        // Given
+        let viewModel = WooShippingServiceViewModel()
+        let card = try XCTUnwrap(viewModel.serviceTabs.first?.cards.first)
+        XCTAssertNil(viewModel.selectedRate)
+        XCTAssertFalse(card.selected)
+
+        // When
+        card.selectRate()
+
+        // Then
+        XCTAssertEqual(viewModel.selectedRate?.title, card.title)
+        XCTAssertEqual(viewModel.serviceTabs.first?.cards.first?.selected, true)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -8,7 +8,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel()
 
         // Then
-        XCTAssertNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.selectedStandardRate)
     }
 
     func test_generateServiceTabs_returns_expected_data() throws {
@@ -63,19 +63,60 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertNil(rate3.adultSignatureRequiredLabel)
     }
 
-    func test_selecting_service_card_rate_updates_expected_values() throws {
+    func test_selecting_service_card_standard_rate_updates_expected_values() throws {
         // Given
         let viewModel = WooShippingServiceViewModel()
-        let card = try XCTUnwrap(viewModel.serviceTabs.first?.cards.first)
-        XCTAssertNil(viewModel.selectedRate)
+        let card = try XCTUnwrap(viewModel.serviceTabs[0].cards[1])
+        XCTAssertNil(viewModel.selectedStandardRate)
         XCTAssertFalse(card.selected)
 
         // When
         card.selectRate()
 
         // Then
-        XCTAssertEqual(viewModel.selectedRate?.title, card.title)
-        XCTAssertEqual(viewModel.serviceTabs.first?.cards.first?.selected, true)
+        XCTAssertNotNil(viewModel.selectedStandardRate)
+        XCTAssertNil(viewModel.selectedSignatureRate)
+        XCTAssertNil(viewModel.selectedAdultSignatureRate)
+        XCTAssertEqual(viewModel.selectedStandardRate?.title, card.title)
+        XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
+    }
+
+    func test_selecting_service_card_signature_rate_updates_expected_values() throws {
+        // Given
+        let viewModel = WooShippingServiceViewModel()
+        let card = try XCTUnwrap(viewModel.serviceTabs[0].cards[1])
+        XCTAssertNil(viewModel.selectedStandardRate)
+        XCTAssertNil(viewModel.selectedSignatureRate)
+        XCTAssertFalse(card.selected)
+
+        // When
+        card.signatureRequirement = .signatureRequired
+        card.selectRate()
+
+        // Then
+        XCTAssertNotNil(viewModel.selectedStandardRate)
+        XCTAssertNotNil(viewModel.selectedSignatureRate)
+        XCTAssertNil(viewModel.selectedAdultSignatureRate)
+        XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
+    }
+
+    func test_selecting_service_card_adult_signature_rate_updates_expected_values() throws {
+        // Given
+        let viewModel = WooShippingServiceViewModel()
+        let card = try XCTUnwrap(viewModel.serviceTabs[0].cards[1])
+        XCTAssertNil(viewModel.selectedStandardRate)
+        XCTAssertNil(viewModel.selectedAdultSignatureRate)
+        XCTAssertFalse(card.selected)
+
+        // When
+        card.signatureRequirement = .adultSignatureRequired
+        card.selectRate()
+
+        // Then
+        XCTAssertNotNil(viewModel.selectedStandardRate)
+        XCTAssertNil(viewModel.selectedSignatureRate)
+        XCTAssertNotNil(viewModel.selectedAdultSignatureRate)
+        XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14141
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the UI interactions and data handling to select a card in the Shipping Service section of the new Woo Shipping label creation flow:

1. Tapping on a shipping rate card in the shipping service section now expands the card and selects its standard rate.
2. When a card is expanded, selecting one of the signature options selects the signature rate.

### How

* `WooShippingServiceCardViewModel` now has a completion callback that includes the selected rate title and signature requirement. This is called when the card is selected and when a signature option is selected.
* `WooShippingServiceViewModel` now handles the new callback:
   * The view model has properties for the selected rate(s). If a signature rate is selected, we also save the standard rate so we can track the base rate versus the signature add-on.
   * When a rate is selected, we also regenerate the card view models to reflect the new selection (expanding the selected card).

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This UI is not yet used in the app, but it can be testing in the `WooShippingServiceView` SwiftUI preview:

1. Tap on a card to expand it.
2. Tap on a signature option to select it.
4. Tap on a different card to expand it and collapse the previously selected card.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/600189fe-ea96-4708-b1ae-7226dce27b34



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.