### PR TITLE
[Shipping labels] Sort shipping services by price or delivery time

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -19,8 +19,28 @@ struct WooShippingServiceView: View {
                 Text(Localization.shippingService)
                     .headlineStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal)
+                Menu {
+                    ForEach(WooShippingServiceViewModel.SortOrder.allCases, id: \.self) { option in
+                        Button {
+                            // TODO: Sort shipping rates on this tab
+                        } label: {
+                            HStack {
+                                Text(option.displayName)
+                                if viewModel.sortOrder == option {
+                                    Image(uiImage: .checkmarkStyledImage)
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    HStack {
+                        Text(Localization.sortBy)
+                        Image(systemName: "chevron.up.chevron.down")
+                    }
+                    .foregroundStyle(Color(.primary))
+                }
             }
+            .padding(.horizontal)
             TopTabView(tabs: carriers,
                        tabsContainerHorizontalPadding: 16,
                        unselectedStateColor: .secondary,
@@ -52,6 +72,9 @@ private extension WooShippingServiceView {
         static let shippingService = NSLocalizedString("wooShipping.createLabels.rates.shippingService",
                                                        value: "Shipping service",
                                                        comment: "Heading for the shipping service section in the shipping label creation screen.")
+        static let sortBy = NSLocalizedString("wooShipping.createLabels.rates.sortBy",
+                                              value: "Sort by",
+                                              comment: "Label for the menu to select a sort order for shipping rates in the shipping label creation screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -22,7 +22,7 @@ struct WooShippingServiceView: View {
                 Menu {
                     ForEach(WooShippingServiceViewModel.SortOrder.allCases, id: \.self) { option in
                         Button {
-                            // TODO: Sort shipping rates on this tab
+                            viewModel.sortShipping(by: option)
                         } label: {
                             HStack {
                                 Text(option.displayName)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -19,6 +19,9 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Available shipping rates with adult signature required.
     private let adultSignatureRates: [ShippingLabelCarrierRate]
 
+    /// Sort order for shipping services.
+    @Published var sortOrder: SortOrder = .price
+
     init() {
         // TODO: Replace with real data from remote
         standardRates = [ShippingLabelCarrierRate(title: "USPS - Media Mail",
@@ -130,10 +133,38 @@ final class WooShippingServiceViewModel: ObservableObject {
             }
             .sorted(by: { $0.id < $1.id })
     }
+}
 
+extension WooShippingServiceViewModel {
     /// Holds the data needed to display a tab in `WooShippingServiceViewModel`.
     struct WooShippingServiceTab: Identifiable {
         let id: WooShippingCarrier
         let cards: [WooShippingServiceCardViewModel]
+    }
+
+    /// Options for sorting available shipping services.
+    enum SortOrder: CaseIterable {
+        case price
+        case deliveryTime
+
+        var displayName: String {
+            switch self {
+            case .price:
+                Localization.sortByPrice
+            case .deliveryTime:
+                Localization.sortByDeliveryTime
+            }
+        }
+    }
+}
+
+private extension WooShippingServiceViewModel {
+    enum Localization {
+        static let sortByPrice = NSLocalizedString("wooShipping.createLabels.rates.sortBy.price",
+                                                   value: "Cheapest",
+                                                   comment: "Option to sort shipping rates by price in the shipping label creation screen.")
+        static let sortByDeliveryTime = NSLocalizedString("wooShipping.createLabels.rates.sortBy.deliveryTime",
+                                                          value: "Fastest",
+                                                          comment: "Option to sort shipping rates by delivery time in the shipping label creation screen.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -92,6 +92,12 @@ final class WooShippingServiceViewModel: ObservableObject {
         generateServiceTabs()
     }
 
+    /// Sorts the shipping services by the provided sort order.
+    func sortShipping(by order: SortOrder) {
+        sortOrder = order
+        generateServiceTabs()
+    }
+
     /// Generates the data to display available shipping rates, grouped by carrier ID.
     private func generateServiceTabs() {
         serviceTabs = standardRates.grouped(by: { $0.carrierID })
@@ -99,36 +105,48 @@ final class WooShippingServiceViewModel: ObservableObject {
                 guard let carrier = WooShippingCarrier(rawValue: carrierID) else {
                     return nil
                 }
-                let cards = rates.map { rate in
-                    let signature = signatureRates.first { rate.title == $0.title }
-                    let adultSignature = adultSignatureRates.first { rate.title == $0.title }
-                    return WooShippingServiceCardViewModel(selected: selectedStandardRate?.title == rate.title,
-                                                           signatureRequired: signature != nil && selectedSignatureRate == signature,
-                                                           adultSignatureRequired: adultSignature != nil && selectedAdultSignatureRate == adultSignature,
-                                                           rate: rate,
-                                                           signatureRate: signature,
-                                                           adultSignatureRate: adultSignature) { [weak self] rateTitle, signatureRequirement in
-                        guard let self else { return }
-                        let standardRate = standardRates.first(where: { $0.title == rateTitle })
-                        let signatureRate = signatureRates.first(where: { $0.title == rateTitle })
-                        let adultSignatureRate = adultSignatureRates.first(where: { $0.title == rateTitle })
-                        switch signatureRequirement {
-                        case .none:
-                            selectedStandardRate = standardRate
-                            selectedSignatureRate = nil
-                            selectedAdultSignatureRate = nil
-                        case .signatureRequired:
-                            selectedStandardRate = standardRate
-                            selectedSignatureRate = signatureRate
-                            selectedAdultSignatureRate = nil
-                        case .adultSignatureRequired:
-                            selectedStandardRate = standardRate
-                            selectedSignatureRate = nil
-                            selectedAdultSignatureRate = adultSignatureRate
+                let cards = rates
+                    .sorted(by: { lhs, rhs in
+                        switch sortOrder {
+                        case .price:
+                            return lhs.rate < rhs.rate
+                        case .deliveryTime:
+                            guard let lhsDeliveryDays = lhs.deliveryDays, let rhsDeliveryDays = rhs.deliveryDays else {
+                                return lhs.deliveryDays != nil // Sort rates with nil delivery days to the end of the list
+                            }
+                            return lhsDeliveryDays < rhsDeliveryDays
                         }
-                        self.generateServiceTabs()
+                    })
+                    .map { rate in
+                        let signature = signatureRates.first { rate.title == $0.title }
+                        let adultSignature = adultSignatureRates.first { rate.title == $0.title }
+                        return WooShippingServiceCardViewModel(selected: selectedStandardRate?.title == rate.title,
+                                                               signatureRequired: signature != nil && selectedSignatureRate == signature,
+                                                               adultSignatureRequired: adultSignature != nil && selectedAdultSignatureRate == adultSignature,
+                                                               rate: rate,
+                                                               signatureRate: signature,
+                                                               adultSignatureRate: adultSignature) { [weak self] rateTitle, signatureRequirement in
+                            guard let self else { return }
+                            let standardRate = standardRates.first(where: { $0.title == rateTitle })
+                            let signatureRate = signatureRates.first(where: { $0.title == rateTitle })
+                            let adultSignatureRate = adultSignatureRates.first(where: { $0.title == rateTitle })
+                            switch signatureRequirement {
+                            case .none:
+                                selectedStandardRate = standardRate
+                                selectedSignatureRate = nil
+                                selectedAdultSignatureRate = nil
+                            case .signatureRequired:
+                                selectedStandardRate = standardRate
+                                selectedSignatureRate = signatureRate
+                                selectedAdultSignatureRate = nil
+                            case .adultSignatureRequired:
+                                selectedStandardRate = standardRate
+                                selectedSignatureRate = nil
+                                selectedAdultSignatureRate = adultSignatureRate
+                            }
+                            self.generateServiceTabs()
+                        }
                     }
-                }
                 return WooShippingServiceTab(id: carrier, cards: cards)
             }
             .sorted(by: { $0.id < $1.id })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -63,10 +63,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertNil(rate3.adultSignatureRequiredLabel)
     }
 
-    func test_selecting_service_card_standard_rate_updates_expected_values() throws {
+    func test_selecting_service_card_standard_rate_updates_expected_values() {
         // Given
         let viewModel = WooShippingServiceViewModel()
-        let card = try XCTUnwrap(viewModel.serviceTabs[0].cards[1])
+        let card = viewModel.serviceTabs[0].cards[1]
         XCTAssertNil(viewModel.selectedStandardRate)
         XCTAssertFalse(card.selected)
 
@@ -81,10 +81,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 
-    func test_selecting_service_card_signature_rate_updates_expected_values() throws {
+    func test_selecting_service_card_signature_rate_updates_expected_values() {
         // Given
         let viewModel = WooShippingServiceViewModel()
-        let card = try XCTUnwrap(viewModel.serviceTabs[0].cards[1])
+        let card = viewModel.serviceTabs[0].cards[1]
         XCTAssertNil(viewModel.selectedStandardRate)
         XCTAssertNil(viewModel.selectedSignatureRate)
         XCTAssertFalse(card.selected)
@@ -100,10 +100,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 
-    func test_selecting_service_card_adult_signature_rate_updates_expected_values() throws {
+    func test_selecting_service_card_adult_signature_rate_updates_expected_values() {
         // Given
         let viewModel = WooShippingServiceViewModel()
-        let card = try XCTUnwrap(viewModel.serviceTabs[0].cards[1])
+        let card = viewModel.serviceTabs[0].cards[1]
         XCTAssertNil(viewModel.selectedStandardRate)
         XCTAssertNil(viewModel.selectedAdultSignatureRate)
         XCTAssertFalse(card.selected)
@@ -117,6 +117,32 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.selectedSignatureRate)
         XCTAssertNotNil(viewModel.selectedAdultSignatureRate)
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
+    }
+
+    func test_sortShipping_by_price_returns_sorted_list() {
+        // Given
+        let viewModel = WooShippingServiceViewModel()
+
+        // When
+        viewModel.sortShipping(by: .price)
+
+        // Then
+        let uspsCards = viewModel.serviceTabs.first?.cards
+        XCTAssertEqual(uspsCards?.count, 2)
+        XCTAssertEqual(uspsCards?.first?.title, "USPS - Media Mail")
+    }
+
+    func test_shortShipping_by_deliveryDays_returns_sorted_list() {
+        // Given
+        let viewModel = WooShippingServiceViewModel()
+
+        // When
+        viewModel.sortShipping(by: .deliveryTime)
+
+        // Then
+        let uspsCards = viewModel.serviceTabs.first?.cards
+        XCTAssertEqual(uspsCards?.count, 2)
+        XCTAssertEqual(uspsCards?.first?.title, "USPS - Parcel Select Mail")
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14142
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the option to sort the shipping services by price or delivery time, in the new Woo Shipping label creation flow.

### How

* Adds the UI for a dropdown menu shows "Fastest" and "Cheapest" sort options.
* When a new sort option is selected, it saves the selection and resorts the cards by the standard shipping rate (cheapest) or delivery days (fastest).

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This UI isn't yet used in the app, but you can test it with the `WooShippingServiceView` SwiftUI preview:

1. Confirm the cards are loaded by default in price order (cheapest first).
2. Tap the "Sort by" menu and confirm the "Cheapest" option is selected.
3. Select the "Fastest" option and confirm the cards are re-sorted with the shortest delivery time first.
4. Select the "Cheapest" option again and confirm the cards are re-sorted in price order.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f723c4ef-a7c2-48a1-9276-cdee37a7798e

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.