### PR TITLE
[Woo POS] Add shimmering card while loading next page

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -157,18 +157,38 @@ struct GhostItemCardView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     var body: some View {
-        RoundedRectangle(cornerRadius: Constants.cornerRadius)
+        HStack(spacing: 0) {
+            Rectangle()
+                .frame(width: Constants.productCardSize * scale, height: Constants.productCardSize * scale)
+            HStack {
+                Rectangle()
+                    .foregroundColor(Constants.textForegroundColor)
+                    .frame(width: Constants.textWidth * 2 * scale, height: Constants.textHeight * scale)
+                    .padding(.horizontal)
+                Spacer()
+                Rectangle()
+                    .foregroundColor(Constants.textForegroundColor)
+                    .frame(width: Constants.textWidth * scale, height: Constants.textHeight * scale)
+                    .padding(.horizontal)
+            }
             .frame(height: Constants.productCardSize * scale)
-            .foregroundColor(Constants.foregroundColor)
-            .shimmering()
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.cornerRadius)
+        }
+        .foregroundColor(Constants.cardForegroundColor)
+        .shimmering()
     }
 }
 
 private extension GhostItemCardView {
     enum Constants {
         static let cornerRadius: CGFloat = 8
-        static let foregroundColor: Color = Color.gray.opacity(0.5)
+        static let cardForegroundColor: Color = Color.gray.opacity(0.5)
+        static let textForegroundColor: Color = Color.gray.opacity(0.8)
         static let productCardSize: CGFloat = 112
+        static let textWidth: CGFloat = 112
+        static let textHeight: CGFloat = 32
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -130,6 +130,8 @@ private extension ItemListView {
                         ItemCardView(item: item)
                     })
                 }
+                GhostItemCardView()
+                    .renderedIf(viewModel.state == .loading)
             }
             .padding(.bottom, floatingControlAreaSize.height)
             .padding(.horizontal, Constants.itemListPadding)
@@ -148,6 +150,25 @@ private extension ItemListView {
                     }
             })
         }
+    }
+}
+
+struct GhostItemCardView: View {
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: Constants.cornerRadius)
+            .frame(height: Constants.productCardSize * scale)
+            .foregroundColor(Constants.foregroundColor)
+            .shimmering()
+    }
+}
+
+private extension GhostItemCardView {
+    enum Constants {
+        static let cornerRadius: CGFloat = 8
+        static let foregroundColor: Color = Color.gray.opacity(0.5)
+        static let productCardSize: CGFloat = 112
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-ios/issues/14186
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds a "ghost" shimmering GhostItemCardView that renders at the end of our item list while the we're waiting for the next page to load. Since we do not have designs I didn't want to spend too much time on the details, so we're just rendering some greyed-out shapes to represent the card/image/name/price, but happy to iterate further 👍 

![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-10-28 at 12 03 40](https://github.com/user-attachments/assets/fc1b5636-6ea0-4d19-b94e-9d7b3f6dd3b9)

## Testing
1. For easiness, update the `ProductsRemote`'s `Constants.productsPerPage` to a lower threshold, like 7 or 10  (generally more than 5, so there are more items than the height of the iPad's screen).
2. Run POS, and observe that infinite scrolling is triggered on scrolling down, rendering the `GhostItemCardView` when needed.

No new unit tests have been added, changes are merely UI-based.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
