### PR TITLE
[Woo POS - payments onboarding] Show onboarding with POS modal instead of sheet

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
@@ -9,8 +9,7 @@ struct PointOfSaleCardPresentPaymentAlert: View {
 
     var body: some View {
         alertContent
-            .padding(PointOfSaleReaderConnectionModalLayout.contentPadding)
-            .frame(width: frameWidth, height: frameHeight)
+            .posModalSizing()
     }
 
     @ViewBuilder
@@ -53,58 +52,6 @@ struct PointOfSaleCardPresentPaymentAlert: View {
         case .connectionSuccess(let alertViewModel):
             PointOfSaleCardPresentPaymentConnectionSuccessAlertView(viewModel: alertViewModel, animation: animation)
         }
-    }
-
-    @Environment(\.sizeCategory) private var sizeCategory
-
-    private var frameWidth: CGFloat {
-        switch sizeCategory {
-        case .extraSmall, .small:
-            return 560
-        case .medium, .large, .extraLarge:
-            return 640
-        case .extraExtraLarge, .extraExtraExtraLarge:
-            return 720
-        case .accessibilityMedium,
-                .accessibilityLarge,
-                .accessibilityExtraLarge,
-                .accessibilityExtraExtraLarge,
-                .accessibilityExtraExtraExtraLarge:
-            return windowBounds.width
-        @unknown default:
-            return 640
-        }
-    }
-
-    private var frameHeight: CGFloat {
-        switch sizeCategory {
-        case .extraSmall, .small:
-            return 624
-        case .medium, .large, .extraLarge:
-            return 656
-        case .extraExtraLarge, .extraExtraExtraLarge:
-            return 688
-        case .accessibilityMedium,
-                .accessibilityLarge,
-                .accessibilityExtraLarge,
-                .accessibilityExtraExtraLarge,
-                .accessibilityExtraExtraExtraLarge:
-            return windowBounds.height
-        @unknown default:
-            return 656
-        }
-    }
-
-    private var windowBounds: CGRect {
-        window?.bounds ?? UIScreen.main.bounds
-    }
-
-    private var window: UIWindow? {
-        UIApplication
-            .shared
-            .connectedScenes
-            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-            .last
     }
 
     // MARK: - Animations

--- a/WooCommerce/Classes/POS/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Displays the WooPayments onboarding UI based on the state.
+struct PointOfSaleCardPresentPaymentOnboardingView: View {
+    @ObservedObject var viewModel: PointOfSaleCardPresentPaymentOnboardingViewModel
+
+    var body: some View {
+        VStack(spacing: Constants.verticalSpacing) {
+            HStack {
+                Spacer()
+                Button {
+                    viewModel.cancelOnboarding()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.posButtonSymbol)
+                }
+                .accessibilityLabel(Localization.cancelOnboarding)
+                .foregroundColor(Color.posTertiaryText)
+            }
+            CardPresentPaymentsOnboardingView(viewModel: viewModel.onboardingViewModel)
+                // Hides the navigation bar title `navigationTitle` in `CardPresentPaymentsOnboardingView`.
+                .toolbar(.hidden)
+        }
+        .padding(Constants.padding)
+        .safariSheet(url: $viewModel.onboardingURL)
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentOnboardingView {
+    enum Constants {
+        static let verticalSpacing: CGFloat = 20.0
+        static let padding: CGFloat = 40.0
+    }
+
+    enum Localization {
+        static let cancelOnboarding = NSLocalizedString(
+            "pointOfSaleDashboard.payments.onboarding.cancel",
+            value: "Cancel",
+            comment: "Button to dismiss the payments onboarding sheet from the POS dashboard."
+        )
+    }
+}
+
+#Preview {
+    PointOfSaleCardPresentPaymentOnboardingView(viewModel: .init(onboardingViewModel: .init(fixedState: .genericError), onDismissTap: nil))
+}

--- a/WooCommerce/Classes/POS/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
@@ -6,30 +6,20 @@ struct PointOfSaleCardPresentPaymentOnboardingView: View {
 
     var body: some View {
         VStack(spacing: Constants.verticalSpacing) {
-            HStack {
-                Spacer()
-                Button {
-                    viewModel.cancelOnboarding()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.posButtonSymbol)
-                }
-                .accessibilityLabel(Localization.cancelOnboarding)
-                .foregroundColor(Color.posTertiaryText)
-            }
             CardPresentPaymentsOnboardingView(viewModel: viewModel.onboardingViewModel)
                 // Hides the navigation bar title `navigationTitle` in `CardPresentPaymentsOnboardingView`.
                 .toolbar(.hidden)
         }
-        .padding(Constants.padding)
+        .posModalCloseButton(action: viewModel.cancelOnboarding,
+                             accessibilityLabel: Localization.cancelOnboarding)
         .safariSheet(url: $viewModel.onboardingURL)
+        .posModalSizing()
     }
 }
 
 private extension PointOfSaleCardPresentPaymentOnboardingView {
     enum Constants {
         static let verticalSpacing: CGFloat = 20.0
-        static let padding: CGFloat = 40.0
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class PointOfSaleCardPresentPaymentOnboardingViewModel: ObservableObject {
+    let onboardingViewModel: CardPresentPaymentsOnboardingViewModel
+    @Published var onboardingURL: URL?
+
+    private let onDismissTap: (() -> Void)?
+
+    init(onboardingViewModel: CardPresentPaymentsOnboardingViewModel,
+         onDismissTap: (() -> Void)?) {
+        self.onboardingViewModel = onboardingViewModel
+        self.onDismissTap = onDismissTap
+        onboardingViewModel.showURL = { [weak self] url in
+            self?.onboardingURL = url
+        }
+    }
+
+    /// Called when the user taps to dismiss the onboarding UI.
+    func cancelOnboarding() {
+        onDismissTap?()
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -62,7 +62,6 @@ struct PointOfSaleDashboardView: View {
             totalsViewModel.cancelOnboarding()
         }) { viewModel in
             paymentsOnboardingView(from: viewModel)
-                .posInteractiveDismissDisabled(true)
         }
         .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel,
                   onDismiss: {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -58,8 +58,11 @@ struct PointOfSaleDashboardView: View {
         .animation(.easeInOut(duration: Constants.connectivityAnimationDuration), value: viewModel.showsConnectivityError)
         .background(Color.posPrimaryBackground)
         .navigationBarBackButtonHidden(true)
-        .sheet(item: $totalsViewModel.cardPresentPaymentOnboardingViewModel) { viewModel in
+        .posModal(item: $totalsViewModel.cardPresentPaymentOnboardingViewModel, onDismiss: {
+            totalsViewModel.cancelOnboarding()
+        }) { viewModel in
             paymentsOnboardingView(from: viewModel)
+                .posInteractiveDismissDisabled(true)
         }
         .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel,
                   onDismiss: {
@@ -133,25 +136,10 @@ private extension PointOfSaleDashboardView {
             totalsViewModel.cardPresentPaymentOnboardingViewModel = nil
             viewModel.showSupport = true
         }
-        onboardingViewModel.showURL = { url in
-            totalsViewModel.cardPresentPaymentOnboardingURL = url
-        }
-        return NavigationStack {
-            CardPresentPaymentsOnboardingView(viewModel: onboardingViewModel)
-                .navigationBarTitleDisplayMode(.inline)
-                .interactiveDismissDisabled()
-                .toolbar {
-                    Button(action: {
-                        totalsViewModel.cardPresentPaymentOnboardingViewModel = nil
-                    }) {
-                        Text(Localization.cancelOnboarding)
-                    }
-                }
-                .safariSheet(url: $totalsViewModel.cardPresentPaymentOnboardingURL)
-                .onDisappear {
-                    totalsViewModel.cancelOnboarding()
-                }
-        }
+        return PointOfSaleCardPresentPaymentOnboardingView(viewModel: .init(onboardingViewModel: onboardingViewModel,
+                                                                            onDismissTap: {
+            totalsViewModel.cardPresentPaymentOnboardingViewModel = nil
+        }))
     }
 }
 
@@ -183,11 +171,6 @@ private extension PointOfSaleDashboardView {
             "pointOfSaleDashboard.support.done",
             value: "Done",
             comment: "Button to dismiss the support form from the POS dashboard."
-        )
-        static let cancelOnboarding = NSLocalizedString(
-            "pointOfSaleDashboard.payments.onboarding.cancel",
-            value: "Cancel",
-            comment: "Button to dismiss the payments onboarding sheet from the POS dashboard."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+extension View {
+    /// Sets the frame size and applies a padding to a modal in POS.
+    func posModalSizing() -> some View {
+        self.modifier(POSModalSizing())
+    }
+}
+
+struct POSModalSizing: ViewModifier {
+    @Environment(\.sizeCategory) private var sizeCategory
+
+    func body(content: Content) -> some View {
+        content
+            .padding(PointOfSaleReaderConnectionModalLayout.contentPadding)
+            .frame(width: frameWidth, height: frameHeight)
+    }
+}
+
+private extension POSModalSizing {
+    var frameWidth: CGFloat {
+        switch sizeCategory {
+        case .extraSmall, .small:
+            return 560
+        case .medium, .large, .extraLarge:
+            return 640
+        case .extraExtraLarge, .extraExtraExtraLarge:
+            return 720
+        case .accessibilityMedium,
+                .accessibilityLarge,
+                .accessibilityExtraLarge,
+                .accessibilityExtraExtraLarge,
+                .accessibilityExtraExtraExtraLarge:
+            return windowBounds.width
+        @unknown default:
+            return 640
+        }
+    }
+
+    var frameHeight: CGFloat {
+        switch sizeCategory {
+        case .extraSmall, .small:
+            return 624
+        case .medium, .large, .extraLarge:
+            return 656
+        case .extraExtraLarge, .extraExtraExtraLarge:
+            return 688
+        case .accessibilityMedium,
+                .accessibilityLarge,
+                .accessibilityExtraLarge,
+                .accessibilityExtraExtraLarge,
+                .accessibilityExtraExtraExtraLarge:
+            return windowBounds.height
+        @unknown default:
+            return 656
+        }
+    }
+
+    var windowBounds: CGRect {
+        window?.bounds ?? UIScreen.main.bounds
+    }
+
+    var window: UIWindow? {
+        UIApplication
+            .shared
+            .connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .last
+    }
+}
+
+private extension POSModalSizing {
+    enum Localization {
+        static let defaultAccessibilityLabel = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.connection.modal.close.button.accessibilityLabel.default",
+            value: "Close",
+            comment: "The default accessibility label for an `x` close button on a card reader connection modal.")
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
@@ -68,12 +68,3 @@ private extension POSModalSizing {
             .last
     }
 }
-
-private extension POSModalSizing {
-    enum Localization {
-        static let defaultAccessibilityLabel = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.connection.modal.close.button.accessibilityLabel.default",
-            value: "Close",
-            comment: "The default accessibility label for an `x` close button on a card reader connection modal.")
-    }
-}

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -21,7 +21,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     }
 
     @Published var cardPresentPaymentOnboardingViewModel: CardPresentPaymentsOnboardingViewModel?
-    @Published var cardPresentPaymentOnboardingURL: URL?
     private var onOnboardingCancellation: (() -> Void)?
     @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
@@ -131,6 +130,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     }
 
     /// Called when the onboarding UI is dismissed.
+    /// It is set when receiving an onboarding view model to display, and necessary to reset the internal onboarding state on UI dismissal.
     func cancelOnboarding() {
         onOnboardingCancellation?()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
@@ -148,7 +148,11 @@ extension CardPresentPaymentsOnboardingViewModel: Equatable {
         lhs.state == rhs.state &&
         lhs.userIsAdministrator == rhs.userIsAdministrator &&
         lhs.learnMoreURL == rhs.learnMoreURL &&
-        lhs.shouldShow == rhs.shouldShow
+        lhs.shouldShow == rhs.shouldShow &&
+        (lhs.showSupport != nil) == (rhs.showSupport != nil) &&
+        (lhs.showURL != nil) == (rhs.showURL != nil) &&
+        (lhs.didChangeShouldShow != nil) == (rhs.didChangeShouldShow != nil) &&
+        (lhs.didUpdate != nil) == (rhs.didUpdate != nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
@@ -143,6 +143,14 @@ final class CardPresentPaymentsOnboardingViewModel: ObservableObject, PaymentSet
     var didUpdate: (() -> Void)? = nil
 }
 
+extension CardPresentPaymentsOnboardingViewModel: Equatable {
+    static func == (lhs: CardPresentPaymentsOnboardingViewModel, rhs: CardPresentPaymentsOnboardingViewModel) -> Bool {
+        lhs.state == rhs.state &&
+        lhs.userIsAdministrator == rhs.userIsAdministrator &&
+        lhs.learnMoreURL == rhs.learnMoreURL
+    }
+}
+
 private extension CardPresentPaymentsOnboardingViewModel {
     var countryCode: CountryCode {
         CardPresentConfigurationLoader().configuration.countryCode

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
@@ -147,7 +147,8 @@ extension CardPresentPaymentsOnboardingViewModel: Equatable {
     static func == (lhs: CardPresentPaymentsOnboardingViewModel, rhs: CardPresentPaymentsOnboardingViewModel) -> Bool {
         lhs.state == rhs.state &&
         lhs.userIsAdministrator == rhs.userIsAdministrator &&
-        lhs.learnMoreURL == rhs.learnMoreURL
+        lhs.learnMoreURL == rhs.learnMoreURL &&
+        lhs.shouldShow == rhs.shouldShow
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -445,6 +445,9 @@
 		02ACD25A2852E11700EC928E /* CloseAccountCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ACD2592852E11700EC928E /* CloseAccountCoordinator.swift */; };
 		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
 		02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */; };
+		02B191502CCF27F300CF38C9 /* PointOfSaleCardPresentPaymentOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1914F2CCF27F300CF38C9 /* PointOfSaleCardPresentPaymentOnboardingView.swift */; };
+		02B191522CCF28E600CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B191512CCF28E600CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModel.swift */; };
+		02B191542CCF377E00CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B191532CCF377E00CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift */; };
 		02B1AA6529A4705A00D54FCB /* TabbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AA6429A4705A00D54FCB /* TabbedViewController.swift */; };
 		02B1AA6729A4709400D54FCB /* FilterTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AA6629A4709400D54FCB /* FilterTabBar.swift */; };
 		02B1AFEC24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AFEB24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift */; };
@@ -3529,6 +3532,9 @@
 		02ACD2592852E11700EC928E /* CloseAccountCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseAccountCoordinator.swift; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
+		02B1914F2CCF27F300CF38C9 /* PointOfSaleCardPresentPaymentOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentOnboardingView.swift; sourceTree = "<group>"; };
+		02B191512CCF28E600CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentOnboardingViewModel.swift; sourceTree = "<group>"; };
+		02B191532CCF377E00CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		02B1AA6429A4705A00D54FCB /* TabbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewController.swift; sourceTree = "<group>"; };
 		02B1AA6629A4709400D54FCB /* FilterTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTabBar.swift; sourceTree = "<group>"; };
 		02B1AFEB24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductListSelectorDataSource.swift; sourceTree = "<group>"; };
@@ -6810,6 +6816,7 @@
 				02E71DB42C118C470036C2FD /* Card Present Payments */,
 				026826B02BF59E170036F959 /* CardReaderConnection */,
 				014BD4B62C64E26B0011A66E /* Order Messages */,
+				02B1914A2CCF278100CF38C9 /* Payments Onboarding */,
 				026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */,
 				026826A52BF59DF60036F959 /* PointOfSaleDashboardView.swift */,
 				DA013F502C65125100D9A391 /* PointOfSaleExitPosAlertView.swift */,
@@ -7152,6 +7159,15 @@
 				4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */,
 			);
 			path = BottomSheetListSelector;
+			sourceTree = "<group>";
+		};
+		02B1914A2CCF278100CF38C9 /* Payments Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				02B1914F2CCF27F300CF38C9 /* PointOfSaleCardPresentPaymentOnboardingView.swift */,
+				02B191512CCF28E600CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModel.swift */,
+			);
+			path = "Payments Onboarding";
 			sourceTree = "<group>";
 		};
 		02B1AA6329A4704C00D54FCB /* FilterTabBar */ = {
@@ -12426,6 +12442,7 @@
 				683763172C2E497000AD51D0 /* ItemListViewModelTests.swift */,
 				683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */,
 				6885E2CD2C32B2E2004C8D70 /* TotalsViewModelTests.swift */,
+				02B191532CCF377E00CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -14944,6 +14961,7 @@
 				03076D38290C223E008EE839 /* WooNavigationSheet.swift in Sources */,
 				022CE91A29BB143000F210E0 /* ProductSelectorNavigationView.swift in Sources */,
 				B99686E02A13C8CC00D1AF62 /* ScanToPayView.swift in Sources */,
+				02B191502CCF27F300CF38C9 /* PointOfSaleCardPresentPaymentOnboardingView.swift in Sources */,
 				CE070A3E2BBC608A00017578 /* GiftCardsReportCardViewModel.swift in Sources */,
 				E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */,
 				2662D90626E1571900E25611 /* ListSelector.swift in Sources */,
@@ -16300,6 +16318,7 @@
 				014BD4BA2C64FC0E0011A66E /* PointOfSaleOrderSyncErrorMessageViewModel.swift in Sources */,
 				DEA88F502AA9D0100037273B /* AddEditProductCategoryViewModel.swift in Sources */,
 				451C77712404518600413F73 /* ProductSettingsRows.swift in Sources */,
+				02B191522CCF28E600CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModel.swift in Sources */,
 				CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */,
 				68E674A12A4DA0B30034BA1E /* InAppPurchasesError.swift in Sources */,
 				743E272021AEF20100D6DC82 /* FancyAlertViewController+Upgrade.swift in Sources */,
@@ -16634,6 +16653,7 @@
 				CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */,
 				2667BFE3252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift in Sources */,
 				DEBAB70F2A7A6F3800743185 /* MockConnectivityObserver.swift in Sources */,
+				02B191542CCF377E00CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift in Sources */,
 				DABF35272C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift in Sources */,
 				EEEA41F22869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift in Sources */,
 				2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -458,6 +458,7 @@
 		02B2828E27C35061004A332A /* RefreshableInfiniteScrollList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2828D27C35061004A332A /* RefreshableInfiniteScrollList.swift */; };
 		02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2828F27C352DA004A332A /* RefreshableScrollView.swift */; };
 		02B2829227C4808D004A332A /* InfiniteScrollIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */; };
+		02B2AD8D2CD0A89800929CE8 /* POSModalSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2AD8C2CD0A87B00929CE8 /* POSModalSizing.swift */; };
 		02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */; };
 		02B334A12BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B334A02BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift */; };
 		02B41A96296D09D100FE3311 /* DomainSettingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */; };
@@ -3545,6 +3546,7 @@
 		02B2828D27C35061004A332A /* RefreshableInfiniteScrollList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableInfiniteScrollList.swift; sourceTree = "<group>"; };
 		02B2828F27C352DA004A332A /* RefreshableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableScrollView.swift; sourceTree = "<group>"; };
 		02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollIndicator.swift; sourceTree = "<group>"; };
+		02B2AD8C2CD0A87B00929CE8 /* POSModalSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalSizing.swift; sourceTree = "<group>"; };
 		02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignmentTests.swift; sourceTree = "<group>"; };
 		02B334A02BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleCustomerCardAddressViewModel.swift; sourceTree = "<group>"; };
 		02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsListView.swift; sourceTree = "<group>"; };
@@ -6167,6 +6169,7 @@
 				204D1D612C5A50840064A6BE /* POSModalViewModifier.swift */,
 				20D2CCA42C7E328300051705 /* POSModalCloseButton.swift */,
 				209EEF8F2C762ED5007969A4 /* POSModalManager.swift */,
+				02B2AD8C2CD0A87B00929CE8 /* POSModalSizing.swift */,
 				01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */,
 				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
 				20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */,
@@ -15354,6 +15357,7 @@
 				174CA86C27D90E8900126524 /* WooAboutScreenConfiguration.swift in Sources */,
 				02A652FF246A908D00755A01 /* BottomSheetListSelectorPresenter.swift in Sources */,
 				D82BB3AA26454F3300A82741 /* CardPresentModalProcessing.swift in Sources */,
+				02B2AD8D2CD0A89800929CE8 /* POSModalSizing.swift in Sources */,
 				B9CB14DC2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift in Sources */,
 				0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift
@@ -19,9 +19,9 @@ final class PointOfSaleCardPresentPaymentOnboardingViewModelTests: XCTestCase {
 
     func test_onboardingURL_is_set_when_onboarding_vm_showURL_is_invoked() throws {
         // Given
-        var isDismissTapInvoked = false
         let onboardingViewModel = CardPresentPaymentsOnboardingViewModel(fixedState: .noConnectionError)
         let sut = PointOfSaleCardPresentPaymentOnboardingViewModel(onboardingViewModel: onboardingViewModel, onDismissTap: nil)
+        XCTAssertNil(sut.onboardingURL)
 
         // When
         let url = try XCTUnwrap(URL(string: "https://example.com"))

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentOnboardingViewModelTests: XCTestCase {
+    func test_onDismissTap_is_invoked_when_cancelOnboarding_is_called() throws {
+        // Given
+        var isDismissTapInvoked = false
+        let sut = PointOfSaleCardPresentPaymentOnboardingViewModel(onboardingViewModel: .init(fixedState: .genericError),
+            onDismissTap: {
+                isDismissTapInvoked = true
+            })
+
+        // When
+        sut.cancelOnboarding()
+
+        // Then
+        XCTAssertTrue(isDismissTapInvoked)
+    }
+
+    func test_onboardingURL_is_set_when_onboarding_vm_showURL_is_invoked() throws {
+        // Given
+        var isDismissTapInvoked = false
+        let onboardingViewModel = CardPresentPaymentsOnboardingViewModel(fixedState: .noConnectionError)
+        let sut = PointOfSaleCardPresentPaymentOnboardingViewModel(onboardingViewModel: onboardingViewModel, onDismissTap: nil)
+
+        // When
+        let url = try XCTUnwrap(URL(string: "https://example.com"))
+        onboardingViewModel.showURL?(url)
+
+        // Then
+        XCTAssertEqual(sut.onboardingURL, url)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentOnboardingViewModelTests.swift
@@ -150,4 +150,14 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
         // Then
         assertEqual(.isFalse, receivedShouldShow)
     }
+
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+        // Given
+        let sut = CardPresentPaymentsOnboardingViewModel(useCase: onboardingUseCase)
+
+        // Then
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 10,
+                               messageHint: "Please check that the manual equatable conformance includes new properties.")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14209 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Previously, the onboarding UI is shown in the default sheet in SwiftUI which doesn't match the style of other modals in POS. For example, the modal about exiting POS, and the modal about the product type. This PR updates the presentation to show the same onboarding view in `posModal` instead of `sheet`.

## How

A new SwiftUI view `PointOfSaleCardPresentPaymentOnboardingView` was created as a POS-specific view that contains a HStack with a X CTA to dismiss the modal, and the same onboarding view as before. This way, we can customize the modal content and potentially swap out the onboarding UI for any future potential customizations. Onboarding view model's `showURL` can also be handled in the new view's view model, removing the need for a URL property in `TotalsViewModel`.

For `CardPresentPaymentsOnboardingViewModel` to be used with `posModal`, `Equatable` conformance is required and implemented in https://github.com/woocommerce/woocommerce-ios/pull/14224/commits/61392d376c0530a2810df4d5614b0298b41d004d.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: store is eligible for POS, and onboarding isn't completed (missing some requirements, or plugin not activated with a Shop Manager role). Alternatively, you can hard code the state by returning `.stripeAccountOverdueRequirement(plugin: .wcPay)` in `CardPresentPaymentsOnboardingUseCase.checkOnboardingState`.

- Switch to store/user in the prerequisite, if needed
- Go to Menu > POS Mode
- Tap `Connect your reader` --> an onboarding modal should be shown shortly with an X CTA at the top right, with a `Learn more` CTA and `Contact us` CTA
- Tap outside of the modal --> the modal should be dismissed
- Tap `Connect your reader` again
- Tap `Learn more` --> a Safari sheet should be shown about the onboarding error
- Dismiss the webview
- Tap `Contact us` --> the onboarding modal should be dismissed, then support form is presented
- Tap `Connect your reader` again
- Repeat the steps above to tap on the 2 CTAs
- Optionally & if not hard-coding the error state, try resolving the onboarding error(s) to proceed to reader connection

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I tested in iPad Pro 11in iOS 17.5 simulator and 17.5.1 device with Xcode 16, in several stores in different states.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/b4cdb944-0fee-4e23-a6da-0e30a7f5a53e





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
