### PR TITLE
[Shipping labels] Integrate shipping service section in main Woo Shipping label creation screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -6,11 +6,11 @@ final class WooShippingServiceViewModel: ObservableObject {
     @Published private(set) var serviceTabs: [WooShippingServiceTab] = []
 
     /// Selected standard shipping service rate.
-    private(set) var selectedStandardRate: ShippingLabelCarrierRate?
+    @Published private(set) var selectedStandardRate: ShippingLabelCarrierRate?
     /// Selected signature shipping service rate (if signature is required).
-    private(set) var selectedSignatureRate: ShippingLabelCarrierRate?
+    @Published private(set) var selectedSignatureRate: ShippingLabelCarrierRate?
     /// Selected adult signature shipping service rate (if adult signature is required).
-    private(set) var selectedAdultSignatureRate: ShippingLabelCarrierRate?
+    @Published private(set) var selectedAdultSignatureRate: ShippingLabelCarrierRate?
 
     /// Available standard shipping rates.
     private let standardRates: [ShippingLabelCarrierRate]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -42,9 +42,18 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingHazmat()
 
-                    WooShippingPackageAndRatePlaceholder()
+                    if viewModel.hasPackage {
+                        // TODO: Display package section
+                        // Package heading and edit button
+                        // Selected package details
+                        // Total shipment weight field
+                        WooShippingServiceView(viewModel: viewModel.shippingService)
+                            .padding(.horizontal, -16)
+                    } else {
+                        WooShippingPackageAndRatePlaceholder()
+                    }
                 }
-                .padding()
+                .padding(16)
             }
             .safeAreaInset(edge: .bottom) {
                 ExpandableBottomSheet(onChangeOfExpansion: { isExpanded in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -63,20 +63,19 @@ struct WooShippingCreateLabelsView: View {
                         CollapsibleHStack(spacing: Layout.bottomSheetSpacing) {
                             Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
                                 .font(.subheadline)
-
-                            Button {
-                                viewModel.purchaseLabel()
-                            } label: {
-                                Text(Localization.BottomSheet.purchase)
-                            }
-                            .buttonStyle(PrimaryButtonStyle())
-                            .disabled(true) // TODO: 13556 - Enable button when shipping label is ready to purchase
+                            purchaseButton
                         }
                         .padding(.horizontal, Layout.bottomSheetPadding)
                     } else {
-                        Text(Localization.BottomSheet.shipmentDetails)
-                            .foregroundStyle(Color(.primary))
-                            .bold()
+                        VStack {
+                            Text(Localization.BottomSheet.shipmentDetails)
+                                .foregroundStyle(Color(.primary))
+                                .bold()
+                            if viewModel.hasPackage {
+                                purchaseButton
+                            }
+                        }
+                        .padding(.horizontal, Layout.bottomSheetPadding)
                     }
                 } expandableContent: {
                     VStack(alignment: .leading, spacing: Layout.bottomSheetSpacing) {
@@ -205,6 +204,17 @@ private extension WooShippingCreateLabelsView {
             }
             .frame(idealHeight: Layout.rowHeight)
         }
+    }
+
+    /// View showing the shipping label purchase button.
+    var purchaseButton: some View {
+        Button {
+            viewModel.purchaseLabel()
+        } label: {
+            Text(Localization.BottomSheet.purchase)
+        }
+        .buttonStyle(PrimaryButtonStyle())
+        .disabled(true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -8,6 +8,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
+    // TODO: Update this to a property that refers to the package, when selected
+    /// Whether there is a package selected for the shipping label.
+    /// Temporary property that can be set to `true` to enable features that require a selected package, until package feature is complete.
+    let hasPackage: Bool = false
+
+    /// View model for the label shipping service.
+    @Published private(set) var shippingService = WooShippingServiceViewModel()
+
     /// Address to ship from (store address), formatted for display.
     let originAddress: String
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -14,7 +14,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     let hasPackage: Bool = false
 
     /// View model for the label shipping service.
-    @Published private(set) var shippingService = WooShippingServiceViewModel()
+    let shippingService = WooShippingServiceViewModel()
 
     /// Address to ship from (store address), formatted for display.
     let originAddress: String


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14143
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the "Shipping service" section to the main screen in the Woo Shipping label creation flow. After a package is selected during label creation:

* The shipping service section is displayed.
* The purchase button is displayed (disabled) when the bottom sheet is collapsed.

### How

* Adds a temporary `hasPackage` property to `WooShippingCreateLabelsViewModel`. This can be used while the package flow under development to enable the shipping service section. (Once complete, the shipping service section will be visible after a package is selected.)
* Adds `WooShippingServiceView` to `WooShippingCreateLabelsView`, visible when `hasPackage` is true.
* Adds the purchase button to the collapsed bottom sheet, displayed when `hasPackage` is true.
* Updates the shipping rate properties in `WooShippingServiceViewModel` to be `@Published`. This ensures the main screen is redrawn when the selected shipping rate changes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Make sure the feature flag `revampedShippingLabelCreation` is enabled.
2. Set `hasPackage` to `true` in `WooShippingCreateLabelsViewModel` [here](https://github.com/woocommerce/woocommerce-ios/blob/3b56d3d785a5a895dcc1579a86384c9f2cf4d2d1/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Shipping%20Labels/WooShipping%20Create%20Shipping%20Labels/WooShippingCreateLabelsViewModel.swift#L14).
3. Build and run the app.
4. Create an order with the processing status and at least one physical product.
5. In the order details, select "Create Shipping Label."
6. Confirm the "Shipping service" section appears on the main label creation screen.
7. Confirm you can switch tabs, sort, and select the shipping rates and signature options.
8. Confirm the (disabled) purchase button appears at the bottom of the collapsed bottom sheet.
9. Open the bottom sheet and confirm the (disabled) purchase button still appears there as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Shipping service|Selecting rates|Bottom sheet
-|-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 14 37 16](https://github.com/user-attachments/assets/6f1910dd-b872-4a28-916d-4c2bc0c3726e)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 14 37 25](https://github.com/user-attachments/assets/90caf1ab-e75d-4e11-b347-ed05cb0609b2)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 14 37 31](https://github.com/user-attachments/assets/dc10cea4-c6df-4611-bcab-6a1d80e6fe45)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.