### PR TITLE
[Custom Fields] Show discard changes prompt

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+DiscardChanges.swift
+++ b/WooCommerce/Classes/View Modifiers/View+DiscardChanges.swift
@@ -81,13 +81,14 @@ struct DiscardChangesWrapper<Content: View>: UIViewControllerRepresentable {
     }
 }
 
-struct CloseButtonWithDiscardPrompt: ViewModifier {
+struct CloseButtonWithDiscardPrompt<Label>: ViewModifier where Label: View {
     let title: String
     let message: String
     let discardButtonTitle: String
     let cancelButtonTitle: String
 
     let showPrompt: Bool
+    let closeButtonLabel: () -> Label
     let didDismiss: (() -> Void)?
 
     @State private var isShowingPrompt: Bool = false
@@ -104,10 +105,7 @@ struct CloseButtonWithDiscardPrompt: ViewModifier {
                             didDismiss?()
                             dismiss()
                         }
-                    }, label: {
-                        Image(uiImage: .closeButton)
-                            .secondaryBodyStyle()
-                    })
+                    }, label: closeButtonLabel)
                 }
             })
             .interactiveDismissDisabled()
@@ -155,18 +153,21 @@ extension View {
     ///   - discardButtonTitle: Title for the discard changes button on the action sheet. Defaults to "Discard changes".
     ///   - cancelButtonTitle: Title for the cancel button on the action sheet. Defaults to "Cancel".
     ///   - hasChanges: Whether there are changes to be discarded.
+    ///   - closeButtonLabel: Customize the close button shown in the toolbar, defaults to a close icon.
     ///   - didDismiss: Optional method to be invoked when the view is dismissed.
-    func closeButtonWithDiscardChangesPrompt(title: String = "",
-                                             message: String = Localization.message,
-                                             discardButtonTitle: String = Localization.discard,
-                                             cancelButtonTitle: String = Localization.cancel,
-                                             hasChanges: Bool,
-                                             didDismiss: (() -> Void)? = nil) -> some View {
+    func closeButtonWithDiscardChangesPrompt<Label: View>(title: String = "",
+                                                          message: String = Localization.message,
+                                                          discardButtonTitle: String = Localization.discard,
+                                                          cancelButtonTitle: String = Localization.cancel,
+                                                          hasChanges: Bool,
+                                                          closeButtonLabel: @escaping () -> Label = { Image(uiImage: .closeButton).secondaryBodyStyle() },
+                                                          didDismiss: (() -> Void)? = nil) -> some View {
         ModifiedContent(content: self, modifier: CloseButtonWithDiscardPrompt(title: title,
                                                                               message: message,
                                                                               discardButtonTitle: discardButtonTitle,
                                                                               cancelButtonTitle: cancelButtonTitle,
                                                                               showPrompt: hasChanges,
+                                                                              closeButtonLabel: closeButtonLabel,
                                                                               didDismiss: didDismiss))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -106,13 +106,6 @@ struct CustomFieldEditorView: View {
         }
         .background(Color(.listBackground))
         .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button {
-                    dismiss()
-                } label: {
-                    Text(Localization.cancelButton)
-                }
-            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack {
                     Button {
@@ -135,6 +128,8 @@ struct CustomFieldEditorView: View {
                 }
             }
         }
+        .closeButtonWithDiscardChangesPrompt(hasChanges: hasUnsavedChanges,
+                                             closeButtonLabel: { Text(Localization.cancelButton) })
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -112,7 +112,7 @@ struct CustomFieldEditorView: View {
                         saveChanges()
                         dismiss()
                     } label: {
-                        Text(Localization.saveButton)
+                        Text(Localization.doneButton)
                     }
                     .disabled(!hasUnsavedChanges)
 
@@ -174,10 +174,10 @@ private extension CustomFieldEditorView {
             comment: "Label for the Cancel button to close the editor"
         )
 
-        static let saveButton = NSLocalizedString(
-            "customFieldEditorView.save",
-            value: "Save",
-            comment: "Label for the Save button to save changes"
+        static let doneButton = NSLocalizedString(
+            "customFieldEditorView.done",
+            value: "Done",
+            comment: "Label for the Done button to save changes"
         )
 
         static let keyLabel = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -47,6 +47,20 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
     }
 }
 
+extension CustomFieldsListHostingController {
+    override func shouldPopOnBackButton() -> Bool {
+        if viewModel.hasChanges {
+            presentBackNavigationActionSheet()
+            return false
+        }
+        return true
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+}
+
 private extension CustomFieldsListHostingController {
     func configureNavigation() {
         title = Localization.title
@@ -94,6 +108,12 @@ private extension CustomFieldsListHostingController {
 
     func dismissInProgressController() {
         dismiss(animated: true)
+    }
+
+    func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        })
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14066 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds logic to display a discard changes prompt for two cases:
1. The user attempts to leave the editor where there are some unsaved changes.
2. The user attempts to leave the list screen with unsaved changes.

I also updated the text of the Done button in the editor from saying "Save" to "Done" to make it clearer the changes are not saved remotely.

## Steps to reproduce
1. Open a product or an order in the app.
2. Open custom fields.
3. Open or create a new field.

## Testing information
- Confirm that leaving the editor with unsaved changes will show the discard changes prompt.
- Confirm that leaving the list screen with unsaved changes will show the discard changes prompt.

## Screenshots
| List | Editor |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2024-10-28 at 18 11 36](https://github.com/user-attachments/assets/122eaecc-7aaf-4649-b0a8-6a19deee0c15)  | ![Simulator Screenshot - iPhone 15 - 2024-10-28 at 18 11 28](https://github.com/user-attachments/assets/3c5c4c94-1844-45b1-bc53-a0a6bffc177b) |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
