### PR TITLE
[Shipping labels] Integrate selected shipping rate into main Woo Shipping label creation screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedRate.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedRate.swift
@@ -1,0 +1,24 @@
+import Yosemite
+
+/// Represents a selected shipping rate with the Woo Shipping extension.
+struct WooShippingSelectedRate {
+    /// Basic rate for the selected carrier without additional service.
+    let rate: ShippingLabelCarrierRate
+
+    /// Rate for shipping with signature, if selected.
+    let signatureRate: ShippingLabelCarrierRate?
+
+    /// Rate for shipping with adult signature, if selected.
+    let adultSignatureRate: ShippingLabelCarrierRate?
+}
+
+extension WooShippingSelectedRate {
+    var totalRate: Double {
+        if let signatureRate = signatureRate {
+            return signatureRate.rate
+        } else if let adultSignatureRate = adultSignatureRate {
+            return adultSignatureRate.rate
+        }
+        return rate.rate
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -62,7 +62,6 @@ private struct WooShippingServiceCardListView: View {
                     .fixedSize(horizontal: false, vertical: true) // Prevents card text from being truncated
             }
         }
-        .frame(maxHeight: .infinity, alignment: .top)
         .padding()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -5,12 +5,8 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Contains the data about available shipping rates, grouped by carrier.
     @Published private(set) var serviceTabs: [WooShippingServiceTab] = []
 
-    /// Selected standard shipping service rate.
-    @Published private(set) var selectedStandardRate: ShippingLabelCarrierRate?
-    /// Selected signature shipping service rate (if signature is required).
-    @Published private(set) var selectedSignatureRate: ShippingLabelCarrierRate?
-    /// Selected adult signature shipping service rate (if adult signature is required).
-    @Published private(set) var selectedAdultSignatureRate: ShippingLabelCarrierRate?
+    /// Selected shipping service rate.
+    @Published private(set) var selectedRate: WooShippingSelectedRate?
 
     /// Available standard shipping rates.
     private let standardRates: [ShippingLabelCarrierRate]
@@ -120,30 +116,19 @@ final class WooShippingServiceViewModel: ObservableObject {
                     .map { rate in
                         let signature = signatureRates.first { rate.title == $0.title }
                         let adultSignature = adultSignatureRates.first { rate.title == $0.title }
-                        return WooShippingServiceCardViewModel(selected: selectedStandardRate?.title == rate.title,
-                                                               signatureRequired: signature != nil && selectedSignatureRate == signature,
-                                                               adultSignatureRequired: adultSignature != nil && selectedAdultSignatureRate == adultSignature,
+                        return WooShippingServiceCardViewModel(selected: selectedRate?.rate.title == rate.title,
+                                                               signatureRequired: signature != nil && selectedRate?.signatureRate == signature,
+                                                               adultSignatureRequired: adultSignature != nil && selectedRate?.adultSignatureRate == adultSignature,
                                                                rate: rate,
                                                                signatureRate: signature,
                                                                adultSignatureRate: adultSignature) { [weak self] rateTitle, signatureRequirement in
-                            guard let self else { return }
-                            let standardRate = standardRates.first(where: { $0.title == rateTitle })
-                            let signatureRate = signatureRates.first(where: { $0.title == rateTitle })
-                            let adultSignatureRate = adultSignatureRates.first(where: { $0.title == rateTitle })
-                            switch signatureRequirement {
-                            case .none:
-                                selectedStandardRate = standardRate
-                                selectedSignatureRate = nil
-                                selectedAdultSignatureRate = nil
-                            case .signatureRequired:
-                                selectedStandardRate = standardRate
-                                selectedSignatureRate = signatureRate
-                                selectedAdultSignatureRate = nil
-                            case .adultSignatureRequired:
-                                selectedStandardRate = standardRate
-                                selectedSignatureRate = nil
-                                selectedAdultSignatureRate = adultSignatureRate
-                            }
+                            guard let self, let rate = standardRates.first(where: { $0.title == rateTitle }) else { return }
+                            let signatureRate = signatureRequirement == .signatureRequired ? signatureRates.first(where: { $0.title == rateTitle }) : nil
+                            let adultSignatureRate = signatureRequirement == .adultSignatureRequired ?
+                                adultSignatureRates.first(where: { $0.title == rateTitle }) : nil
+                            selectedRate = WooShippingSelectedRate(rate: rate,
+                                                                   signatureRate: signatureRate,
+                                                                   adultSignatureRate: adultSignatureRate)
                             self.generateServiceTabs()
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -211,7 +211,7 @@ private extension WooShippingCreateLabelsView {
         Button {
             viewModel.purchaseLabel()
         } label: {
-            Text(Localization.BottomSheet.purchase)
+            Text(Localization.BottomSheet.purchaseLabel(with: viewModel.totalCost))
         }
         .buttonStyle(PrimaryButtonStyle())
         .disabled(!viewModel.canPurchaseLabel)
@@ -268,9 +268,18 @@ private extension WooShippingCreateLabelsView {
             static let paperSize = NSLocalizedString("wooShipping.createLabels.bottomSheet.paperSize",
                                                      value: "Choose label paper size",
                                                      comment: "Label for the menu to select a paper size on the shipping label creation screen")
+            static func purchaseLabel(with price: String?) -> String {
+                guard let price else {
+                    return purchase
+                }
+                return String.localizedStringWithFormat(purchaseFormat, price)
+            }
             static let purchase = NSLocalizedString("wooShipping.createLabels.bottomSheet.purchase",
                                                     value: "Purchase Label",
                                                     comment: "Label for button to purchase the shipping label on the shipping label creation screen")
+            static let purchaseFormat = NSLocalizedString("wooShipping.createLabels.bottomSheet.purchaseFormat",
+                                                          value: "Purchase Label · %1$@",
+                                                          comment: "Label for button to purchase the shipping label on the shipping label creation screen, including the label price. Reads like: 'Purchase Label · $7.63'")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -184,23 +184,44 @@ private extension WooShippingCreateLabelsView {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
             Text(Localization.BottomSheet.shipmentCosts)
                 .footnoteStyle()
-            AdaptiveStack {
-                Text(Localization.BottomSheet.subtotal)
-                Spacer()
-                Text("$0.00") // TODO: 13554 - Show subtotal value(s) for selected rate
-                    .if(true) { subtotal in // TODO: 13554 - Only show placeholder if subtotal is not available
-                        subtotal.redacted(reason: .placeholder)
+            Group {
+                if let selectedRate = viewModel.shippingService.selectedRate {
+                    AdaptiveStack {
+                        Text(Localization.BottomSheet.rateLabel(for: selectedRate))
+                        Spacer()
+                        Text(viewModel.formatAmount(for: selectedRate.rate))
                     }
-            }
-            .frame(idealHeight: Layout.rowHeight)
-            AdaptiveStack {
-                Text(Localization.BottomSheet.total)
-                    .bold()
-                Spacer()
-                Text("$0.00") // TODO: 13554 - Show total value for selected shipping rate
-                    .if(true) { total in // TODO: 13554 - Only show placeholder if total is not available
-                        total.redacted(reason: .placeholder)
+                    if let signature = selectedRate.signatureRate {
+                        AdaptiveStack {
+                            Text(Localization.BottomSheet.signatureRequired)
+                            Spacer()
+                            Text(viewModel.formatAmount(for: signature))
+                        }
                     }
+                    if let adultSignature = selectedRate.adultSignatureRate {
+                        AdaptiveStack {
+                            Text(Localization.BottomSheet.adultSignatureRequired)
+                            Spacer()
+                            Text(viewModel.formatAmount(for: adultSignature))
+                        }
+                    }
+                } else {
+                    AdaptiveStack {
+                        Text(Localization.BottomSheet.subtotal)
+                        Spacer()
+                        Text("$0.00")
+                            .redacted(reason: .placeholder)
+                    }
+                }
+                AdaptiveStack {
+                    Text(Localization.BottomSheet.total)
+                        .bold()
+                    Spacer()
+                    Text(viewModel.totalCost ?? "$0.00")
+                        .if(viewModel.totalCost == nil) { total in
+                            total.redacted(reason: .placeholder)
+                        }
+                }
             }
             .frame(idealHeight: Layout.rowHeight)
         }
@@ -259,6 +280,25 @@ private extension WooShippingCreateLabelsView {
             static let subtotal = NSLocalizedString("wooShipping.createLabels.bottomSheet.subtotal",
                                                         value: "Subtotal",
                                                         comment: "Label for row showing the subtotal for shipment costs on the shipping label creation screen")
+            static func rateLabel(for selectedRate: WooShippingSelectedRate) -> String {
+                if selectedRate.signatureRate == nil && selectedRate.adultSignatureRate == nil {
+                    return selectedRate.rate.title
+                } else {
+                    return String.localizedStringWithFormat(baseFeeFormat, selectedRate.rate.title)
+                }
+            }
+            private static let baseFeeFormat = NSLocalizedString("wooShipping.createLabels.bottomSheet.baseFee",
+                                                                 value: "%1$@ (base fee)",
+                                                                 comment: "Label for row showing the base fee for the selected shipping service " +
+                                                                 "on the shipping label creation screen. Reads like: 'USPS - Media Mail (base fee)'")
+            static let signatureRequired = NSLocalizedString("wooShipping.createLabels.bottomSheet.signatureRequired",
+                                                             value: "Signature Required",
+                                                             comment: "Label for row showing the additional cost to require a signature " +
+                                                             "on the shipping label creation screen")
+            static let adultSignatureRequired = NSLocalizedString("wooShipping.createLabels.bottomSheet.adultSignatureRequired",
+                                                             value: "Adult Signature Required",
+                                                             comment: "Label for row showing the additional cost to require an adult signature " +
+                                                                  "on the shipping label creation screen")
             static let total = NSLocalizedString("wooShipping.createLabels.bottomSheet.total",
                                                         value: "Total",
                                                         comment: "Label for row showing the total for shipment costs on the shipping label creation screen")
@@ -279,7 +319,8 @@ private extension WooShippingCreateLabelsView {
                                                     comment: "Label for button to purchase the shipping label on the shipping label creation screen")
             static let purchaseFormat = NSLocalizedString("wooShipping.createLabels.bottomSheet.purchaseFormat",
                                                           value: "Purchase Label · %1$@",
-                                                          comment: "Label for button to purchase the shipping label on the shipping label creation screen, including the label price. Reads like: 'Purchase Label · $7.63'")
+                                                          comment: "Label for button to purchase the shipping label on the shipping label creation screen, " +
+                                                          "including the label price. Reads like: 'Purchase Label · $7.63'")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -122,7 +122,7 @@ struct WooShippingCreateLabelsView: View {
                                 shipmentDetails
                             }
                         } else {
-                            HStack(spacing: Layout.bottomSheetPadding) {
+                            HStack(alignment: .top, spacing: Layout.bottomSheetPadding) {
                                 orderDetails
                                 Divider()
                                     .padding(.trailing, Layout.bottomSheetPadding * -1)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -214,7 +214,7 @@ private extension WooShippingCreateLabelsView {
             Text(Localization.BottomSheet.purchase)
         }
         .buttonStyle(PrimaryButtonStyle())
-        .disabled(true)
+        .disabled(!viewModel.canPurchaseLabel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -57,6 +57,15 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         // TODO: 13556 - Add action to purchase label remotely
         onLabelPurchase?(markOrderComplete) // TODO: 13556 - Only call this closure if the remote purchase is successful
     }
+
+    /// Provides the formatted amount for the given shipping rate.
+    func formatAmount(for rate: ShippingLabelCarrierRate) -> String {
+        guard let baseRate = shippingService.selectedRate?.rate else {
+            return ""
+        }
+        let amount = rate == baseRate ? rate.rate : rate.rate - baseRate.rate
+        return currencyFormatter.formatAmount(Decimal(amount)) ?? amount.description
+    }
 }
 
 private extension WooShippingCreateLabelsViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -5,6 +5,8 @@ import WooFoundation
 /// Provides view data for `WooShippingCreateLabelsView`.
 ///
 final class WooShippingCreateLabelsViewModel: ObservableObject {
+    private let currencyFormatter: CurrencyFormatter
+
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
@@ -31,13 +33,18 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// If the purchase button should be enabled.
     @Published private(set) var canPurchaseLabel: Bool = false
 
+    /// Total cost of the shipping label, formatted for display.
+    @Published private(set) var totalCost: String?
+
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
     init(order: Order,
          siteAddress: SiteAddress = SiteAddress(),
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase
         self.originAddress = Self.formatOriginAddress(siteAddress: siteAddress)
         self.destinationAddressLines = (order.shippingAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
@@ -59,6 +66,13 @@ private extension WooShippingCreateLabelsViewModel {
                 selectedRate != nil
             }
             .assign(to: &$canPurchaseLabel)
+
+        shippingService.$selectedRate
+            .map { [weak self] selectedRate -> String? in
+                guard let self, let selectedRate else { return nil }
+                return currencyFormatter.formatAmount(Decimal(selectedRate.totalRate))
+            }
+            .assign(to: &$totalCost)
     }
 
     /// Formats the origin address from the provided `SiteAddress`.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -28,6 +28,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Whether to mark the order as complete after the label is purchased.
     @Published var markOrderComplete: Bool = false
 
+    /// If the purchase button should be enabled.
+    @Published private(set) var canPurchaseLabel: Bool = false
+
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
@@ -39,6 +42,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.originAddress = Self.formatOriginAddress(siteAddress: siteAddress)
         self.destinationAddressLines = (order.shippingAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
+        bindViewModelsToProperties()
     }
 
     /// Purchases a shipping label with the provided label details and settings.
@@ -49,6 +53,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 }
 
 private extension WooShippingCreateLabelsViewModel {
+    func bindViewModelsToProperties() {
+        shippingService.$selectedRate
+            .map { selectedRate in
+                selectedRate != nil
+            }
+            .assign(to: &$canPurchaseLabel)
+    }
+
     /// Formats the origin address from the provided `SiteAddress`.
     static func formatOriginAddress(siteAddress: SiteAddress) -> String {
         let address = Address(firstName: "",

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -151,7 +151,7 @@ struct TopTabView<Content: View>: View {
             // Display all the tabs in an HStack, each tab the same width as the TopTabView
             // This GeometryReader is used to set the width and drag offsets for swiping between views
             GeometryReader { geometry in
-                HStack(spacing: 0) {
+                HStack(alignment: .top, spacing: 0) {
                     ForEach(0..<tabs.count, id: \.self) { index in
                         // Tab content as passed to the TopTabView at init
                         tabs[index].content()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2191,6 +2191,7 @@
 		CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24BCCD212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift */; };
 		CE24BCD0212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE24BCCE212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib */; };
 		CE24BCD8212F25D4001CD12E /* StorageOrder+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24BCD7212F25D4001CD12E /* StorageOrder+Woo.swift */; };
+		CE26360E2CCFC78100BE59E2 /* WooShippingSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE26360D2CCFC78100BE59E2 /* WooShippingSelectedRate.swift */; };
 		CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE263DE7206ACE3E0015A693 /* MainTabBarController.swift */; };
 		CE27257C21924A8C002B22EB /* HelpAndSupportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27257B21924A8C002B22EB /* HelpAndSupportViewController.swift */; };
 		CE27257F21925AE8002B22EB /* ValueOneTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27257D21925AE8002B22EB /* ValueOneTableViewCell.swift */; };
@@ -5249,6 +5250,7 @@
 		CE24BCCD212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlineLabelTableViewCell.swift; sourceTree = "<group>"; };
 		CE24BCCE212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeadlineLabelTableViewCell.xib; sourceTree = "<group>"; };
 		CE24BCD7212F25D4001CD12E /* StorageOrder+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageOrder+Woo.swift"; sourceTree = "<group>"; };
+		CE26360D2CCFC78100BE59E2 /* WooShippingSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingSelectedRate.swift; sourceTree = "<group>"; };
 		CE263DE7206ACE3E0015A693 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		CE27257B21924A8C002B22EB /* HelpAndSupportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpAndSupportViewController.swift; sourceTree = "<group>"; };
 		CE27257D21925AE8002B22EB /* ValueOneTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueOneTableViewCell.swift; sourceTree = "<group>"; };
@@ -11936,6 +11938,7 @@
 			isa = PBXGroup;
 			children = (
 				CE315DC52CC93CCE00A06748 /* WooShippingCarrier.swift */,
+				CE26360D2CCFC78100BE59E2 /* WooShippingSelectedRate.swift */,
 				CECEFA6C2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift */,
 				DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */,
 				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
@@ -14674,6 +14677,7 @@
 				0205021E27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift in Sources */,
 				26E7EE6E29300E8100793045 /* AnalyticsTopPerformersCard.swift in Sources */,
 				03E471DA29424E82001A58AD /* CardPresentModalBuiltInSuccess.swift in Sources */,
+				CE26360E2CCFC78100BE59E2 /* WooShippingSelectedRate.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
 				DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */,
 				026826B52BF59E330036F959 /* CardReaderConnectionStatusView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import WooCommerce
 @testable import Networking
+import WooFoundation
 
 final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_inits_with_expected_values() {
@@ -13,6 +14,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.markOrderComplete)
         XCTAssertFalse(viewModel.canPurchaseLabel)
+        XCTAssertNil(viewModel.totalCost)
     }
 
     func test_site_address_converted_to_formatted_originAddress() {
@@ -99,6 +101,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.canPurchaseLabel)
+    }
+
+    func test_selecting_shipping_rate_sets_totalCost() throws {
+        // Given
+        let order = Order.fake()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+
+        // When
+        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards.first)
+        card.selectRate()
+
+        // Then
+        XCTAssertEqual(viewModel.totalCost, "$7.53")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -115,6 +115,37 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.totalCost, "$7.53")
     }
+
+    func test_formatAmount_for_standard_shipping_rate_returns_formatted_rate() throws {
+        // Given
+        let order = Order.fake()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
+        card.selectRate()
+
+        // When
+        let selectedRate = try XCTUnwrap(viewModel.shippingService.selectedRate)
+        let formattedAmount = viewModel.formatAmount(for: selectedRate.rate)
+
+        // Then
+        XCTAssertEqual(formattedAmount, "$40.06")
+    }
+
+    func test_formatAmount_for_signature_shipping_rate_returns_formatted_difference_from_base_rate() throws {
+        // Given
+        let order = Order.fake()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
+        card.signatureRequirement = .signatureRequired
+        card.selectRate()
+
+        // When
+        let signatureRate = try XCTUnwrap(viewModel.shippingService.selectedRate?.signatureRate)
+        let formattedAmount = viewModel.formatAmount(for: signatureRate)
+
+        // Then
+        XCTAssertEqual(formattedAmount, "$2.70")
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -12,6 +12,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.markOrderComplete)
+        XCTAssertFalse(viewModel.canPurchaseLabel)
     }
 
     func test_site_address_converted_to_formatted_originAddress() {
@@ -84,6 +85,20 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(markOrderComplete)
+    }
+
+    func test_canPurchaseLabel_true_after_shipping_rate_is_selected() throws {
+        // Given
+        let order = Order.fake()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order)
+        XCTAssertFalse(viewModel.canPurchaseLabel)
+
+        // When
+        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards.first)
+        card.selectRate()
+
+        // Then
+        XCTAssertTrue(viewModel.canPurchaseLabel)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -8,7 +8,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel()
 
         // Then
-        XCTAssertNil(viewModel.selectedStandardRate)
+        XCTAssertNil(viewModel.selectedRate)
     }
 
     func test_generateServiceTabs_returns_expected_data() throws {
@@ -67,17 +67,17 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Given
         let viewModel = WooShippingServiceViewModel()
         let card = viewModel.serviceTabs[0].cards[1]
-        XCTAssertNil(viewModel.selectedStandardRate)
+        XCTAssertNil(viewModel.selectedRate)
         XCTAssertFalse(card.selected)
 
         // When
         card.selectRate()
 
         // Then
-        XCTAssertNotNil(viewModel.selectedStandardRate)
-        XCTAssertNil(viewModel.selectedSignatureRate)
-        XCTAssertNil(viewModel.selectedAdultSignatureRate)
-        XCTAssertEqual(viewModel.selectedStandardRate?.title, card.title)
+        XCTAssertNotNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.selectedRate?.signatureRate)
+        XCTAssertNil(viewModel.selectedRate?.adultSignatureRate)
+        XCTAssertEqual(viewModel.selectedRate?.rate.title, card.title)
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 
@@ -85,8 +85,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Given
         let viewModel = WooShippingServiceViewModel()
         let card = viewModel.serviceTabs[0].cards[1]
-        XCTAssertNil(viewModel.selectedStandardRate)
-        XCTAssertNil(viewModel.selectedSignatureRate)
+        XCTAssertNil(viewModel.selectedRate)
         XCTAssertFalse(card.selected)
 
         // When
@@ -94,9 +93,9 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         card.selectRate()
 
         // Then
-        XCTAssertNotNil(viewModel.selectedStandardRate)
-        XCTAssertNotNil(viewModel.selectedSignatureRate)
-        XCTAssertNil(viewModel.selectedAdultSignatureRate)
+        XCTAssertNotNil(viewModel.selectedRate)
+        XCTAssertNotNil(viewModel.selectedRate?.signatureRate)
+        XCTAssertNil(viewModel.selectedRate?.adultSignatureRate)
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 
@@ -104,8 +103,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Given
         let viewModel = WooShippingServiceViewModel()
         let card = viewModel.serviceTabs[0].cards[1]
-        XCTAssertNil(viewModel.selectedStandardRate)
-        XCTAssertNil(viewModel.selectedAdultSignatureRate)
+        XCTAssertNil(viewModel.selectedRate)
         XCTAssertFalse(card.selected)
 
         // When
@@ -113,9 +111,9 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         card.selectRate()
 
         // Then
-        XCTAssertNotNil(viewModel.selectedStandardRate)
-        XCTAssertNil(viewModel.selectedSignatureRate)
-        XCTAssertNotNil(viewModel.selectedAdultSignatureRate)
+        XCTAssertNotNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.selectedRate?.signatureRate)
+        XCTAssertNotNil(viewModel.selectedRate?.adultSignatureRate)
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14143
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This integrates a selected shipping rate into the UI on the main screen in the Woo Shipping label creation flow. After a shipping rate is selected:

* The purchase button is enabled.
* The purchase button includes the total label cost.
* The bottom sheet shows rate details in the Shipment Costs section (separate lines for base rate + any signature options selected).

### How

* Introduces a `WooShippingSelectedRate` entity to represent a selected shipping rate.
* Updates `WooShippingServiceViewModel` to use `WooShippingSelectedRate` (consolidates the selection into a single property).
* Adds properties/methods to `WooShippingCreateLabelsViewModel`:
   * `canPurchaseLabel` to determine if the purchase button should be enabled (when a shipping rate is selected).
   * `totalCost` for the formatted total cost of the label (to show on the purchase button).
   * `formatAmount(for:)` to format the amount for a given shipping rate, to display in the Shipment Costs section. This returns the rate for the base fee, and the difference between the rate and the base fee for a selected signature option.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Make sure the feature flag `revampedShippingLabelCreation` is enabled.
2. Set `hasPackage` to true in WooShippingCreateLabelsViewModel [here](https://github.com/woocommerce/woocommerce-ios/blob/3b56d3d785a5a895dcc1579a86384c9f2cf4d2d1/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Shipping%20Labels/WooShipping%20Create%20Shipping%20Labels/WooShippingCreateLabelsViewModel.swift#L14).
3. Build and run the app.
4. Create an order with the processing status and at least one physical product.
5. In the order details, select "Create Shipping Label."
6. In the shipping label screen, open the bottom sheet and confirm the Shipment Costs placeholder rows are displayed.
7. Select a shipping rate and confirm the purchase button is enabled and shows the total cost.
8. Open the bottom sheet and confirm the Shipment Costs section shows the expected amounts (base fee, signature option costs if selected, and total cost).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Selected rate|Shipment Costs
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 25](https://github.com/user-attachments/assets/be76e683-b1b4-4cd7-807f-471f22cc94d9)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 22](https://github.com/user-attachments/assets/ad395735-64dc-4683-aca7-7e804de599e9)
![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 38](https://github.com/user-attachments/assets/e08076e0-f639-432b-8fdf-d6d50a27e046)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 40](https://github.com/user-attachments/assets/e53c82b1-c458-44bf-bb0b-bcd59ad4f5c0)
![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 45](https://github.com/user-attachments/assets/015a5e2f-3851-4730-8522-275c3005e5a8)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 49](https://github.com/user-attachments/assets/404d8208-2438-47d1-86ed-db082bfa2242)
![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 53](https://github.com/user-attachments/assets/ebd0f491-ab78-48f6-8692-3430d29fc081)|![Simulator Screenshot - iPhone 15 Pro - 2024-10-28 at 17 24 56](https://github.com/user-attachments/assets/975c5e68-4434-4b40-a622-115e335bb3a2)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.