### PR TITLE
[Custom Fields] Editor validation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -131,8 +131,7 @@ struct CustomFieldEditorView: View {
             viewModel.notice = Notice(title: Localization.valueCopiedNotice)
         }
 
-        // Do not show Delete button if there's no callback, i.e: when creating a new field.
-        if viewModel.onDelete != nil {
+        if viewModel.showDeleteButton {
             Button(Localization.deleteButton, role: .destructive) {
                 viewModel.deleteField()
                 dismiss()

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -121,18 +121,19 @@ struct CustomFieldEditorView: View {
                 }
             }
         }
+        .notice($viewModel.notice)
     }
 
     @ViewBuilder
     private var actionSheetContent: some View {
         Button(Localization.copyKeyButton) {
             UIPasteboard.general.string = viewModel.key
-            // todo-13493: Show a notice that the key was copied using Localization.keycopiedNotice
+            viewModel.notice = Notice(title: Localization.keycopiedNotice)
         }
 
         Button(Localization.copyValueButton) {
             UIPasteboard.general.string = viewModel.value
-            // todo-13493: Show a notice that the value was copied using Localization.valuecopiedNotice
+            viewModel.notice = Notice(title: Localization.valuecopiedNotice)
         }
 
         // Do not show Delete button if there's no callback, i.e: when creating a new field.

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -2,46 +2,20 @@ import SwiftUI
 
 struct CustomFieldEditorView: View {
     @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var viewModel: CustomFieldEditorViewModel
 
-    @State private var key: String
-    @State private var value: String
     @State private var showRichTextEditor = false
-    @State private var showingActionSheet = false
-    @State private var keyErrorMessage: String? = nil
+    @State private var showActionSheet = false
 
-    private let initialKey: String
-    private let initialValue: String
     private let isReadOnlyValue: Bool
-    private let onSave: (String, String) -> Void
-    private let onDelete: (() -> Void)?
-
-    private var hasUnsavedChanges: Bool {
-        key != initialKey || value != initialValue
-    }
-
-    private var hasValidKey: Bool {
-        !key.isEmpty && !key.hasPrefix("_")
-    }
 
     /// Initializer for custom field editor
     /// - Parameters:
-    ///  - key: The key for the custom field
-    ///  - value: The value for the custom field
+    ///  - viewModel: The viewModel for this View.
     ///  - isReadOnlyValue: Whether the value is read-only or not. To be used if the value is not string but JSON.
-    ///  - onSave: Closure to handle save action
-    ///  - onDelete: Closure to handle delete action, defaults to nil when the editor doesn't support deleting.
-    init(key: String,
-         value: String,
-         isReadOnlyValue: Bool = false,
-         onSave: @escaping (String, String) -> Void,
-         onDelete: (() -> Void)? = nil) {
-        self._key = State(initialValue: key)
-        self._value = State(initialValue: value)
-        self.initialKey = key
-        self.initialValue = value
+    init(viewModel: CustomFieldEditorViewModel, isReadOnlyValue: Bool = false) {
+        self.viewModel = viewModel
         self.isReadOnlyValue = isReadOnlyValue
-        self.onSave = onSave
-        self.onDelete = onDelete
     }
 
     var body: some View {
@@ -53,21 +27,18 @@ struct CustomFieldEditorView: View {
                         .foregroundColor(Color(.text))
                         .subheadlineStyle()
 
-                    TextField(Localization.keyPlaceholder, text: $key)
+                    TextField(Localization.keyPlaceholder, text: $viewModel.key)
                         .foregroundColor(Color(.text))
                         .subheadlineStyle()
                         .padding(insets: Layout.inputInsets)
                         .background(Color(.listForeground(modal: false)))
                         .overlay(
                             RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                                .stroke(keyErrorMessage != nil ? Color(.error) : Color(.separator))
+                                .stroke(viewModel.keyErrorMessage != nil ? Color(.error) : Color(.separator))
                         )
                         .cornerRadius(Layout.cornerRadius)
-                        .onChange(of: key) { newValue in
-                            validateKey(newValue)
-                        }
 
-                    if let error = keyErrorMessage {
+                    if let error = viewModel.keyErrorMessage {
                         Text(error)
                             .foregroundColor(Color(.error))
                             .font(.caption)
@@ -94,7 +65,7 @@ struct CustomFieldEditorView: View {
                     }
 
                     if showRichTextEditor {
-                        AztecEditorView(content: $value)
+                        AztecEditorView(content: $viewModel.value)
                         .frame(minHeight: Layout.minimumEditorSize)
                         .clipped()
                         .padding(insets: Layout.inputInsets)
@@ -104,7 +75,7 @@ struct CustomFieldEditorView: View {
                         )
                         .cornerRadius(Layout.cornerRadius)
                     } else {
-                        TextEditor(text: isReadOnlyValue ? .constant(value) : $value)
+                        TextEditor(text: isReadOnlyValue ? .constant(viewModel.value) : $viewModel.value)
                             .foregroundColor(Color(.text))
                             .subheadlineStyle()
                             .frame(minHeight: Layout.minimumEditorSize)
@@ -131,20 +102,20 @@ struct CustomFieldEditorView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack {
                     Button {
-                        saveChanges()
+                        viewModel.saveChanges()
                         dismiss()
                     } label: {
                         Text(Localization.saveButton)
                     }
-                    .disabled(!hasUnsavedChanges || !hasValidKey)
+                    .disabled(!viewModel.hasUnsavedChanges || !viewModel.hasValidKey)
 
                     Button(action: {
-                        showingActionSheet = true
+                        showActionSheet = true
                     }, label: {
                         Image(systemName: "ellipsis")
                             .renderingMode(.template)
                     })
-                    .confirmationDialog("More Options", isPresented: $showingActionSheet) {
+                    .confirmationDialog("More Options", isPresented: $showActionSheet) {
                         actionSheetContent
                     }
                 }
@@ -155,32 +126,21 @@ struct CustomFieldEditorView: View {
     @ViewBuilder
     private var actionSheetContent: some View {
         Button("Copy Key") { // todo-13493: set String to be translatable
-            UIPasteboard.general.string = key
+            UIPasteboard.general.string = viewModel.key
             // todo-13493: Show a notice that the key was copied
         }
 
         Button("Copy Value") { // todo-13493: set String to be translatable
-            UIPasteboard.general.string = value
+            UIPasteboard.general.string = viewModel.value
             // todo-13493: Show a notice that the value was copied
         }
 
-        if let onDelete = onDelete {
+        // Do not show Delete button if there's no callback, i.e: when creating a new field.
+        if viewModel.onDelete != nil {
             Button(Localization.deleteButton, role: .destructive) {
-                onDelete()
+                viewModel.deleteField()
                 dismiss()
             }
-        }
-    }
-
-    private func saveChanges() {
-        onSave(key, value)
-    }
-
-    private func validateKey(_ newValue: String) {
-        if newValue.hasPrefix("_") {
-            keyErrorMessage = Localization.keyErrorPrefix
-        } else {
-            keyErrorMessage = nil
         }
     }
 }
@@ -249,15 +209,9 @@ private extension CustomFieldEditorView {
             value: "Delete custom field",
             comment: "Button title for deleting a custom field"
         )
-
-        static let keyErrorPrefix = NSLocalizedString(
-            "customFieldEditorView.keyErrorPrefix",
-            value: "Invalid key: please remove the '_' character from the beginning.",
-            comment: "Error message shown when key starts with underscore"
-        )
     }
 }
 
 #Preview {
-    CustomFieldEditorView(key: "title", value: "value", onSave: { _, _ in }, onDelete: {})
+    CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(key: "title", value: "value", onSave: { _, _ in }, onDelete: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -115,7 +115,7 @@ struct CustomFieldEditorView: View {
                         Image(systemName: "ellipsis")
                             .renderingMode(.template)
                     })
-                    .confirmationDialog("More Options", isPresented: $showActionSheet) {
+                    .confirmationDialog(Localization.actionSheetTitle, isPresented: $showActionSheet) {
                         actionSheetContent
                     }
                 }
@@ -125,14 +125,14 @@ struct CustomFieldEditorView: View {
 
     @ViewBuilder
     private var actionSheetContent: some View {
-        Button("Copy Key") { // todo-13493: set String to be translatable
+        Button(Localization.copyKeyButton) {
             UIPasteboard.general.string = viewModel.key
-            // todo-13493: Show a notice that the key was copied
+            // todo-13493: Show a notice that the key was copied using Localization.keycopiedNotice
         }
 
-        Button("Copy Value") { // todo-13493: set String to be translatable
+        Button(Localization.copyValueButton) {
             UIPasteboard.general.string = viewModel.value
-            // todo-13493: Show a notice that the value was copied
+            // todo-13493: Show a notice that the value was copied using Localization.valuecopiedNotice
         }
 
         // Do not show Delete button if there's no callback, i.e: when creating a new field.
@@ -208,6 +208,36 @@ private extension CustomFieldEditorView {
             "customFieldEditorView.deleteButton",
             value: "Delete custom field",
             comment: "Button title for deleting a custom field"
+        )
+
+        static let actionSheetTitle = NSLocalizedString(
+            "customFieldEditorView.actionSheetTitle",
+            value: "More Options",
+            comment: "Title for the action sheet with additional options"
+        )
+
+        static let copyKeyButton = NSLocalizedString(
+            "customFieldEditorView.copyKeyButton",
+            value: "Copy Key",
+            comment: "Button title for copying the custom field key"
+        )
+
+        static let copyValueButton = NSLocalizedString(
+            "customFieldEditorView.copyValueButton",
+            value: "Copy Value",
+            comment: "Button title for copying the custom field value"
+        )
+
+        static let keycopiedNotice = NSLocalizedString(
+            "customFieldEditorView.keyCopiedNotice",
+            value: "Key copied to clipboard",
+            comment: "Notice shown when the key has been copied to clipboard"
+        )
+
+        static let valuecopiedNotice = NSLocalizedString(
+            "customFieldEditorView.valueCopiedNotice",
+            value: "Value copied to clipboard",
+            comment: "Notice shown when the value has been copied to clipboard"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -128,12 +128,12 @@ struct CustomFieldEditorView: View {
     private var actionSheetContent: some View {
         Button(Localization.copyKeyButton) {
             UIPasteboard.general.string = viewModel.key
-            viewModel.notice = Notice(title: Localization.keycopiedNotice)
+            viewModel.notice = Notice(title: Localization.keyCopiedNotice)
         }
 
         Button(Localization.copyValueButton) {
             UIPasteboard.general.string = viewModel.value
-            viewModel.notice = Notice(title: Localization.valuecopiedNotice)
+            viewModel.notice = Notice(title: Localization.valueCopiedNotice)
         }
 
         // Do not show Delete button if there's no callback, i.e: when creating a new field.
@@ -229,13 +229,13 @@ private extension CustomFieldEditorView {
             comment: "Button title for copying the custom field value"
         )
 
-        static let keycopiedNotice = NSLocalizedString(
+        static let keyCopiedNotice = NSLocalizedString(
             "customFieldEditorView.keyCopiedNotice",
             value: "Key copied to clipboard",
             comment: "Notice shown when the key has been copied to clipboard"
         )
 
-        static let valuecopiedNotice = NSLocalizedString(
+        static let valueCopiedNotice = NSLocalizedString(
             "customFieldEditorView.valueCopiedNotice",
             value: "Value copied to clipboard",
             comment: "Notice shown when the value has been copied to clipboard"

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -7,6 +7,7 @@ struct CustomFieldEditorView: View {
     @State private var value: String
     @State private var showRichTextEditor = false
     @State private var showingActionSheet = false
+    @State private var keyErrorMessage: String? = nil
 
     private let initialKey: String
     private let initialValue: String
@@ -16,6 +17,10 @@ struct CustomFieldEditorView: View {
 
     private var hasUnsavedChanges: Bool {
         key != initialKey || value != initialValue
+    }
+
+    private var hasValidKey: Bool {
+        !key.isEmpty && !key.hasPrefix("_")
     }
 
     /// Initializer for custom field editor
@@ -54,9 +59,19 @@ struct CustomFieldEditorView: View {
                         .padding(insets: Layout.inputInsets)
                         .background(Color(.listForeground(modal: false)))
                         .overlay(
-                            RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
+                            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                                .stroke(keyErrorMessage != nil ? Color(.error) : Color(.separator))
                         )
                         .cornerRadius(Layout.cornerRadius)
+                        .onChange(of: key) { newValue in
+                            validateKey(newValue)
+                        }
+
+                    if let error = keyErrorMessage {
+                        Text(error)
+                            .foregroundColor(Color(.error))
+                            .font(.caption)
+                    }
                 }
 
                 // Value Input
@@ -121,7 +136,7 @@ struct CustomFieldEditorView: View {
                     } label: {
                         Text(Localization.saveButton)
                     }
-                    .disabled(!hasUnsavedChanges)
+                    .disabled(!hasUnsavedChanges || !hasValidKey)
 
                     Button(action: {
                         showingActionSheet = true
@@ -159,6 +174,14 @@ struct CustomFieldEditorView: View {
 
     private func saveChanges() {
         onSave(key, value)
+    }
+
+    private func validateKey(_ newValue: String) {
+        if newValue.hasPrefix("_") {
+            keyErrorMessage = Localization.keyErrorPrefix
+        } else {
+            keyErrorMessage = nil
+        }
     }
 }
 
@@ -225,6 +248,12 @@ private extension CustomFieldEditorView {
             "customFieldEditorView.deleteButton",
             value: "Delete custom field",
             comment: "Button title for deleting a custom field"
+        )
+
+        static let keyErrorPrefix = NSLocalizedString(
+            "customFieldEditorView.keyErrorPrefix",
+            value: "Invalid key: please remove the '_' character from the beginning.",
+            comment: "Error message shown when key starts with underscore"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -114,7 +114,7 @@ struct CustomFieldEditorView: View {
                 }
             }
         }
-        .closeButtonWithDiscardChangesPrompt(hasChanges: hasUnsavedChanges,
+        .closeButtonWithDiscardChangesPrompt(hasChanges: viewModel.hasUnsavedChanges,
                                              closeButtonLabel: { Text(Localization.cancelButton) })
         .notice($viewModel.notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -12,6 +12,11 @@ final class CustomFieldEditorViewModel: ObservableObject {
 
     private let initialKey: String
     private let initialValue: String
+
+    /// Due to the API limitation, when creating a new field, the new key should not be the same as existing custom fields's key value. Those existing key values should be
+    /// provided here. Note that this rule only applies for new field creation, not when editing.
+    private let disallowedKeys: [String]
+
     private let onSave: (String, String) -> Void
 
     /// Closure invoked during field deletion. Optional as it's not needed when creating a new field. Not private because it is used in the view for display logic.
@@ -22,17 +27,21 @@ final class CustomFieldEditorViewModel: ObservableObject {
     }
 
     var hasValidKey: Bool {
-        !key.isEmpty && !key.hasPrefix("_")
+        !key.isEmpty &&
+        !key.hasPrefix("_") &&
+        !disallowedKeys.contains(key)
     }
 
     init(key: String,
          value: String,
+         disallowedKeys: [String] = [],
          onSave: @escaping (String, String) -> Void,
          onDelete: (() -> Void)? = nil) {
         self.key = key
         self.value = value
         self.initialKey = key
         self.initialValue = value
+        self.disallowedKeys = disallowedKeys
         self.onSave = onSave
         self.onDelete = onDelete
     }
@@ -40,6 +49,8 @@ final class CustomFieldEditorViewModel: ObservableObject {
     func validateKey(_ newValue: String) {
         if newValue.hasPrefix("_") {
             keyErrorMessage = Localization.keyErrorPrefix
+        } else if disallowedKeys.contains(newValue) {
+            keyErrorMessage = Localization.keyErrorDisallowedKey
         } else {
             keyErrorMessage = nil
         }
@@ -61,6 +72,13 @@ private extension CustomFieldEditorViewModel {
             "customFieldEditorView.keyErrorPrefix",
             value: "Invalid key: please remove the '_' character from the beginning.",
             comment: "Error message shown when key starts with underscore"
+        )
+
+        static let keyErrorDisallowedKey = NSLocalizedString(
+            "customFieldEditorView.keyErrorDisallowedKey",
+            value: "Invalid key: This key is already used for another custom field. \n" +
+            "The app currently does not support creating duplicate keys. Please use wp-admin to duplicate a key if needed.",
+            comment: "Error message shown when the entered key is identical to an existing key."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -54,7 +54,7 @@ final class CustomFieldEditorViewModel: ObservableObject {
     func validateKey(_ newValue: String) {
         if newValue.hasPrefix("_") {
             keyErrorMessage = Localization.keyErrorPrefix
-        } else if disallowedKeys.contains(newValue) {
+        } else if disallowedKeys.first(where: { $0 == newValue }) != nil {
             keyErrorMessage = Localization.keyErrorDisallowedKey
         } else {
             keyErrorMessage = nil

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -26,10 +26,9 @@ final class CustomFieldEditorViewModel: ObservableObject {
         key != initialKey || value != initialValue
     }
 
+    /// Note that `isEmpty` is validated separately, because we don't want to show error message when it's still empty, and instead just disable the button.
     var hasValidKey: Bool {
-        !key.isEmpty &&
-        !key.hasPrefix("_") &&
-        !disallowedKeys.contains(key)
+        !key.isEmpty && keyErrorMessage == nil
     }
 
     init(key: String,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -10,11 +10,14 @@ final class CustomFieldEditorViewModel: ObservableObject {
     @Published var value: String
     @Published private(set) var keyErrorMessage: String?
 
+    /// To be set by the View
+    @Published var notice: Notice?
+
     private let initialKey: String
     private let initialValue: String
 
-    /// Due to the API limitation, when creating a new field, the new key should not be the same as existing custom fields's key value. Those existing key values should be
-    /// provided here. Note that this rule only applies for new field creation, not when editing.
+    /// Due to the API limitation, when creating a new field, the new key should not be the same as existing custom fields's key value.
+    /// Those existing key values should be provided here. Note that this rule only applies for new field creation, not when editing.
     private let disallowedKeys: [String]
 
     private let onSave: (String, String) -> Void

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -20,8 +20,13 @@ final class CustomFieldEditorViewModel: ObservableObject {
 
     private let onSave: (String, String) -> Void
 
-    /// Closure invoked during field deletion. Optional as it's not needed when creating a new field. Not private because it is used in the view for display logic.
-    let onDelete: (() -> Void)?
+    /// Closure invoked during field deletion. Optional as it's not needed when creating a new field.
+    private let onDelete: (() -> Void)?
+
+    var showDeleteButton: Bool {
+        onDelete != nil
+    }
+
 
     var hasUnsavedChanges: Bool {
         key != initialKey || value != initialValue

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -16,8 +16,6 @@ final class CustomFieldEditorViewModel: ObservableObject {
     private let initialKey: String
     private let initialValue: String
 
-    /// Due to the API limitation, when creating a new field, the new key should not be the same as existing custom fields's key value.
-    /// Those existing key values should be provided here. Note that this rule only applies for new field creation, not when editing.
     private let disallowedKeys: [String]
 
     private let onSave: (String, String) -> Void

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+final class CustomFieldEditorViewModel: ObservableObject {
+    @Published var key: String {
+        didSet {
+            validateKey(key)
+        }
+    }
+
+    @Published var value: String
+    @Published private(set) var keyErrorMessage: String?
+
+    private let initialKey: String
+    private let initialValue: String
+    private let onSave: (String, String) -> Void
+
+    /// Closure invoked during field deletion. Optional as it's not needed when creating a new field. Not private because it is used in the view for display logic.
+    let onDelete: (() -> Void)?
+
+    var hasUnsavedChanges: Bool {
+        key != initialKey || value != initialValue
+    }
+
+    var hasValidKey: Bool {
+        !key.isEmpty && !key.hasPrefix("_")
+    }
+
+    init(key: String,
+         value: String,
+         onSave: @escaping (String, String) -> Void,
+         onDelete: (() -> Void)? = nil) {
+        self.key = key
+        self.value = value
+        self.initialKey = key
+        self.initialValue = value
+        self.onSave = onSave
+        self.onDelete = onDelete
+    }
+
+    func validateKey(_ newValue: String) {
+        if newValue.hasPrefix("_") {
+            keyErrorMessage = Localization.keyErrorPrefix
+        } else {
+            keyErrorMessage = nil
+        }
+    }
+
+    func saveChanges() {
+        onSave(key, value)
+    }
+
+    func deleteField() {
+        onDelete?()
+    }
+}
+
+// MARK: Constants
+private extension CustomFieldEditorViewModel {
+    enum Localization {
+        static let keyErrorPrefix = NSLocalizedString(
+            "customFieldEditorView.keyErrorPrefix",
+            value: "Invalid key: please remove the '_' character from the beginning.",
+            comment: "Error message shown when key starts with underscore"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -212,7 +212,10 @@ private struct CustomFieldRow: View {
 // MARK: - Helpers
 //
 private extension CustomFieldsListView {
-    /// Builds the Custom Field Editor View.
+    /// Builds the Custom Field Editor View. There are two possible modes for the editor:
+    /// - Creating a new custom field: the Key and Value fields will be empty, and deleting option should be hidden.
+    /// - Editing an existing custom field: the Key and Value fields will use the values from the provided `customField`
+    ///
     /// Parameters:
     /// - `customField`: Provide one when editing an existing field, otherwise (i.e: when creating a new field) keep it nil.
     /// - `disallowedKeys`: List of String that can't be used when editing a custom field key.
@@ -231,6 +234,7 @@ private extension CustomFieldsListView {
                     )
                 },
                 onDelete: customField != nil ? {
+                    // Only provide delete callback when editing existing field
                     viewModel.deleteField(customField!)
                 } : nil
             ))

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -193,7 +193,7 @@ private extension CustomFieldsListView {
     /// - When `customField` is nil, it configures the editor for creating a new field
     func buildCustomFieldEditorView(customField: CustomFieldsListViewModel.CustomFieldUI?) -> some View {
         NavigationView {
-            CustomFieldEditorView(
+            CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(
                 key: customField?.key ?? "",
                 value: customField?.value ?? "",
                 onSave: { updatedKey, updatedValue in
@@ -206,7 +206,7 @@ private extension CustomFieldsListView {
                 onDelete: customField != nil ? {
                     viewModel.deleteField(customField!)
                 } : nil
-            )
+            ))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -102,11 +102,13 @@ struct CustomFieldsListView: View {
     @ObservedObject private var viewModel: CustomFieldsListViewModel
 
     let isEditable: Bool
+    let disallowedKeysForCeation: [String]
 
     init(isEditable: Bool,
          viewModel: CustomFieldsListViewModel) {
         self.isEditable = isEditable
         self.viewModel = viewModel
+        self.disallowedKeysForCeation = viewModel.originalCustomFields.map(\.title)
     }
 
     var body: some View {
@@ -120,10 +122,14 @@ struct CustomFieldsListView: View {
         }
         .listStyle(.plain)
         .sheet(item: $viewModel.selectedCustomField) { customField in
-            buildCustomFieldEditorView(customField: customField)
+            /// When editing a newly added and unsaved custom field (identified by it having nil `fieldId`), provide disallowed keys.
+            let disallowedKeys = customField.fieldId == nil ? disallowedKeysForCeation : []
+
+            buildCustomFieldEditorView(customField: customField,
+                                       disallowedKeys: disallowedKeys)
         }
         .sheet(isPresented: $viewModel.isAddingNewField) {
-            buildCustomFieldEditorView(customField: nil)
+            buildCustomFieldEditorView(customField: nil, disallowedKeys: disallowedKeysForCeation)
         }
         .notice($viewModel.notice)
     }
@@ -189,13 +195,16 @@ private struct CustomFieldRow: View {
 //
 private extension CustomFieldsListView {
     /// Builds the Custom Field Editor View.
-    /// - When `customField` is provided, it configures the editor for editing an existing field
-    /// - When `customField` is nil, it configures the editor for creating a new field
-    func buildCustomFieldEditorView(customField: CustomFieldsListViewModel.CustomFieldUI?) -> some View {
+    /// Parameters:
+    /// - `customField`: Provide one when editing an existing field, otherwise (i.e: when creating a new field) keep it nil.
+    /// - `disallowedKeys`: List of String that can't be used when editing a custom field key.
+    func buildCustomFieldEditorView(customField: CustomFieldsListViewModel.CustomFieldUI?,
+                                    disallowedKeys: [String] = []) -> some View {
         NavigationView {
             CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(
                 key: customField?.key ?? "",
                 value: customField?.value ?? "",
+                disallowedKeys: disallowedKeys,
                 onSave: { updatedKey, updatedValue in
                     viewModel.saveField(
                         key: updatedKey,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -102,13 +102,11 @@ struct CustomFieldsListView: View {
     @ObservedObject private var viewModel: CustomFieldsListViewModel
 
     let isEditable: Bool
-    let disallowedKeysForCeation: [String]
 
     init(isEditable: Bool,
          viewModel: CustomFieldsListViewModel) {
         self.isEditable = isEditable
         self.viewModel = viewModel
-        self.disallowedKeysForCeation = viewModel.originalCustomFields.map(\.title)
     }
 
     var body: some View {
@@ -123,13 +121,13 @@ struct CustomFieldsListView: View {
         .listStyle(.plain)
         .sheet(item: $viewModel.selectedCustomField) { customField in
             /// When editing a newly added and unsaved custom field (identified by it having nil `fieldId`), provide disallowed keys.
-            let disallowedKeys = customField.fieldId == nil ? disallowedKeysForCeation : []
+            let disallowedKeys = customField.fieldId == nil ? viewModel.disallowedKeysForCreation : []
 
             buildCustomFieldEditorView(customField: customField,
                                        disallowedKeys: disallowedKeys)
         }
         .sheet(isPresented: $viewModel.isAddingNewField) {
-            buildCustomFieldEditorView(customField: nil, disallowedKeys: disallowedKeysForCeation)
+            buildCustomFieldEditorView(customField: nil, disallowedKeys: viewModel.disallowedKeysForCreation)
         }
         .notice($viewModel.notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -33,6 +33,14 @@ final class CustomFieldsListViewModel: ObservableObject {
     }
     @Published private(set) var hasChanges: Bool = false
 
+    /// Due to the API limitation, when creating a new field, the new key should not be the same as an existing custom fields's key.
+    /// We also don't want newly added fields to have duplicate key, because that way the API only accepts saving one of them.
+    /// Note that this rule only applies to new field creation, and duplicates are allowed when editing existing fields.
+    var disallowedKeysForCreation: [String] {
+        originalCustomFields.map { $0.title }
+        + addedFields.map { $0.key }
+    }
+
     init(customFields: [CustomFieldViewModel],
          siteID: Int64,
          parentItemID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 final class CustomFieldsListViewModel: ObservableObject {
     private let stores: StoresManager
-    @Published private(set) var originalCustomFields: [CustomFieldViewModel]
+    @Published private var originalCustomFields: [CustomFieldViewModel]
     private let customFieldsType: MetaDataType
     private let siteID: Int64
     private let parentItemID: Int64

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 final class CustomFieldsListViewModel: ObservableObject {
     private let stores: StoresManager
-    @Published private var originalCustomFields: [CustomFieldViewModel]
+    @Published private(set) var originalCustomFields: [CustomFieldViewModel]
     private let customFieldsType: MetaDataType
     private let siteID: Int64
     private let parentItemID: Int64

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1703,6 +1703,7 @@
 		86DE68822B4BA47A00B437A6 /* BlazeAdDestinationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */; };
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
 		86EC6EB72CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86EC6EB62CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift */; };
+		86EC6EB92CD0BA6A00D7D2FE /* CustomFieldEditorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86EC6EB82CD0BA6A00D7D2FE /* CustomFieldEditorViewModelTests.swift */; };
 		86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */; };
 		86F5FFE22CA302B300C767C4 /* CustomFieldsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */; };
 		86F5FFE42CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */; };
@@ -4729,6 +4730,7 @@
 		86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModel.swift; sourceTree = "<group>"; };
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		86EC6EB62CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldEditorViewModel.swift; sourceTree = "<group>"; };
+		86EC6EB82CD0BA6A00D7D2FE /* CustomFieldEditorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldEditorViewModelTests.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
 		86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModel.swift; sourceTree = "<group>"; };
 		86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModelTests.swift; sourceTree = "<group>"; };
@@ -9762,6 +9764,7 @@
 			children = (
 				CC5BA5F4287EDC900072F307 /* CustomFieldViewModelTests.swift */,
 				86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */,
+				86EC6EB82CD0BA6A00D7D2FE /* CustomFieldEditorViewModelTests.swift */,
 			);
 			path = "Custom Fields";
 			sourceTree = "<group>";
@@ -16574,6 +16577,7 @@
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
 				0375799D2822F9040083F2E1 /* MockCardPresentPaymentsOnboardingPresenter.swift in Sources */,
 				455800CC24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift in Sources */,
+				86EC6EB92CD0BA6A00D7D2FE /* CustomFieldEditorViewModelTests.swift in Sources */,
 				CE86C8332CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift in Sources */,
 				26F92DBE2C7ECAB20074A208 /* EditOrderFormTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1702,6 +1702,7 @@
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		86DE68822B4BA47A00B437A6 /* BlazeAdDestinationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */; };
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
+		86EC6EB72CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86EC6EB62CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift */; };
 		86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */; };
 		86F5FFE22CA302B300C767C4 /* CustomFieldsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */; };
 		86F5FFE42CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */; };
@@ -4727,6 +4728,7 @@
 		86B3E2562C6B249C0002420B /* HelpAndSupportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpAndSupportViewModelTests.swift; sourceTree = "<group>"; };
 		86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModel.swift; sourceTree = "<group>"; };
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
+		86EC6EB62CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldEditorViewModel.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
 		86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModel.swift; sourceTree = "<group>"; };
 		86F5FFE32CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModelTests.swift; sourceTree = "<group>"; };
@@ -10564,6 +10566,7 @@
 				B6C838DD28793B3A003AB786 /* CustomFieldViewModel.swift */,
 				86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */,
 				86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */,
+				86EC6EB62CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift */,
 			);
 			path = "Custom Fields";
 			sourceTree = "<group>";
@@ -15972,6 +15975,7 @@
 				02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */,
 				B9DA153C280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift in Sources */,
 				02FE734B2B21613D00CD486B /* ProductWithQuantityStepperView.swift in Sources */,
+				86EC6EB72CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift in Sources */,
 				DEDA8DBC2B1983570076BF0F /* ThemeSettingView.swift in Sources */,
 				03825FE92A97B63800363BDA /* AdaptiveImage.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldEditorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldEditorViewModelTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import WooCommerce
+
+final class CustomFieldEditorViewModelTests: XCTestCase {
+    private var viewModel: CustomFieldEditorViewModel!
+    private var savedKey: String?
+    private var savedValue: String?
+    private var deleteCallCount: Int = 0
+
+    override func setUp() {
+        super.setUp()
+        savedKey = nil
+        savedValue = nil
+        deleteCallCount = 0
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial State Tests
+
+    func test_given_initial_state_then_values_match_initial_input() {
+        // Given
+        let initialKey = "testKey"
+        let initialValue = "testValue"
+
+        // When
+        viewModel = createViewModel(key: initialKey, value: initialValue)
+
+        // Then
+        XCTAssertEqual(viewModel.key, initialKey)
+        XCTAssertEqual(viewModel.value, initialValue)
+        XCTAssertNil(viewModel.keyErrorMessage)
+        XCTAssertTrue(viewModel.hasValidKey)
+        XCTAssertFalse(viewModel.hasUnsavedChanges)
+    }
+
+    // MARK: - Key Validation Tests
+
+    func test_given_key_starting_with_underscore_then_show_error_message() {
+        // Given
+        viewModel = createViewModel(key: "key", value: "value")
+
+        // When
+        viewModel.key = "_invalidKey"
+
+        // Then
+        XCTAssertEqual(viewModel.keyErrorMessage, Expectations.keyErrorPrefix)
+        XCTAssertFalse(viewModel.hasValidKey)
+    }
+
+    func test_given_key_similar_to_disallowed_key_then_show_error_message() {
+        // Given
+        let disallowedKeys = ["existingKey"]
+        viewModel = createViewModel(key: "key", value: "value", disallowedKeys: disallowedKeys)
+
+        // When
+        viewModel.key = "existingKey"
+
+        // Then
+        XCTAssertEqual(viewModel.keyErrorMessage, Expectations.keyErrorDisallowedKey)
+        XCTAssertFalse(viewModel.hasValidKey)
+    }
+
+    func test_given_empty_key_then_hasValidKey_is_false_but_show_no_error_message() {
+        // Given
+        viewModel = createViewModel(key: "key", value: "value")
+
+        // When
+        viewModel.key = ""
+
+        // Then
+        XCTAssertFalse(viewModel.hasValidKey)
+        XCTAssertNil(viewModel.keyErrorMessage)
+    }
+
+    func test_given_valid_key_then_show_no_error_message() {
+        // Given
+        viewModel = createViewModel(key: "key", value: "value")
+
+        // When
+        viewModel.key = "validKey"
+
+        // Then
+        XCTAssertNil(viewModel.keyErrorMessage)
+        XCTAssertTrue(viewModel.hasValidKey)
+    }
+
+    // MARK: - Value Changes Tests
+
+    func test_given_value_change_then_hasUnsavedChanges_is_true() {
+        // Given
+        viewModel = createViewModel(key: "key", value: "value")
+
+        // When
+        viewModel.value = "newValue"
+
+        // Then
+        XCTAssertTrue(viewModel.hasUnsavedChanges)
+    }
+
+    // MARK: - Save Changes Tests
+
+    func test_given_valid_changes_when_saveChanges_is_called_then_onSave_is_called() {
+        // Given
+        viewModel = createViewModel(key: "key", value: "value")
+        viewModel.key = "newKey"
+        viewModel.value = "newValue"
+
+        // When
+        viewModel.saveChanges()
+
+        // Then
+        XCTAssertEqual(savedKey, "newKey")
+        XCTAssertEqual(savedValue, "newValue")
+    }
+
+    // MARK: - Delete Tests
+
+    func test_given_delete_enabled_when_deleteField_is_called_then_onDelete_is_called() {
+        // Given
+        viewModel = createViewModel(key: "key", value: "value", onDelete: {
+            self.deleteCallCount += 1
+        })
+
+        // When
+        viewModel.deleteField()
+
+        // Then
+        XCTAssertEqual(deleteCallCount, 1)
+    }
+
+    func test_given_delete_disabled_when_deleteField_is_called_then_onDelete_is_not_called() {
+        // Given
+        viewModel = createViewModel(key: "key", value: "value", onDelete: nil)
+
+        // When
+        viewModel.deleteField()
+
+        // Then
+        XCTAssertEqual(deleteCallCount, 0)
+    }
+}
+
+// MARK: - Helpers
+private extension CustomFieldEditorViewModelTests {
+    func createViewModel(
+        key: String,
+        value: String,
+        disallowedKeys: [String] = [],
+        onDelete: (() -> Void)? = nil
+    ) -> CustomFieldEditorViewModel {
+        CustomFieldEditorViewModel(
+            key: key,
+            value: value,
+            disallowedKeys: disallowedKeys,
+            onSave: { newKey, newValue in
+                self.savedKey = newKey
+                self.savedValue = newValue
+            },
+            onDelete: onDelete
+        )
+    }
+}
+
+// MARK: - Constants
+private extension CustomFieldEditorViewModelTests {
+    enum Expectations {
+        static let keyErrorPrefix = NSLocalizedString(
+            "customFieldEditorViewModelTests.keyErrorPrefix",
+            value: "Invalid key: please remove the '_' character from the beginning.",
+            comment: "Error message shown when key starts with underscore"
+        )
+
+        static let keyErrorDisallowedKey = NSLocalizedString(
+            "customFieldEditorViewModelTests.keyErrorDisallowedKey",
+            value: "Invalid key: This key is already used for another custom field. \n" +
+            "The app currently does not support creating duplicate keys. Please use wp-admin to duplicate a key if needed.",
+            comment: "Error message shown when the entered key is identical to an existing key."
+        )
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -275,4 +275,141 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // Then: The listener should be called
         XCTAssertEqual(listenerReceivedItems, originalMetadata)
     }
+
+    // MARK: - Disallowed Keys for Creation with local changes
+
+    func test_given_originalAndAddedFields_then_disallowedKeysForCreationContainsAllKeys() {
+        // Given: Original fields from setup and a new field
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+
+        // When: Adding the new field
+        viewModel.addField(newField)
+
+        // Then: disallowedKeysForCreation should contain both original and new keys
+        XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 3)
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key1"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("NewKey"))
+    }
+
+    func test_given_editedFields_then_disallowedKeysForCreationStillContainsOriginalKeys() {
+        // Given: Original fields and an edited field
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
+
+        // When: Editing a field (not yet saved remotely)
+        viewModel.editField(at: 0, newField: editedField)
+
+        // Then: disallowedKeysForCreation should contain original keys since changes aren't saved
+        XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 2)
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key1"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
+    }
+
+    func test_given_deletedField_then_disallowedKeysForCreationStillContainsOriginalKey() {
+        // Given: A field to delete
+        let fieldToDelete = CustomFieldsListViewModel.CustomFieldUI(key: originalFields[0].title,
+                                                                  value: originalFields[0].content,
+                                                                  fieldId: originalFields[0].id)
+
+        // When: Deleting the field (not yet saved remotely)
+        viewModel.deleteField(fieldToDelete)
+
+        // Then: disallowedKeysForCreation should still contain all original keys since deletion isn't saved yet
+        XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 2)
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key1"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
+    }
+
+    func test_given_multipleChanges_then_disallowedKeysForCreationReflectsOriginalAndAddedKeys() {
+        // Given: Original fields
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+        let fieldToDelete = CustomFieldsListViewModel.CustomFieldUI(key: originalFields[1].title,
+                                                                  value: originalFields[1].content,
+                                                                  fieldId: originalFields[1].id)
+
+        // When: Making multiple changes (not yet saved remotely)
+        viewModel.editField(at: 0, newField: editedField)
+        viewModel.addField(newField)
+        viewModel.deleteField(fieldToDelete)
+
+        // Then: disallowedKeysForCreation should contain all original keys plus new keys
+        XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 3)
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key1"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("NewKey"))
+    }
+
+    // MARK: - Disallowed Keys for Creation with remote changes
+
+    func test_given_addField_then_saveChanges_then_disallowedKeysUpdates() async {
+        // Given: Initial state with two fields ("Key1", "Key2")
+
+        let newMetadata = MetaData(metadataID: 3, key: "NewKey", value: "NewValue")
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: newMetadata.key, value: newMetadata.value)
+        viewModel.addField(newField)
+
+        stores.whenReceivingAction(ofType: MetaDataAction.self) { [originalMetadata] action in
+            switch action {
+                case let .updateMetaData(_, _, _, _, onCompletion):
+                    onCompletion(.success(originalMetadata + [newMetadata]))
+            }
+        }
+
+        // When: Saving changes
+        await viewModel.saveChanges()
+
+        // Then: disallowedKeysForCreation includes the new saved field
+        XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 3)
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key1"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("NewKey"))
+    }
+
+    func test_given_saveField_then_saveChanges_then_disallowedKeysUpdates() async {
+        // Given: Initial state with two fields ("Key1", "Key2")
+
+        let editedMetadata = MetaData(metadataID: 1, key: "EditedKey1", value: "EditedValue1")
+        viewModel.saveField(key: editedMetadata.key, value: editedMetadata.value, fieldId: editedMetadata.metadataID)
+
+        stores.whenReceivingAction(ofType: MetaDataAction.self) { [originalMetadata] action in
+            switch action {
+                case let .updateMetaData(_, _, _, _, onCompletion):
+                    let updatedMetadata = originalMetadata.map { $0.metadataID == 1 ? editedMetadata : $0 }
+                    onCompletion(.success(updatedMetadata))
+            }
+        }
+
+        // When: Saving changes
+        await viewModel.saveChanges()
+
+        // Then: disallowedKeysForCreation reflects the edited field
+        XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 2)
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("EditedKey1"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
+    }
+
+    func test_given_deleteField_then_saveChanges_then_disallowedKeysUpdates() async {
+        // Given: Initial state with two fields ("Key1", "Key2")
+        let fieldToDelete = CustomFieldsListViewModel.CustomFieldUI(key: originalFields[0].title,
+                                                                  value: originalFields[0].content,
+                                                                  fieldId: originalFields[0].id)
+        viewModel.deleteField(fieldToDelete)
+
+        stores.whenReceivingAction(ofType: MetaDataAction.self) { [originalMetadata] action in
+            switch action {
+                case let .updateMetaData(_, _, _, _, onCompletion):
+                    let updatedMetadata = originalMetadata.filter { $0.metadataID != fieldToDelete.fieldId }
+                    onCompletion(.success(updatedMetadata))
+            }
+        }
+
+        // When: Saving changes
+        await viewModel.saveChanges()
+
+        // Then: disallowedKeysForCreation excludes the deleted field
+        XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 1)
+        XCTAssertFalse(viewModel.disallowedKeysForCreation.contains("Key1"))
+        XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13888 

Pardon the big line changes, more than half of it are unit tests.
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the required validations in the Custom Fields Editor screen:
1. For all cases, disallow adding a key that starts with underscore ("_")
2. When creating a new custom field, or editing a newly added and unsaved custom field, disallow adding key that already exists
3. Show error messages for the cases above, matching Android, and make sure "Save" button is disabled
4. To do the above, a view model is created to handle the validations. The view model is then also used to handle the key/value states and save/delete handling.
5. Unit tests are added for the newly added view model.

Finally, the PR also adds smaller things to complete the Editor screen:
1. Remaining string localization
2. Notice when copying key/value

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open an Order Details or Product Details of an item that already has multiple existing custom fields,
2. Keep note of the key value of the first field,
3. Create a new custom field, and in the Key field enter the same key value as in step 2. Ensure error message about duplicate key is shown, and Save button is disabled,
4. Empty the Key field, then enter "_". Ensure error message about underscore is shown, and Save button is disabled,
5. Empty the Key field, then enter a random new value for both Key and Value. Ensure error message disappears and Save button is enabled
6. Go back to List screen,
7. Tap the second existing custom field,
8. In the editor, edit the Key field to be the same string as the key value from step 2 above. Ensure there's no error message about duplicate key.

Notice tests:
1. Edit an existing custom field,
2. In the Editor, go to triple dot icon and tap Copy Key. Ensure a notice is shown.
3. Back in triple dot icon again and tap Copy Value. Ensure a notice is shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested the above using Simulator with iPhone on iOS 17.5.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Validation for duplicate key | Validation for underscore | 
|-|-|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-10-29 at 14 20 11](https://github.com/user-attachments/assets/199a4853-5e0a-4bd6-b44a-34d0a511f16d) | ![Simulator Screenshot - iPhone 15 Pro - 2024-10-29 at 14 20 19](https://github.com/user-attachments/assets/54075c25-5772-4c11-9ab0-c1011965293e) |

| Notice for Value copying | Notice for Key copying |
|-|-|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-10-29 at 14 20 31](https://github.com/user-attachments/assets/c5d70344-3933-47b0-8f5f-25b258131741) | ![Simulator Screenshot - iPhone 15 Pro - 2024-10-29 at 14 20 25](https://github.com/user-attachments/assets/6b3022bc-2534-4ac7-a3eb-56108b85d83d) |
---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.