### PR TITLE
Update TopTopTabView with few options

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -154,71 +154,72 @@ struct TopTabView<Content: View>: View {
                 Divider()
             }
 
-            // Display all the tabs in an HStack, each tab the same width as the TopTabView
-            // This GeometryReader is used to set the width and drag offsets for swiping between views
-            GeometryReader { geometry in
-                HStack(spacing: 0) {
-                    ForEach(0..<tabs.count, id: \.self) { index in
-                        // Tab content as passed to the TopTabView at init
-                        tabs[index].content()
-                            .frame(width: geometry.size.width)
-                            .frame(height: max(geometry.size.height, contentSize.height))
+            if showContent {
+                // Display all the tabs in an HStack, each tab the same width as the TopTabView
+                // This GeometryReader is used to set the width and drag offsets for swiping between views
+                GeometryReader { geometry in
+                    HStack(spacing: 0) {
+                        ForEach(0..<tabs.count, id: \.self) { index in
+                            // Tab content as passed to the TopTabView at init
+                            tabs[index].content()
+                                .frame(width: geometry.size.width)
+                        }
                     }
+                    .background(
+                        // Use a background GeometryReader to get the height of the tab content.
+                        // This is used later as the height of the top-level GeometryReader, to override the default
+                        // behaviour of setting the frame to zero (and hiding the content.)
+                        GeometryReader { contentGeometry in
+                            Color.clear
+                                .onAppear {
+                                    contentSize = contentGeometry.size
+                                }
+                                .onChange(of: contentGeometry.size) { newSize in
+                                    contentSize = newSize
+                                }
+                        })
+                    .offset(x: self.dragOffset(width: geometry.size.width))
+                    .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
+                    // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
+                    .contentShape(Rectangle())
+                    // The gesture could be simultaneous with an external scroll view
+                    .simultaneousGesture(
+                        DragGesture()
+                            .updating($dragState) { drag, state, transaction in
+                                let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
+                                if isHorizontalDrag {
+                                    state = .dragging(translation: drag.translation)
+                                }
+                            }
+                            .onEnded { drag in
+                                // We use `predictedEndTranslation` to account for velocity as the user ends the drag
+                                // For fast, short swipes, this will likely be higher than `translation`, and lead to a
+                                // more natural feeling animation.
+                                let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
+                                let threshold: CGFloat = geometry.size.width / 2
+                                let newIndex: Int
+                                if horizontalAmount > threshold {
+                                    // A swipe more than 50% to the right: move back
+                                    newIndex = max(selectedTab - 1, 0)
+                                } else if horizontalAmount < -threshold {
+                                    // A swipe more than 50% to the left: move forward
+                                    newIndex = min(selectedTab + 1, tabs.count - 1)
+                                } else {
+                                    newIndex = selectedTab
+                                }
+                                // Notifiy the new tab that it's been selected, but only if it's changed
+                                if newIndex != selectedTab {
+                                    tabs[newIndex].onSelected?()
+                                }
+                                // Update the selected tab to the new index
+                                withAnimation(.easeOut) {
+                                    selectedTab = newIndex
+                                }
+                            }
+                    )
                 }
-                .background(
-                    // Use a background GeometryReader to get the height of the tab content.
-                    // This is used later as the height of the top-level GeometryReader, to override the default
-                    // behaviour of setting the frame to zero (and hiding the content.)
-                    GeometryReader { contentGeometry in
-                        Color.clear
-                        .onAppear {
-                            contentSize = contentGeometry.size
-                        }
-                        .onChange(of: contentGeometry.size) { newSize in
-                            contentSize = newSize
-                        }
-                    })
-                .offset(x: self.dragOffset(width: geometry.size.width))
-                .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
-                // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
-                .contentShape(Rectangle())
-                // The gesture could be simultaneous with an external scroll view
-                .simultaneousGesture(
-                    DragGesture()
-                        .updating($dragState) { drag, state, transaction in
-                            let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
-                            if isHorizontalDrag {
-                                state = .dragging(translation: drag.translation)
-                            }
-                        }
-                        .onEnded { drag in
-                            // We use `predictedEndTranslation` to account for velocity as the user ends the drag
-                            // For fast, short swipes, this will likely be higher than `translation`, and lead to a
-                            // more natural feeling animation.
-                            let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
-                            let threshold: CGFloat = geometry.size.width / 2
-                            let newIndex: Int
-                            if horizontalAmount > threshold {
-                                // A swipe more than 50% to the right: move back
-                                newIndex = max(selectedTab - 1, 0)
-                            } else if horizontalAmount < -threshold {
-                                // A swipe more than 50% to the left: move forward
-                                newIndex = min(selectedTab + 1, tabs.count - 1)
-                            } else {
-                                newIndex = selectedTab
-                            }
-                            // Notifiy the new tab that it's been selected, but only if it's changed
-                            if newIndex != selectedTab {
-                                tabs[newIndex].onSelected?()
-                            }
-                            // Update the selected tab to the new index
-                            withAnimation(.easeOut) {
-                                selectedTab = newIndex
-                            }
-                        }
-                )
+                .frame(height: contentSize.height)
             }
-            .frame(height: contentSize.height)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -18,7 +18,7 @@ struct TopTabItem<Content: View> {
 }
 
 struct TopTabView<Content: View>: View {
-    @Binding var selectedTab: Int
+    @State private var selectedTab = 0
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
     @GestureState private var dragState: DragState = .inactive
@@ -26,6 +26,7 @@ struct TopTabView<Content: View>: View {
 
     @Binding var showTabs: Bool
     @Binding var showContent: Bool
+    @Binding var selectedTabIndex: Int?
 
     let tabs: [TopTabItem<Content>]
 
@@ -51,10 +52,10 @@ struct TopTabView<Content: View>: View {
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?
 
-    init(selectedTab: Binding<Int> = .constant(0),
-         tabs: [TopTabItem<Content>],
+    init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
          showContent: Binding<Bool> = .constant(true),
+         selectedTabIndex: Binding<Int?> = .constant(nil),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
@@ -64,10 +65,10 @@ struct TopTabView<Content: View>: View {
          tabsIconSize: CGFloat? = 20.0,
          tabItemContentHorizontalPadding: CGFloat? = nil,
          tabItemContentVerticalPadding: CGFloat? = nil) {
-        self._selectedTab = selectedTab
         self.tabs = tabs
         self._showTabs = showTabs
         self._showContent = showContent
+        self._selectedTabIndex = selectedTabIndex
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
         self.selectedStateColor = selectedStateColor
@@ -142,6 +143,7 @@ struct TopTabView<Content: View>: View {
                                 alignment: .bottomLeading
                             )
                             .onChange(of: selectedTab, perform: { newSelectedTab in
+                                selectedTabIndex = newSelectedTab
                                 withAnimation {
                                     scrollViewProxy.scrollTo(newSelectedTab, anchor: .center)
                                     underlineOffset = calculateOffset(index: newSelectedTab)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -154,73 +154,71 @@ struct TopTabView<Content: View>: View {
                 Divider()
             }
 
-            if showContent {
-                // Display all the tabs in an HStack, each tab the same width as the TopTabView
-                // This GeometryReader is used to set the width and drag offsets for swiping between views
-                GeometryReader { geometry in
-                    HStack(spacing: 0) {
-                        ForEach(0..<tabs.count, id: \.self) { index in
-                            // Tab content as passed to the TopTabView at init
-                            tabs[index].content()
-                                .frame(width: geometry.size.width)
-                                .frame(height: max(geometry.size.height, contentSize.height))
-                        }
+            // Display all the tabs in an HStack, each tab the same width as the TopTabView
+            // This GeometryReader is used to set the width and drag offsets for swiping between views
+            GeometryReader { geometry in
+                HStack(spacing: 0) {
+                    ForEach(0..<tabs.count, id: \.self) { index in
+                        // Tab content as passed to the TopTabView at init
+                        tabs[index].content()
+                            .frame(width: geometry.size.width)
+                            .frame(height: max(geometry.size.height, contentSize.height))
                     }
-                    .background(
-                        // Use a background GeometryReader to get the height of the tab content.
-                        // This is used later as the height of the top-level GeometryReader, to override the default
-                        // behaviour of setting the frame to zero (and hiding the content.)
-                        GeometryReader { contentGeometry in
-                            Color.clear
-                                .onAppear {
-                                    contentSize = contentGeometry.size
-                                }
-                                .onChange(of: contentGeometry.size) { newSize in
-                                    contentSize = newSize
-                                }
-                        })
-                    .offset(x: self.dragOffset(width: geometry.size.width))
-                    .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
-                    // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
-                    .contentShape(Rectangle())
-                    // The gesture could be simultaneous with an external scroll view
-                    .simultaneousGesture(
-                        DragGesture()
-                            .updating($dragState) { drag, state, transaction in
-                                let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
-                                if isHorizontalDrag {
-                                    state = .dragging(translation: drag.translation)
-                                }
-                            }
-                            .onEnded { drag in
-                                // We use `predictedEndTranslation` to account for velocity as the user ends the drag
-                                // For fast, short swipes, this will likely be higher than `translation`, and lead to a
-                                // more natural feeling animation.
-                                let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
-                                let threshold: CGFloat = geometry.size.width / 2
-                                let newIndex: Int
-                                if horizontalAmount > threshold {
-                                    // A swipe more than 50% to the right: move back
-                                    newIndex = max(selectedTab - 1, 0)
-                                } else if horizontalAmount < -threshold {
-                                    // A swipe more than 50% to the left: move forward
-                                    newIndex = min(selectedTab + 1, tabs.count - 1)
-                                } else {
-                                    newIndex = selectedTab
-                                }
-                                // Notifiy the new tab that it's been selected, but only if it's changed
-                                if newIndex != selectedTab {
-                                    tabs[newIndex].onSelected?()
-                                }
-                                // Update the selected tab to the new index
-                                withAnimation(.easeOut) {
-                                    selectedTab = newIndex
-                                }
-                            }
-                    )
                 }
-                .frame(height: contentSize.height)
+                .background(
+                    // Use a background GeometryReader to get the height of the tab content.
+                    // This is used later as the height of the top-level GeometryReader, to override the default
+                    // behaviour of setting the frame to zero (and hiding the content.)
+                    GeometryReader { contentGeometry in
+                        Color.clear
+                            .onAppear {
+                                contentSize = contentGeometry.size
+                            }
+                            .onChange(of: contentGeometry.size) { newSize in
+                                contentSize = newSize
+                            }
+                    })
+                .offset(x: self.dragOffset(width: geometry.size.width))
+                .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
+                // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
+                .contentShape(Rectangle())
+                // The gesture could be simultaneous with an external scroll view
+                .simultaneousGesture(
+                    DragGesture()
+                        .updating($dragState) { drag, state, transaction in
+                            let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
+                            if isHorizontalDrag {
+                                state = .dragging(translation: drag.translation)
+                            }
+                        }
+                        .onEnded { drag in
+                            // We use `predictedEndTranslation` to account for velocity as the user ends the drag
+                            // For fast, short swipes, this will likely be higher than `translation`, and lead to a
+                            // more natural feeling animation.
+                            let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
+                            let threshold: CGFloat = geometry.size.width / 2
+                            let newIndex: Int
+                            if horizontalAmount > threshold {
+                                // A swipe more than 50% to the right: move back
+                                newIndex = max(selectedTab - 1, 0)
+                            } else if horizontalAmount < -threshold {
+                                // A swipe more than 50% to the left: move forward
+                                newIndex = min(selectedTab + 1, tabs.count - 1)
+                            } else {
+                                newIndex = selectedTab
+                            }
+                            // Notifiy the new tab that it's been selected, but only if it's changed
+                            if newIndex != selectedTab {
+                                tabs[newIndex].onSelected?()
+                            }
+                            // Update the selected tab to the new index
+                            withAnimation(.easeOut) {
+                                selectedTab = newIndex
+                            }
+                        }
+                )
             }
+            .frame(height: contentSize.height)
         }
     }
 
@@ -366,7 +364,18 @@ struct ContentView_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
             .preferredColorScheme(.dark)
             .previewDisplayName("Carrier Packages Dark Style")
-
+        TopTabView(tabs: carrierTabs,
+                   showContent: .constant(false),
+                   tabsContainerHorizontalPadding: nil,
+                   unselectedStateColor: .secondary,
+                   selectedTabIndicatorHeight: 3.0,
+                   tabPadding: 0,
+                   tabsNameFont: Font.subheadline.bold(),
+                   tabItemContentHorizontalPadding: 16.0,
+                   tabItemContentVerticalPadding: 9.0)
+            .previewLayout(.sizeThatFits)
+            .preferredColorScheme(.dark)
+            .previewDisplayName("Carrier Packages Without Content Dark Style")
         let oneTab: [TopTabItem] = [
             TopTabItem(name: "A tab name", content: {
                 List {
@@ -380,20 +389,7 @@ struct ContentView_Previews: PreviewProvider {
                         .font(.largeTitle)
                         .padding()
                 }
-            }),
-            TopTabItem(name: "A tab name", content: {
-                List {
-                    Text("Content for Tab 1")
-                        .font(.largeTitle)
-                        .padding()
-                    Text("Content for Tab 1")
-                        .font(.largeTitle)
-                        .padding()
-                    Text("Content for Tab 1")
-                        .font(.largeTitle)
-                        .padding()
-                }
-            }),
+            })
         ]
         TopTabView(tabs: oneTab)
             .previewLayout(.sizeThatFits)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -171,12 +171,12 @@ struct TopTabView<Content: View>: View {
                     // behaviour of setting the frame to zero (and hiding the content.)
                     GeometryReader { contentGeometry in
                         Color.clear
-                            .onAppear {
-                                contentSize = contentGeometry.size
-                            }
-                            .onChange(of: contentGeometry.size) { newSize in
-                                contentSize = newSize
-                            }
+                        .onAppear {
+                            contentSize = contentGeometry.size
+                        }
+                        .onChange(of: contentGeometry.size) { newSize in
+                            contentSize = newSize
+                        }
                     })
                 .offset(x: self.dragOffset(width: geometry.size.width))
                 .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -379,17 +379,9 @@ struct ContentView_Previews: PreviewProvider {
             .previewDisplayName("Carrier Packages Without Content Dark Style")
         let oneTab: [TopTabItem] = [
             TopTabItem(name: "A tab name", content: {
-                List {
-                    Text("Content for Tab 1")
-                        .font(.largeTitle)
-                        .padding()
-                    Text("Content for Tab 1")
-                        .font(.largeTitle)
-                        .padding()
-                    Text("Content for Tab 1")
-                        .font(.largeTitle)
-                        .padding()
-                }
+                Text("Content for Tab 1")
+                    .font(.largeTitle)
+                    .padding()
             })
         ]
         TopTabView(tabs: oneTab)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -18,13 +18,14 @@ struct TopTabItem<Content: View> {
 }
 
 struct TopTabView<Content: View>: View {
-    @State private var selectedTab = 0
+    @Binding var selectedTab: Int
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
     @GestureState private var dragState: DragState = .inactive
     @State private var contentSize: CGSize = .zero
 
     @Binding var showTabs: Bool
+    @Binding var showContent: Bool
 
     let tabs: [TopTabItem<Content>]
 
@@ -50,8 +51,10 @@ struct TopTabView<Content: View>: View {
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?
 
-    init(tabs: [TopTabItem<Content>],
+    init(selectedTab: Binding<Int> = .constant(0),
+         tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
+         showContent: Binding<Bool> = .constant(true),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
@@ -61,8 +64,10 @@ struct TopTabView<Content: View>: View {
          tabsIconSize: CGFloat? = 20.0,
          tabItemContentHorizontalPadding: CGFloat? = nil,
          tabItemContentVerticalPadding: CGFloat? = nil) {
+        self._selectedTab = selectedTab
         self.tabs = tabs
         self._showTabs = showTabs
+        self._showContent = showContent
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
         self.selectedStateColor = selectedStateColor
@@ -89,12 +94,13 @@ struct TopTabView<Content: View>: View {
                 .font(tabsNameFont)
                 .foregroundColor(selected ? selectedStateColor : unselectedStateColor)
                 .id(index)
-                .onTapGesture {
-                    withAnimation {
-                        selectedTab = index
-                        tabs[selectedTab].onSelected?()
-                    }
-                }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation {
+                selectedTab = index
+                tabs[selectedTab].onSelected?()
+            }
         }
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(selected ? [.isSelected, .isHeader] : [])
@@ -148,72 +154,73 @@ struct TopTabView<Content: View>: View {
                 Divider()
             }
 
-            // Display all the tabs in an HStack, each tab the same width as the TopTabView
-            // This GeometryReader is used to set the width and drag offsets for swiping between views
-            GeometryReader { geometry in
-                HStack(spacing: 0) {
-                    ForEach(0..<tabs.count, id: \.self) { index in
-                        // Tab content as passed to the TopTabView at init
-                        tabs[index].content()
-                            .frame(width: geometry.size.width)
+            if showContent {
+                // Display all the tabs in an HStack, each tab the same width as the TopTabView
+                // This GeometryReader is used to set the width and drag offsets for swiping between views
+                GeometryReader { geometry in
+                    HStack(spacing: 0) {
+                        ForEach(0..<tabs.count, id: \.self) { index in
+                            // Tab content as passed to the TopTabView at init
+                            tabs[index].content()
+                                .frame(width: geometry.size.width)
+                                .frame(height: max(geometry.size.height, contentSize.height))
+                        }
                     }
+                    .background(
+                        // Use a background GeometryReader to get the height of the tab content.
+                        // This is used later as the height of the top-level GeometryReader, to override the default
+                        // behaviour of setting the frame to zero (and hiding the content.)
+                        GeometryReader { contentGeometry in
+                            Color.clear
+                                .onAppear {
+                                    contentSize = contentGeometry.size
+                                }
+                                .onChange(of: contentGeometry.size) { newSize in
+                                    contentSize = newSize
+                                }
+                        })
+                    .offset(x: self.dragOffset(width: geometry.size.width))
+                    .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
+                    // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
+                    .contentShape(Rectangle())
+                    // The gesture could be simultaneous with an external scroll view
+                    .simultaneousGesture(
+                        DragGesture()
+                            .updating($dragState) { drag, state, transaction in
+                                let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
+                                if isHorizontalDrag {
+                                    state = .dragging(translation: drag.translation)
+                                }
+                            }
+                            .onEnded { drag in
+                                // We use `predictedEndTranslation` to account for velocity as the user ends the drag
+                                // For fast, short swipes, this will likely be higher than `translation`, and lead to a
+                                // more natural feeling animation.
+                                let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
+                                let threshold: CGFloat = geometry.size.width / 2
+                                let newIndex: Int
+                                if horizontalAmount > threshold {
+                                    // A swipe more than 50% to the right: move back
+                                    newIndex = max(selectedTab - 1, 0)
+                                } else if horizontalAmount < -threshold {
+                                    // A swipe more than 50% to the left: move forward
+                                    newIndex = min(selectedTab + 1, tabs.count - 1)
+                                } else {
+                                    newIndex = selectedTab
+                                }
+                                // Notifiy the new tab that it's been selected, but only if it's changed
+                                if newIndex != selectedTab {
+                                    tabs[newIndex].onSelected?()
+                                }
+                                // Update the selected tab to the new index
+                                withAnimation(.easeOut) {
+                                    selectedTab = newIndex
+                                }
+                            }
+                    )
                 }
-                .background(
-                    // Use a background GeometryReader to get the height of the tab content.
-                    // This is used later as the height of the top-level GeometryReader, to override the default
-                    // behaviour of setting the frame to zero (and hiding the content.)
-                    GeometryReader { contentGeometry in
-                        Color.clear
-                        .onAppear {
-                            contentSize = contentGeometry.size
-                        }
-                        .onChange(of: contentGeometry.size) { newSize in
-                            contentSize = newSize
-                        }
-                    })
-                .offset(x: self.dragOffset(width: geometry.size.width))
-                .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
-                // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
-                .contentShape(Rectangle())
-                // The gesture could be simultaneous with an external scroll view
-                .simultaneousGesture(
-                    DragGesture()
-                        .updating($dragState) { drag, state, transaction in
-                            let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
-                            if isHorizontalDrag {
-                                state = .dragging(translation: drag.translation)
-                            }
-                        }
-                        .onEnded { drag in
-                            // We use `predictedEndTranslation` to account for velocity as the user ends the drag
-                            // For fast, short swipes, this will likely be higher than `translation`, and lead to a
-                            // more natural feeling animation.
-                            let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
-                            let threshold: CGFloat = geometry.size.width / 2
-                            let newIndex: Int
-                            if horizontalAmount > threshold {
-                                // A swipe more than 50% to the right: move back
-                                newIndex = max(selectedTab - 1, 0)
-                            } else if horizontalAmount < -threshold {
-                                // A swipe more than 50% to the left: move forward
-                                newIndex = min(selectedTab + 1, tabs.count - 1)
-                            } else {
-                                newIndex = selectedTab
-                            }
-
-                            // Notifiy the new tab that it's been selected, but only if it's changed
-                            if newIndex != selectedTab {
-                                tabs[newIndex].onSelected?()
-                            }
-
-                            // Update the selected tab to the new index
-                            withAnimation(.easeOut) {
-                                selectedTab = newIndex
-                            }
-                        }
-                )
+                .frame(height: contentSize.height)
             }
-            .frame(height: contentSize.height)
         }
     }
 
@@ -362,10 +369,31 @@ struct ContentView_Previews: PreviewProvider {
 
         let oneTab: [TopTabItem] = [
             TopTabItem(name: "A tab name", content: {
-                Text("Content for Tab 1")
-                    .font(.largeTitle)
-                    .padding()
-            })
+                List {
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                }
+            }),
+            TopTabItem(name: "A tab name", content: {
+                List {
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                }
+            }),
         ]
         TopTabView(tabs: oneTab)
             .previewLayout(.sizeThatFits)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -18,13 +18,14 @@ struct TopTabItem<Content: View> {
 }
 
 struct TopTabView<Content: View>: View {
-    @State private var selectedTab = 0
+    @Binding var selectedTab: Int
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
     @GestureState private var dragState: DragState = .inactive
     @State private var contentSize: CGSize = .zero
 
     @Binding var showTabs: Bool
+    @Binding var showContent: Bool
 
     let tabs: [TopTabItem<Content>]
 
@@ -50,8 +51,10 @@ struct TopTabView<Content: View>: View {
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?
 
-    init(tabs: [TopTabItem<Content>],
+    init(selectedTab: Binding<Int> = .constant(0),
+         tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
+         showContent: Binding<Bool> = .constant(true),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
@@ -61,8 +64,10 @@ struct TopTabView<Content: View>: View {
          tabsIconSize: CGFloat? = 20.0,
          tabItemContentHorizontalPadding: CGFloat? = nil,
          tabItemContentVerticalPadding: CGFloat? = nil) {
+        self._selectedTab = selectedTab
         self.tabs = tabs
         self._showTabs = showTabs
+        self._showContent = showContent
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
         self.selectedStateColor = selectedStateColor
@@ -89,12 +94,13 @@ struct TopTabView<Content: View>: View {
                 .font(tabsNameFont)
                 .foregroundColor(selected ? selectedStateColor : unselectedStateColor)
                 .id(index)
-                .onTapGesture {
-                    withAnimation {
-                        selectedTab = index
-                        tabs[selectedTab].onSelected?()
-                    }
-                }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation {
+                selectedTab = index
+                tabs[selectedTab].onSelected?()
+            }
         }
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(selected ? [.isSelected, .isHeader] : [])
@@ -148,72 +154,72 @@ struct TopTabView<Content: View>: View {
                 Divider()
             }
 
-            // Display all the tabs in an HStack, each tab the same width as the TopTabView
-            // This GeometryReader is used to set the width and drag offsets for swiping between views
-            GeometryReader { geometry in
-                HStack(alignment: .top, spacing: 0) {
-                    ForEach(0..<tabs.count, id: \.self) { index in
-                        // Tab content as passed to the TopTabView at init
-                        tabs[index].content()
-                            .frame(width: geometry.size.width)
+            if showContent {
+                // Display all the tabs in an HStack, each tab the same width as the TopTabView
+                // This GeometryReader is used to set the width and drag offsets for swiping between views
+                GeometryReader { geometry in
+                    HStack(alignment: .top, spacing: 0) {
+                        ForEach(0..<tabs.count, id: \.self) { index in
+                            // Tab content as passed to the TopTabView at init
+                            tabs[index].content()
+                                .frame(width: geometry.size.width)
+                        }
                     }
+                    .background(
+                        // Use a background GeometryReader to get the height of the tab content.
+                        // This is used later as the height of the top-level GeometryReader, to override the default
+                        // behaviour of setting the frame to zero (and hiding the content.)
+                        GeometryReader { contentGeometry in
+                            Color.clear
+                                .onAppear {
+                                    contentSize = contentGeometry.size
+                                }
+                                .onChange(of: contentGeometry.size) { newSize in
+                                    contentSize = newSize
+                                }
+                        })
+                    .offset(x: self.dragOffset(width: geometry.size.width))
+                    .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
+                    // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
+                    .contentShape(Rectangle())
+                    // The gesture could be simultaneous with an external scroll view
+                    .simultaneousGesture(
+                        DragGesture()
+                            .updating($dragState) { drag, state, transaction in
+                                let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
+                                if isHorizontalDrag {
+                                    state = .dragging(translation: drag.translation)
+                                }
+                            }
+                            .onEnded { drag in
+                                // We use `predictedEndTranslation` to account for velocity as the user ends the drag
+                                // For fast, short swipes, this will likely be higher than `translation`, and lead to a
+                                // more natural feeling animation.
+                                let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
+                                let threshold: CGFloat = geometry.size.width / 2
+                                let newIndex: Int
+                                if horizontalAmount > threshold {
+                                    // A swipe more than 50% to the right: move back
+                                    newIndex = max(selectedTab - 1, 0)
+                                } else if horizontalAmount < -threshold {
+                                    // A swipe more than 50% to the left: move forward
+                                    newIndex = min(selectedTab + 1, tabs.count - 1)
+                                } else {
+                                    newIndex = selectedTab
+                                }
+                                // Notifiy the new tab that it's been selected, but only if it's changed
+                                if newIndex != selectedTab {
+                                    tabs[newIndex].onSelected?()
+                                }
+                                // Update the selected tab to the new index
+                                withAnimation(.easeOut) {
+                                    selectedTab = newIndex
+                                }
+                            }
+                    )
                 }
-                .background(
-                    // Use a background GeometryReader to get the height of the tab content.
-                    // This is used later as the height of the top-level GeometryReader, to override the default
-                    // behaviour of setting the frame to zero (and hiding the content.)
-                    GeometryReader { contentGeometry in
-                        Color.clear
-                        .onAppear {
-                            contentSize = contentGeometry.size
-                        }
-                        .onChange(of: contentGeometry.size) { newSize in
-                            contentSize = newSize
-                        }
-                    })
-                .offset(x: self.dragOffset(width: geometry.size.width))
-                .animation(.interactiveSpring(), value: dragOffset(width: geometry.size.width))
-                // Allows swipes to be started on any part of the content view area, not just occupied space e.g. Text.
-                .contentShape(Rectangle())
-                // The gesture could be simultaneous with an external scroll view
-                .simultaneousGesture(
-                    DragGesture()
-                        .updating($dragState) { drag, state, transaction in
-                            let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
-                            if isHorizontalDrag {
-                                state = .dragging(translation: drag.translation)
-                            }
-                        }
-                        .onEnded { drag in
-                            // We use `predictedEndTranslation` to account for velocity as the user ends the drag
-                            // For fast, short swipes, this will likely be higher than `translation`, and lead to a
-                            // more natural feeling animation.
-                            let horizontalAmount = drag.predictedEndTranslation.width as CGFloat
-                            let threshold: CGFloat = geometry.size.width / 2
-                            let newIndex: Int
-                            if horizontalAmount > threshold {
-                                // A swipe more than 50% to the right: move back
-                                newIndex = max(selectedTab - 1, 0)
-                            } else if horizontalAmount < -threshold {
-                                // A swipe more than 50% to the left: move forward
-                                newIndex = min(selectedTab + 1, tabs.count - 1)
-                            } else {
-                                newIndex = selectedTab
-                            }
-
-                            // Notifiy the new tab that it's been selected, but only if it's changed
-                            if newIndex != selectedTab {
-                                tabs[newIndex].onSelected?()
-                            }
-
-                            // Update the selected tab to the new index
-                            withAnimation(.easeOut) {
-                                selectedTab = newIndex
-                            }
-                        }
-                )
+                .frame(height: contentSize.height)
             }
-            .frame(height: contentSize.height)
         }
     }
 
@@ -359,12 +365,31 @@ struct ContentView_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
             .preferredColorScheme(.dark)
             .previewDisplayName("Carrier Packages Dark Style")
-
+        TopTabView(tabs: carrierTabs,
+                   showContent: .constant(false),
+                   tabsContainerHorizontalPadding: nil,
+                   unselectedStateColor: .secondary,
+                   selectedTabIndicatorHeight: 3.0,
+                   tabPadding: 0,
+                   tabsNameFont: Font.subheadline.bold(),
+                   tabItemContentHorizontalPadding: 16.0,
+                   tabItemContentVerticalPadding: 9.0)
+            .previewLayout(.sizeThatFits)
+            .preferredColorScheme(.dark)
+            .previewDisplayName("Carrier Packages Without Content Dark Style")
         let oneTab: [TopTabItem] = [
             TopTabItem(name: "A tab name", content: {
-                Text("Content for Tab 1")
-                    .font(.largeTitle)
-                    .padding()
+                List {
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                    Text("Content for Tab 1")
+                        .font(.largeTitle)
+                        .padding()
+                }
             })
         ]
         TopTabView(tabs: oneTab)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing 
“See original issue” – clarify what the problem was and how you’ve fixed it. -->

Few more additions on top of previous PR https://github.com/woocommerce/woocommerce-ios/pull/14192

Added:
- option to show or hide content, which is useful if we just want to use that top part of the whole UI component
- added optional `selectedTabIndex ` Binding so we can get updated on what tab is selected (from the outside)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Showing content    | Hiding content |
| -------- | ------- |
| <img width="568" alt="Screenshot 2024-10-29 at 11 22 28" src="https://github.com/user-attachments/assets/c7797c81-ca22-4f04-90f2-6fb58ff13829"> | <img width="567" alt="Screenshot 2024-10-29 at 11 22 49" src="https://github.com/user-attachments/assets/b382793a-481d-4c51-ab59-7bc2b33bf999"> |

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
