### PR TITLE
Revert 'Log storage usage for core data crashes'

### DIFF
--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -47,7 +47,7 @@ public final class CoreDataManager: StorageManagerType {
             // We'll throw a fatalError() because we can't really proceed without a
             // ManagedObjectModel.
             let error = CoreDataManagerError.modelInventoryLoadingFailed(name, error)
-            crashLogger.logFatalErrorAndExit(error, userInfo: ["storageUsage": Self.storageSizeLogProperties() as Any])
+            crashLogger.logFatalErrorAndExit(error, userInfo: nil)
         }
     }
 
@@ -121,8 +121,7 @@ public final class CoreDataManager: StorageManagerType {
                                                      "persistentStoreRemovalError": persistentStoreRemovalError,
                                                      "retryError": underlyingError,
                                                      "appState": UIApplication.shared.applicationState.rawValue,
-                                                     "migrationMessages": migrationDebugMessages,
-                                                     "storageUsage": Self.storageSizeLogProperties()]
+                                                     "migrationMessages": migrationDebugMessages]
                 self?.crashLogger.logFatalErrorAndExit(error,
                                                        userInfo: logProperties.compactMapValues { $0 })
             }
@@ -130,8 +129,7 @@ public final class CoreDataManager: StorageManagerType {
             let logProperties: [String: Any?] = ["persistentStoreLoadingError": persistentStoreLoadingError,
                                                  "persistentStoreRemovalError": persistentStoreRemovalError,
                                                  "appState": UIApplication.shared.applicationState.rawValue,
-                                                 "migrationMessages": migrationDebugMessages,
-                                                 "storageUsage": Self.storageSizeLogProperties()]
+                                                 "migrationMessages": migrationDebugMessages]
             self.crashLogger.logMessage("[CoreDataManager] Recovered from persistent store loading error",
                                         properties: logProperties.compactMapValues { $0 },
                                         level: .info)
@@ -272,66 +270,6 @@ public final class CoreDataManager: StorageManagerType {
             debugMessages.append(migrationErrorMessage)
             DDLogError(migrationErrorMessage)
             return debugMessages
-        }
-    }
-
-    /// Note that we have to enumerate all the files in our sandbox to get these properties, so this takes some time.
-    /// It is intended _only_ for use when logging a crash, or other high-value log which won't get in the user's way.
-    private static func storageSizeLogProperties() -> [String: String]? {
-        let directoryUrls: [String: URL] = [
-            "Bundle": Bundle.main.bundleURL,
-            "Documents": FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
-            "Library": FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first,
-            "Temp": FileManager.default.temporaryDirectory,
-        ].compactMapValues { $0 }
-
-        let sizes = directoryAndTotalSizes(for: directoryUrls)
-
-        return formatStorageSizeLogs(sizes)
-    }
-
-    private static func directoryAndTotalSizes(for directoryUrls: [String: URL]) -> [String: Int64] {
-        let directorySizes = directoryUrls.mapValues { url in
-            getAllocatedStorageSize(for: url)
-        }
-
-        let totalSize = directorySizes.values.reduce(0) { partialResult, size in
-            return partialResult + size
-        }
-
-        return directorySizes.merging(["Total": totalSize]) { first, _ in
-            first
-        }
-    }
-
-    /// Getting the size on disk isn't straightforward – this does not take into account all extended attributes, for example.
-    /// Generally the value returned here is an underestimate, but within 10% of the value iOS settings reports.
-    /// Using `fileAllocatedSize` as a fallback helps avoid counting some files as 0.
-    private static func getAllocatedStorageSize(for url: URL) -> Int64 {
-        let fileSizeKeys: [URLResourceKey] = [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
-        guard let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: fileSizeKeys) else {
-            return 0
-        }
-
-        var totalSize: Int64 = 0
-
-        let fileSizeKeysSet = Set(fileSizeKeys)
-        for case let fileUrl as URL in enumerator {
-            if let fileSizeResource = try? fileUrl.resourceValues(forKeys: fileSizeKeysSet),
-               let fileSize = fileSizeResource.totalFileAllocatedSize ?? fileSizeResource.fileAllocatedSize {
-                totalSize += Int64(fileSize)
-            }
-        }
-
-        return totalSize
-    }
-
-    private static func formatStorageSizeLogs(_ sizes: [String: Int64]) -> [String: String] {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useMB]
-
-        return sizes.mapValues { byteCount in
-            formatter.string(fromByteCount: byteCount)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->


Revert https://github.com/woocommerce/woocommerce-ios/pull/14008/.

We no longer receive crash reports for the case we added additional logging. More context: peaMlT-Np-p2#comment-2447

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This PR reverts to the previous functionality of not logging any storage issues. The CI build should succeed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.