### PR TITLE
[Global Unique Identifier • Product] Edit Value

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2658,6 +2658,7 @@ extension Networking.ProductVariation {
         status: CopiableProp<ProductStatus> = .copy,
         description: NullableCopiableProp<String> = .copy,
         sku: NullableCopiableProp<String> = .copy,
+        globalUniqueID: NullableCopiableProp<String> = .copy,
         price: CopiableProp<String> = .copy,
         regularPrice: NullableCopiableProp<String> = .copy,
         salePrice: NullableCopiableProp<String> = .copy,
@@ -2700,6 +2701,7 @@ extension Networking.ProductVariation {
         let status = status ?? self.status
         let description = description ?? self.description
         let sku = sku ?? self.sku
+        let globalUniqueID = globalUniqueID ?? self.globalUniqueID
         let price = price ?? self.price
         let regularPrice = regularPrice ?? self.regularPrice
         let salePrice = salePrice ?? self.salePrice

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -691,6 +691,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
 
         // Inventory Settings.
         try container.encode(sku, forKey: .sku)
+        try container.encode(globalUniqueID, forKey: .globalUniqueID)
         try container.encode(manageStock, forKey: .manageStock)
         try container.encode(soldIndividually, forKey: .soldIndividually)
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
@@ -4,6 +4,7 @@ import Yosemite
 ///
 struct ProductInventoryEditableData: Equatable {
     let sku: String?
+    let globalUniqueIdentifier: String?
     let manageStock: Bool
     let soldIndividually: Bool?
     let stockQuantity: Decimal?
@@ -14,6 +15,7 @@ struct ProductInventoryEditableData: Equatable {
 extension ProductInventoryEditableData {
     init(productModel: ProductFormDataModel) {
         self.sku = productModel.sku
+        self.globalUniqueIdentifier = productModel.globalUniqueID
         self.manageStock = productModel.manageStock
         self.soldIndividually = productModel.soldIndividually
         self.stockQuantity = productModel.stockQuantity

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -286,6 +286,7 @@ private extension ProductInventorySettingsViewController {
             break
         }
         cell.configure(viewModel: cellViewModel)
+        cell.setSpacingBetweenTitleAndTextField(30)
 
         // Configures accessory view for adding SKU from barcode scanner if camera is available.
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -306,7 +306,8 @@ private extension ProductInventorySettingsViewController {
     }
 
     func configureGlobalUniqueIdentifier(cell: TitleAndTextFieldTableViewCell) {
-        let cellViewModel = Product.createGlobalUniqueIdentifierViewModel(globalUniqueID: viewModel.globalUniqueID) { _ in
+        let cellViewModel = Product.createGlobalUniqueIdentifierViewModel(globalUniqueID: viewModel.globalUniqueID) { [weak self] value in
+            self?.viewModel.handleGlobalUniqueIdentifierChange(value)
         }
 
         cell.configure(viewModel: cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -218,6 +218,7 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
 
         // Checks general settings regardless of whether stock management is enabled.
         let hasChangesInGeneralSettings = sku != productModel.sku
+            || globalUniqueID != productModel.globalUniqueID
             || manageStockEnabled != productModel.manageStock
             || soldIndividually != productModel.soldIndividually
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -44,6 +44,7 @@ protocol ProductInventorySettingsViewModelOutput {
 protocol ProductInventorySettingsActionHandler {
     // Input field actions
     func handleSKUChange(_ sku: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void)
+    func handleGlobalUniqueIdentifierChange(_ globalUniqueID: String?)
     func handleSKUFromBarcodeScanner(_ sku: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void)
     func handleManageStockEnabledChange(_ manageStockEnabled: Bool)
     func handleSoldIndividuallyChange(_ soldIndividually: Bool?)
@@ -160,6 +161,11 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
         }
     }
 
+    func handleGlobalUniqueIdentifierChange(_ globalUniqueID: String?) {
+        self.globalUniqueID = globalUniqueID
+        reloadSections()
+    }
+
     func handleSKUFromBarcodeScanner(_ sku: String?, onValidation: @escaping (Bool, Bool) -> Void) {
         // Displays SKU before validation.
         self.sku = sku
@@ -196,6 +202,7 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
     func completeUpdating(onCompletion: (ProductInventoryEditableData) -> Void) {
         if skuIsValid {
             let data = ProductInventoryEditableData(sku: sku,
+                                                    globalUniqueIdentifier: globalUniqueID,
                                                     manageStock: manageStockEnabled,
                                                     soldIndividually: soldIndividually,
                                                     stockQuantity: stockQuantity,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -163,7 +163,6 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
 
     func handleGlobalUniqueIdentifierChange(_ globalUniqueID: String?) {
         self.globalUniqueID = globalUniqueID
-        reloadSections()
     }
 
     func handleSKUFromBarcodeScanner(_ sku: String?, onValidation: @escaping (Bool, Bool) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1619,6 +1619,7 @@ private extension ProductFormViewController {
             return
         }
         viewModel.updateInventorySettings(sku: data.sku,
+                                          globalUniqueIdentifier: data.globalUniqueIdentifier,
                                           manageStock: data.manageStock,
                                           soldIndividually: data.soldIndividually,
                                           stockQuantity: data.stockQuantity,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -400,12 +400,14 @@ extension ProductFormViewModel {
     }
 
     func updateInventorySettings(sku: String?,
+                                 globalUniqueIdentifier: String?,
                                  manageStock: Bool,
                                  soldIndividually: Bool?,
                                  stockQuantity: Decimal?,
                                  backordersSetting: ProductBackordersSetting?,
                                  stockStatus: ProductStockStatus?) {
         product = EditableProductModel(product: product.product.copy(sku: sku,
+                                                                     globalUniqueID: globalUniqueIdentifier,
                                                                      manageStock: manageStock,
                                                                      stockQuantity: stockQuantity,
                                                                      stockStatusKey: stockStatus?.rawValue,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -113,6 +113,7 @@ protocol ProductFormViewModelProtocol {
                              taxClass: TaxClass?)
 
     func updateInventorySettings(sku: String?,
+                                 globalUniqueIdentifier: String?,
                                  manageStock: Bool,
                                  soldIndividually: Bool?,
                                  stockQuantity: Decimal?,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -266,12 +266,14 @@ extension ProductVariationFormViewModel {
     }
 
     func updateInventorySettings(sku: String?,
+                                 globalUniqueIdentifier: String?,
                                  manageStock: Bool,
                                  soldIndividually: Bool?,
                                  stockQuantity: Decimal?,
                                  backordersSetting: ProductBackordersSetting?,
                                  stockStatus: ProductStockStatus?) {
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(sku: sku,
+                                                                                                                  globalUniqueID: globalUniqueIdentifier,
                                                                                                                   manageStock: manageStock,
                                                                                                                   stockQuantity: stockQuantity,
                                                                                                                   stockStatus: stockStatus,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
@@ -268,6 +268,19 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
+    func testViewModelHasUnsavedChangesAfterUpdatingGlobalUniqueId() {
+        // Arrange
+        let product = Product.fake().copy(globalUniqueID: "321")
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
+
+        // Act
+        viewModel.handleGlobalUniqueIdentifierChange("123")
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
     func testViewModelHasNoUnsavedChangesAfterUpdatingWithTheOriginalValues() {
         // Arrange
         let product = Product.fake()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -67,6 +67,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
                                       taxStatus: product.productTaxStatus,
                                       taxClass: taxClass)
         viewModel.updateInventorySettings(sku: product.sku,
+                                          globalUniqueIdentifier: product.globalUniqueID,
                                           manageStock: product.manageStock,
                                           soldIndividually: product.soldIndividually,
                                           stockQuantity: product.stockQuantity,
@@ -230,6 +231,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         // When
         viewModel.updateInventorySettings(
             sku: "",
+            globalUniqueIdentifier: "",
             manageStock: false,
             soldIndividually: true,
             stockQuantity: 888888,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -102,6 +102,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                       taxStatus: product.productTaxStatus,
                                       taxClass: taxClass)
         viewModel.updateInventorySettings(sku: product.sku,
+                                          globalUniqueIdentifier: product.globalUniqueID,
                                           manageStock: product.manageStock,
                                           soldIndividually: product.soldIndividually,
                                           stockQuantity: product.stockQuantity,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -130,12 +130,14 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
 
         // Action
         let newSKU = "94115"
+        let newGlobalUniqueID = "22341"
         let newManageStock = !product.manageStock
         let newSoldIndividually = !product.soldIndividually
         let newStockQuantity: Decimal = 17
         let newBackordersSetting = ProductBackordersSetting.allowedAndNotifyCustomer
         let newStockStatus = ProductStockStatus.onBackOrder
         viewModel.updateInventorySettings(sku: newSKU,
+                                          globalUniqueIdentifier: newGlobalUniqueID,
                                           manageStock: newManageStock,
                                           soldIndividually: newSoldIndividually,
                                           stockQuantity: newStockQuantity,
@@ -144,6 +146,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.productModel.sku, newSKU)
+        XCTAssertEqual(viewModel.productModel.globalUniqueID, newGlobalUniqueID)
         XCTAssertEqual(viewModel.productModel.manageStock, newManageStock)
         XCTAssertEqual(viewModel.productModel.product.soldIndividually, newSoldIndividually)
         XCTAssertEqual(viewModel.productModel.stockQuantity, newStockQuantity)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -53,6 +53,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
                                       taxStatus: model.productTaxStatus,
                                       taxClass: nil)
         viewModel.updateInventorySettings(sku: productVariation.sku,
+                                          globalUniqueIdentifier: productVariation.globalUniqueID,
                                           manageStock: productVariation.manageStock,
                                           soldIndividually: nil,
                                           stockQuantity: productVariation.stockQuantity,
@@ -158,7 +159,13 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
 
     func test_product_variation_has_unsaved_changes_from_editing_inventory_settings() {
         // Action
-        viewModel.updateInventorySettings(sku: "", manageStock: false, soldIndividually: nil, stockQuantity: 888888, backordersSetting: nil, stockStatus: nil)
+        viewModel.updateInventorySettings(sku: "",
+                                          globalUniqueIdentifier: "",
+                                          manageStock: false,
+                                          soldIndividually: nil,
+                                          stockQuantity: 888888,
+                                          backordersSetting: nil,
+                                          stockStatus: nil)
 
         // Assert
         XCTAssertTrue(viewModel.hasUnsavedChanges())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -64,6 +64,7 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
                                       taxStatus: model.productTaxStatus,
                                       taxClass: nil)
         viewModel.updateInventorySettings(sku: productVariation.sku,
+                                          globalUniqueIdentifier: productVariation.globalUniqueID,
                                           manageStock: productVariation.manageStock,
                                           soldIndividually: nil,
                                           stockQuantity: productVariation.stockQuantity,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -97,11 +97,13 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
 
         // Action
         let newSKU = "94115"
+        let newGlobalUniqueID = "12345"
         let newManageStock = !productVariation.manageStock
         let newStockQuantity: Decimal = 17
         let newBackordersSetting = ProductBackordersSetting.allowedAndNotifyCustomer
         let newStockStatus = ProductStockStatus.onBackOrder
         viewModel.updateInventorySettings(sku: newSKU,
+                                          globalUniqueIdentifier: newGlobalUniqueID,
                                           manageStock: newManageStock,
                                           soldIndividually: nil,
                                           stockQuantity: newStockQuantity,
@@ -110,6 +112,7 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(viewModel.productModel.sku, newSKU)
+        XCTAssertEqual(viewModel.productModel.globalUniqueID, newGlobalUniqueID)
         XCTAssertEqual(viewModel.productModel.manageStock, newManageStock)
         XCTAssertEqual(viewModel.productModel.stockQuantity, newStockQuantity)
         XCTAssertEqual(viewModel.productModel.backordersSetting, newBackordersSetting)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14191 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we edit the global unique identifier value for products in the Inventory settings. Validation and edition via barcode scanner will be part of subsequent PRs.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to Products
2. Tap on a product
3. Tap on Inventory
4. Edit the field on GTIN, UPC, EAN, ISBN
5. Tap on Done
6. Tap on Save

Verify that the value is properly edited. You can check in the app and wp-admin. Repeat the process for variations.

### Unsaved Changes
1. Go to Products
2. Tap on a product
3. Tap on Inventory
4. Edit the field on GTIN, UPC, EAN, ISBN
5. Tap on Back arrow

An alert should be displayed to warn that there are unsaved changes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
See steps above

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Product

https://github.com/user-attachments/assets/3202afe4-ee7a-4db2-93e9-4e954c31eb18

### Variation

https://github.com/user-attachments/assets/d23661b4-5ff4-4011-bae9-22547d9f4585

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
