### PR TITLE
[Global Unique Identifier • Product] Scan barcode and set to value in Inventory

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -751,6 +751,8 @@ enum WooAnalyticsStat: String {
     case productDetailViewProductAddOnsTapped = "product_detail_view_product_addons_tapped"
     case productInventorySettingsSKUScannerButtonTapped = "product_inventory_settings_sku_scanner_button_tapped"
     case productInventorySettingsSKUScanned = "product_inventory_settings_sku_scanned"
+    case productInventorySettingsGlobalUniqueIDScannerButtonTapped = "product_inventory_settings_global_unique_id_scanner_button_tapped"
+    case productInventorySettingsGlobalUniqueIDScanned = "product_inventory_settings_global_unique_id_scanned"
     case productDetailPreviewTapped = "product_detail_preview_tapped"
     case productDetailPreviewFailed = "product_detail_preview_failed"
     case productDetailViewBundledProductsTapped = "product_detail_view_bundled_products_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -1032,7 +1032,7 @@ private struct ProductSKUInputScannerView: UIViewControllerRepresentable {
     let onBarcodeScanned: ((ScannedBarcode) -> Void)?
 
     func makeUIViewController(context: Context) -> ScannerContainerViewController {
-        SKUCodeScannerProvider.SKUCodeScanner(onBarcodeScanned: { barcode in
+        ProductBarcodeScannerProvider.barcodeScanner(onBarcodeScanned: { barcode in
             onBarcodeScanned?(barcode)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -68,7 +68,7 @@ final class OrdersRootViewController: UIViewController {
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
-    private var barcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
+    private var barcodeScannerCoordinator: ProducBarcodeScannerCoordinator?
 
     private let switchDetailsHandler: OrderListViewController.SelectOrderDetails
 
@@ -251,8 +251,8 @@ final class OrdersRootViewController: UIViewController {
             return
         }
 
-        let productSKUBarcodeScannerCoordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
-                                                                                      onSKUBarcodeScanned: { [weak self] scannedBarcode in
+        let productSKUBarcodeScannerCoordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                                                  onBarcodeScanned: { [weak self] scannedBarcode in
             self?.analytics.track(event: .BarcodeScanning.barcodeScanningSuccess(from: .orderList))
 
             self?.navigationItem.configureLeftBarButtonItemAsLoader()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -322,6 +322,9 @@ private extension ProductInventorySettingsViewController {
         }
 
         let button = UIButton(type: .detailDisclosure)
+        button.addAction(UIAction(handler: { [weak self] _ in
+            self?.scanGlobalUniqueIdentifierButtonTapped()
+        }), for: .touchUpInside)
         button.applyIconButtonStyle(icon: .scanImage)
         button.accessibilityLabel = NSLocalizedString("Scan products", comment: "Scan Products")
         button.accessibilityHint = NSLocalizedString("productInventorySettings.GlobalUniqueIdentifier.ScanButton",
@@ -374,16 +377,34 @@ private extension ProductInventorySettingsViewController {
 //
 private extension ProductInventorySettingsViewController {
     func scanSKUButtonTapped() {
+        ServiceLocator.analytics.track(.productInventorySettingsSKUScannerButtonTapped)
+
+        startBarcodeScanning(onCompletion: { [weak self] barcode in
+            ServiceLocator.analytics.track(.productInventorySettingsSKUScanned)
+            self?.onSKUBarcodeScanned(barcode: barcode)
+        })
+    }
+
+    func scanGlobalUniqueIdentifierButtonTapped() {
+        ServiceLocator.analytics.track(.productInventorySettingsSKUScannerButtonTapped)
+
+        startBarcodeScanning(onCompletion: { [weak self] barcode in
+            ServiceLocator.analytics.track(.productInventorySettingsSKUScanned)
+            self?.viewModel.handleGlobalUniqueIdentifierFromBarcodeScanner(barcode)
+        })
+    }
+
+    func startBarcodeScanning(onCompletion: @escaping (_ barcode: String) -> Void) {
         guard let navigationController = navigationController else {
             return
         }
 
         ServiceLocator.analytics.track(.productInventorySettingsSKUScannerButtonTapped)
 
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController) { [weak self] barcode in
-            ServiceLocator.analytics.track(.productInventorySettingsSKUScanned)
-            self?.onSKUBarcodeScanned(barcode: barcode.payloadStringValue)
+        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController) { barcode in
+            onCompletion(barcode.payloadStringValue)
         }
+
         view.endEditing(true)
         skuBarcodeScannerCoordinator = coordinator
         coordinator.start()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -27,7 +27,7 @@ final class ProductInventorySettingsViewController: UIViewController {
     typealias Completion = (_ data: ProductInventoryEditableData) -> Void
     private let onCompletion: Completion
 
-    private var skuBarcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
+    private var skuBarcodeScannerCoordinator: ProducBarcodeScannerCoordinator?
 
     private var sectionsSubscription: AnyCancellable?
 
@@ -386,10 +386,10 @@ private extension ProductInventorySettingsViewController {
     }
 
     func scanGlobalUniqueIdentifierButtonTapped() {
-        ServiceLocator.analytics.track(.productInventorySettingsSKUScannerButtonTapped)
+        ServiceLocator.analytics.track(.productInventorySettingsGlobalUniqueIDScannerButtonTapped)
 
         startBarcodeScanning(onCompletion: { [weak self] barcode in
-            ServiceLocator.analytics.track(.productInventorySettingsSKUScanned)
+            ServiceLocator.analytics.track(.productInventorySettingsGlobalUniqueIDScanned)
             self?.viewModel.handleGlobalUniqueIdentifierFromBarcodeScanner(barcode)
         })
     }
@@ -399,9 +399,7 @@ private extension ProductInventorySettingsViewController {
             return
         }
 
-        ServiceLocator.analytics.track(.productInventorySettingsSKUScannerButtonTapped)
-
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController) { barcode in
+        let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController) { barcode in
             onCompletion(barcode.payloadStringValue)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -46,6 +46,7 @@ protocol ProductInventorySettingsActionHandler {
     func handleSKUChange(_ sku: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void)
     func handleGlobalUniqueIdentifierChange(_ globalUniqueID: String?)
     func handleSKUFromBarcodeScanner(_ sku: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void)
+    func handleGlobalUniqueIdentifierFromBarcodeScanner(_ globalUniqueID: String?)
     func handleManageStockEnabledChange(_ manageStockEnabled: Bool)
     func handleSoldIndividuallyChange(_ soldIndividually: Bool?)
     func handleStockQuantityChange(_ stockQuantity: String?)
@@ -170,6 +171,11 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
         self.sku = sku
         reloadSections()
         handleSKUChange(sku, onValidation: onValidation)
+    }
+
+    func handleGlobalUniqueIdentifierFromBarcodeScanner(_ globalUniqueID: String?) {
+        handleGlobalUniqueIdentifierChange(globalUniqueID)
+        reloadSections()
     }
 
     func handleManageStockEnabledChange(_ manageStockEnabled: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -27,7 +27,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
     ///
     @IBOutlet weak var tableView: UITableView!
 
-    private var barcodeScannerCoordinator: ProductSKUBarcodeScannerCoordinator?
+    private var barcodeScannerCoordinator: ProducBarcodeScannerCoordinator?
 
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(sectionHeaderVerticalSpace: .medium,
                                                                                                 cellClass: ProductsTabProductTableViewCell.self,
@@ -324,8 +324,8 @@ private extension ProductsViewController {
 
         self.configureLeftBarBarButtomItemAsScanningButtonIfApplicable()
 
-        let productSKUBarcodeScannerCoordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
-                                                                                      onSKUBarcodeScanned: { [weak self] scannedBarcode in
+        let productSKUBarcodeScannerCoordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+                                                                                  onBarcodeScanned: { [weak self] scannedBarcode in
             guard let self = self else { return }
             ServiceLocator.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningSuccess(from: .productList))
 

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProducBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProducBarcodeScannerCoordinator.swift
@@ -1,20 +1,20 @@
 import Experiments
 import UIKit
 
-/// Coordinates navigation for product SKU barcode scanner based on camera permission.
-final class ProductSKUBarcodeScannerCoordinator: Coordinator {
+/// Coordinates navigation for product barcode scanner based on camera permission.
+final class ProducBarcodeScannerCoordinator: Coordinator {
     let navigationController: UINavigationController
     private let permissionChecker: CaptureDevicePermissionChecker
-    private let onSKUBarcodeScanned: (_ barcode: ScannedBarcode) -> Void
+    private let onBarcodeScanned: (_ barcode: ScannedBarcode) -> Void
     private let onPermissionsDenied: (() -> Void)?
 
     init(sourceNavigationController: UINavigationController,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
-         onSKUBarcodeScanned: @escaping (_ barcode: ScannedBarcode) -> Void,
+         onBarcodeScanned: @escaping (_ barcode: ScannedBarcode) -> Void,
          onPermissionsDenied: (() -> Void)? = nil) {
         self.navigationController = sourceNavigationController
         self.permissionChecker = permissionChecker
-        self.onSKUBarcodeScanned = onSKUBarcodeScanned
+        self.onBarcodeScanned = onBarcodeScanned
         self.onPermissionsDenied = onPermissionsDenied
     }
 
@@ -29,19 +29,19 @@ final class ProductSKUBarcodeScannerCoordinator: Coordinator {
         case .notDetermined:
             permissionChecker.requestAccess(for: .video) { [weak self] granted in
                 if granted {
-                    self?.showSKUScanner()
+                    self?.showScanner()
                 }
             }
         default:
-            showSKUScanner()
+            showScanner()
         }
     }
 }
 
-private extension ProductSKUBarcodeScannerCoordinator {
-    func showSKUScanner() {
-        let scannerViewController = SKUCodeScannerProvider.SKUCodeScanner(onBarcodeScanned: { [weak self] barcode in
-            self?.onSKUBarcodeScanned(barcode)
+private extension ProducBarcodeScannerCoordinator {
+    func showScanner() {
+        let scannerViewController = ProductBarcodeScannerProvider.barcodeScanner(onBarcodeScanned: { [weak self] barcode in
+            self?.onBarcodeScanned(barcode)
             self?.navigationController.dismiss(animated: true)
         })
 

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/SKUCodeScannerProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/SKUCodeScannerProvider.swift
@@ -1,22 +1,22 @@
 import Foundation
 
-/// Provides a `ScannerContainerViewController` customized to find Product SKU strings
+/// Provides a `ScannerContainerViewController` customized to find Product Barcode strings
 ///
-class SKUCodeScannerProvider {
-    static func SKUCodeScanner(onBarcodeScanned: @escaping (ScannedBarcode) -> Void) -> ScannerContainerViewController {
+class ProductBarcodeScannerProvider {
+    static func barcodeScanner(onBarcodeScanned: @escaping (ScannedBarcode) -> Void) -> ScannerContainerViewController {
         ScannerContainerViewController(navigationTitle: Localization.title,
                                        instructionText: Localization.instructionText,
                                        onBarcodeScanned: onBarcodeScanned)
     }
 }
 
-private extension SKUCodeScannerProvider {
+private extension ProductBarcodeScannerProvider {
     enum Localization {
-        static let title = NSLocalizedString("ProductSKUInputScanner.titleView",
-                                             value: "Scan barcode or QR Code to update SKU",
-                                             comment: "Navigation bar title for scanning a barcode or QR Code to use as a product's SKU.")
-        static let instructionText = NSLocalizedString("ProductSKUInputScanner.instructionText",
+        static let title = NSLocalizedString("ProductBarcodeInputScanner.titleView",
+                                             value: "Scan barcode or QR Code",
+                                             comment: "Navigation bar title for scanning a barcode or QR Code to use as a product's barcode.")
+        static let instructionText = NSLocalizedString("ProductBarcodeInputScanner.instructionText",
                                                        value: "Scan product barcode or QR Code",
-                                                       comment: "The instruction text below the scan area in the barcode scanner for product SKU.")
+                                                       comment: "The instruction text below the scan area in the barcode scanner for product barcode.")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
 		02CD3BFE2C35D04C00E575C4 /* MockCardPresentPaymentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CD3BFD2C35D04C00E575C4 /* MockCardPresentPaymentService.swift */; };
-		02CE43022768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */; };
+		02CE43022768CBF60006EAEF /* ProducBarcodeScannerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE43012768CBF60006EAEF /* ProducBarcodeScannerCoordinator.swift */; };
 		02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */; };
 		02CE4307276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */; };
 		02CE43092769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE43082769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift */; };
@@ -3595,7 +3595,7 @@
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		02CD3BFD2C35D04C00E575C4 /* MockCardPresentPaymentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentService.swift; sourceTree = "<group>"; };
-		02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSKUBarcodeScannerCoordinator.swift; sourceTree = "<group>"; };
+		02CE43012768CBF60006EAEF /* ProducBarcodeScannerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProducBarcodeScannerCoordinator.swift; sourceTree = "<group>"; };
 		02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureDevicePermissionChecker.swift; sourceTree = "<group>"; };
 		02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSKUBarcodeScannerCoordinatorTests.swift; sourceTree = "<group>"; };
 		02CE43082769953D0006EAEF /* MockCaptureDevicePermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCaptureDevicePermissionChecker.swift; sourceTree = "<group>"; };
@@ -6694,7 +6694,7 @@
 				025C00652550DE4700FAC222 /* CodeScannerViewController.xib */,
 				025C00642550DE4600FAC222 /* ScannerContainerViewController.swift */,
 				025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */,
-				02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */,
+				02CE43012768CBF60006EAEF /* ProducBarcodeScannerCoordinator.swift */,
 				02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */,
 				B90DACBF2A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift */,
 				B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */,
@@ -15035,7 +15035,7 @@
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				EE2A57D729E399CC009F61E1 /* CaseIterable+Helpers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
-				02CE43022768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift in Sources */,
+				02CE43022768CBF60006EAEF /* ProducBarcodeScannerCoordinator.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
 				AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */,
 				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
@@ -281,6 +281,19 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
+    func testViewModelHasUnsavedChangesAfterScanningANewGlobalUniqueId() {
+        // Arrange
+        let product = Product.fake().copy(globalUniqueID: "321")
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model)
+
+        // Act
+        viewModel.handleGlobalUniqueIdentifierFromBarcodeScanner("123")
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
     func testViewModelHasNoUnsavedChangesAfterUpdatingWithTheOriginalValues() {
         // Arrange
         let product = Product.fake()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
@@ -31,7 +31,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
         // Grants access.
         permissionChecker.whenRequestingAccess(thenReturn: true)
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+        let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: permissionChecker,
                                                               onSKUBarcodeScanned: { _ in })
 
@@ -47,7 +47,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)
         // Denies access.
         permissionChecker.whenRequestingAccess(thenReturn: false)
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+        let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: permissionChecker,
                                                               onSKUBarcodeScanned: { _ in })
 
@@ -61,7 +61,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
 
     func test_coordinator_shows_sku_scanner_when_permission_is_authorized() {
         // Given
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+        let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .authorized),
                                                               onSKUBarcodeScanned: { _ in })
 
@@ -74,7 +74,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
 
     func test_coordinator_shows_alert_when_permission_is_denied() {
         // Given
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+        let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .denied),
                                                               onSKUBarcodeScanned: { _ in })
 
@@ -88,7 +88,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
 
     func test_coordinator_shows_alert_when_permission_is_restricted() {
         // Given
-        let coordinator = ProductSKUBarcodeScannerCoordinator(sourceNavigationController: navigationController,
+        let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .restricted),
                                                               onSKUBarcodeScanned: { _ in })
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
@@ -33,7 +33,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         permissionChecker.whenRequestingAccess(thenReturn: true)
         let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: permissionChecker,
-                                                              onSKUBarcodeScanned: { _ in })
+                                                              onBarcodeScanned: { _ in })
 
         // When
         coordinator.start()
@@ -49,7 +49,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         permissionChecker.whenRequestingAccess(thenReturn: false)
         let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: permissionChecker,
-                                                              onSKUBarcodeScanned: { _ in })
+                                                              onBarcodeScanned: { _ in })
 
         // When
         coordinator.start()
@@ -63,7 +63,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         // Given
         let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .authorized),
-                                                              onSKUBarcodeScanned: { _ in })
+                                                              onBarcodeScanned: { _ in })
 
         // When
         coordinator.start()
@@ -76,7 +76,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         // Given
         let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .denied),
-                                                              onSKUBarcodeScanned: { _ in })
+                                                              onBarcodeScanned: { _ in })
 
         // When
         coordinator.start()
@@ -90,7 +90,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         // Given
         let coordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                               permissionChecker: MockCaptureDevicePermissionChecker(authorizationStatus: .restricted),
-                                                              onSKUBarcodeScanned: { _ in })
+                                                              onBarcodeScanned: { _ in })
 
         // When
         coordinator.start()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14246 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement barcode scanning for the global unique identifier in inventory, so the user can scan a barcode and assign it to that value. In order to achieve that, we make the scanner classes more generic instead of just coupling them to the SKU value as before.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to Products
2. Tap on a product
3. Tap on Inventory
4. Tap on the barcode scanner button besides the GTIN, UPC, EAN, ISBN field
5. Scan a barcode
6. See how the barcode value is set in the field
7. Tap Done and save. It should set the value as expected before.

## Tracking

Please check that these events are triggered when scanning a barcode:

Button tapped

`🔵 Tracked product_inventory_settings_global_unique_id_scanner_button_tapped, properties: [was_ecommerce_trial: false, store_id: 78fb3abe-869e-4280-8dcf-c4c94c9b84b6, blog_id: 214253715, plan: ecommerce-bundle, site_url: https://superlativecentaur.wpcomstaging.com, is_wpcom_store: true]`

Barcode scanned

`🔵 Tracked product_inventory_settings_global_unique_id_scanned, properties: [blog_id: 214253715, is_wpcom_store: true, plan: ecommerce-bundle, site_url: https://superlativecentaur.wpcomstaging.com, store_id: 78fb3abe-869e-4280-8dcf-c4c94c9b84b6, was_ecommerce_trial: false]`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- I also checked that the SKU scanner keeps working fine

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/895b17db-cdb6-42d3-95af-a04635d333e3


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- X ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
