### PR TITLE
Update error logging in `OrderDetailsDataSource` for cellForRowAtIndexPath`

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -376,9 +376,16 @@ extension OrderDetailsDataSource: UITableViewDataSource {
         guard indexPath.row >= 0 && indexPath.row < section.rows.count else {
             ServiceLocator.crashLogging.logMessage(
                 "Invalid row in cellForRowAtIndexPath in OrderDetailsDataSource",
-                properties: ["row": indexPath.section, "section": indexPath.section],
+                properties: [
+                    "row": indexPath.row,
+                    "section": indexPath.section,
+                    "actualRowCount": section.rows.count,
+                    "totalSections": sections.count,
+                    "sectionCategory": String(describing: section.category),
+                    "sectionTitle": section.title ?? "nil"
+                ],
                 level: .error
-            )
+            )            
             return UITableViewCell()
         }
         let row = section.rows[indexPath.row]

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -385,7 +385,7 @@ extension OrderDetailsDataSource: UITableViewDataSource {
                     "sectionTitle": section.title ?? "nil"
                 ],
                 level: .error
-            )            
+            )
             return UITableViewCell()
         }
         let row = section.rows[indexPath.row]


### PR DESCRIPTION
To help with https://github.com/woocommerce/woocommerce-ios/issues/14236

Internal - peaMlT-Xu-p2

### Description

we intentionally added error logging mentioned in that Sentry issue in https://github.com/woocommerce/woocommerce-ios/pull/14018 (Related CUW: peaMlT-QW-p2)

However, the logged properties did not help with debugging because in the PR where `"row": indexPath.section`, it should be `"row": indexPath.row` instead.

This PR added the fix for that.

Additionally I'm adding more properties to help with debugging as well.

### Steps to reproduce
As with before, we're pretty much unable to replicate this crash, so instead verify the new logging and ensure the code looks fine.

### Testing information
Please smoke test the Order Detail section to make sure everything works like before.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.