### PR TITLE
[Custom Fields] Top banner

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -63,7 +63,8 @@ extension Storage.GeneralAppSettings {
         lastJetpackBenefitsBannerDismissedTime: NullableCopiableProp<Date> = .copy,
         featureAnnouncementCampaignSettings: CopiableProp<[FeatureAnnouncementCampaign: FeatureAnnouncementCampaignSettings]> = .copy,
         sitesWithAtLeastOneIPPTransactionFinished: CopiableProp<Set<Int64>> = .copy,
-        isEUShippingNoticeDismissed: CopiableProp<Bool> = .copy
+        isEUShippingNoticeDismissed: CopiableProp<Bool> = .copy,
+        isCustomFieldsTopBannerDismissed: CopiableProp<Bool> = .copy
     ) -> Storage.GeneralAppSettings {
         let installationDate = installationDate ?? self.installationDate
         let feedbacks = feedbacks ?? self.feedbacks
@@ -75,6 +76,7 @@ extension Storage.GeneralAppSettings {
         let featureAnnouncementCampaignSettings = featureAnnouncementCampaignSettings ?? self.featureAnnouncementCampaignSettings
         let sitesWithAtLeastOneIPPTransactionFinished = sitesWithAtLeastOneIPPTransactionFinished ?? self.sitesWithAtLeastOneIPPTransactionFinished
         let isEUShippingNoticeDismissed = isEUShippingNoticeDismissed ?? self.isEUShippingNoticeDismissed
+        let isCustomFieldsTopBannerDismissed = isCustomFieldsTopBannerDismissed ?? self.isCustomFieldsTopBannerDismissed
 
         return Storage.GeneralAppSettings(
             installationDate: installationDate,
@@ -86,7 +88,8 @@ extension Storage.GeneralAppSettings {
             lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime,
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
             sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+            isCustomFieldsTopBannerDismissed: isCustomFieldsTopBannerDismissed
         )
     }
 }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -52,6 +52,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var isEUShippingNoticeDismissed: Bool
 
+    /// Whether the Custom Fields top banner was dismissed
+    ///
+    public var isCustomFieldsTopBannerDismissed: Bool
+
     public init(installationDate: Date?,
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
@@ -61,7 +65,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
                 lastJetpackBenefitsBannerDismissedTime: Date? = nil,
                 featureAnnouncementCampaignSettings: [FeatureAnnouncementCampaign: FeatureAnnouncementCampaignSettings],
                 sitesWithAtLeastOneIPPTransactionFinished: Set<Int64>,
-                isEUShippingNoticeDismissed: Bool) {
+                isEUShippingNoticeDismissed: Bool,
+                isCustomFieldsTopBannerDismissed: Bool) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
@@ -72,6 +77,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         self.isInAppPurchasesSwitchEnabled = isInAppPurchasesSwitchEnabled
         self.sitesWithAtLeastOneIPPTransactionFinished = sitesWithAtLeastOneIPPTransactionFinished
         self.isEUShippingNoticeDismissed = isEUShippingNoticeDismissed
+        self.isCustomFieldsTopBannerDismissed = isCustomFieldsTopBannerDismissed
     }
 
     public static var `default`: Self {
@@ -83,7 +89,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
               lastEligibilityErrorInfo: nil,
               featureAnnouncementCampaignSettings: [:],
               sitesWithAtLeastOneIPPTransactionFinished: [],
-              isEUShippingNoticeDismissed: false)
+              isEUShippingNoticeDismissed: false,
+              isCustomFieldsTopBannerDismissed: false)
     }
 
     /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
@@ -112,7 +119,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
             sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+            isCustomFieldsTopBannerDismissed: isCustomFieldsTopBannerDismissed
         )
     }
 
@@ -132,7 +140,8 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             lastEligibilityErrorInfo: lastEligibilityErrorInfo,
             featureAnnouncementCampaignSettings: updatedSettings,
             sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed
+            isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+            isCustomFieldsTopBannerDismissed: isCustomFieldsTopBannerDismissed
         )
     }
 }
@@ -157,6 +166,7 @@ extension GeneralAppSettings {
         self.sitesWithAtLeastOneIPPTransactionFinished = try container.decodeIfPresent(Set<Int64>.self,
                                                                                         forKey: .sitesWithAtLeastOneIPPTransactionFinished) ?? Set<Int64>([])
         self.isEUShippingNoticeDismissed = try container.decodeIfPresent(Bool.self, forKey: .isEUShippingNoticeDismissed) ?? false
+        self.isCustomFieldsTopBannerDismissed = try container.decodeIfPresent(Bool.self, forKey: .isCustomFieldsTopBannerDismissed) ?? false
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -62,6 +62,7 @@ final class GeneralAppSettingsTests: XCTestCase {
             FeatureAnnouncementCampaign.linkedProductsPromo:
                 FeatureAnnouncementCampaignSettings(dismissedDate: Date(), remindAfter: nil)]
         let sitesWithAtLeastOneIPPTransactionFinished: Set<Int64> = [1234, 123, 12, 1]
+        let isCustomFieldsTopBannerDismissed = true
         let previousSettings = GeneralAppSettings(installationDate: installationDate,
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
@@ -71,7 +72,8 @@ final class GeneralAppSettingsTests: XCTestCase {
                                                   lastJetpackBenefitsBannerDismissedTime: jetpackBannerDismissedDate,
                                                   featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
                                                   sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-                                                  isEUShippingNoticeDismissed: false)
+                                                  isEUShippingNoticeDismissed: false,
+                                                  isCustomFieldsTopBannerDismissed: isCustomFieldsTopBannerDismissed)
 
         let previousEncodedSettings = try JSONEncoder().encode(previousSettings)
         var previousSettingsJson = try JSONSerialization.jsonObject(with: previousEncodedSettings, options: .allowFragments) as? [String: Any]
@@ -90,6 +92,7 @@ final class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.lastJetpackBenefitsBannerDismissedTime, jetpackBannerDismissedDate)
         assertEqual(newSettings.featureAnnouncementCampaignSettings, featureAnnouncementCampaignSettings)
         assertEqual(newSettings.sitesWithAtLeastOneIPPTransactionFinished, sitesWithAtLeastOneIPPTransactionFinished)
+        assertEqual(newSettings.isCustomFieldsTopBannerDismissed, isCustomFieldsTopBannerDismissed)
     }
 }
 
@@ -107,7 +110,8 @@ private extension GeneralAppSettingsTests {
                                   lastJetpackBenefitsBannerDismissedTime: Date? = nil,
                                   featureAnnouncementCampaignSettings: [Campaign: CampaignSettings] = [:],
                                   sitesWithAtLeastOneIPPTransactionFinished: Set<Int64> = [],
-                                  isEUShippingNoticeDismissed: Bool = false
+                                  isEUShippingNoticeDismissed: Bool = false,
+                                  isCustomFieldsTopBannerDismissed: Bool = false
     ) -> GeneralAppSettings {
         GeneralAppSettings(installationDate: installationDate,
                            feedbacks: feedbacks,
@@ -118,6 +122,7 @@ private extension GeneralAppSettingsTests {
                            lastJetpackBenefitsBannerDismissedTime: lastJetpackBenefitsBannerDismissedTime,
                            featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
                            sitesWithAtLeastOneIPPTransactionFinished: sitesWithAtLeastOneIPPTransactionFinished,
-                           isEUShippingNoticeDismissed: isEUShippingNoticeDismissed)
+                           isEUShippingNoticeDismissed: isEUShippingNoticeDismissed,
+                           isCustomFieldsTopBannerDismissed: isCustomFieldsTopBannerDismissed)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
@@ -36,7 +36,7 @@ struct CustomFieldsListTopBanner: UIViewRepresentable {
                                                                infoText: Localization.description,
                                                                icon: .speakerIcon.withRenderingMode(.alwaysTemplate),
                                                                iconTintColor: .primary,
-                                                               isExpanded: false, // TODO: set to true on portrait mode
+                                                               isExpanded: UIDevice.current.orientation.isPortrait, // Expanded by default in portrait mode
                                                                topButton: expandButton,
                                                                actionButtons: [dismissButton])
         let mainBanner = TopBannerView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
@@ -36,7 +36,7 @@ struct CustomFieldsListTopBanner: UIViewRepresentable {
                                                                infoText: Localization.description,
                                                                icon: .speakerIcon.withRenderingMode(.alwaysTemplate),
                                                                iconTintColor: .primary,
-                                                               isExpanded: UIDevice.current.orientation.isPortrait, // Expanded by default in portrait mode
+                                                               isExpanded: !UIDevice.current.orientation.isLandscape, // Collapsed by default in landscape mode
                                                                topButton: expandButton,
                                                                actionButtons: [dismissButton])
         let mainBanner = TopBannerView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
@@ -33,12 +33,12 @@ struct CustomFieldsListTopBanner: UIViewRepresentable {
         }
 
         let viewModel = TopBannerViewModel(title: Localization.title,
-                                                               infoText: Localization.description,
-                                                               icon: .speakerIcon.withRenderingMode(.alwaysTemplate),
-                                                               iconTintColor: .primary,
-                                                               isExpanded: !UIDevice.current.orientation.isLandscape, // Collapsed by default in landscape mode
-                                                               topButton: expandButton,
-                                                               actionButtons: [dismissButton])
+                                           infoText: Localization.description,
+                                           icon: .speakerIcon.withRenderingMode(.alwaysTemplate),
+                                           iconTintColor: .wooCommercePurple(.shade50),
+                                           isExpanded: !UIDevice.current.orientation.isLandscape, // Collapsed by default in landscape mode
+                                           topButton: expandButton,
+                                           actionButtons: [dismissButton])
         let mainBanner = TopBannerView(viewModel: viewModel)
 
         // Set the current super view width and the real view to be displayed inside the wrapper.

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListTopBanner.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftUI
+
+/// Banner to inform the users how custom fields are saved.
+///
+struct CustomFieldsListTopBanner: UIViewRepresentable {
+    typealias Callback = () -> ()
+
+    /// Desired `width` of the view.
+    ///
+    private let width: CGFloat
+
+    /// Closure to be invoked when the "Dismiss" button is pressed.
+    ///
+    private var onDismiss: Callback? = nil
+
+    /// Create a view with the desired `width`. Needed to calculate a correct view `height` later.
+    ///
+    init(width: CGFloat) {
+        self.width = width
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(bannerWrapper: TopBannerWrapperView())
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let expandButton = TopBannerViewModel.TopButtonType.chevron {
+            context.coordinator.bannerWrapper.invalidateIntrinsicContentSize() // Forces the view to recalculate it's size as it collapses/expands
+        }
+        let dismissButton = TopBannerViewModel.ActionButton(title: Localization.dismiss) { _ in
+            onDismiss?()
+        }
+
+        let viewModel = TopBannerViewModel(title: Localization.title,
+                                                               infoText: Localization.description,
+                                                               icon: .speakerIcon.withRenderingMode(.alwaysTemplate),
+                                                               iconTintColor: .primary,
+                                                               isExpanded: false, // TODO: set to true on portrait mode
+                                                               topButton: expandButton,
+                                                               actionButtons: [dismissButton])
+        let mainBanner = TopBannerView(viewModel: viewModel)
+
+        // Set the current super view width and the real view to be displayed inside the wrapper.
+        context.coordinator.bannerWrapper.width = width
+        context.coordinator.bannerWrapper.setBanner(mainBanner)
+        return context.coordinator.bannerWrapper
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.bannerWrapper.width = width
+    }
+
+    /// Returns a copy of the view with `onDismiss` handling.
+    ///
+    func onDismiss(_ handler: @escaping Callback) -> CustomFieldsListTopBanner {
+        var copy = self
+        copy.onDismiss = handler
+        return copy
+    }
+}
+
+// MARK: Coordinator
+extension CustomFieldsListTopBanner {
+    /// Hold state across `SwiftUI` lifecycle passes.
+    ///
+    struct Coordinator {
+        /// Banner wrapper that will contain a `TopBannerView`.
+        ///
+        let bannerWrapper: TopBannerWrapperView
+    }
+}
+
+// MARK: Localization
+private extension CustomFieldsListTopBanner {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "customFieldsListTopBanner.title",
+            value: "View and edit custom fields",
+            comment: "Title of the banner when there are unsaved custom fields")
+        static let description = NSLocalizedString(
+            "customFieldsListTopBanner.description",
+            value: "When saving changes to custom fields, they will take effect immediately.",
+            comment: "Content of the banner when there are unsaved custom fields")
+        static let dismiss = NSLocalizedString(
+            "customFieldsListTopBanner.dismiss",
+            value: "Dismiss",
+            comment: "Dismiss button title")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -130,26 +130,31 @@ struct CustomFieldsListView: View {
     }
 
     var body: some View {
-        List(viewModel.combinedList) { customField in
-            Button(action: { viewModel.selectedCustomField = customField }) {
-                CustomFieldRow(isEditable: isEditable,
-                               title: customField.key,
-                               content: customField.value.removedHTMLTags,
-                               contentURL: nil)
+        GeometryReader { geometry in
+            VStack(spacing: .zero) {
+                CustomFieldsListTopBanner(width: geometry.size.width)
+                    .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
+                List(viewModel.combinedList) { customField in
+                    Button(action: { viewModel.selectedCustomField = customField }) {
+                        CustomFieldRow(isEditable: isEditable,
+                                    title: customField.key,
+                                    content: customField.value.removedHTMLTags,
+                                    contentURL: nil)
+                    }
+                }.listStyle(.plain)
             }
-        }
-        .listStyle(.plain)
-        .sheet(item: $viewModel.selectedCustomField) { customField in
-            /// When editing a newly added and unsaved custom field (identified by it having nil `fieldId`), provide disallowed keys.
-            let disallowedKeys = customField.fieldId == nil ? viewModel.disallowedKeysForCreation : []
+            .sheet(item: $viewModel.selectedCustomField) { customField in
+	            /// When editing a newly added and unsaved custom field (identified by it having nil `fieldId`), provide disallowed keys.
+	            let disallowedKeys = customField.fieldId == nil ? viewModel.disallowedKeysForCreation : []
 
-            buildCustomFieldEditorView(customField: customField,
-                                       disallowedKeys: disallowedKeys)
+	            buildCustomFieldEditorView(customField: customField,
+	                                       disallowedKeys: disallowedKeys)
+            }
+            .sheet(isPresented: $viewModel.isAddingNewField) {
+	            buildCustomFieldEditorView(customField: nil, disallowedKeys: viewModel.disallowedKeysForCreation)
+            }
+            .notice($viewModel.notice)
         }
-        .sheet(isPresented: $viewModel.isAddingNewField) {
-            buildCustomFieldEditorView(customField: nil, disallowedKeys: viewModel.disallowedKeysForCreation)
-        }
-        .notice($viewModel.notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -133,7 +133,9 @@ struct CustomFieldsListView: View {
         GeometryReader { geometry in
             VStack(spacing: .zero) {
                 CustomFieldsListTopBanner(width: geometry.size.width)
+                    .onDismiss { viewModel.dismissTopBanner() }
                     .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
+                    .renderedIf(viewModel.shouldShowTopBanner)
                 List(viewModel.combinedList) { customField in
                     Button(action: { viewModel.selectedCustomField = customField }) {
                         CustomFieldRow(isEditable: isEditable,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -136,6 +136,7 @@ struct CustomFieldsListView: View {
                     .onDismiss { viewModel.dismissTopBanner() }
                     .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
                     .renderedIf(viewModel.shouldShowTopBanner)
+
                 List(viewModel.combinedList) { customField in
                     Button(action: { viewModel.selectedCustomField = customField }) {
                         CustomFieldRow(isEditable: isEditable,
@@ -143,7 +144,8 @@ struct CustomFieldsListView: View {
                                     content: customField.value.removedHTMLTags,
                                     contentURL: nil)
                     }
-                }.listStyle(.plain)
+                }
+                .listStyle(.plain)
             }
             .sheet(item: $viewModel.selectedCustomField) { customField in
 	            /// When editing a newly added and unsaved custom field (identified by it having nil `fieldId`), provide disallowed keys.

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -120,7 +120,7 @@ extension CustomFieldsListViewModel {
 
     func dismissTopBanner() {
         stores.dispatch(AppSettingsAction.dismissCustomFieldsTopBanner { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             if result.isSuccess {
                 isTopBannerDismissed = true
             }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -10,10 +10,14 @@ final class CustomFieldsListViewModel: ObservableObject {
     private let siteID: Int64
     private let parentItemID: Int64
     private let onChangesSaved: (([MetaData]) -> Void)?
+    @Published private var isTopBannerDismissed: Bool = false
 
     @Published var selectedCustomField: CustomFieldUI? = nil
     @Published var isAddingNewField: Bool = false
     @Published var isSavingChanges: Bool = false
+    var shouldShowTopBanner: Bool {
+        hasChanges && !isTopBannerDismissed
+    }
 
     @Published private(set) var combinedList: [CustomFieldUI] = []
     @Published var notice: Notice?
@@ -55,6 +59,7 @@ final class CustomFieldsListViewModel: ObservableObject {
         self.onChangesSaved = onChangesSaved
 
         observePendingChanges()
+        loadTopBannerDismissState()
     }
 }
 
@@ -113,6 +118,15 @@ extension CustomFieldsListViewModel {
         }
     }
 
+    func dismissTopBanner() {
+        stores.dispatch(AppSettingsAction.dismissCustomFieldsTopBanner { [weak self] result in
+            guard let self = self else { return }
+            if result.isSuccess {
+                isTopBannerDismissed = true
+            }
+        })
+    }
+
     /// Save changes to the server, uses async/await
     @MainActor
     func saveChanges() async {
@@ -169,6 +183,13 @@ private extension CustomFieldsListViewModel {
         } else {
             addedFields.append(field)
         }
+    }
+
+    func loadTopBannerDismissState() {
+        stores.dispatch(AppSettingsAction.loadCustomFieldsTopBannerDismissState { [weak self] result in
+            guard let self else { return }
+            isTopBannerDismissed = result
+        })
     }
 
     func observePendingChanges() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1717,6 +1717,7 @@
 		93BCF01F20DC2CE200EBF7A1 /* bash_secrets.tpl in Resources */ = {isa = PBXBuildFile; fileRef = 93BCF01E20DC2CE200EBF7A1 /* bash_secrets.tpl */; };
 		93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA787121CD2A1A00B663E5 /* CurrencySettingsTests.swift */; };
 		953728F82B23635300FDF1D1 /* UIAlertController+helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953728F72B23635300FDF1D1 /* UIAlertController+helpers.swift */; };
+		95968A512CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95968A502CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift */; };
 		A650BE862578E76600C655E0 /* MockStorageManager+Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE842578E76600C655E0 /* MockStorageManager+Sample.swift */; };
 		A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE852578E76600C655E0 /* MockStorageManager.swift */; };
 		A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
@@ -4750,6 +4751,7 @@
 		93BCF01E20DC2CE200EBF7A1 /* bash_secrets.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = bash_secrets.tpl; sourceTree = "<group>"; };
 		93FA787121CD2A1A00B663E5 /* CurrencySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencySettingsTests.swift; sourceTree = "<group>"; };
 		953728F72B23635300FDF1D1 /* UIAlertController+helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertController+helpers.swift"; sourceTree = "<group>"; };
+		95968A502CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListTopBanner.swift; sourceTree = "<group>"; };
 		9D2992FEF3D1246B8CCC2EBB /* Pods-WooCommerceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A650BE842578E76600C655E0 /* MockStorageManager+Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MockStorageManager+Sample.swift"; path = "../../../Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift"; sourceTree = "<group>"; };
 		A650BE852578E76600C655E0 /* MockStorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockStorageManager.swift; path = ../../../Yosemite/YosemiteTests/Mocks/MockStorageManager.swift; sourceTree = "<group>"; };
@@ -10572,6 +10574,7 @@
 				86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */,
 				86F5FFE12CA302B300C767C4 /* CustomFieldsListViewModel.swift */,
 				86EC6EB62CD0A53E00D7D2FE /* CustomFieldEditorViewModel.swift */,
+				95968A502CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift */,
 			);
 			path = "Custom Fields";
 			sourceTree = "<group>";
@@ -16347,6 +16350,7 @@
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
 				7E7C5F872719A93C00315B61 /* ProductCategoryListViewController.swift in Sources */,
 				2631D4FE29F2141D00F13F20 /* StorePlanBannerPresenter.swift in Sources */,
+				95968A512CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift in Sources */,
 				68DF5A8D2CB38EEA000154C9 /* EditableOrderCouponLineViewModel.swift in Sources */,
 				CEC3CC762C934F5500B93FBE /* WooShippingItemsDataSource.swift in Sources */,
 				DEC51B06276B3F3C009F3DF4 /* Int64+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -412,4 +412,73 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.disallowedKeysForCreation.contains("Key1"))
         XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
     }
+
+    // MARK: - Top Banner
+    func test_given_bannerNotDismissed_when_hasChanges_then_showBanner() async {
+        // Given: The banner is not dismissed
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+                case let .loadCustomFieldsTopBannerDismissState(onCompletion):
+                    onCompletion(false)
+                default:
+                    break
+            }
+        }
+        viewModel = CustomFieldsListViewModel(customFields: originalFields,
+                                              siteID: sampleSiteID,
+                                              parentItemID: sampleParentItemID,
+                                              customFieldType: sampleCustomFieldType,
+                                              stores: stores)
+
+        // When: Making changes
+        viewModel.addField(CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue"))
+
+        // Then: The banner should be shown
+        XCTAssertTrue(viewModel.shouldShowTopBanner)
+    }
+
+    func test_given_bannerDismissed_when_hasChanges_then_hideBanner() async {
+        // Given: The banner is dismissed
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+                case let .loadCustomFieldsTopBannerDismissState(onCompletion):
+                    onCompletion(true)
+                default:
+                    break
+            }
+        }
+        viewModel = CustomFieldsListViewModel(customFields: originalFields,
+                                              siteID: sampleSiteID,
+                                              parentItemID: sampleParentItemID,
+                                              customFieldType: sampleCustomFieldType,
+                                              stores: stores)
+
+        // When: Making changes
+        viewModel.addField(CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue"))
+
+        // Then: The banner should not be shown
+        XCTAssertFalse(viewModel.shouldShowTopBanner)
+    }
+
+    func test_given_bannerShown_when_dismissBannerCalled_then_bannerIsDismissed() async {
+        // Given: The banner is shown
+        var wasDismissed = false
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+                case let .loadCustomFieldsTopBannerDismissState(onCompletion):
+                    onCompletion(false)
+                case let .dismissCustomFieldsTopBanner(onCompletion):
+                    wasDismissed = true
+                    onCompletion(.success(()))
+                default:
+                    break
+            }
+        }
+
+        // When: Dismissing the banner
+        viewModel.dismissTopBanner()
+
+        // Then: The banner should be dismissed
+        XCTAssertTrue(wasDismissed)
+    }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -144,6 +144,14 @@ public enum AppSettingsAction: Action {
     ///
     case loadEUShippingNoticeDismissState(onCompletion: (Result<Bool, Error>) -> Void)
 
+    /// Sets the dismiss state for the Custom Fields top banner
+    ///
+    case dismissCustomFieldsTopBanner(onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Loads the dismiss state of the Custom Fields top banner
+    ///
+    case loadCustomFieldsTopBannerDismissState(onCompletion: (Bool) -> Void)
+
     // MARK: - General Store Settings
 
     /// Sets the store uuid.

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -244,6 +244,10 @@ public class AppSettingsStore: Store {
             removeProductIDAsFavorite(productID: productID, siteID: siteID)
         case .loadFavoriteProductIDs(let siteID, let onCompletion):
             loadFavoriteProductIDs(for: siteID, onCompletion: onCompletion)
+        case .dismissCustomFieldsTopBanner(let onCompletion):
+            dismissCustomFieldsTopBanner(onCompletion: onCompletion)
+        case .loadCustomFieldsTopBannerDismissState(let onCompletion):
+            loadCustomFieldsTopBannerDismissState(onCompletion: onCompletion)
         }
     }
 }
@@ -1061,6 +1065,23 @@ private extension AppSettingsStore {
 
     func loadFavoriteProductIDs(for siteID: Int64, onCompletion: ([Int64]) -> Void) {
         onCompletion(getStoreSettings(for: siteID).favoriteProductIDs)
+    }
+}
+
+// MARK: - Custom Fields
+//
+private extension AppSettingsStore {
+    func dismissCustomFieldsTopBanner(onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            try generalAppSettings.setValue(true, for: \.isCustomFieldsTopBannerDismissed)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+    }
+
+    func loadCustomFieldsTopBannerDismissState(onCompletion: (Bool) -> Void) {
+        onCompletion(generalAppSettings.value(for: \.isCustomFieldsTopBannerDismissed))
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -245,7 +245,8 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             knownCardReaders: [],
             featureAnnouncementCampaignSettings: [:],
             sitesWithAtLeastOneIPPTransactionFinished: [],
-            isEUShippingNoticeDismissed: false)
+            isEUShippingNoticeDismissed: false,
+            isCustomFieldsTopBannerDismissed: false)
         return settings
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1659,7 +1659,8 @@ private extension AppSettingsStoreTests {
             knownCardReaders: [],
             featureAnnouncementCampaignSettings: [:],
             sitesWithAtLeastOneIPPTransactionFinished: [],
-            isEUShippingNoticeDismissed: false
+            isEUShippingNoticeDismissed: false,
+            isCustomFieldsTopBannerDismissed: false
         )
         return (settings, feedback)
     }
@@ -1673,7 +1674,8 @@ private extension AppSettingsStoreTests {
             knownCardReaders: [],
             featureAnnouncementCampaignSettings: featureAnnouncementCampaignSettings,
             sitesWithAtLeastOneIPPTransactionFinished: [],
-            isEUShippingNoticeDismissed: false
+            isEUShippingNoticeDismissed: false,
+            isCustomFieldsTopBannerDismissed: false
         )
         return settings
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14066  

## Description
This PR adds a top banner to the custom fields screen, the banner is shown when there are some unsaved changes, and can be dismissed, when it's dismissed, it won't be shown again in the future.

The banner will be expanded by default when the device is in portrait orientation, and collapsed by default otherwise.

## Steps to reproduce
1. Open an order or a product.
2. Open the custom fields.
3. Make some changes.
4. Notice the banner.

## Testing information
- Confirm the banner is expanded by default in portrait orientation and not otherwise.
- Confirm dismissing the banner survives app restarts.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width=360 src=https://github.com/user-attachments/assets/42233856-fc4f-4a39-80aa-e2327bc3df01/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.