### PR TITLE
[Shipping label] Add UI for after purchasing a shipping label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -48,6 +48,7 @@ struct WooShippingPostPurchaseView: View {
                         Image(systemName: "info.circle")
                         Text(Localization.info)
                             .font(.footnote)
+                            .multilineTextAlignment(.leading)
                     }
                 }
                 Divider()
@@ -57,6 +58,7 @@ struct WooShippingPostPurchaseView: View {
                     } label: {
                         HStack {
                             Text(Localization.trackShipment)
+                                .multilineTextAlignment(.leading)
                             Image(systemName: "arrow.up.right.square")
                         }
                     }
@@ -65,6 +67,7 @@ struct WooShippingPostPurchaseView: View {
                     } label: {
                         HStack {
                             Text(Localization.schedulePickup)
+                                .multilineTextAlignment(.leading)
                             Image(systemName: "arrow.up.right.square")
                         }
                     }
@@ -74,6 +77,7 @@ struct WooShippingPostPurchaseView: View {
                         Text(Localization.requestRefund)
                     }
                 }
+                .fixedSize(horizontal: false, vertical: true)
                 .font(.subheadline)
                 .bold()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -1,20 +1,128 @@
 import SwiftUI
+import Yosemite
 
 struct WooShippingPostPurchaseView: View {
+    private let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .legal]
+
+    @State var selectedLabelSize: ShippingLabelPaperSize = .label
+
     var body: some View {
-        Text(Localization.readyToPrint)
-            .headlineStyle()
+        VStack(alignment: .leading, spacing: 8) {
+            Text(Localization.readyToPrint)
+                .headlineStyle()
+            Text(Localization.printMessage)
+                .font(.subheadline)
+                .foregroundStyle(Color(.text))
+
+            VStack(alignment: .leading, spacing: 16) {
+                Menu {
+                    ForEach(labelSizes, id: \.self) { labelSize in
+                        Button {
+                            selectedLabelSize = labelSize
+                        } label: {
+                            Text(labelSize.description)
+                            if labelSize == selectedLabelSize {
+                                Image(uiImage: .checkmarkStyledImage.withTintColor(UIColor(Layout.panelHighlight)))
+                            }
+                        }
+                    }
+                } label: {
+                    HStack {
+                        Text(selectedLabelSize.description)
+                            .bodyStyle()
+                        Spacer()
+                        Image(systemName: "chevron.up.chevron.down")
+                            .bold()
+                    }
+                    .padding()
+                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+                }
+                Button {
+                    // TODO: Request label from remote and open print dialog
+                } label: {
+                    Text(Localization.printButton)
+                        .bold()
+                }
+                .buttonStyle(HighlightButtonStyle(background: Layout.panelHighlight, backgroundPressed: Layout.buttonPressed))
+                Button {
+                    // TODO: Open instructions for how to print
+                } label: {
+                    Text(Localization.info)
+                        .font(.footnote)
+                }
+                Divider()
+                Group {
+                    Button {
+                        // TODO: Open link for shipment tracking
+                    } label: {
+                        Text(Localization.trackShipment)
+                    }
+                    Button {
+                        // TODO: Open link to schedule pickup
+                    } label: {
+                        Text(Localization.schedulePickup)
+                    }
+                    Button {
+                        // TODO: Request label refund
+                    } label: {
+                        Text(Localization.requestRefund)
+                    }
+                }
+                .font(.subheadline)
+                .bold()
+            }
+            .padding()
+            .foregroundStyle(Layout.panelHighlight)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Layout.panelBackground)
+            )
+
+            Text(Localization.note)
+                .footnoteStyle()
+        }
+        .padding(.vertical)
     }
 }
 
 private extension WooShippingPostPurchaseView {
+    enum Layout {
+        static let panelBackground: Color = Color(light: .withColorStudio(name: .green, shade: .shade0),
+                                                  dark: .withColorStudio(name: .green, shade: .shade100))
+        static let panelHighlight: Color = Color(light: .withColorStudio(name: .green, shade: .shade70),
+                                                 dark: .withColorStudio(name: .green, shade: .shade50))
+        static let buttonPressed: Color = .withColorStudio(name: .green, shade: .shade90)
+    }
+
     enum Localization {
         static let readyToPrint = NSLocalizedString("wooShipping.createLabels.postPurchase.readyToPrint",
                                                     value: "Your shipping label is ready to print",
+                                                    comment: "Heading displayed on the shipping label screen when a purchased shipping label can be printed")
+        static let printMessage = NSLocalizedString("wooShipping.createLabels.postPurchase.printMessage",
+                                                    value: "From here you can print the shipping label again or change the paper size of the label.",
                                                     comment: "Message displayed on the shipping label screen when a purchased shipping label can be printed")
+        static let printButton = NSLocalizedString("wooShipping.createLabels.postPurchase.printButton",
+                                                   value: "Print Shipping Label",
+                                                   comment: "Title for button to print a purchased shipping label on the shipping label screen")
+        static let info = NSLocalizedString("wooShipping.createLabels.postPurchase.info",
+                                            value: "Learn how to print from your mobile device",
+                                            comment: "Link for more information about how to print a purchased shipping label on the shipping label screen")
+        static let trackShipment = NSLocalizedString("wooShipping.createLabels.postPurchase.trackShipment",
+                                                     value: "Track shipment",
+                                                     comment: "Link to track a shipment for a purchase shipping label on the shipping label screen")
+        static let schedulePickup = NSLocalizedString("wooShipping.createLabels.postPurchase.schedulePickup",
+                                                      value: "Schedule pickup",
+                                                      comment: "Link to schedule a pickup for a purchased shipping label on the shipping label screen")
+        static let requestRefund = NSLocalizedString("wooShipping.createLabels.postPurchase.requestRefund",
+                                                     value: "Request refund",
+                                                     comment: "Link to request a refund for a purchased shipping label on the shipping label screen")
+        static let note = NSLocalizedString("wooShipping.createLabels.postPurchase.note",
+                                            value: "Note: Reusing a printed label is a violation of our terms of service and may result in criminal charges.",
+                                            comment: "Note about reusing a purchased shipping label on the shipping label screen")
     }
 }
 
 #Preview {
     WooShippingPostPurchaseView()
+        .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -22,7 +22,7 @@ struct WooShippingPostPurchaseView: View {
                         } label: {
                             Text(labelSize.description)
                             if labelSize == selectedLabelSize {
-                                Image(uiImage: .checkmarkStyledImage.withTintColor(UIColor(Layout.panelHighlight)))
+                                Image(systemName: "checkmark")
                             }
                         }
                     }
@@ -47,20 +47,29 @@ struct WooShippingPostPurchaseView: View {
                 Button {
                     // TODO: Open instructions for how to print
                 } label: {
-                    Text(Localization.info)
-                        .font(.footnote)
+                    HStack {
+                        Image(systemName: "info.circle")
+                        Text(Localization.info)
+                            .font(.footnote)
+                    }
                 }
                 Divider()
                 Group {
                     Button {
                         // TODO: Open link for shipment tracking
                     } label: {
-                        Text(Localization.trackShipment)
+                        HStack {
+                            Text(Localization.trackShipment)
+                            Image(systemName: "arrow.up.right.square")
+                        }
                     }
                     Button {
                         // TODO: Open link to schedule pickup
                     } label: {
-                        Text(Localization.schedulePickup)
+                        HStack {
+                            Text(Localization.schedulePickup)
+                            Image(systemName: "arrow.up.right.square")
+                        }
                     }
                     Button {
                         // TODO: Request label refund

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct WooShippingPostPurchaseView: View {
+    var body: some View {
+        Text(Localization.readyToPrint)
+            .headlineStyle()
+    }
+}
+
+private extension WooShippingPostPurchaseView {
+    enum Localization {
+        static let readyToPrint = NSLocalizedString("wooShipping.createLabels.postPurchase.readyToPrint",
+                                                    value: "Your shipping label is ready to print",
+                                                    comment: "Message displayed on the shipping label screen when a purchased shipping label can be printed")
+    }
+}
+
+#Preview {
+    WooShippingPostPurchaseView()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -1,10 +1,7 @@
 import SwiftUI
-import Yosemite
 
 struct WooShippingPostPurchaseView: View {
-    private let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .legal]
-
-    @State var selectedLabelSize: ShippingLabelPaperSize = .label
+    @State private var viewModel = WooShippingPostPurchaseViewModel()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -16,19 +13,19 @@ struct WooShippingPostPurchaseView: View {
 
             VStack(alignment: .leading, spacing: 16) {
                 Menu {
-                    ForEach(labelSizes, id: \.self) { labelSize in
+                    ForEach(viewModel.labelSizes, id: \.self) { labelSize in
                         Button {
-                            selectedLabelSize = labelSize
+                            viewModel.selectedLabelSize = labelSize
                         } label: {
                             Text(labelSize.description)
-                            if labelSize == selectedLabelSize {
+                            if labelSize == viewModel.selectedLabelSize {
                                 Image(systemName: "checkmark")
                             }
                         }
                     }
                 } label: {
                     HStack {
-                        Text(selectedLabelSize.description)
+                        Text(viewModel.selectedLabelSize.description)
                             .bodyStyle()
                         Spacer()
                         Image(systemName: "chevron.up.chevron.down")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -1,0 +1,9 @@
+import Yosemite
+
+struct WooShippingPostPurchaseViewModel {
+    /// Available paper sizes for printing the shipping label.
+    let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .legal]
+
+    /// Selected paper size for printing the shipping label.
+    var selectedLabelSize: ShippingLabelPaperSize = .label
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -165,6 +165,19 @@ struct PrimaryLoadingButtonStyle: PrimitiveButtonStyle {
     }
 }
 
+/// Creates a button with a solid background in the provided highlight color.
+struct HighlightButtonStyle: ButtonStyle {
+    /// Background color for the button.
+    let background: Color
+
+    /// Background color when the button is pressed.
+    let backgroundPressed: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        HighlightButton(configuration: configuration, background: background, backgroundPressed: backgroundPressed)
+    }
+}
+
 private struct BaseButton: View {
     let configuration: ButtonStyleConfiguration
 
@@ -434,6 +447,34 @@ private struct RoundedBorderedButton: View {
                         lineWidth: Style.defaultBorderWidth
                     )
             )
+    }
+}
+
+private struct HighlightButton: View {
+    let configuration: ButtonStyleConfiguration
+
+    /// Background color for the button.
+    let background: Color
+
+    /// Background color when the button is pressed.
+    let backgroundPressed: Color
+
+    var body: some View {
+        BaseButton(configuration: configuration)
+            .foregroundColor(Color(.primaryButtonTitle))
+            .font(.headline)
+            .background(
+                RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
+                    .fill(backgroundColor)
+            )
+    }
+
+    var backgroundColor: Color {
+        if configuration.isPressed {
+            return backgroundPressed
+        } else {
+            return background
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2284,6 +2284,7 @@
 		CEA7C32D2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */; };
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEAB739C2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */; };
+		CEAEB75A2CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAEB7592CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift */; };
 		CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */; };
 		CEC3CC6D2C93127300B93FBE /* WooShippingItemsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */; };
 		CEC3CC6F2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */; };
@@ -5345,6 +5346,7 @@
 		CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GoogleAdsCampaignStatsTotals+UI.swift"; sourceTree = "<group>"; };
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsView.swift; sourceTree = "<group>"; };
+		CEAEB7592CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPostPurchaseView.swift; sourceTree = "<group>"; };
 		CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModel.swift; sourceTree = "<group>"; };
 		CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsViewModel.swift; sourceTree = "<group>"; };
 		CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsViewModel.swift; sourceTree = "<group>"; };
@@ -11883,11 +11885,20 @@
 				CE6E11092C91DA3D00563DD4 /* WooShipping Items Section */,
 				CE7B4A592CA1BF7800F764EB /* WooShipping Hazmat Section */,
 				CECEFA6B2CA2CE990071C7DB /* WooShipping Package and Rate Selection */,
+				CEAEB7582CD0F96800C3E117 /* WooShipping Post-Purchase */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
 				CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */,
 				CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
+			sourceTree = "<group>";
+		};
+		CEAEB7582CD0F96800C3E117 /* WooShipping Post-Purchase */ = {
+			isa = PBXGroup;
+			children = (
+				CEAEB7592CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift */,
+			);
+			path = "WooShipping Post-Purchase";
 			sourceTree = "<group>";
 		};
 		CEC3CC722C9343BC00B93FBE /* WooShipping Create Shipping Labels */ = {
@@ -15269,6 +15280,7 @@
 				039298C82A45EE3900F393D5 /* MyStoreRoute.swift in Sources */,
 				0221121E288973C20028F0AF /* LocalNotification.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
+				CEAEB75A2CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift in Sources */,
 				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2226,6 +2226,7 @@
 		CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */; };
 		CE49C4752CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */; };
 		CE49C4772CBEC8C300EA5C84 /* WooShipping_ShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */; };
+		CE4AFE462CD135B20013C52B /* WooShippingPostPurchaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4AFE452CD135AC0013C52B /* WooShippingPostPurchaseViewModel.swift */; };
 		CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */; };
 		CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
 		CE4ECA582BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4ECA572BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift */; };
@@ -5288,6 +5289,7 @@
 		CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CNContact+Helpers.swift"; sourceTree = "<group>"; };
 		CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShipping_ShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShipping_ShippingLineViewModelTests.swift; sourceTree = "<group>"; };
+		CE4AFE452CD135AC0013C52B /* WooShippingPostPurchaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPostPurchaseViewModel.swift; sourceTree = "<group>"; };
 		CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatterTests.swift; sourceTree = "<group>"; };
 		CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		CE4ECA572BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCAnalyticsStatsTotals+UI.swift"; sourceTree = "<group>"; };
@@ -11897,6 +11899,7 @@
 			isa = PBXGroup;
 			children = (
 				CEAEB7592CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift */,
+				CE4AFE452CD135AC0013C52B /* WooShippingPostPurchaseViewModel.swift */,
 			);
 			path = "WooShipping Post-Purchase";
 			sourceTree = "<group>";
@@ -16274,6 +16277,7 @@
 				269098B827D68CCD001FEB07 /* FeesInputTransformer.swift in Sources */,
 				B6C78B8C293BADAA008934A1 /* AnalyticsHubLastWeekRangeData.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
+				CE4AFE462CD135B20013C52B /* WooShippingPostPurchaseViewModel.swift in Sources */,
 				02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */,
 				D89C004725B467C7000E4683 /* ULAccountMismatchViewModel.swift in Sources */,
 				037D270D28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14240
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a UI component to be used after purchasing a shipping label in the new Woo Shipping label creation flow. It will be added to the main label creation screen, but for now it isn't yet used in the app.

The UI includes a menu to select a label paper size, a print button, and various links to additional details/actions. For now, none of the buttons are functional; navigation will be added in a separate PR (and support for refunds will be added in project milestone 4).

### How

* Adds a `HighlightButtonStyle` style to support buttons with a highlight background color other than the primary/accent color.
* Adds the view for the new component `WooShippingPostPurchaseView`.
* Adds a view model `WooShippingPostPurchaseViewModel`. For now the view uses static data, so there aren't any unit tests. Eventually the view model will handle e.g. loading the default label size, fetching the label to print, and refunding the label.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This component is not yet used in the app, so you can check it in the corresponding SwiftUI preview.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Design:
![Create Order](https://github.com/user-attachments/assets/8f9c56ca-9774-485c-9b96-4fdd15a9d7f7)

Light|Dark|Dynamic text
-|-|-
![Screenshot 2024-10-29 at 15 21 58](https://github.com/user-attachments/assets/8f01f543-7909-420b-a409-ddd975a9a91f)|![Screenshot 2024-10-29 at 15 22 40](https://github.com/user-attachments/assets/807e629c-b1df-4b31-88ef-f8cc36637184)|![Screenshot 2024-10-29 at 16 40 05](https://github.com/user-attachments/assets/a408d53d-cdaf-4efb-acd7-21e6a97fa3af)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.