### PR TITLE
[Woo POS - payments onboarding] Show payments setup admin URL in authenticated webview for site credentials login to skip login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 21.0
 -----
-
+- [*] Payments onboarding: for two onboarding errors that show a wp-admin Payments setup URL in a webview ("Payments plugin not setup" and "Stripe overdue" errors that can occur to both WooPayments and Stripe Extension), the webview is now pre-authenticated for merchants with site credentials login [https://github.com/woocommerce/woocommerce-ios/pull/14252]
 
 20.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/Components/CardPresentPaymentSetupSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/Components/CardPresentPaymentSetupSheet.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+extension View {
+    /// Displays a sheet that contains a webview to show a card present payment setup URL.
+    /// The webview is pre-authenticated for merchants who log in with site credentials.
+    func cardPresentPaymentSetupSheet(url: Binding<URL?>, dismiss: @escaping (() -> Void)) -> some View {
+        self.modifier(CardPresentPaymentSetupSheet(url: url, dismiss: dismiss))
+    }
+}
+
+struct CardPresentPaymentSetupSheet: ViewModifier {
+    @Binding var url: URL?
+    let dismiss: (() -> Void)
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: $url) { url in
+                // For WPCOM login, wp-admin URL gets redirected to a WPCOM page in a webview and cannot be pre-authenticated easily.
+                // For site credentials login, wp-admin URL can be pre-authenticated in a webview.
+                // Therefore, authenticated webview is only enabled for site credentials login.
+                WebViewSheet(viewModel: .init(url: url,
+                                              navigationTitle: Localization.webviewSetupTitle,
+                                              authenticated: ServiceLocator.stores.isAuthenticatedWithoutWPCom)) {
+                    dismiss()
+                }
+            }
+    }
+}
+
+private extension CardPresentPaymentSetupSheet {
+    enum Localization {
+        static let webviewSetupTitle = NSLocalizedString(
+            "card.present.payment.setup.webview.title", value: "Payments Setup",
+            comment: "Button to refresh the state of the in-person payments setup")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -50,15 +50,8 @@ struct InPersonPaymentsPluginNotSetup: View {
             InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(tappedAnalyticEvent: learnMoreAnalyticEvent))
                 .padding(.vertical, 8)
         }
-        .sheet(item: $presentedSetupURL) { setupURL in
-            // For WPCOM login, wp-admin URL gets redirected to a WPCOM page in a webview and cannot be pre-authenticated easily.
-            // For site credentials login, wp-admin URL can be pre-authenticated in a webview.
-            // Therefore, authenticated webview is only enabled for site credentials login.
-            WebViewSheet(viewModel: .init(url: setupURL,
-                                          navigationTitle: Localization.webviewSetupTitle,
-                                          authenticated: ServiceLocator.stores.isAuthenticatedWithoutWPCom)) {
-                presentedSetupURL = nil
-            }
+        .cardPresentPaymentSetupSheet(url: $presentedSetupURL) {
+            presentedSetupURL = nil
         }
     }
 
@@ -89,10 +82,6 @@ private enum Localization {
 
     static let refreshButton = NSLocalizedString(
         "Refresh",
-        comment: "Button to refresh the state of the in-person payments setup")
-
-    static let webviewSetupTitle = NSLocalizedString(
-        "payments.plugin.setup.webview.title", value: "Payments Setup",
         comment: "Button to refresh the state of the in-person payments setup")
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -50,7 +50,16 @@ struct InPersonPaymentsPluginNotSetup: View {
             InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(tappedAnalyticEvent: learnMoreAnalyticEvent))
                 .padding(.vertical, 8)
         }
-        .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
+        .sheet(item: $presentedSetupURL) { setupURL in
+            // For WPCOM login, wp-admin URL gets redirected to a WPCOM page in a webview and cannot be pre-authenticated easily.
+            // For site credentials login, wp-admin URL can be pre-authenticated in a webview.
+            // Therefore, authenticated webview is only enabled for site credentials login.
+            WebViewSheet(viewModel: .init(url: setupURL,
+                                          navigationTitle: Localization.webviewSetupTitle,
+                                          authenticated: ServiceLocator.stores.isAuthenticatedWithoutWPCom)) {
+                presentedSetupURL = nil
+            }
+        }
     }
 
     private var setupURL: URL? {
@@ -80,6 +89,10 @@ private enum Localization {
 
     static let refreshButton = NSLocalizedString(
         "Refresh",
+        comment: "Button to refresh the state of the in-person payments setup")
+
+    static let webviewSetupTitle = NSLocalizedString(
+        "payments.plugin.setup.webview.title", value: "Payments Setup",
         comment: "Button to refresh the state of the in-person payments setup")
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -32,7 +32,16 @@ struct InPersonPaymentsStripeAccountOverdue: View {
                                                                                      plugin: plugin,
                                                                                      action: onRefresh)
         )
-        .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
+        .sheet(item: $presentedSetupURL) { setupURL in
+            // For WPCOM login, wp-admin URL gets redirected to a WPCOM page in a webview and cannot be pre-authenticated easily.
+            // For site credentials login, wp-admin URL can be pre-authenticated in a webview.
+            // Therefore, authenticated webview is only enabled for site credentials login.
+            WebViewSheet(viewModel: .init(url: setupURL,
+                                          navigationTitle: Localization.webviewSetupTitle,
+                                          authenticated: ServiceLocator.stores.isAuthenticatedWithoutWPCom)) {
+                presentedSetupURL = nil
+            }
+        }
      }
 
     private var setupURL: URL? {
@@ -72,6 +81,10 @@ private enum Localization {
     static let secondaryButtonTitle = NSLocalizedString(
         "Refresh",
         comment: "Button to refresh the state of the in-person payments setup.")
+
+    static let webviewSetupTitle = NSLocalizedString(
+        "payments.stripe.account.overdue.webview.title", value: "Payments Setup",
+        comment: "Button to refresh the state of the in-person payments setup")
  }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -32,15 +32,8 @@ struct InPersonPaymentsStripeAccountOverdue: View {
                                                                                      plugin: plugin,
                                                                                      action: onRefresh)
         )
-        .sheet(item: $presentedSetupURL) { setupURL in
-            // For WPCOM login, wp-admin URL gets redirected to a WPCOM page in a webview and cannot be pre-authenticated easily.
-            // For site credentials login, wp-admin URL can be pre-authenticated in a webview.
-            // Therefore, authenticated webview is only enabled for site credentials login.
-            WebViewSheet(viewModel: .init(url: setupURL,
-                                          navigationTitle: Localization.webviewSetupTitle,
-                                          authenticated: ServiceLocator.stores.isAuthenticatedWithoutWPCom)) {
-                presentedSetupURL = nil
-            }
+        .cardPresentPaymentSetupSheet(url: $presentedSetupURL) {
+            presentedSetupURL = nil
         }
      }
 
@@ -81,10 +74,6 @@ private enum Localization {
     static let secondaryButtonTitle = NSLocalizedString(
         "Refresh",
         comment: "Button to refresh the state of the in-person payments setup.")
-
-    static let webviewSetupTitle = NSLocalizedString(
-        "payments.stripe.account.overdue.webview.title", value: "Payments Setup",
-        comment: "Button to refresh the state of the in-person payments setup")
  }
 
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		02312797277D4F650060E180 /* StoreStatsPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02312796277D4F640060E180 /* StoreStatsPeriodViewModel.swift */; };
 		023453F22579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */; };
 		0234680A282CEA5F00CFC503 /* LegacyReceiptViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02346809282CEA5F00CFC503 /* LegacyReceiptViewModelTests.swift */; };
+		0234BF122CD1D7F800F0F2FF /* CardPresentPaymentSetupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0234BF112CD1D7BC00F0F2FF /* CardPresentPaymentSetupSheet.swift */; };
 		0235354E2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */; };
 		0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */; };
 		0235595124496853004BE2B8 /* BottomSheetListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */; };
@@ -3258,6 +3259,7 @@
 		02312796277D4F640060E180 /* StoreStatsPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsPeriodViewModel.swift; sourceTree = "<group>"; };
 		023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingInstructionsViewController.swift; sourceTree = "<group>"; };
 		02346809282CEA5F00CFC503 /* LegacyReceiptViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyReceiptViewModelTests.swift; sourceTree = "<group>"; };
+		0234BF112CD1D7BC00F0F2FF /* CardPresentPaymentSetupSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentSetupSheet.swift; sourceTree = "<group>"; };
 		0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorViewController.swift; sourceTree = "<group>"; };
 		0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorViewController.xib; sourceTree = "<group>"; };
@@ -6462,6 +6464,14 @@
 				02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */,
 			);
 			path = Implementation;
+			sourceTree = "<group>";
+		};
+		0234BF102CD1D7AD00F0F2FF /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				0234BF112CD1D7BC00F0F2FF /* CardPresentPaymentSetupSheet.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		0235594024496414004BE2B8 /* BottomSheet */ = {
@@ -13061,6 +13071,7 @@
 		E107FCDD26C1295600BAF51B /* Onboarding Errors */ = {
 			isa = PBXGroup;
 			children = (
+				0234BF102CD1D7AD00F0F2FF /* Components */,
 				D85A3C5126C15DE200C0E026 /* InPersonPaymentsPluginNotSupportedVersionView.swift */,
 				D85A3C5526C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift */,
 				E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */,
@@ -15930,6 +15941,7 @@
 				205B7EC92C19FCDB00D14A36 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift in Sources */,
 				0269A63C2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift in Sources */,
 				3188533C2639FE5800F66A9C /* PaymentSettingsFlowPresentedViewModel.swift in Sources */,
+				0234BF122CD1D7F800F0F2FF /* CardPresentPaymentSetupSheet.swift in Sources */,
 				CE55F2D42B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift in Sources */,
 				DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */,
 				02B41A96296D09D100FE3311 /* DomainSettingsListView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14233 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As suggested in https://github.com/woocommerce/woocommerce-ios/pull/14224#discussion_r1818511415, we can improve the UX of the payments setup flow so that the admin URL can be pre-authenticated in the webview whenever possible. This way, the merchant doesn't have to enter their site credentials again which could raise the onboarding completion rate. After testing with both WPCOM and site credentials login for a self-hosted site (which is 90%+ of the stores in the app), it appears that the site can only be pre-authenticated for site credentials login. With WPCOM login for the same site, authenticated webview just redirects to a WPCOM page that is not the payments setup URL. This behavior makes sense because the admin URL requires the site credentials, which isn't immediately available from WPCOM login credentials. As a result, this PR updates the existing "plugin not setup" and "Stripe overdue" onboarding error views to show an authenticated webview for site credentials login using `WebViewSheet`. These two views are the only use cases of the payments setup URL `site.cardPresentPluginHasPendingTasksURL`.

## How

A new SwiftUI modifier `CardPresentPaymentSetupSheet` was created to show a webview in a sheet, pre-authenticated for site credentials login (`ServiceLocator.stores.isAuthenticatedWithoutWPCom`). For WPCOM login, a `WKWebView` wrapper webview should be shown like before.

There are two use cases of the payments setup URL, whose `safariSheet` was replaced with `cardPresentPaymentSetupSheet` from the new modifier:

- `InPersonPaymentsPluginNotSetup`
- `InPersonPaymentsStripeAccountOverdue`

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Since this change affects the existing onboarding flow for all entry points (POS, IPP, Payments menu), I think focusing on testing the most critical flow, IPP, is the best use of time.

### Stripe overdue

Prerequisite: store payment gateway is active and set up but account has `account.wcpayStatus == .restricted && account.hasOverdueRequirements`. Alternatively, you can hard code the state by returning `.stripeAccountOverdueRequirement(plugin: .wcPay)` at the beginning of `CardPresentPaymentsOnboardingUseCase.checkOnboardingState`.

- Log in to the store with site credentials
- Go to the orders tab
- Create an order
- Enter a custom amount or add some products then recalculate
- Collect payment
- Tap `Card Reader` --> an onboarding modal should be shown. after the loading state, the Stripe overdue UI should be shown
- Tap `Resolve Now` --> the webview should be shown pre-authenticated
- Log out and log in with WPCOM
- Repeat the same steps above after the login --> the webview should show a wp-admin login form for the first time
- Enter site credentials --> it should redirect to the wp-admin Payments Overview page

### Payments plugin not set up

Prerequisite: store payment gateway is active but isn't set up completely. Alternatively, you can hard code the state by returning `.pluginSetupNotCompleted(plugin: .wcPay)` at the beginning of `CardPresentPaymentsOnboardingUseCase.checkOnboardingState`.

- Log in to the store with site credentials
- Go to the orders tab
- Create an order with a custom amount or product, or tap on an order ready for payment collection
- Collect payment
- Tap `Card Reader` --> an onboarding modal should be shown. after the loading state, the plugin not set up UI should be shown
- Tap `Finish Setup in Store Admin` --> the webview should be shown pre-authenticated
- Log out and log in with WPCOM
- Repeat the same steps above after the login --> the webview should show a wp-admin login form for the first time (credentials be remembered int the browser after the first time)
- Enter site credentials --> it should redirect to the wp-admin Payments Overview page

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [x] @jaclync tests the onboarding flow in Menu > Payments > Continue setup
- [x] @jaclync tests the POS use case by Menu > Point of Sale > Connect your reader

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

🗒️ Screencasts were recorded with the POS entry point.

Site credentials login (pre-authenticated):


https://github.com/user-attachments/assets/8a4ebfcf-9092-45db-b9cf-a6f4703f1e00



WPCOM login (Safari sheet):



https://github.com/user-attachments/assets/b46437ae-457e-474d-8d0a-524f819c9b1e





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.