### PR TITLE
[Custom Fields] List empty state

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -366,7 +366,8 @@ extension WooConstants {
 
         case ordersScreen = "https://woocommerce.com/mobile/orders"
 
-        case customFieldsLearnMore = "https://woocommerce.com/document/custom-product-fields/"
+        case customFieldsProductLearnMore = "https://woocommerce.com/document/custom-product-fields/"
+        case customFieldsOrderLearnMore = "https://woocommerce.com/document/managing-orders/view-edit-or-add-an-order/#custom-fields"
 
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -366,6 +366,8 @@ extension WooConstants {
 
         case ordersScreen = "https://woocommerce.com/mobile/orders"
 
+        case customFieldsLearnMore = "https://woocommerce.com/document/custom-product-fields/"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1233,10 +1233,6 @@ extension OrderDetailsDataSource {
         }()
 
         let customFields: Section? = {
-            guard order.customFields.isNotEmpty else {
-                return nil
-            }
-
             return Section(category: .customFields, row: .customFields)
         }()
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -119,7 +119,12 @@ private extension CustomFieldsListHostingController {
     }
 
     func displayLearnMoreWebContent() {
-        WebviewHelper.launch(WooConstants.URLs.customFieldsLearnMore.asURL(), with: self)
+        switch viewModel.customFieldsType {
+        case .order:
+            WebviewHelper.launch(WooConstants.URLs.customFieldsOrderLearnMore.asURL(), with: self)
+        case .product:
+            WebviewHelper.launch(WooConstants.URLs.customFieldsProductLearnMore.asURL(), with: self)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -137,15 +137,24 @@ struct CustomFieldsListView: View {
                     .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
                     .renderedIf(viewModel.shouldShowTopBanner)
 
-                List(viewModel.combinedList) { customField in
-                    Button(action: { viewModel.selectedCustomField = customField }) {
-                        CustomFieldRow(isEditable: isEditable,
-                                    title: customField.key,
-                                    content: customField.value.removedHTMLTags,
-                                    contentURL: nil)
+                if viewModel.combinedList.isEmpty {
+                    EmptyState(title: CustomFieldsListHostingController.Localization.emptyStateTitle,
+                               description: CustomFieldsListHostingController.Localization.emptyStateDescription,
+                               image: .customerSearchImage,
+                               buttonTitle: CustomFieldsListHostingController.Localization.emptyStateButton,
+                               buttonAction: { })
+                        .frame(maxHeight: .infinity)
+                } else {
+                    List(viewModel.combinedList) { customField in
+                        Button(action: { viewModel.selectedCustomField = customField }) {
+                            CustomFieldRow(isEditable: isEditable,
+                                           title: customField.key,
+                                           content: customField.value.removedHTMLTags,
+                                           contentURL: nil)
+                        }
                     }
+                    .listStyle(.plain)
                 }
-                .listStyle(.plain)
             }
             .sheet(item: $viewModel.selectedCustomField) { customField in
 	            /// When editing a newly added and unsaved custom field (identified by it having nil `fieldId`), provide disallowed keys.
@@ -308,6 +317,22 @@ extension CustomFieldsListHostingController {
             "customFieldsListHostingController.saveErrorMessage",
             value: "There was an error saving your changes. Please try again.",
             comment: "Message for the error message when saving changes"
+        )
+        static let emptyStateTitle = NSLocalizedString(
+            "customFieldsListHostingController.emptyStateTitle",
+            value: "No custom fields found",
+            comment: "Title for the message when the list is empty."
+        )
+        static let emptyStateDescription = NSLocalizedString(
+            "customFieldsListHostingController.emptyStateDescription",
+            value: "Custom fields are optional metadata to display extra information or customize "
+            + "your store's shopping experience",
+            comment: "Message when the list is empty."
+        )
+        static let emptyStateButton = NSLocalizedString(
+            "customFieldsListHostingController.emptyStateButton",
+            value: "Learn more",
+            comment: "Text for button that's shown when the list is empty."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -65,6 +65,8 @@ private extension CustomFieldsListHostingController {
     func configureNavigation() {
         title = Localization.title
         navigationItem.rightBarButtonItems = [saveCustomFieldButtonItem, addCustomFieldButtonItem]
+
+        rootView.emptyStateButtonAction = displayLearnMoreWebContent
     }
 
     @objc func openAddCustomFieldScreen() {
@@ -115,6 +117,10 @@ private extension CustomFieldsListHostingController {
             self?.navigationController?.popViewController(animated: true)
         })
     }
+
+    func displayLearnMoreWebContent() {
+        WebviewHelper.launch(WooConstants.URLs.customFieldsLearnMore.asURL(), with: self)
+    }
 }
 
 struct CustomFieldsListView: View {
@@ -122,6 +128,7 @@ struct CustomFieldsListView: View {
     @ObservedObject private var viewModel: CustomFieldsListViewModel
 
     let isEditable: Bool
+    var emptyStateButtonAction: (() -> Void)?
 
     init(isEditable: Bool,
          viewModel: CustomFieldsListViewModel) {
@@ -142,7 +149,7 @@ struct CustomFieldsListView: View {
                                description: CustomFieldsListHostingController.Localization.emptyStateDescription,
                                image: .customerSearchImage,
                                buttonTitle: CustomFieldsListHostingController.Localization.emptyStateButton,
-                               buttonAction: { })
+                               buttonAction: emptyStateButtonAction)
                         .frame(maxHeight: .infinity)
                 } else {
                     List(viewModel.combinedList) { customField in

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -6,7 +6,7 @@ import Yosemite
 final class CustomFieldsListViewModel: ObservableObject {
     private let stores: StoresManager
     @Published private var originalCustomFields: [CustomFieldViewModel]
-    private let customFieldsType: MetaDataType
+    let customFieldsType: MetaDataType
     private let siteID: Int64
     private let parentItemID: Int64
     private let onChangesSaved: (([MetaData]) -> Void)?

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
@@ -32,6 +32,8 @@ struct EmptyState: View {
                     buttonAction?()
                 }
                 .buttonStyle(PrimaryButtonStyle())
+                .padding(.top, Constants.verticalSpacing)
+                .frame(maxWidth: Constants.buttonWidth)
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
@@ -44,6 +46,7 @@ private extension EmptyState {
         static let verticalSpacing: CGFloat = 16
         static let horizontalSpacing: CGFloat = 24
         static let width: CGFloat = 168
+        static let buttonWidth: CGFloat = 228
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
@@ -5,6 +5,8 @@ struct EmptyState: View {
     @State var title: String
     @State var description: String?
     @State var image: UIImage?
+    @State var buttonTitle: String?
+    @State var buttonAction: (() -> Void)?
 
     var body: some View {
         VStack(spacing: Constants.verticalSpacing) {
@@ -23,6 +25,13 @@ struct EmptyState: View {
                     .multilineTextAlignment(.center)
                     .bodyStyle()
                     .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let buttonTitle {
+                Button(buttonTitle) {
+                    buttonAction?()
+                }
+                .buttonStyle(PrimaryButtonStyle())
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -544,7 +544,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(customFieldSection)
     }
 
-    func test_custom_fields_button_is_hidden_when_order_contains_no_custom_fields_to_display() throws {
+    func test_custom_fields_button_is_visible_when_order_contains_no_custom_fields_to_display() throws {
         // Given
         let order = MockOrders().makeOrder(customFields: [])
         let dataSource = OrderDetailsDataSource(
@@ -557,7 +557,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let customFieldSection = section(withCategory: .customFields, from: dataSource)
-        XCTAssertNil(customFieldSection)
+        XCTAssertNotNil(customFieldSection)
     }
 
     func test_subscriptions_section_is_visible_when_order_has_associated_subscriptions() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14254 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the empty state for Custom Fields List screen. The text and design matches the one in Android, except for the image. I can't find the same image in iOS, so I opted for something that looks somewhat close. Please check the comparison in the screenshot area below.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to product details of a product with no custom fields (Product Details > Add More Details > Custom Fields)
2. Ensure empty state view is shown like in screenshot below,
3. Test the "Learn more" button, ensure it opens webview correctly to the Custom Fields documentation page in WooCommerce.com,
4. Go back and test adding a new custom field, ensure the empty view is then replaced by the list.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested the steps above with iPhone simulator with iOS 17.5.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Android light | Android dark |
|-|-|
| ![2024-10-30 18 23 51](https://github.com/user-attachments/assets/3b40ca06-796f-4e52-aa6d-6740fd05a799) | ![2024-10-30 18 19 25](https://github.com/user-attachments/assets/47114aa2-2adc-4385-94ee-0370e0eaaff5) |

| iOS light | iOS dark |
|-|-|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-10-30 at 18 16 12](https://github.com/user-attachments/assets/b7614f1b-2b40-4196-bc5f-68a733f438a2) |  ![Simulator Screenshot - iPhone 15 Pro - 2024-10-30 at 18 25 26](https://github.com/user-attachments/assets/37badff8-5c01-431d-a593-04edeeae0cf2) |

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.42