### PR TITLE
[Shipping labels] Integrate post-purchase UI into main Woo Shipping screen

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSize+UI.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSize+UI.swift
@@ -10,9 +10,8 @@ extension ShippingLabelPaperSize {
             return NSLocalizedString("Legal (8.5 x 14 in)", comment: "Title of legal paper size option for printing a shipping label")
         case .letter:
             return NSLocalizedString("Letter (8.5 x 11 in)", comment: "Title of letter paper size option for printing a shipping label")
-        default:
-            assertionFailure("Unexpected paper size: \(self)")
-            return ""
+        case .a4:
+            return NSLocalizedString("A4", comment: "Title of a4 paper size option for printing a shipping label")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -1,9 +1,21 @@
 import Yosemite
+import WooFoundation
 
 struct WooShippingPostPurchaseViewModel {
     /// Available paper sizes for printing the shipping label.
-    let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .legal]
+    let labelSizes: [ShippingLabelPaperSize]
 
     /// Selected paper size for printing the shipping label.
     var selectedLabelSize: ShippingLabelPaperSize = .label
+
+    init(siteAddress: SiteAddress = SiteAddress()) {
+        // Label sizes aren't provided by the API, so we can hard-code them to match the extension behavior:
+        labelSizes = {
+            var availableLabelSizes: [ShippingLabelPaperSize] = [.label, .letter]
+            if [.US, .CA, .MX, .DO].contains(siteAddress.countryCode) {
+                availableLabelSizes.append(.a4)
+            }
+            return availableLabelSizes
+        }()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -38,6 +38,10 @@ struct WooShippingCreateLabelsView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: Layout.verticalSpacing) {
+                    if viewModel.displayPostPurchase {
+                        WooShippingPostPurchaseView()
+                    }
+
                     WooShippingItems(viewModel: viewModel.items)
 
                     WooShippingHazmat()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -38,7 +38,7 @@ struct WooShippingCreateLabelsView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: Layout.verticalSpacing) {
-                    if viewModel.displayPostPurchase {
+                    if viewModel.canViewLabel {
                         WooShippingPostPurchaseView()
                     }
 
@@ -138,11 +138,11 @@ struct WooShippingCreateLabelsView: View {
                 }
                 .ignoresSafeArea(edges: .horizontal)
             }
-            .navigationTitle(Localization.title)
+            .navigationTitle(viewModel.canViewLabel ? Localization.viewLabelTitle : Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(Localization.cancel) {
+                    Button(viewModel.canViewLabel ? Localization.close : Localization.cancel) {
                         dismiss()
                     }
                 }
@@ -258,9 +258,15 @@ private extension WooShippingCreateLabelsView {
         static let title = NSLocalizedString("wooShipping.createLabels.title",
                                              value: "Create Shipping Labels",
                                              comment: "Title for the screen to create a shipping label")
+        static let viewLabelTitle = NSLocalizedString("wooShipping.createLabels.viewLabelTitle",
+                                                      value: "View Shipping Label",
+                                                      comment: "Title for the screen to view a shipping label")
         static let cancel = NSLocalizedString("wooShipping.createLabel.cancelButton",
                                               value: "Cancel",
                                               comment: "Title of the button to dismiss the shipping label creation screen")
+        static let close = NSLocalizedString("wooShipping.createLabel.closeButton",
+                                             value: "Close",
+                                             comment: "Title of the button to dismiss the shipping label screen")
 
         enum BottomSheet {
             static let shipmentDetails = NSLocalizedString("wooShipping.createLabels.bottomSheet.title",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -7,6 +7,14 @@ import WooFoundation
 final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
 
+    /// The purchased shipping label.
+    let shippingLabel: ShippingLabel?
+
+    /// Whether to display the post-purchase section (with actions to e.g. print, track, and refund the label).
+    var displayPostPurchase: Bool {
+        shippingLabel != nil
+    }
+
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
@@ -40,9 +48,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
     init(order: Order,
+         shippingLabel: ShippingLabel? = nil,
          siteAddress: SiteAddress = SiteAddress(),
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          onLabelPurchase: ((Bool) -> Void)? = nil) {
+        self.shippingLabel = shippingLabel
         self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -10,8 +10,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// The purchased shipping label.
     let shippingLabel: ShippingLabel?
 
-    /// Whether to display the post-purchase section (with actions to e.g. print, track, and refund the label).
-    var displayPostPurchase: Bool {
+    /// Whether an existing label can be viewed (and printed, tracked, refunded, etc.).
+    var canViewLabel: Bool {
         shippingLabel != nil
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2228,6 +2228,7 @@
 		CE49C4752CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */; };
 		CE49C4772CBEC8C300EA5C84 /* WooShipping_ShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */; };
 		CE4AFE462CD135B20013C52B /* WooShippingPostPurchaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4AFE452CD135AC0013C52B /* WooShippingPostPurchaseViewModel.swift */; };
+		CE4AFE482CD239B90013C52B /* WooShippingPostPurchaseViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4AFE472CD239B90013C52B /* WooShippingPostPurchaseViewModelTests.swift */; };
 		CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */; };
 		CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
 		CE4ECA582BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4ECA572BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift */; };
@@ -5294,6 +5295,7 @@
 		CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShipping_ShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE49C4762CBEC8BA00EA5C84 /* WooShipping_ShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShipping_ShippingLineViewModelTests.swift; sourceTree = "<group>"; };
 		CE4AFE452CD135AC0013C52B /* WooShippingPostPurchaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPostPurchaseViewModel.swift; sourceTree = "<group>"; };
+		CE4AFE472CD239B90013C52B /* WooShippingPostPurchaseViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPostPurchaseViewModelTests.swift; sourceTree = "<group>"; };
 		CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatterTests.swift; sourceTree = "<group>"; };
 		CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		CE4ECA572BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCAnalyticsStatsTotals+UI.swift"; sourceTree = "<group>"; };
@@ -11922,6 +11924,7 @@
 				DA40806D2CC29650002A4577 /* WooShippingAddCustomPackageViewModelTests.swift */,
 				CE86C8322CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift */,
 				CE315DC72CC942A200A06748 /* WooShippingServiceViewModelTests.swift */,
+				CE4AFE472CD239B90013C52B /* WooShippingPostPurchaseViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -17074,6 +17077,7 @@
 				DECEA4492C81C1A800C28C10 /* ProductImagePickerViewModelTests.swift in Sources */,
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,
 				579CDF01274D811D00E8903D /* StoreStatsUsageTracksEventEmitterTests.swift in Sources */,
+				CE4AFE482CD239B90013C52B /* WooShippingPostPurchaseViewModelTests.swift in Sources */,
 				EE3272A429A88F750015F8D0 /* StoreOnboardingViewModelTests.swift in Sources */,
 				262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */,
 				027F240C258371150021DB06 /* RefundShippingLabelViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -147,7 +147,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(formattedAmount, "$2.70")
     }
 
-    func test_displayPostPurchase_true_when_shipping_label_exists() {
+    func test_canViewLabel_true_when_shipping_label_exists() {
         // Given
         let order = Order.fake()
         let label = ShippingLabel.fake()
@@ -157,8 +157,8 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let existingLabelViewModel = WooShippingCreateLabelsViewModel(order: order, shippingLabel: label)
 
         // Then
-        XCTAssertFalse(newLabelViewModel.displayPostPurchase)
-        XCTAssertTrue(existingLabelViewModel.displayPostPurchase)
+        XCTAssertFalse(newLabelViewModel.canViewLabel)
+        XCTAssertTrue(existingLabelViewModel.canViewLabel)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -146,6 +146,20 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(formattedAmount, "$2.70")
     }
+
+    func test_displayPostPurchase_true_when_shipping_label_exists() {
+        // Given
+        let order = Order.fake()
+        let label = ShippingLabel.fake()
+
+        // When
+        let newLabelViewModel = WooShippingCreateLabelsViewModel(order: order)
+        let existingLabelViewModel = WooShippingCreateLabelsViewModel(order: order, shippingLabel: label)
+
+        // Then
+        XCTAssertFalse(newLabelViewModel.displayPostPurchase)
+        XCTAssertTrue(existingLabelViewModel.displayPostPurchase)
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class WooShippingPostPurchaseViewModelTests: XCTestCase {
+
+    func test_labelSizes_includes_expected_default_values() {
+        // Given
+        let countrySetting = SiteSetting.fake().copy(settingID: "woocommerce_default_country",
+                                                  value: "GB")
+        let siteAddress = SiteAddress(siteSettings: [countrySetting])
+
+        // When
+        let viewModel = WooShippingPostPurchaseViewModel(siteAddress: siteAddress)
+
+        // Then
+        assertEqual([.label, .letter], viewModel.labelSizes)
+    }
+
+    func test_labelSizes_includes_expected_values_for_country_with_a4_label_size() {
+        // Given
+        let countrySetting = SiteSetting.fake().copy(settingID: "woocommerce_default_country",
+                                                  value: "US:NY")
+        let siteAddress = SiteAddress(siteSettings: [countrySetting])
+
+        // When
+        let viewModel = WooShippingPostPurchaseViewModel(siteAddress: siteAddress)
+
+        // Then
+        assertEqual([.label, .letter, .a4], viewModel.labelSizes)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14241
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This integrates the new post-purchase UI component into the main screen in the Woo Shipping label creation flow. This component will appear in two scenarios:

* Immediately after a label is successfully purchased.
* When viewing a previously purchased shipping label (e.g. from order details).

When this component is visible, the navigation title and dismiss button are also updated to reflect the new state (viewing instead of creating a label).

### How

* This adds an optional `shippingLabel` property to hold the shipping label and `canViewLabel` that is `true` when the shipping label is non-nil.
* In the view, the post-purchase component is shown, the navigation title is updated, and the dismiss button label is changed when `canViewLabel` is true.
* This also includes a small update to the post-purchase component to set the available label sizes based on the store. This list is not available from the API, so instead we [match the web behavior](https://github.com/woocommerce/woocommerce-shipping/blob/2d85581fae87a33b7a49ab8381be38f82b2158b1/client/components/label-purchase/label/utils.ts#L4) to make the label and letter sizes always available and add the A4 size for certain countries.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Confirm the post-purchase component is not displayed by default:

1. Install and set up the Woo Shipping extension on your store.
2. Enable the `revampedShippingLabelCreation` feature flag.
3. Build and run the app.
4. Create an order with the processing status and at least one physical product.
5. In the order details, select "Create Shipping Label."
6. In the shipping label screen, confirm you don't see the post-purchase component.

There is not yet a way to set a shipping label in the view model, but you can manually test the component on this screen:

1. Install and set up the Woo Shipping extension on your store.
2. Enable the `revampedShippingLabelCreation` feature flag.
3. In `WooShippingCreateLabelsViewModel`, set `canViewLabel` to always return `true`.
4. Build and run the app.
5. Create an order with the processing status and at least one physical product.
6. In the order details, select "Create Shipping Label."
7. Confirm the component appears at the top of the screen, with the updated navigation title and dismiss button.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Without shipping label (no change)|With shipping label
-|-
![Simulator Screenshot - iPhone 16 Pro - 2024-10-30 at 15 11 51](https://github.com/user-attachments/assets/a1c78436-22bb-4cd9-b227-5faa1914c754)|![Simulator Screenshot - iPhone 16 Pro - 2024-10-30 at 15 12 41](https://github.com/user-attachments/assets/f90e7071-b5c2-4faf-808a-8b45ef4b7b37)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.