### PR TITLE
[Login] Improve error messaging when application password is disabled.

### DIFF
--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// View model for `ApplicationPasswordAuthorizationWebViewController`.
 ///
 final class ApplicationPasswordAuthorizationViewModel {
-    private let siteURL: String
+    let siteURL: String
     private let stores: StoresManager
 
     init(siteURL: String,

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -157,7 +157,20 @@ private extension ApplicationPasswordAuthorizationWebViewController {
                 guard let url = try await viewModel.fetchAuthURL() else {
                     DDLogError("⛔️ No authorization URL found for application passwords")
                     analytics.track(.applicationPasswordAuthorizationURLNotAvailable)
-                    return showErrorAlert(message: Localization.applicationPasswordDisabled)
+
+                    let errorUI = applicationPasswordDisabledUI(for: viewModel.siteURL)
+                    // When the error view controller is popped, also pop the web view
+                    errorUI.navigationItem.leftBarButtonItem = UIBarButtonItem(
+                        image: UIImage(systemName: "chevron.backward"),
+                        style: .plain,
+                        target: self,
+                        action: #selector(popBothControllers)
+                    )
+
+                    // Push instead of present
+                    navigationController?.pushViewController(errorUI, animated: true)
+
+                    return
                 }
                 loadAuthorizationPage(url: url)
             } catch {
@@ -169,6 +182,12 @@ private extension ApplicationPasswordAuthorizationWebViewController {
             }
             activityIndicator.stopAnimating()
         }
+    }
+
+    @objc private func popBothControllers() {
+        // Pop back two view controllers to remove both error and web view
+        navigationController?.popViewController(animated: false)
+        navigationController?.popViewController(animated: true)
     }
 
     func loadAuthorizationPage(url: URL) {
@@ -220,6 +239,14 @@ private extension ApplicationPasswordAuthorizationWebViewController {
         }
         present(alertController, animated: true)
     }
+
+    /// The error screen to be displayed when the user tries to log in with site credentials
+    /// with application password disabled.
+    ///
+    func applicationPasswordDisabledUI(for siteURL: String) -> UIViewController {
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: siteURL)
+        return ULErrorViewController(viewModel: viewModel)
+    }
 }
 
 extension ApplicationPasswordAuthorizationWebViewController: WKNavigationDelegate {
@@ -251,6 +278,13 @@ extension ApplicationPasswordAuthorizationWebViewController: WKNavigationDelegat
         onSuccess(applicationPassword, navigationController)
         DDLogInfo("✅ Application password authorized")
         return .cancel
+    }
+}
+
+extension ApplicationPasswordAuthorizationWebViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        // This will be called when the error UI is dismissed
+        navigationController?.dismiss(animated: true)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ApplicationPasswordDisabledViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ApplicationPasswordDisabledViewModel.swift
@@ -5,11 +5,14 @@ import WordPressAuthenticator
 /// modeling an error when application password is disabled.
 ///
 struct ApplicationPasswordDisabledViewModel: ULErrorViewModel {
-    init(siteURL: String) {
+    init(siteURL: String,
+         authentication: Authentication = ServiceLocator.authenticationManager) {
         self.siteURL = siteURL
+        self.authentication = authentication
     }
 
     let siteURL: String
+    let authentication: Authentication
     let image: UIImage = .errorImage // TODO: update this if needed
 
     var text: NSAttributedString {
@@ -55,6 +58,17 @@ struct ApplicationPasswordDisabledViewModel: ULErrorViewModel {
         }
         WebviewHelper.launch(Constants.applicationPasswordLink, with: viewController)
     }
+
+    var rightBarButtonItemTitle: String? {
+        return Localization.helpButtonTitle
+    }
+
+    func didTapRightBarButtonItem(in viewController: UIViewController?) {
+        guard let viewController else {
+            return
+        }
+        authentication.presentSupport(from: viewController, screen: .noWooError)
+    }
 }
 
 private extension ApplicationPasswordDisabledViewModel {
@@ -77,6 +91,10 @@ private extension ApplicationPasswordDisabledViewModel {
         static let primaryButtonTitle = NSLocalizedString(
             "Log in with WordPress.com",
             comment: "Button that will navigate to the authentication flow with WP.com"
+        )
+        static let helpButtonTitle = NSLocalizedString(
+            "Help",
+            comment: "Button that will navigate to the support area"
         )
     }
     enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14004
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create test site with WooCommerce and no Jetpack,
2. Install and active this plugin https://wordpress.org/plugins/disable-application-passwords/
3. Try to log in using application password to the test site,
4. Confirm that the new dialog is shown

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.