### PR TITLE
[Custom Fields] Read-only mode for JSON values

### DIFF
--- a/Networking/Networking/Model/MetaData.swift
+++ b/Networking/Networking/Model/MetaData.swift
@@ -23,9 +23,9 @@ public struct MetaData: Codable, Equatable, Sendable, GeneratedCopiable, Generat
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let metadataID = try container.decode(Int64.self, forKey: .metadataID)
         let key = try container.decode(String.self, forKey: .key)
-        let value = container.failsafeDecodeIfPresent(String.self, forKey: .value) ?? ""
+        let rawValue = container.failsafeDecodeIfPresent(AnyCodable.self, forKey: .value) ?? ""
 
-        self.init(metadataID: metadataID, key: key, value: value)
+        self.init(metadataID: metadataID, key: key, value: rawValue.getAsString())
     }
 }
 
@@ -36,5 +36,21 @@ private extension MetaData {
         case metadataID = "id"
         case key
         case value
+    }
+}
+
+private extension AnyCodable {
+    func getAsString() -> String {
+        switch value {
+        case let string as String:
+            return string
+        default:
+            if JSONSerialization.isValidJSONObject(value) {
+                let data = (try? JSONSerialization.data(withJSONObject: value)) ?? Data()
+                return String(data: data, encoding: .utf8) ?? ""
+            } else {
+                return "\(value)"
+            }
+        }
     }
 }

--- a/Networking/NetworkingTests/Mapper/MetaDataMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/MetaDataMapperTests.swift
@@ -15,23 +15,16 @@ final class MetaDataMapperTests: XCTestCase {
         let metadata = try mapper.map(response: data)
 
         // Then
-        XCTAssertEqual(metadata.count, 4)
+        XCTAssertEqual(metadata.count, 7)
 
-        XCTAssertEqual(metadata[0].metadataID, 1)
-        XCTAssertEqual(metadata[0].key, "lorem_key_1")
-        XCTAssertEqual(metadata[0].value, "Lorem ipsum")
-
-        XCTAssertEqual(metadata[1].metadataID, 2)
-        XCTAssertEqual(metadata[1].key, "ipsum_key_2")
-        XCTAssertEqual(metadata[1].value, "dolor sit amet")
-
-        XCTAssertEqual(metadata[2].metadataID, 3)
-        XCTAssertEqual(metadata[2].key, "dolor_key_3")
-        XCTAssertEqual(metadata[2].value, "consectetur adipiscing elit")
-
-        XCTAssertEqual(metadata[3].metadataID, 4)
-        XCTAssertEqual(metadata[3].key, "sit_key_4")
-        XCTAssertEqual(metadata[3].value, "Nisi ut aliquip")
+        XCTAssertEqual(metadata[0], MetaData(metadataID: 1, key: "text_field", value: "Lorem ipsum"))
+        XCTAssertEqual(metadata[1], MetaData(metadataID: 2, key: "json_field", value: "{\"key\":\"value\"}"))
+        XCTAssertEqual(metadata[2], MetaData(metadataID: 3, key: "json_array_field", value: "[{\"key\":\"value\"}]"))
+        // For now, the iOS implementation doesn't differentiate between wrapped and unwrapped JSON.
+        XCTAssertEqual(metadata[3], MetaData(metadataID: 4, key: "json_field_wrapped", value: "{\"key\":\"value\"}"))
+        XCTAssertEqual(metadata[4], MetaData(metadataID: 5, key: "boolean_field", value: "true"))
+        XCTAssertEqual(metadata[5], MetaData(metadataID: 6, key: "number_field", value: "42"))
+        XCTAssertEqual(metadata[6], MetaData(metadataID: 7, key: "empty_field", value: ""))
     }
 
     /// Tests that MetaData is correctly mapped from a meta_data nested in data response.
@@ -46,23 +39,16 @@ final class MetaDataMapperTests: XCTestCase {
         let metadata = try mapper.map(response: data)
 
         // Then
-        XCTAssertEqual(metadata.count, 4)
+        XCTAssertEqual(metadata.count, 7)
 
-        XCTAssertEqual(metadata[0].metadataID, 1)
-        XCTAssertEqual(metadata[0].key, "lorem_key_1")
-        XCTAssertEqual(metadata[0].value, "Lorem ipsum")
-
-        XCTAssertEqual(metadata[1].metadataID, 2)
-        XCTAssertEqual(metadata[1].key, "ipsum_key_2")
-        XCTAssertEqual(metadata[1].value, "dolor sit amet")
-
-        XCTAssertEqual(metadata[2].metadataID, 3)
-        XCTAssertEqual(metadata[2].key, "dolor_key_3")
-        XCTAssertEqual(metadata[2].value, "consectetur adipiscing elit")
-
-        XCTAssertEqual(metadata[3].metadataID, 4)
-        XCTAssertEqual(metadata[3].key, "sit_key_4")
-        XCTAssertEqual(metadata[3].value, "Nisi ut aliquip")
+        XCTAssertEqual(metadata[0], MetaData(metadataID: 1, key: "text_field", value: "Lorem ipsum"))
+        XCTAssertEqual(metadata[1], MetaData(metadataID: 2, key: "json_field", value: "{\"key\":\"value\"}"))
+        XCTAssertEqual(metadata[2], MetaData(metadataID: 3, key: "json_array_field", value: "[{\"key\":\"value\"}]"))
+        // For now, the iOS implementation doesn't differentiate between wrapped and unwrapped JSON.
+        XCTAssertEqual(metadata[3], MetaData(metadataID: 4, key: "json_field_wrapped", value: "{\"key\":\"value\"}"))
+        XCTAssertEqual(metadata[4], MetaData(metadataID: 5, key: "boolean_field", value: "true"))
+        XCTAssertEqual(metadata[5], MetaData(metadataID: 6, key: "number_field", value: "42"))
+        XCTAssertEqual(metadata[6], MetaData(metadataID: 7, key: "empty_field", value: ""))
     }
 }
 

--- a/Networking/NetworkingTests/Responses/meta-data-products-and-orders.json
+++ b/Networking/NetworkingTests/Responses/meta-data-products-and-orders.json
@@ -2,26 +2,47 @@
     "meta_data": [
         {
             "id": 1,
-            "key": "lorem_key_1",
+            "key": "text_field",
             "value": "Lorem ipsum"
         },
         {
             "id": 2,
-            "key": "ipsum_key_2",
-            "value": "dolor sit amet"
+            "key": "json_field",
+            "value": {
+                "key": "value"
+            }
         },
         {
             "id": 3,
-            "key": "dolor_key_3",
-            "value": "consectetur adipiscing elit"
+            "key": "json_array_field",
+            "value": [
+                {
+                    "key": "value"
+                }
+            ]
         },
         {
             "id": 4,
-            "key": "sit_key_4",
-            "value": "Nisi ut aliquip"
+            "key": "json_field_wrapped",
+            "value": "{\"key\":\"value\"}"
         },
         {
             "id": 5,
+            "key": "boolean_field",
+            "value": true
+        },
+        {
+            "id": 6,
+            "key": "number_field",
+            "value": 42
+        },
+        {
+            "id": 7,
+            "key": "empty_field",
+            "value": ""
+        },
+        {
+            "id": 8,
             "key": "_internal_key",
             "value": "In voluptate velit"
         }

--- a/Networking/NetworkingTests/Responses/meta-data-products-and-orders_nested_in_data.json
+++ b/Networking/NetworkingTests/Responses/meta-data-products-and-orders_nested_in_data.json
@@ -1,31 +1,52 @@
 {
-   "data":{
-      "meta_data":[
-         {
-            "id":1,
-            "key":"lorem_key_1",
-            "value":"Lorem ipsum"
-         },
-         {
-            "id":2,
-            "key":"ipsum_key_2",
-            "value":"dolor sit amet"
-         },
-         {
-            "id":3,
-            "key":"dolor_key_3",
-            "value":"consectetur adipiscing elit"
-         },
-         {
-            "id":4,
-            "key":"sit_key_4",
-            "value":"Nisi ut aliquip"
-         },
-         {
-            "id":5,
-            "key":"_internal_key",
-            "value":"In voluptate velit"
-         }
-      ]
-   }
+    "data":{
+        "meta_data":[
+            {
+                "id": 1,
+                "key": "text_field",
+                "value": "Lorem ipsum"
+            },
+            {
+                "id": 2,
+                "key": "json_field",
+                "value": {
+                    "key": "value"
+                }
+            },
+            {
+                "id": 3,
+                "key": "json_array_field",
+                "value": [
+                    {
+                        "key": "value"
+                    }
+                ]
+            },
+            {
+                "id": 4,
+                "key": "json_field_wrapped",
+                "value": "{\"key\":\"value\"}"
+            },
+            {
+                "id": 5,
+                "key": "boolean_field",
+                "value": true
+            },
+            {
+                "id": 6,
+                "key": "number_field",
+                "value": 42
+            },
+            {
+                "id": 7,
+                "key": "empty_field",
+                "value": ""
+            },
+            {
+                "id": 8,
+                "key": "_internal_key",
+                "value": "In voluptate velit"
+            }
+        ]
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -27,7 +27,7 @@ struct CustomFieldEditorView: View {
                         .foregroundColor(Color(.text))
                         .subheadlineStyle()
 
-                    TextField(Localization.keyPlaceholder, text: $viewModel.key)
+                    TextField(Localization.keyPlaceholder, text: isReadOnlyValue ? .constant(viewModel.key) : $viewModel.key)
                         .foregroundColor(Color(.text))
                         .subheadlineStyle()
                         .padding(insets: Layout.inputInsets)
@@ -101,6 +101,7 @@ struct CustomFieldEditorView: View {
                         Text(Localization.doneButton)
                     }
                     .disabled(!viewModel.hasUnsavedChanges || !viewModel.hasValidKey)
+                    .renderedIf(!isReadOnlyValue)
 
                     Button(action: {
                         showActionSheet = true
@@ -115,7 +116,7 @@ struct CustomFieldEditorView: View {
             }
         }
         .closeButtonWithDiscardChangesPrompt(hasChanges: viewModel.hasUnsavedChanges,
-                                             closeButtonLabel: { Text(Localization.cancelButton) })
+                                             closeButtonLabel: { Text(isReadOnlyValue ? Localization.doneButton : Localization.cancelButton) })
         .notice($viewModel.notice)
     }
 
@@ -131,7 +132,7 @@ struct CustomFieldEditorView: View {
             viewModel.notice = Notice(title: Localization.valueCopiedNotice)
         }
 
-        if viewModel.showDeleteButton {
+        if viewModel.showDeleteButton && !isReadOnlyValue {
             Button(Localization.deleteButton, role: .destructive) {
                 viewModel.deleteField()
                 dismiss()

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -7,15 +7,15 @@ struct CustomFieldEditorView: View {
     @State private var showRichTextEditor = false
     @State private var showActionSheet = false
 
-    private let isReadOnlyValue: Bool
+    private var isReadOnlyValue: Bool {
+        viewModel.isReadOnlyValue
+    }
 
     /// Initializer for custom field editor
     /// - Parameters:
     ///  - viewModel: The viewModel for this View.
-    ///  - isReadOnlyValue: Whether the value is read-only or not. To be used if the value is not string but JSON.
-    init(viewModel: CustomFieldEditorViewModel, isReadOnlyValue: Bool = false) {
+    init(viewModel: CustomFieldEditorViewModel) {
         self.viewModel = viewModel
-        self.isReadOnlyValue = isReadOnlyValue
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -27,6 +27,7 @@ final class CustomFieldEditorViewModel: ObservableObject {
         onDelete != nil
     }
 
+    let isReadOnlyValue: Bool
 
     var hasUnsavedChanges: Bool {
         key != initialKey || value != initialValue
@@ -39,13 +40,15 @@ final class CustomFieldEditorViewModel: ObservableObject {
 
     init(key: String,
          value: String,
+         isJsonField: Bool = false,
          disallowedKeys: [String] = [],
          onSave: @escaping (String, String) -> Void,
          onDelete: (() -> Void)? = nil) {
         self.key = key
-        self.value = value
+        self.value = isJsonField ? value.prettyPrint() : value
         self.initialKey = key
-        self.initialValue = value
+        self.initialValue = isJsonField ? value.prettyPrint() : value
+        self.isReadOnlyValue = isJsonField
         self.disallowedKeys = disallowedKeys
         self.onSave = onSave
         self.onDelete = onDelete
@@ -67,6 +70,15 @@ final class CustomFieldEditorViewModel: ObservableObject {
 
     func deleteField() {
         onDelete?()
+    }
+}
+
+private extension String {
+    func prettyPrint() -> String {
+        return (try? JSONSerialization.jsonObject(with: self.data(using: .utf8) ?? Data()))
+            .flatMap { try? JSONSerialization.data(withJSONObject: $0, options: .prettyPrinted) }
+            .flatMap { String(data: $0, encoding: .utf8) }
+            ?? self
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -237,7 +237,8 @@ private extension CustomFieldsListView {
                     // Only provide delete callback when editing existing field
                     viewModel.deleteField(customField!)
                 } : nil
-            ))
+            ),
+            isReadOnlyValue: customField?.isJson ?? false)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -225,6 +225,7 @@ private extension CustomFieldsListView {
             CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(
                 key: customField?.key ?? "",
                 value: customField?.value ?? "",
+                isJsonField: customField?.isJson ?? false,
                 disallowedKeys: disallowedKeys,
                 onSave: { updatedKey, updatedValue in
                     viewModel.saveField(
@@ -237,8 +238,7 @@ private extension CustomFieldsListView {
                     // Only provide delete callback when editing existing field
                     viewModel.deleteField(customField!)
                 } : nil
-            ),
-            isReadOnlyValue: customField?.isJson ?? false)
+            ))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -209,6 +209,10 @@ extension CustomFieldsListViewModel {
         let value: String
         let fieldId: Int64?
 
+        var isJson: Bool {
+            (try? JSONSerialization.jsonObject(with: value.data(using: .utf8) ?? Data())) != nil
+        }
+
         init(key: String, value: String, fieldId: Int64? = nil) {
             self.key = key
             self.value = value

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -412,4 +412,12 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.disallowedKeysForCreation.contains("Key1"))
         XCTAssertTrue(viewModel.disallowedKeysForCreation.contains("Key2"))
     }
+
+    func test_when_isJson_called_then_return_correct_value() {
+        let jsonField = CustomFieldsListViewModel.CustomFieldUI(key: "key", value: "{\"key\":\"value\"}")
+        XCTAssertTrue(jsonField.isJson)
+
+        let nonJsonField = CustomFieldsListViewModel.CustomFieldUI(key: "key", value: "value")
+        XCTAssertFalse(nonJsonField.isJson)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14261 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds initial support for read-only mode of JSON values, the PR attempts to achieve this with the less amount of changes:
- Updates the decoding logic to handle JSON values.
- Add logic to identify JSON values on the UI level to treat them in read-only mode.

But this means a minor difference with how Android and Core behave: both Android and Core will allow editing JSON values that are wrapped as Strings, something like:
```json
{
   "id": 1,
   "key": "key",
   "value": "{\"key\":\"value\"}"
}
```
But for iOS, and given that we don't differentiate between the different forms of MetaData values, the above will be exactly the same as if we received:
```json
{
   "id": 1,
   "key": "key",
   "value": {"key":"value"}
}
```

So for now, both values will be shown as read-only mode, I think this is not a major issue, given that it's an edge case that someone would put JSON data like that. I still intend to try to improve this in a separate PR, I already started working on a POC [here](https://github.com/woocommerce/woocommerce-ios/compare/trunk...json-fields-poc?expand=1), I created this [sub-issue](https://github.com/woocommerce/woocommerce-ios/issues/14271) to keep track of this.

## Steps to reproduce
1. Open wp-admin and add a custom field with the following content: `{"key":"value"}`
2. Use the API to add a true JSON field like this for example:
```
POST {site}/wc/v3/orders/{orderId}

{
    "meta_data": [
        {
            "key": "json_object",
            "value": {
                "Key": "Value"
            }
        },
        {
            "key": "json_array",
            "value": [
                {
                    "Key": "Value"
                }
            ]
        }
    ]
}
```
3. Open the given product or order where the changes were made.
4. Confirm both the added fields are shown in read-only mode.

## Testing information
- Confirm that the editor shows in read-only mode for json fields.
- Confirm no regression for other formats.

## Screenshots
<img width=360 src=https://github.com/user-attachments/assets/dfc92ea4-6dd6-4d85-956e-4711c0bcc356/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.