### PR TITLE
[Order Details] Wrong currency for Shipping Lines

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1027,7 +1027,7 @@ private extension OrderDetailsDataSource {
 
     private func configureShippingLine(cell: HostingConfigurationTableViewCell<ShippingLineRowView>, at indexPath: IndexPath) {
         let shippingLine = shippingLines[indexPath.row]
-        let viewModel = ShippingLineRowViewModel(shippingLine: shippingLine, shippingMethods: siteShippingMethods, editable: false)
+        let viewModel = ShippingLineRowViewModel(shippingLine: shippingLine, currency: order.currency, shippingMethods: siteShippingMethods, editable: false)
         let view = ShippingLineRowView(viewModel: viewModel)
 
         // Reduce cell padding between rows

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
@@ -37,11 +37,12 @@ struct ShippingLineRowViewModel: Identifiable {
     }
 
     init(shippingLine: ShippingLine,
+         currency: String? = nil,
          shippingMethods: [ShippingMethod],
          editable: Bool,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          onEditShippingLine: @escaping (Int64) -> Void = { _ in }) {
-        let formattedAmount = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
+        let formattedAmount = currencyFormatter.formatAmount(shippingLine.total, with: currency) ?? shippingLine.total
         let shippingMethod = shippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title
 
         self.init(id: shippingLine.shippingID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
@@ -30,17 +30,22 @@ final class ShippingLineRowViewModelTests: XCTestCase {
         // Given
         let shippingLine = ShippingLine(shippingID: 1, methodTitle: "Package 1", methodID: "flat_rate", total: "5", totalTax: "0", taxes: [])
         let shippingMethod = ShippingMethod(siteID: 12345, methodID: "flat_rate", title: "Flat Rate")
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let currency = "EUR"
 
         // When
         let viewModel = ShippingLineRowViewModel(shippingLine: shippingLine,
+                                                 currency: currency,
                                                  shippingMethods: [shippingMethod],
                                                  editable: false,
                                                  currencyFormatter: CurrencyFormatter(currencySettings: CurrencySettings()))
 
         // Then
+        let expectedFormattedAmount = currencyFormatter.formatAmount(shippingLine.total, with: currency)
+
         assertEqual(shippingLine.methodTitle, viewModel.shippingTitle)
         assertEqual(shippingMethod.title, viewModel.shippingMethod)
-        assertEqual("$5.00", viewModel.shippingAmount)
+        assertEqual(expectedFormattedAmount, viewModel.shippingAmount)
         XCTAssertFalse(viewModel.editable)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14266 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix the issue where we were showing the store default currency instead of the order one for the shipping lines. This issue surfaced when the order currency was different than the store default one. To fix it we assume that the shipping line amount is in the order currency.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. In your store viewfront, create an order with some items with a currency other than the default one. You can do that by accessing the store from a country with a different currency than the default one (better in Incognito mode in the browser). For that to work, you should have enabled the _Automatically switch customers to their local currency if it has been enabled_ in the Multicurrency setting of WooCommerce wp-admin. Ensure that the order has a shipping line.
2. Open the app and go to orders.
3. Open the order. Before, the shipping line amount was in the store default currency. Now, it is in the order currency.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
See steps above.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before
<img src="https://github.com/user-attachments/assets/802409aa-5f83-40e7-9455-72f75fa9426f" width="375">

### After
<img src="https://github.com/user-attachments/assets/ea52e22d-c8ba-4790-ba3b-8c6959f414bd" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
