### PR TITLE
[Custom Fields] Fix editor state

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CustomFieldEditorView: View {
     @Environment(\.dismiss) private var dismiss
-    @ObservedObject private var viewModel: CustomFieldEditorViewModel
+    @StateObject private var viewModel: CustomFieldEditorViewModel
 
     @State private var showRichTextEditor = false
     @State private var showActionSheet = false
@@ -14,7 +14,7 @@ struct CustomFieldEditorView: View {
     ///  - viewModel: The viewModel for this View.
     ///  - isReadOnlyValue: Whether the value is read-only or not. To be used if the value is not string but JSON.
     init(viewModel: CustomFieldEditorViewModel, isReadOnlyValue: Bool = false) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
         self.isReadOnlyValue = isReadOnlyValue
     }
 


### PR DESCRIPTION
## Description
While working on some changes, I noticed that the editor changes get lost whenever something that triggers re-rendering the top screen occurs:
- Displaying the toolbar menu
- Trying to dismiss the screen using gesture
- ...

Looking further, I found that the cause is that the ViewModel gets re-initialized when this happens, so to fix it, this PR updates the ViewModel to be a `@StateObject`.

## Steps to reproduce
1. Open custom fields of a product or order.
2. Open an existing custom field.
3. Make some changes.
4. Tap on the "..." button.
5. Confirm the changes are preserved.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.