### PR TITLE
[Shipping labels] Update order details button for new shipping label screen

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -737,14 +737,13 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureShippingLabelDetail(cell: WooBasicTableViewCell) {
-        let showRevampedShippingLabelCreation = featureFlags.isFeatureFlagEnabled(.revampedShippingLabelCreation)
-        cell.bodyLabel?.text = showRevampedShippingLabelCreation ? Footer.viewShippingLabel : Footer.showShippingLabelDetails
+        cell.bodyLabel?.text = isEligibleForWooShipping ? Footer.viewShippingLabel : Footer.showShippingLabelDetails
         cell.applyPlainTextStyle()
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
 
         cell.accessibilityTraits = .button
-        if showRevampedShippingLabelCreation {
+        if isEligibleForWooShipping {
             cell.accessibilityLabel = Footer.viewShippingLabel
         } else {
             cell.accessibilityLabel = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -737,21 +737,26 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureShippingLabelDetail(cell: WooBasicTableViewCell) {
-        cell.bodyLabel?.text = Footer.showShippingLabelDetails
+        let showRevampedShippingLabelCreation = featureFlags.isFeatureFlagEnabled(.revampedShippingLabelCreation)
+        cell.bodyLabel?.text = showRevampedShippingLabelCreation ? Footer.viewShippingLabel : Footer.showShippingLabelDetails
         cell.applyPlainTextStyle()
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
 
         cell.accessibilityTraits = .button
-        cell.accessibilityLabel = NSLocalizedString(
-            "View Shipment Details",
-            comment: "Accessibility label for the 'View Shipment Details' button"
-        )
+        if showRevampedShippingLabelCreation {
+            cell.accessibilityLabel = Footer.viewShippingLabel
+        } else {
+            cell.accessibilityLabel = NSLocalizedString(
+                "View Shipment Details",
+                comment: "Accessibility label for the 'View Shipment Details' button"
+            )
 
-        cell.accessibilityHint = NSLocalizedString(
-            "Show the shipment details for this shipping label.",
-            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view shipping label shipment details."
-        )
+            cell.accessibilityHint = NSLocalizedString(
+                "Show the shipment details for this shipping label.",
+                comment: "VoiceOver accessibility hint, informing the user that the button can be used to view shipping label shipment details."
+            )
+        }
     }
 
     private func configureShippingLabelPrintingInfo(cell: ImageAndTitleAndTextTableViewCell) {
@@ -1760,6 +1765,9 @@ extension OrderDetailsDataSource {
                                                    comment: "Button on bottom of Customer's information to show the billing details")
         static let showShippingLabelDetails = NSLocalizedString("View Shipment Details",
                                                                 comment: "Button on bottom of shipping label package card to show shipping details")
+        static let viewShippingLabel = NSLocalizedString("orderDetailsDataSource.shippingLabels.viewLabel",
+                                                         value: "View purchased shipping label",
+                                                         comment: "Button on bottom of shipping label card to view the shipping label")
     }
 
     enum Accessibility {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -466,8 +466,14 @@ extension OrderDetailsViewModel {
             guard let shippingLabel = dataSource.shippingLabel(at: indexPath) else {
                 return
             }
-            let shippingLabelDetailsViewController = ShippingLabelDetailsViewController(shippingLabel: shippingLabel)
-            viewController.show(shippingLabelDetailsViewController, sender: viewController)
+            if featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation) {
+                let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingLabel: shippingLabel)
+                let shippingLabelDetailsViewController = WooShippingCreateLabelsViewHostingController(viewModel: viewModel)
+                viewController.present(shippingLabelDetailsViewController, animated: true)
+            } else {
+                let shippingLabelDetailsViewController = ShippingLabelDetailsViewController(shippingLabel: shippingLabel)
+                viewController.show(shippingLabelDetailsViewController, sender: viewController)
+            }
         case .shippingLabelPrintingInfo:
             let printingInstructionsViewController = ShippingLabelPrintingInstructionsViewController()
             let navigationController = WooNavigationController(rootViewController: printingInstructionsViewController)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -466,7 +466,7 @@ extension OrderDetailsViewModel {
             guard let shippingLabel = dataSource.shippingLabel(at: indexPath) else {
                 return
             }
-            if featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation) {
+            if dataSource.isEligibleForWooShipping {
                 let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingLabel: shippingLabel)
                 let shippingLabelDetailsViewController = WooShippingCreateLabelsViewHostingController(viewModel: viewModel)
                 viewController.present(shippingLabelDetailsViewController, animated: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14242
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the button in order details that opens the shipping label screen. It now has the text "View purchased shipping label" and opens the new Woo Shipping screen (when the feature flag is enabled and the minimum version of the Woo Shipping extension is installed).

### How

* Updates the text and accessibility label configured in `OrderDetailsDataSource`.
* Updates the navigation in `OrderDetailsViewModel`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: The Woo Shipping extension installed and activated, with at least one order with a purchased shipping label.

1. Check that the `revampedShippingLabelCreation` feature flag is enabled.
2. Build and run the app.
3. Open the orders tab and select an order with a purchased shipping label.
4. In the shipping labels section, tap "View purchased shipping label" and confirm the new Woo Shipping screen is presented.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before (feature flag disabled)|After
-|-
![Simulator Screenshot - iPhone 16 Pro - 2024-10-31 at 13 46 57](https://github.com/user-attachments/assets/cc6cdd62-fee9-4e41-b725-9e80fa2858ff)|![Simulator Screenshot - iPhone 16 Pro - 2024-10-31 at 13 40 45](https://github.com/user-attachments/assets/e1c1ad3b-6f17-4f8c-8bcb-76bc9ec67070)
![Simulator Screenshot - iPhone 16 Pro - 2024-10-31 at 13 47 05](https://github.com/user-attachments/assets/9d75537f-e268-4bf1-adf0-9482ad6a5a1f)|![Simulator Screenshot - iPhone 16 Pro - 2024-10-31 at 13 40 48](https://github.com/user-attachments/assets/32bb2d4e-f5b6-482d-b8bf-76a8e59c70c7)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.