### PR TITLE
[Custom Fields] Minor refactoring to simplify models definitions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -246,5 +246,6 @@ private extension CustomFieldEditorView {
 }
 
 #Preview {
-    CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(customField: CustomFieldViewModel(key: "title", value: "value"), onSave: { _, _ in }, onDelete: {}))
+    CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(customField: CustomFieldViewModel(key: "title", value: "value"),
+                                                                onSave: { _, _ in }, onDelete: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -246,5 +246,5 @@ private extension CustomFieldEditorView {
 }
 
 #Preview {
-    CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(key: "title", value: "value", onSave: { _, _ in }, onDelete: {}))
+    CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(customField: CustomFieldViewModel(key: "title", value: "value"), onSave: { _, _ in }, onDelete: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -48,7 +48,7 @@ final class CustomFieldEditorViewModel: ObservableObject {
          onDelete: (() -> Void)? = nil) {
         self.key = customField?.key ?? ""
         self.initialKey = customField?.key ?? ""
-        let value = if customField?.isJson ?? false, let value = customField?.value {
+        let value = if customField?.isJson == true, let value = customField?.value {
             value.prettyPrint()
         } else {
             customField?.value ?? ""

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorViewModel.swift
@@ -42,17 +42,20 @@ final class CustomFieldEditorViewModel: ObservableObject {
         initialKey == "" && initialValue == ""
     }
 
-    init(key: String,
-         value: String,
-         isJsonField: Bool = false,
+    init(customField: CustomFieldViewModel?,
          disallowedKeys: [String] = [],
          onSave: @escaping (String, String) -> Void,
          onDelete: (() -> Void)? = nil) {
-        self.key = key
-        self.value = isJsonField ? value.prettyPrint() : value
-        self.initialKey = key
-        self.initialValue = isJsonField ? value.prettyPrint() : value
-        self.isReadOnlyValue = isJsonField
+        self.key = customField?.key ?? ""
+        self.initialKey = customField?.key ?? ""
+        let value = if customField?.isJson ?? false, let value = customField?.value {
+            value.prettyPrint()
+        } else {
+            customField?.value ?? ""
+        }
+        self.value = value
+        self.initialValue = value
+        self.isReadOnlyValue = customField?.isJson ?? false
         self.disallowedKeys = disallowedKeys
         self.onSave = onSave
         self.onDelete = onDelete

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 
 /// ViewModel for an individual custom field
-struct CustomFieldViewModel: Identifiable {
+struct CustomFieldViewModel: Identifiable, Equatable {
     /// Unique identifier, required by `SwiftUI`
     ///
     let id = UUID()
@@ -25,8 +25,8 @@ struct CustomFieldViewModel: Identifiable {
         (try? JSONSerialization.jsonObject(with: value.data(using: .utf8) ?? Data())) != nil
     }
 
-    init(id: Int64? = nil, key: String, value: String, valueURL: URL? = nil) {
-        self.fieldID = id
+    init(fieldID: Int64? = nil, key: String, value: String, valueURL: URL? = nil) {
+        self.fieldID = fieldID
         self.key = key
         self.value = value
         self.valueURL = valueURL
@@ -41,7 +41,7 @@ struct CustomFieldViewModel: Identifiable {
         }
 
         self.init(
-            id: metadata.metadataID,
+            fieldID: metadata.metadataID,
             key: metadata.key,
             value: metadata.value,
             valueURL: valueURL

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
@@ -5,7 +5,9 @@ import Yosemite
 struct CustomFieldViewModel: Identifiable {
     /// Unique identifier, required by `SwiftUI`
     ///
-    let id: Int64
+    let id = UUID()
+
+    let fieldId: Int64?
 
     /// The title for the Custom Field mapped from the metadata key
     ///
@@ -19,8 +21,12 @@ struct CustomFieldViewModel: Identifiable {
     ///
     let contentURL: URL?
 
-    init(id: Int64, title: String, content: String, contentURL: URL? = nil) {
-        self.id = id
+    var isJson: Bool {
+        (try? JSONSerialization.jsonObject(with: content.data(using: .utf8) ?? Data())) != nil
+    }
+
+    init(id: Int64?, title: String, content: String, contentURL: URL? = nil) {
+        self.fieldId = id
         self.title = title
         self.content = content
         self.contentURL = contentURL
@@ -40,5 +46,15 @@ struct CustomFieldViewModel: Identifiable {
             content: metadata.value,
             contentURL: contentURL
         )
+    }
+
+    func asDictionary() -> [String: Any] {
+        var json: [String: Any] = [:]
+            if let fieldId = fieldId {
+                json["id"] = fieldId
+            }
+            json["key"] = title
+            json["value"] = content
+        return json
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
@@ -7,54 +7,54 @@ struct CustomFieldViewModel: Identifiable {
     ///
     let id = UUID()
 
-    let fieldId: Int64?
+    let fieldID: Int64?
 
-    /// The title for the Custom Field mapped from the metadata key
+    /// The key for the Custom Field
     ///
-    let title: String
+    let key: String
 
-    /// The content for the Custom Field mapped from the metadata value
+    /// The value for the Custom Field
     ///
-    let content: String
+    let value: String
 
-    /// Optional URL used for linking the Custom Field content
+    /// Optional URL used for linking the Custom Field value
     ///
-    let contentURL: URL?
+    let valueURL: URL?
 
     var isJson: Bool {
-        (try? JSONSerialization.jsonObject(with: content.data(using: .utf8) ?? Data())) != nil
+        (try? JSONSerialization.jsonObject(with: value.data(using: .utf8) ?? Data())) != nil
     }
 
-    init(id: Int64?, title: String, content: String, contentURL: URL? = nil) {
-        self.fieldId = id
-        self.title = title
-        self.content = content
-        self.contentURL = contentURL
+    init(id: Int64?, key: String, value: String, valueURL: URL? = nil) {
+        self.fieldID = id
+        self.key = key
+        self.value = value
+        self.valueURL = valueURL
 
     }
 
     init(metadata: MetaData) {
         // Create a URL out of the metadata value, if it is a valid URL that can be opened on device
-        var contentURL: URL?
+        var valueURL: URL?
         if metadata.value.isValidURL(), let url = URL(string: metadata.value), UIApplication.shared.canOpenURL(url) {
-            contentURL = url
+            valueURL = url
         }
 
         self.init(
             id: metadata.metadataID,
-            title: metadata.key,
-            content: metadata.value,
-            contentURL: contentURL
+            key: metadata.key,
+            value: metadata.value,
+            valueURL: valueURL
         )
     }
 
     func asDictionary() -> [String: Any] {
         var json: [String: Any] = [:]
-            if let fieldId = fieldId {
-                json["id"] = fieldId
+            if let fieldID = fieldID {
+                json["id"] = fieldID
             }
-            json["key"] = title
-            json["value"] = content
+            json["key"] = key
+            json["value"] = value
         return json
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
@@ -25,7 +25,7 @@ struct CustomFieldViewModel: Identifiable {
         (try? JSONSerialization.jsonObject(with: value.data(using: .utf8) ?? Data())) != nil
     }
 
-    init(id: Int64?, key: String, value: String, valueURL: URL? = nil) {
+    init(id: Int64? = nil, key: String, value: String, valueURL: URL? = nil) {
         self.fieldID = id
         self.key = key
         self.value = value

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -380,8 +380,8 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
             isEditable: true,
             viewModel: CustomFieldsListViewModel(
                 customFields: [
-                    CustomFieldViewModel(id: 0, key: "First Title", value: "First Content"),
-                    CustomFieldViewModel(id: 1, key: "Second Title", value: "Second Content", valueURL: URL(string: "https://woocommerce.com/"))
+                    CustomFieldViewModel(fieldID: 0, key: "First Title", value: "First Content"),
+                    CustomFieldViewModel(fieldID: 1, key: "Second Title", value: "Second Content", valueURL: URL(string: "https://woocommerce.com/"))
                 ],
                 siteID: 0,
                 parentItemID: 0,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -176,8 +176,8 @@ struct CustomFieldsListView: View {
 							viewModel.trackCustomFieldTapped()
 						}) {
                             CustomFieldRow(isEditable: isEditable,
-                                           title: customField.title,
-                                           content: customField.content.removedHTMLTags,
+                                           title: customField.key,
+                                           content: customField.value.removedHTMLTags,
                                            contentURL: nil)
                         }
                     }
@@ -185,8 +185,8 @@ struct CustomFieldsListView: View {
                 }
             }
             .sheet(item: $viewModel.selectedCustomField) { customField in
-                /// When editing a newly added and unsaved custom field (identified by it having nil `fieldId`), provide disallowed keys.
-                let disallowedKeys = customField.fieldId == nil ? viewModel.disallowedKeysForCreation : []
+	            /// When editing a newly added and unsaved custom field (identified by it having nil `fieldID`), provide disallowed keys.
+	            let disallowedKeys = customField.fieldID == nil ? viewModel.disallowedKeysForCreation : []
 
                 buildCustomFieldEditorView(customField: customField,
                                            disallowedKeys: disallowedKeys)
@@ -269,15 +269,15 @@ private extension CustomFieldsListView {
                                     disallowedKeys: [String] = []) -> some View {
         NavigationView {
             CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(
-                key: customField?.title ?? "",
-                value: customField?.content ?? "",
+                key: customField?.key ?? "",
+                value: customField?.value ?? "",
                 isJsonField: customField?.isJson ?? false,
                 disallowedKeys: disallowedKeys,
                 onSave: { updatedKey, updatedValue in
                     viewModel.saveField(
                         key: updatedKey,
                         value: updatedValue,
-                        fieldId: customField?.fieldId
+                        fieldID: customField?.fieldID
                     )
                 },
                 onDelete: customField != nil ? {
@@ -382,8 +382,8 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
             isEditable: true,
             viewModel: CustomFieldsListViewModel(
                 customFields: [
-                    CustomFieldViewModel(id: 0, title: "First Title", content: "First Content"),
-                    CustomFieldViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
+                    CustomFieldViewModel(id: 0, key: "First Title", value: "First Content"),
+                    CustomFieldViewModel(id: 1, key: "Second Title", value: "Second Content", valueURL: URL(string: "https://woocommerce.com/"))
                 ],
                 siteID: 0,
                 parentItemID: 0,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -176,8 +176,8 @@ struct CustomFieldsListView: View {
 							viewModel.trackCustomFieldTapped()
 						}) {
                             CustomFieldRow(isEditable: isEditable,
-                                           title: customField.key,
-                                           content: customField.value.removedHTMLTags,
+                                           title: customField.title,
+                                           content: customField.content.removedHTMLTags,
                                            contentURL: nil)
                         }
                     }
@@ -265,12 +265,12 @@ private extension CustomFieldsListView {
     /// Parameters:
     /// - `customField`: Provide one when editing an existing field, otherwise (i.e: when creating a new field) keep it nil.
     /// - `disallowedKeys`: List of String that can't be used when editing a custom field key.
-    func buildCustomFieldEditorView(customField: CustomFieldsListViewModel.CustomFieldUI?,
+    func buildCustomFieldEditorView(customField: CustomFieldViewModel?,
                                     disallowedKeys: [String] = []) -> some View {
         NavigationView {
             CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(
-                key: customField?.key ?? "",
-                value: customField?.value ?? "",
+                key: customField?.title ?? "",
+                value: customField?.content ?? "",
                 isJsonField: customField?.isJson ?? false,
                 disallowedKeys: disallowedKeys,
                 onSave: { updatedKey, updatedValue in

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -269,9 +269,7 @@ private extension CustomFieldsListView {
                                     disallowedKeys: [String] = []) -> some View {
         NavigationView {
             CustomFieldEditorView(viewModel: CustomFieldEditorViewModel(
-                key: customField?.key ?? "",
-                value: customField?.value ?? "",
-                isJsonField: customField?.isJson ?? false,
+                customField: customField,
                 disallowedKeys: disallowedKeys,
                 onSave: { updatedKey, updatedValue in
                     viewModel.saveField(

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -78,7 +78,7 @@ final class CustomFieldsListViewModel: ObservableObject {
 // MARK: - Items actions
 extension CustomFieldsListViewModel {
     func saveField(key: String, value: String, fieldID: Int64?) {
-        let newField = CustomFieldViewModel(id: fieldID, key: key, value: value)
+        let newField = CustomFieldViewModel(fieldID: fieldID, key: key, value: value)
         if let fieldID = fieldID {
             if let index = combinedList.firstIndex(where: { $0.fieldID == fieldID }) {
                 editField(at: index, newField: newField)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -24,22 +24,22 @@ final class CustomFieldsListViewModel: ObservableObject {
     private let onChangesSaved: (([MetaData]) -> Void)?
     @Published private var isTopBannerDismissed: Bool = false
 
-    @Published var selectedCustomField: CustomFieldUI? = nil
+    @Published var selectedCustomField: CustomFieldViewModel? = nil
     @Published var isAddingNewField: Bool = false
     @Published var isSavingChanges: Bool = false
     var shouldShowTopBanner: Bool {
         hasChanges && !isTopBannerDismissed
     }
 
-    @Published private(set) var combinedList: [CustomFieldUI] = []
+    @Published private(set) var combinedList: [CustomFieldViewModel] = []
     @Published var notice: Notice?
 
     @Published private var pendingChanges = PendingCustomFieldsChanges()
-    private var editedFields: [CustomFieldUI] {
+    private var editedFields: [CustomFieldViewModel] {
         get { pendingChanges.editedFields }
         set { pendingChanges = pendingChanges.copy(editedFields: newValue) }
     }
-    private var addedFields: [CustomFieldUI] {
+    private var addedFields: [CustomFieldViewModel] {
         get { pendingChanges.addedFields }
         set { pendingChanges = pendingChanges.copy(addedFields: newValue) }
     }
@@ -54,7 +54,7 @@ final class CustomFieldsListViewModel: ObservableObject {
     /// Note that this rule only applies to new field creation, and duplicates are allowed when editing existing fields.
     var disallowedKeysForCreation: [String] {
         originalCustomFields.map { $0.title }
-        + addedFields.map { $0.key }
+        + addedFields.map { $0.title }
     }
 
     init(customFields: [CustomFieldViewModel],
@@ -77,33 +77,18 @@ final class CustomFieldsListViewModel: ObservableObject {
 
 // MARK: - Items actions
 extension CustomFieldsListViewModel {
-    /// Params:
-    /// - index: The index of field to be edited, taken from the `combinedList` array
-    /// - newField: The new content for the custom field in question
-    func editField(at index: Int, newField: CustomFieldUI) {
-        guard index >= 0 && index < combinedList.count else {
-            DDLogError("⛔️ Error: Invalid index for editing a custom field")
-            return
-        }
-
-        let oldField = combinedList[index]
-        if newField.fieldId == nil {
-            // When editing a field that has no id yet, it means the field has only been added locally.
-            editLocallyAddedField(oldField: oldField, newField: newField)
-        } else {
-            if let existingId = oldField.fieldId {
-                editExistingField(idToEdit: existingId, newField: newField)
-            } else {
-                DDLogError("⛔️ Error: Trying to edit an existing field but it has no id. It might be the wrong field to edit.")
+    func saveField(key: String, value: String, fieldId: Int64?) {
+        let newField = CustomFieldViewModel(id: fieldId, title: key, content: value)
+        if let fieldId = fieldId {
+            if let index = combinedList.firstIndex(where: { $0.fieldId == fieldId }) {
+                editField(at: index, newField: newField)
             }
+        } else {
+            addField(newField)
         }
     }
 
-    func addField(_ field: CustomFieldUI) {
-        addedFields.append(field)
-    }
-
-    func deleteField(_ field: CustomFieldUI) {
+    func deleteField(_ field: CustomFieldViewModel) {
         if let fieldId = field.fieldId {
             deletedFieldIds.append(fieldId)
         } else {
@@ -119,16 +104,6 @@ extension CustomFieldsListViewModel {
                         })
     }
 
-    func saveField(key: String, value: String, fieldId: Int64?) {
-        let newField = CustomFieldUI(key: key, value: value, fieldId: fieldId)
-        if let fieldId = fieldId {
-            if let index = combinedList.firstIndex(where: { $0.fieldId == fieldId }) {
-                editField(at: index, newField: newField)
-            }
-        } else {
-            addField(newField)
-        }
-    }
 
     func dismissTopBanner() {
         stores.dispatch(AppSettingsAction.dismissCustomFieldsTopBanner { [weak self] result in
@@ -176,8 +151,34 @@ extension CustomFieldsListViewModel {
 }
 
 private extension CustomFieldsListViewModel {
-    func editLocallyAddedField(oldField: CustomFieldUI, newField: CustomFieldUI) {
-        if let index = pendingChanges.addedFields.firstIndex(where: { $0.key == oldField.key }) {
+    /// Params:
+    /// - index: The index of field to be edited, taken from the `combinedList` array
+    /// - newField: The new content for the custom field in question
+    func editField(at index: Int, newField: CustomFieldViewModel) {
+        guard index >= 0 && index < combinedList.count else {
+            DDLogError("⛔️ Error: Invalid index for editing a custom field")
+            return
+        }
+
+        let oldField = combinedList[index]
+        if newField.fieldId == nil {
+            // When editing a field that has no id yet, it means the field has only been added locally.
+            editLocallyAddedField(oldField: oldField, newField: newField)
+        } else {
+            if let existingId = oldField.fieldId {
+                editExistingField(idToEdit: existingId, newField: newField)
+            } else {
+                DDLogError("⛔️ Error: Trying to edit an existing field but it has no id. It might be the wrong field to edit.")
+            }
+        }
+    }
+
+    func addField(_ field: CustomFieldViewModel) {
+        addedFields.append(field)
+    }
+
+    func editLocallyAddedField(oldField: CustomFieldViewModel, newField: CustomFieldViewModel) {
+        if let index = pendingChanges.addedFields.firstIndex(where: { $0.title == oldField.title }) {
             addedFields[index] = newField
         } else {
             // This shouldn't happen in normal flow, but logging just in case
@@ -186,7 +187,7 @@ private extension CustomFieldsListViewModel {
     }
 
     /// Checking by id when editing an existing field since existing fields will always have them.
-    func editExistingField(idToEdit: Int64, newField: CustomFieldUI) {
+    func editExistingField(idToEdit: Int64, newField: CustomFieldViewModel) {
         guard idToEdit == newField.fieldId else {
             DDLogError("⛔️ Error: Trying to edit existing field but supplied new id is different.")
             return
@@ -201,7 +202,7 @@ private extension CustomFieldsListViewModel {
         }
     }
 
-    func undoDeletion(of field: CustomFieldUI) {
+    func undoDeletion(of field: CustomFieldViewModel) {
         if let fieldId = field.fieldId {
             deletedFieldIds.removeAll { $0 == fieldId }
         } else {
@@ -221,8 +222,8 @@ private extension CustomFieldsListViewModel {
             .combineLatest($originalCustomFields)
             .map { (pendingChanges, originalFields) in
                 return originalFields
-                    .filter { field in !pendingChanges.deletedFieldIds.contains(where: { $0 == field.id }) }
-                    .map { field in pendingChanges.editedFields.first(where: { $0.fieldId == field.id }) ?? CustomFieldUI(customField: field) }
+                    .filter { field in !pendingChanges.deletedFieldIds.contains(where: { $0 == field.fieldId }) }
+                    .map { field in pendingChanges.editedFields.first(where: { $0.fieldId == field.fieldId }) ?? field }
                     + pendingChanges.addedFields
             }
             .assign(to: &$combinedList)
@@ -276,58 +277,25 @@ extension CustomFieldsListViewModel {
 }
 
 extension CustomFieldsListViewModel {
-    struct CustomFieldUI: Identifiable {
-        let id = UUID()
-        let key: String
-        let value: String
-        let fieldId: Int64?
-
-        var isJson: Bool {
-            (try? JSONSerialization.jsonObject(with: value.data(using: .utf8) ?? Data())) != nil
-        }
-
-        init(key: String, value: String, fieldId: Int64? = nil) {
-            self.key = key
-            self.value = value
-            self.fieldId = fieldId
-        }
-
-        init(customField: CustomFieldViewModel) {
-            self.key = customField.title
-            self.value = customField.content
-            self.fieldId = customField.id
-        }
-
-        func asDictionary() -> [String: Any] {
-            var json: [String: Any] = [:]
-                if let fieldId = fieldId {
-                    json["id"] = fieldId
-                }
-                json["key"] = key
-                json["value"] = value
-            return json
-        }
-    }
-
     struct PendingCustomFieldsChanges {
-        let editedFields: [CustomFieldUI]
-        let addedFields: [CustomFieldUI]
+        let editedFields: [CustomFieldViewModel]
+        let addedFields: [CustomFieldViewModel]
         let deletedFieldIds: [Int64]
 
         var hasChanges: Bool {
             editedFields.isNotEmpty || addedFields.isNotEmpty || deletedFieldIds.isNotEmpty
         }
 
-        init(editedFields: [CustomFieldUI] = [],
-             addedFields: [CustomFieldUI] = [],
+        init(editedFields: [CustomFieldViewModel] = [],
+             addedFields: [CustomFieldViewModel] = [],
              deletedFieldIds: [Int64] = []) {
             self.editedFields = editedFields
             self.addedFields = addedFields
             self.deletedFieldIds = deletedFieldIds
         }
 
-        func copy(editedFields: [CustomFieldUI]? = nil,
-                  addedFields: [CustomFieldUI]? = nil,
+        func copy(editedFields: [CustomFieldViewModel]? = nil,
+                  addedFields: [CustomFieldViewModel]? = nil,
                   deletedFieldIds: [Int64]? = nil) -> PendingCustomFieldsChanges {
             PendingCustomFieldsChanges(editedFields: editedFields ?? self.editedFields,
                                        addedFields: addedFields ?? self.addedFields,

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -14,7 +14,7 @@ final class CustomFieldsListViewModel: ObservableObject {
     var originalCustomFieldsSize: Int64 {
         Int64(
             // Total byte size of custom field values
-            originalCustomFields.map { $0.content.utf8.count }.reduce(0, +)
+            originalCustomFields.map { $0.value.utf8.count }.reduce(0, +)
         )
     }
 
@@ -53,8 +53,8 @@ final class CustomFieldsListViewModel: ObservableObject {
     /// We also don't want newly added fields to have duplicate key, because that way the API only accepts saving one of them.
     /// Note that this rule only applies to new field creation, and duplicates are allowed when editing existing fields.
     var disallowedKeysForCreation: [String] {
-        originalCustomFields.map { $0.title }
-        + addedFields.map { $0.title }
+        originalCustomFields.map { $0.key }
+        + addedFields.map { $0.key }
     }
 
     init(customFields: [CustomFieldViewModel],
@@ -77,10 +77,10 @@ final class CustomFieldsListViewModel: ObservableObject {
 
 // MARK: - Items actions
 extension CustomFieldsListViewModel {
-    func saveField(key: String, value: String, fieldId: Int64?) {
-        let newField = CustomFieldViewModel(id: fieldId, title: key, content: value)
-        if let fieldId = fieldId {
-            if let index = combinedList.firstIndex(where: { $0.fieldId == fieldId }) {
+    func saveField(key: String, value: String, fieldID: Int64?) {
+        let newField = CustomFieldViewModel(id: fieldID, key: key, value: value)
+        if let fieldID = fieldID {
+            if let index = combinedList.firstIndex(where: { $0.fieldID == fieldID }) {
                 editField(at: index, newField: newField)
             }
         } else {
@@ -89,8 +89,8 @@ extension CustomFieldsListViewModel {
     }
 
     func deleteField(_ field: CustomFieldViewModel) {
-        if let fieldId = field.fieldId {
-            deletedFieldIds.append(fieldId)
+        if let fieldID = field.fieldID {
+            deletedFieldIds.append(fieldID)
         } else {
             // The deleted field is not yet saved on the server, so we remove it from the added fields
             addedFields.removeAll { $0.id == field.id }
@@ -161,11 +161,11 @@ private extension CustomFieldsListViewModel {
         }
 
         let oldField = combinedList[index]
-        if newField.fieldId == nil {
+        if newField.fieldID == nil {
             // When editing a field that has no id yet, it means the field has only been added locally.
             editLocallyAddedField(oldField: oldField, newField: newField)
         } else {
-            if let existingId = oldField.fieldId {
+            if let existingId = oldField.fieldID {
                 editExistingField(idToEdit: existingId, newField: newField)
             } else {
                 DDLogError("⛔️ Error: Trying to edit an existing field but it has no id. It might be the wrong field to edit.")
@@ -178,7 +178,7 @@ private extension CustomFieldsListViewModel {
     }
 
     func editLocallyAddedField(oldField: CustomFieldViewModel, newField: CustomFieldViewModel) {
-        if let index = pendingChanges.addedFields.firstIndex(where: { $0.title == oldField.title }) {
+        if let index = pendingChanges.addedFields.firstIndex(where: { $0.key == oldField.key }) {
             addedFields[index] = newField
         } else {
             // This shouldn't happen in normal flow, but logging just in case
@@ -188,12 +188,12 @@ private extension CustomFieldsListViewModel {
 
     /// Checking by id when editing an existing field since existing fields will always have them.
     func editExistingField(idToEdit: Int64, newField: CustomFieldViewModel) {
-        guard idToEdit == newField.fieldId else {
+        guard idToEdit == newField.fieldID else {
             DDLogError("⛔️ Error: Trying to edit existing field but supplied new id is different.")
             return
         }
 
-        if let index = editedFields.firstIndex(where: { $0.fieldId == idToEdit }) {
+        if let index = editedFields.firstIndex(where: { $0.fieldID == idToEdit }) {
             // Existing field has been locally edited, let's update it again
             editedFields[index] = newField
         } else {
@@ -203,8 +203,8 @@ private extension CustomFieldsListViewModel {
     }
 
     func undoDeletion(of field: CustomFieldViewModel) {
-        if let fieldId = field.fieldId {
-            deletedFieldIds.removeAll { $0 == fieldId }
+        if let fieldID = field.fieldID {
+            deletedFieldIds.removeAll { $0 == fieldID }
         } else {
             addedFields.append(field)
         }
@@ -222,8 +222,8 @@ private extension CustomFieldsListViewModel {
             .combineLatest($originalCustomFields)
             .map { (pendingChanges, originalFields) in
                 return originalFields
-                    .filter { field in !pendingChanges.deletedFieldIds.contains(where: { $0 == field.fieldId }) }
-                    .map { field in pendingChanges.editedFields.first(where: { $0.fieldId == field.fieldId }) ?? field }
+                    .filter { field in !pendingChanges.deletedFieldIds.contains(where: { $0 == field.fieldID }) }
+                    .map { field in pendingChanges.editedFields.first(where: { $0.fieldID == field.fieldID }) ?? field }
                     + pendingChanges.addedFields
             }
             .assign(to: &$combinedList)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldEditorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldEditorViewModelTests.swift
@@ -153,8 +153,7 @@ private extension CustomFieldEditorViewModelTests {
         onDelete: (() -> Void)? = nil
     ) -> CustomFieldEditorViewModel {
         CustomFieldEditorViewModel(
-            key: key,
-            value: value,
+            customField: CustomFieldViewModel(key: key, value: value),
             disallowedKeys: disallowedKeys,
             onSave: { newKey, newValue in
                 self.savedKey = newKey

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldViewModelTests.swift
@@ -8,13 +8,13 @@ class CustomFieldViewModelTests: XCTestCase {
     func test_view_model_inits_with_expected_values() throws {
         // Given
         let url = URL(string: "https://woocommerce.com/")
-        let viewModel = CustomFieldViewModel(id: 1, title: "First Metadata", content: "First Content", contentURL: url)
+        let viewModel = CustomFieldViewModel(fieldID: 1, key: "First Metadata", value: "First Content", valueURL: url)
 
         // Then
-        XCTAssertEqual(viewModel.id, 1)
-        XCTAssertEqual(viewModel.title, "First Metadata")
-        XCTAssertEqual(viewModel.content, "First Content")
-        XCTAssertEqual(viewModel.contentURL, url)
+        XCTAssertEqual(viewModel.fieldID, 1)
+        XCTAssertEqual(viewModel.key, "First Metadata")
+        XCTAssertEqual(viewModel.value, "First Content")
+        XCTAssertEqual(viewModel.valueURL, url)
     }
 
     func test_init_with_MetaData_creates_contentURL_from_metadata_value() throws {
@@ -26,7 +26,14 @@ class CustomFieldViewModelTests: XCTestCase {
         let viewModel = CustomFieldViewModel(metadata: metadata)
 
         // Then
-        XCTAssertEqual(viewModel.contentURL, URL(string: urlString))
+        XCTAssertEqual(viewModel.valueURL, URL(string: urlString))
     }
 
+    func test_when_isJson_called_then_return_correct_value() {
+        let jsonField = CustomFieldViewModel(key: "key", value: "{\"key\":\"value\"}")
+        XCTAssertTrue(jsonField.isJson)
+
+        let nonJsonField = CustomFieldViewModel(key: "key", value: "value")
+        XCTAssertFalse(nonJsonField.isJson)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -42,18 +42,18 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.combinedList.count, 2)
         XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
         XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
-        XCTAssertEqual(viewModel.combinedList[0].fieldId, 1)
+        XCTAssertEqual(viewModel.combinedList[0].fieldID, 1)
         XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
         XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
-        XCTAssertEqual(viewModel.combinedList[1].fieldId, 2)
+        XCTAssertEqual(viewModel.combinedList[1].fieldID, 2)
     }
 
     func test_given_existingField_when_editFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
         // Given: A custom field UI to edit an existing field
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
+        let editedField = CustomFieldViewModel(metadata: originalMetadata[0].copy(key: "EditedKey1", value: "EditedValue1"))
 
         // When: Editing the field
-        viewModel.editField(at: 0, newField: editedField)
+        viewModel.saveField(key: editedField.key, value: editedField.value, fieldID: editedField.fieldID)
 
         // Then: The number of displayed items remains the same as before and the value is edited correctly
         XCTAssertEqual(viewModel.combinedList.count, 2)
@@ -63,10 +63,10 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_newField_when_addFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
         // Given: A new custom field UI to add
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+        let newField = CustomFieldViewModel(key: "NewKey", value: "NewValue")
 
         // When: Adding the new field
-        viewModel.addField(newField)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
 
         // Then: The pending changes and displayed items should be updated
         XCTAssertEqual(viewModel.combinedList.count, 3)
@@ -76,12 +76,12 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_editedAndNewFields_when_updatingDisplayedItems_then_changesAreReflected() {
         // Given: An edited field and a new field
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+        let editedField = CustomFieldViewModel(metadata: originalMetadata[0].copy(key: "EditedKey1", value: "EditedValue1"))
+        let newField = CustomFieldViewModel(key: "NewKey", value: "NewValue")
 
         // When: Editing and adding fields
-        viewModel.editField(at: 0, newField: editedField)
-        viewModel.addField(newField)
+        viewModel.saveField(key: editedField.key, value: editedField.value, fieldID: editedField.fieldID)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
 
         // Then: The displayed items should reflect both the edited and added fields
         XCTAssertEqual(viewModel.combinedList.count, 3)
@@ -93,26 +93,25 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_existingField_when_deleteFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
         // Given: the field to delete
-        let fieldToDelete = CustomFieldsListViewModel.CustomFieldUI(key: originalFields[0].title,
-                                                                    value: originalFields[0].content,
-                                                                    fieldId: originalFields[0].id)
+        let fieldToDelete = CustomFieldViewModel(metadata: originalMetadata[0])
 
         // When: Deleting the field
         viewModel.deleteField(fieldToDelete)
 
         // Then: The number of displayed items remains the same as before and the value is edited correctly
         XCTAssertEqual(viewModel.combinedList.count, 1)
-        XCTAssertEqual(viewModel.combinedList[0].fieldId, originalFields[1].id)
+        XCTAssertEqual(viewModel.combinedList[0].fieldID, originalFields[1].fieldID)
         XCTAssertTrue(viewModel.hasChanges)
     }
 
     func test_given_newField_when_deleteFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
         // Given: A new field to delete
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+        let newField = CustomFieldViewModel(key: "NewKey", value: "NewValue")
 
         // When: Deleting the new field
-        viewModel.addField(newField)
-        viewModel.deleteField(newField)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
+        let fieldToDelete = viewModel.combinedList.last!
+        viewModel.deleteField(fieldToDelete)
 
         // Then: The displayed items should be updated
         XCTAssertEqual(viewModel.combinedList.count, 2)
@@ -124,41 +123,26 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasChanges)
 
         // When: Editing a field
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
-        viewModel.editField(at: 0, newField: editedField)
+        let editedField = CustomFieldViewModel(metadata: originalMetadata[0].copy(key: "EditedKey1", value: "EditedValue1"))
+        viewModel.saveField(key: editedField.key, value: editedField.value, fieldID: editedField.fieldID)
 
         // Then: hasChanges should be true
         XCTAssertTrue(viewModel.hasChanges)
 
         // When: Adding a new field
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
-        viewModel.addField(newField)
+        let newField = CustomFieldViewModel(key: "NewKey", value: "NewValue")
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
 
         // Then: hasChanges should be true
         XCTAssertTrue(viewModel.hasChanges)
     }
 
-    func test_given_invalidIndex_when_editFieldCalled_then_noChangesAreMade() {
-        // Given: An invalid index and a custom field UI
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
-
-        // When: Trying to edit a field at an invalid index
-        viewModel.editField(at: -1, newField: editedField)
-
-        // Then: No changes should be made
-        XCTAssertEqual(viewModel.combinedList.count, 2)
-        XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
-        XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
-        XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
-        XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
-    }
-
     func test_given_duplicateKey_when_addFieldCalled_then_fieldIsAdded() {
         // Given: A new custom field UI with a duplicate key
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "Key1", value: "NewValue")
+        let newField = CustomFieldViewModel(key: "Key1", value: "NewValue")
 
         // When: Adding the new field
-        viewModel.addField(newField)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
 
         // Then: The field should be added to the list
         XCTAssertEqual(viewModel.combinedList.count, 3)
@@ -170,32 +154,32 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // Given: An existing field to be updated
         let key = "UpdatedKey1"
         let value = "UpdatedValue1"
-        let fieldId: Int64 = 1
+        let fieldID: Int64 = 1
 
         // When: Saving the field
-        viewModel.saveField(key: key, value: value, fieldId: fieldId)
+        viewModel.saveField(key: key, value: value, fieldID: fieldID)
 
         // Then: The field should be updated in the list
         XCTAssertEqual(viewModel.combinedList.count, 2)
         XCTAssertEqual(viewModel.combinedList[0].key, "UpdatedKey1")
         XCTAssertEqual(viewModel.combinedList[0].value, "UpdatedValue1")
-        XCTAssertEqual(viewModel.combinedList[0].fieldId, 1)
+        XCTAssertEqual(viewModel.combinedList[0].fieldID, 1)
     }
 
     func test_given_saveFieldCalled_when_fieldDoesNotExist_then_fieldIsAdded() {
         // Given: A new field to be added
         let key = "NewKey"
         let value = "NewValue"
-        let fieldId: Int64? = nil
+        let fieldID: Int64? = nil
 
         // When: Saving the field
-        viewModel.saveField(key: key, value: value, fieldId: fieldId)
+        viewModel.saveField(key: key, value: value, fieldID: fieldID)
 
         // Then: The field should be added to the list
         XCTAssertEqual(viewModel.combinedList.count, 3)
         XCTAssertEqual(viewModel.combinedList.last?.key, "NewKey")
         XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
-        XCTAssertNil(viewModel.combinedList.last?.fieldId)
+        XCTAssertNil(viewModel.combinedList.last?.fieldID)
     }
 
     func test_given_savingSucceeds_when_saveChangesCalled_then_changesAreSaved() async {
@@ -209,14 +193,14 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         }
 
         // When: Saving the changes
-        viewModel.saveField(key: newField.key, value: newField.value, fieldId: nil)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
         await viewModel.saveChanges()
 
         // Then: The changes should be saved
         XCTAssertEqual(viewModel.combinedList.count, originalFields.count + 1)
         XCTAssertEqual(viewModel.combinedList.last?.key, newField.key)
         XCTAssertEqual(viewModel.combinedList.last?.value, newField.value)
-        XCTAssertEqual(viewModel.combinedList.last?.fieldId, newField.metadataID)
+        XCTAssertEqual(viewModel.combinedList.last?.fieldID, newField.metadataID)
         XCTAssertFalse(viewModel.hasChanges)
     }
 
@@ -230,7 +214,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         }
 
         // When: Saving the changes
-        viewModel.saveField(key: "NewKey", value: "NewValue", fieldId: nil)
+        viewModel.saveField(key: "NewKey", value: "NewValue", fieldID: nil)
         await viewModel.saveChanges()
 
         // Then: The changes should not be saved
@@ -248,7 +232,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         }
 
         // When: Saving the changes
-        viewModel.saveField(key: "NewKey", value: "NewValue", fieldId: nil)
+        viewModel.saveField(key: "NewKey", value: "NewValue", fieldID: nil)
         await viewModel.saveChanges()
 
         // Then: An error should be thrown
@@ -280,10 +264,10 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_originalAndAddedFields_then_disallowedKeysForCreationContainsAllKeys() {
         // Given: Original fields from setup and a new field
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+        let newField = CustomFieldViewModel(key: "NewKey", value: "NewValue")
 
         // When: Adding the new field
-        viewModel.addField(newField)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
 
         // Then: disallowedKeysForCreation should contain both original and new keys
         XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 3)
@@ -294,10 +278,10 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_editedFields_then_disallowedKeysForCreationStillContainsOriginalKeys() {
         // Given: Original fields and an edited field
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
+        let editedField = CustomFieldViewModel(metadata: originalMetadata[0].copy(key: "EditedKey1", value: "EditedValue1"))
 
         // When: Editing a field (not yet saved remotely)
-        viewModel.editField(at: 0, newField: editedField)
+        viewModel.saveField(key: editedField.key, value: editedField.value, fieldID: editedField.fieldID)
 
         // Then: disallowedKeysForCreation should contain original keys since changes aren't saved
         XCTAssertEqual(viewModel.disallowedKeysForCreation.count, 2)
@@ -307,9 +291,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_deletedField_then_disallowedKeysForCreationStillContainsOriginalKey() {
         // Given: A field to delete
-        let fieldToDelete = CustomFieldsListViewModel.CustomFieldUI(key: originalFields[0].title,
-                                                                  value: originalFields[0].content,
-                                                                  fieldId: originalFields[0].id)
+        let fieldToDelete = originalFields[0]
 
         // When: Deleting the field (not yet saved remotely)
         viewModel.deleteField(fieldToDelete)
@@ -322,15 +304,13 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_multipleChanges_then_disallowedKeysForCreationReflectsOriginalAndAddedKeys() {
         // Given: Original fields
-        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", fieldId: 1)
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
-        let fieldToDelete = CustomFieldsListViewModel.CustomFieldUI(key: originalFields[1].title,
-                                                                  value: originalFields[1].content,
-                                                                  fieldId: originalFields[1].id)
+        let editedField = CustomFieldViewModel(metadata: originalMetadata[0].copy(key: "EditedKey1", value: "EditedValue1"))
+        let newField = CustomFieldViewModel(key: "NewKey", value: "NewValue")
+        let fieldToDelete = originalFields[1]
 
         // When: Making multiple changes (not yet saved remotely)
-        viewModel.editField(at: 0, newField: editedField)
-        viewModel.addField(newField)
+        viewModel.saveField(key: editedField.key, value: editedField.value, fieldID: editedField.fieldID)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: nil)
         viewModel.deleteField(fieldToDelete)
 
         // Then: disallowedKeysForCreation should contain all original keys plus new keys
@@ -346,8 +326,8 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // Given: Initial state with two fields ("Key1", "Key2")
 
         let newMetadata = MetaData(metadataID: 3, key: "NewKey", value: "NewValue")
-        let newField = CustomFieldsListViewModel.CustomFieldUI(key: newMetadata.key, value: newMetadata.value)
-        viewModel.addField(newField)
+        let newField = CustomFieldViewModel(metadata: newMetadata)
+        viewModel.saveField(key: newField.key, value: newField.value, fieldID: newField.fieldID)
 
         stores.whenReceivingAction(ofType: MetaDataAction.self) { [originalMetadata] action in
             switch action {
@@ -370,7 +350,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // Given: Initial state with two fields ("Key1", "Key2")
 
         let editedMetadata = MetaData(metadataID: 1, key: "EditedKey1", value: "EditedValue1")
-        viewModel.saveField(key: editedMetadata.key, value: editedMetadata.value, fieldId: editedMetadata.metadataID)
+        viewModel.saveField(key: editedMetadata.key, value: editedMetadata.value, fieldID: editedMetadata.metadataID)
 
         stores.whenReceivingAction(ofType: MetaDataAction.self) { [originalMetadata] action in
             switch action {
@@ -391,15 +371,14 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_deleteField_then_saveChanges_then_disallowedKeysUpdates() async {
         // Given: Initial state with two fields ("Key1", "Key2")
-        let fieldToDelete = CustomFieldsListViewModel.CustomFieldUI(key: originalFields[0].title,
-                                                                  value: originalFields[0].content,
-                                                                  fieldId: originalFields[0].id)
+        let fieldToDelete = originalFields[0]
+
         viewModel.deleteField(fieldToDelete)
 
         stores.whenReceivingAction(ofType: MetaDataAction.self) { [originalMetadata] action in
             switch action {
                 case let .updateMetaData(_, _, _, _, onCompletion):
-                    let updatedMetadata = originalMetadata.filter { $0.metadataID != fieldToDelete.fieldId }
+                    let updatedMetadata = originalMetadata.filter { $0.metadataID != fieldToDelete.fieldID }
                     onCompletion(.success(updatedMetadata))
             }
         }
@@ -431,7 +410,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
                                               stores: stores)
 
         // When: Making changes
-        viewModel.addField(CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue"))
+        viewModel.saveField(key: "NewKey", value: "NewValue", fieldID: nil)
 
         // Then: The banner should be shown
         XCTAssertTrue(viewModel.shouldShowTopBanner)
@@ -454,7 +433,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
                                               stores: stores)
 
         // When: Making changes
-        viewModel.addField(CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue"))
+        viewModel.saveField(key: "NewKey", value: "NewValue", fieldID: nil)
 
         // Then: The banner should not be shown
         XCTAssertFalse(viewModel.shouldShowTopBanner)
@@ -481,12 +460,4 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // Then: The banner should be dismissed
         XCTAssertTrue(wasDismissed)
 	}
-
-    func test_when_isJson_called_then_return_correct_value() {
-        let jsonField = CustomFieldsListViewModel.CustomFieldUI(key: "key", value: "{\"key\":\"value\"}")
-        XCTAssertTrue(jsonField.isJson)
-
-        let nonJsonField = CustomFieldsListViewModel.CustomFieldUI(key: "key", value: "value")
-        XCTAssertFalse(nonJsonField.isJson)
-    }
 }


### PR DESCRIPTION
## Description
This PR has two main changes:
1. It attempts to simplify the model definitions for custom fields screens, instead of using two models that serve the same purpose on the same layer `CustomFieldViewModel` and `CustomFieldUI`, this PR removes the second one and consolidates the logic on the first one.
2. It marks the not-used functions as private and updates the tests accordingly; this is mainly for the functions `addField` and `editField`, which were referenced only privately from `saveField` and not directly from the UI. This change will ensure that our tests match the actual behavior of the UI, and also allows for an easier refactoring in the future, as the tests will be more rigid.

@hafizrahman this is not urgent given that it doesn't impact the functionality, please review it when you have some free time.

## Steps to reproduce
Hopefully unit tests should catch any potential issues, but please smoke test the custom fields feature.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.