### PR TITLE
[Shipping labels] Add navigation in post-purchase component

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
@@ -34,6 +34,19 @@ enum WooShippingCarrier: String, Comparable, CaseIterable {
         }
     }
 
+    var pickupURL: URL? {
+        switch self {
+        case .usps:
+            return URL(string: "https://tools.usps.com/schedule-pickup-steps.htm")
+        case .ups:
+            return URL(string: "https://wwwapps.ups.com/pickup/request")
+        case .dhlExpress:
+            return URL(string: "https://mydhl.express.dhl/us/en/schedule-pickup.html#/schedule-pickup#label-reference")
+        case .dhlEcommerce, .dhlEcommerceAsia:
+            return nil
+        }
+    }
+
     static func < (lhs: WooShippingCarrier, rhs: WooShippingCarrier) -> Bool {
         guard let lhsIndex = allCases.firstIndex(of: lhs),
               let rhsIndex = allCases.firstIndex(of: rhs) else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -66,13 +66,16 @@ struct WooShippingPostPurchaseView: View {
                             }
                         }
                     }
-                    Button {
-                        // TODO: Open link to schedule pickup
-                    } label: {
-                        HStack {
-                            Text(Localization.schedulePickup)
-                                .multilineTextAlignment(.leading)
-                            Image(systemName: "arrow.up.right.square")
+                    if let pickupURL = viewModel.pickupURL {
+                        NavigationLink {
+                            WebView(isPresented: .constant(true), url: pickupURL)
+                                .navigationTitle(Localization.schedulePickup)
+                        } label: {
+                            HStack {
+                                Text(Localization.schedulePickup)
+                                    .multilineTextAlignment(.leading)
+                                Image(systemName: "arrow.up.right.square")
+                            }
                         }
                     }
                     Button {
@@ -142,11 +145,12 @@ private extension WooShippingPostPurchaseView {
 
 #Preview {
     WooShippingPostPurchaseView(viewModel: WooShippingPostPurchaseViewModel(labelSizes: [.label, .legal, .a4],
-                                                                            trackingURL: URL(string: "https://woocommerce.com")))
+                                                                            trackingURL: URL(string: "https://woocommerce.com"),
+                                                                            pickupURL: WooShippingCarrier.usps.pickupURL))
         .padding()
 }
 
 #Preview("Label without links") {
-    WooShippingPostPurchaseView(viewModel: WooShippingPostPurchaseViewModel(labelSizes: [.label, .legal, .a4], trackingURL: nil))
+    WooShippingPostPurchaseView(viewModel: WooShippingPostPurchaseViewModel(labelSizes: [.label, .legal, .a4], trackingURL: nil, pickupURL: nil))
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct WooShippingPostPurchaseView: View {
-    @State private var viewModel = WooShippingPostPurchaseViewModel()
+    @ObservedObject private(set) var viewModel: WooShippingPostPurchaseViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -54,13 +54,16 @@ struct WooShippingPostPurchaseView: View {
                 }
                 Divider()
                 Group {
-                    Button {
-                        // TODO: Open link for shipment tracking
-                    } label: {
-                        HStack {
-                            Text(Localization.trackShipment)
-                                .multilineTextAlignment(.leading)
-                            Image(systemName: "arrow.up.right.square")
+                    if let trackingURL = viewModel.trackingURL {
+                        NavigationLink {
+                            WebView(isPresented: .constant(true), url: trackingURL)
+                                .navigationTitle(Localization.trackShipment)
+                        } label: {
+                            HStack {
+                                Text(Localization.trackShipment)
+                                    .multilineTextAlignment(.leading)
+                                Image(systemName: "arrow.up.right.square")
+                            }
                         }
                     }
                     Button {
@@ -138,6 +141,12 @@ private extension WooShippingPostPurchaseView {
 }
 
 #Preview {
-    WooShippingPostPurchaseView()
+    WooShippingPostPurchaseView(viewModel: WooShippingPostPurchaseViewModel(labelSizes: [.label, .legal, .a4],
+                                                                            trackingURL: URL(string: "https://woocommerce.com")))
+        .padding()
+}
+
+#Preview("Label without links") {
+    WooShippingPostPurchaseView(viewModel: WooShippingPostPurchaseViewModel(labelSizes: [.label, .legal, .a4], trackingURL: nil))
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -41,8 +41,9 @@ struct WooShippingPostPurchaseView: View {
                         .bold()
                 }
                 .buttonStyle(HighlightButtonStyle(background: Layout.panelHighlight, backgroundPressed: Layout.buttonPressed))
-                Button {
-                    // TODO: Open instructions for how to print
+                NavigationLink {
+                    ShippingLabelPrintingInstructionsView()
+                        .navigationTitle(Localization.infoTitle)
                 } label: {
                     HStack {
                         Image(systemName: "info.circle")
@@ -117,6 +118,10 @@ private extension WooShippingPostPurchaseView {
         static let info = NSLocalizedString("wooShipping.createLabels.postPurchase.info",
                                             value: "Learn how to print from your mobile device",
                                             comment: "Link for more information about how to print a purchased shipping label on the shipping label screen")
+        static let infoTitle =
+            NSLocalizedString("wooShipping.createLabels.postPurchase.infoTitle",
+                              value: "Print from your mobile device",
+                              comment: "Navigation bar title of shipping label printing instructions screen")
         static let trackShipment = NSLocalizedString("wooShipping.createLabels.postPurchase.trackShipment",
                                                      value: "Track shipment",
                                                      comment: "Link to track a shipment for a purchase shipping label on the shipping label screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -1,21 +1,35 @@
 import Yosemite
 import WooFoundation
 
-struct WooShippingPostPurchaseViewModel {
+final class WooShippingPostPurchaseViewModel: ObservableObject {
     /// Available paper sizes for printing the shipping label.
     let labelSizes: [ShippingLabelPaperSize]
 
     /// Selected paper size for printing the shipping label.
-    var selectedLabelSize: ShippingLabelPaperSize = .label
+    @Published var selectedLabelSize: ShippingLabelPaperSize = .label
 
-    init(siteAddress: SiteAddress = SiteAddress()) {
+    /// Tracking URL for the shipping label.
+    let trackingURL: URL?
+
+    init(labelSizes: [ShippingLabelPaperSize],
+         trackingURL: URL?) {
+        self.labelSizes = labelSizes
+        self.trackingURL = trackingURL
+    }
+
+    convenience init(shippingLabel: ShippingLabel,
+                     siteAddress: SiteAddress = SiteAddress()) {
         // Label sizes aren't provided by the API, so we can hard-code them to match the extension behavior:
-        labelSizes = {
+        let labelSizes = {
             var availableLabelSizes: [ShippingLabelPaperSize] = [.label, .letter]
             if [.US, .CA, .MX, .DO].contains(siteAddress.countryCode) {
                 availableLabelSizes.append(.a4)
             }
             return availableLabelSizes
         }()
+        let trackingURL = ShippingLabelTrackingURLGenerator.url(for: shippingLabel)
+
+        self.init(labelSizes: labelSizes,
+                  trackingURL: trackingURL)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -11,10 +11,15 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
     /// Tracking URL for the shipping label.
     let trackingURL: URL?
 
+    /// Shipment pickup URL for the shipping label.
+    let pickupURL: URL?
+
     init(labelSizes: [ShippingLabelPaperSize],
-         trackingURL: URL?) {
+         trackingURL: URL?,
+         pickupURL: URL?) {
         self.labelSizes = labelSizes
         self.trackingURL = trackingURL
+        self.pickupURL = pickupURL
     }
 
     convenience init(shippingLabel: ShippingLabel,
@@ -28,8 +33,10 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
             return availableLabelSizes
         }()
         let trackingURL = ShippingLabelTrackingURLGenerator.url(for: shippingLabel)
+        let pickupURL = WooShippingCarrier(rawValue: shippingLabel.carrierID)?.pickupURL
 
         self.init(labelSizes: labelSizes,
-                  trackingURL: trackingURL)
+                  trackingURL: trackingURL,
+                  pickupURL: pickupURL)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -38,8 +38,8 @@ struct WooShippingCreateLabelsView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: Layout.verticalSpacing) {
-                    if viewModel.canViewLabel {
-                        WooShippingPostPurchaseView()
+                    if viewModel.canViewLabel, let postPurchase = viewModel.postPurchase {
+                        WooShippingPostPurchaseView(viewModel: postPurchase)
                     }
 
                     WooShippingItems(viewModel: viewModel.items)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -15,6 +15,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         shippingLabel != nil
     }
 
+    var postPurchase: WooShippingPostPurchaseViewModel? {
+        guard let shippingLabel else { return nil }
+        return WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+    }
+
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
@@ -8,13 +8,15 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
         // Given
         let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .a4]
         let trackingURL = URL(string: "https://woocommerce.com")
+        let pickupURL = WooShippingCarrier.usps.pickupURL
 
         // When
-        let viewModel = WooShippingPostPurchaseViewModel(labelSizes: labelSizes, trackingURL: trackingURL)
+        let viewModel = WooShippingPostPurchaseViewModel(labelSizes: labelSizes, trackingURL: trackingURL, pickupURL: pickupURL)
 
         // Then
         XCTAssertEqual(viewModel.labelSizes, labelSizes)
         XCTAssertEqual(viewModel.trackingURL, trackingURL)
+        XCTAssertEqual(viewModel.pickupURL, pickupURL)
     }
 
     func test_labelSizes_includes_expected_default_values() {
@@ -53,6 +55,17 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
         // Then
         let expectedTrackingURL = ShippingLabelTrackingURLGenerator.url(for: shippingLabel)
         XCTAssertEqual(viewModel.trackingURL, expectedTrackingURL)
+    }
+
+    func test_pickupUP_parsed_from_shipping_label() {
+        // Given
+        let shippingLabel = ShippingLabel.fake().copy(carrierID: "usps")
+
+        // When
+        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+
+        // Then
+        XCTAssertEqual(viewModel.pickupURL, WooShippingCarrier.usps.pickupURL)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
@@ -4,6 +4,19 @@ import Yosemite
 
 final class WooShippingPostPurchaseViewModelTests: XCTestCase {
 
+    func test_inits_with_provided_properties() {
+        // Given
+        let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .a4]
+        let trackingURL = URL(string: "https://woocommerce.com")
+
+        // When
+        let viewModel = WooShippingPostPurchaseViewModel(labelSizes: labelSizes, trackingURL: trackingURL)
+
+        // Then
+        XCTAssertEqual(viewModel.labelSizes, labelSizes)
+        XCTAssertEqual(viewModel.trackingURL, trackingURL)
+    }
+
     func test_labelSizes_includes_expected_default_values() {
         // Given
         let countrySetting = SiteSetting.fake().copy(settingID: "woocommerce_default_country",
@@ -11,7 +24,7 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
         let siteAddress = SiteAddress(siteSettings: [countrySetting])
 
         // When
-        let viewModel = WooShippingPostPurchaseViewModel(siteAddress: siteAddress)
+        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: ShippingLabel.fake(), siteAddress: siteAddress)
 
         // Then
         assertEqual([.label, .letter], viewModel.labelSizes)
@@ -24,10 +37,22 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
         let siteAddress = SiteAddress(siteSettings: [countrySetting])
 
         // When
-        let viewModel = WooShippingPostPurchaseViewModel(siteAddress: siteAddress)
+        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: ShippingLabel.fake(), siteAddress: siteAddress)
 
         // Then
         assertEqual([.label, .letter, .a4], viewModel.labelSizes)
+    }
+
+    func test_trackingURL_parsed_from_shipping_label() {
+        // Given
+        let shippingLabel = ShippingLabel.fake().copy(carrierID: "usps", trackingNumber: "1234567890")
+
+        // When
+        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+
+        // Then
+        let expectedTrackingURL = ShippingLabelTrackingURLGenerator.url(for: shippingLabel)
+        XCTAssertEqual(viewModel.trackingURL, expectedTrackingURL)
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14242
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the following navigation to the post-purchase shipping label component, in the new Woo Shipping screen:

* Info about printing labels from your mobile device
* Track shipment: Opens the tracking for the purchased label.
* Schedule pickup: Opens the pickup scheduling page for the purchased label's carrier.

The remaining buttons (print shipping label and request refund) require a remote request and will be enabled after the networking support is added.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: The Woo Shipping extension installed and activated, with at least one order with a purchased shipping label.

1. Check that the `revampedShippingLabelCreation` feature flag is enabled.
2. Build and run the app.
3. Open the orders tab and select an order with a purchased shipping label.
4. In the shipping labels section, tap "View purchased shipping label."
5. In the Woo Shipping label screen, tap the info ("Learn how to print ...") text and confirm the printing instructions are shown.
6. Confirm "Track shipment" is shown if the label includes a tracking number, and tapping it opens the carrier's tracking page for that label.
7. Confirm "Schedule pickup" is shown if the carrier supports pickup, and tapping it opens the carrier's pickup scheduling page.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4a3fb926-154e-4d18-bb87-460fa43a4191



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.