### PR TITLE
Trial Expiration tests: Use the same timezone in both Calendar and date calculations to account for DST

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModel.swift
@@ -8,7 +8,7 @@ struct FreeTrialBannerViewModel {
     ///
     let message: String
 
-    init(sitePlan: WPComSitePlan, timeZone: TimeZone = .current) {
+    init(sitePlan: WPComSitePlan, timeZone: TimeZone = .current, calendar: Calendar = .current) {
 
         // Normalize dates in the same timezone.
         let today = Date().startOfDay(timezone: timeZone)
@@ -17,7 +17,7 @@ struct FreeTrialBannerViewModel {
             return
         }
 
-        let daysLeft = Calendar.current.dateComponents([.day], from: today, to: expiryDate).day ?? 0
+        let daysLeft = calendar.dateComponents([.day], from: today, to: expiryDate).day ?? 0
         switch daysLeft {
         case 1:
             message = NSLocalizedString("1 day left in your trial.", comment: "Message of the free trial banner when there is 1 day left")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModelTests.swift
@@ -19,7 +19,7 @@ final class FreeTrialBannerViewModelTests: XCTestCase {
         let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
 
         // When
-        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone)
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone, calendar: Self.calendar)
 
         // Then
         XCTAssertEqual(viewModel.message, NSLocalizedString("3 days left in your trial.", comment: ""))
@@ -31,7 +31,7 @@ final class FreeTrialBannerViewModelTests: XCTestCase {
         let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
 
         // When
-        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone)
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone, calendar: Self.calendar)
 
         // Then
         XCTAssertEqual(viewModel.message, NSLocalizedString("1 day left in your trial.", comment: ""))
@@ -43,7 +43,7 @@ final class FreeTrialBannerViewModelTests: XCTestCase {
         let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
 
         // When
-        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone)
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone, calendar: Self.calendar)
 
         // Then
         XCTAssertEqual(viewModel.message, NSLocalizedString("Your trial has ended.", comment: ""))
@@ -55,7 +55,7 @@ final class FreeTrialBannerViewModelTests: XCTestCase {
         let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
 
         // When
-        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone)
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan, timeZone: Self.gmtTimezone, calendar: Self.calendar)
 
         // Then
         XCTAssertEqual(viewModel.message, NSLocalizedString("Your trial has ended.", comment: ""))


### PR DESCRIPTION
We allow passing a custom timezone to FreeTrialBannerViewModel but we use the current calendar for calculating a distance between two dates.

Issues can occur when there is a DST (Daylight Savings Time) mismatch between the current calendar and the passed timezone.

<!-- Remember about a good descriptive title. -->

Failing PR: https://github.com/woocommerce/woocommerce-ios/pull/14279
Investigation: p1730438829630369-slack-CGPNUU63E
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We noticed `FreeTrialBannerViewModelTests` start failing in the CI but not on local machines for some reason. I tested it locally in:
- Vilnius timezone - tests pass
- Los Angeles timezone - tests fail

The issue is reproducible due to DST (daylight savings time) happening between trial expiration calculation dates. I think the issue is caused by using custom timezones in one set of calculations but using `Calendar.current` when calculating distance between the two dates. This mismatch can cause issues in DST.

![image](https://github.com/user-attachments/assets/67286d24-b24d-4e8b-a9c5-72b2df764b7d)

Solution: Set a custom timezone on a Calendar for consistent calculations

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The CI should succeed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I ran `FreeTrialBannerViewModelTests` locally in different time zones and now it succeeds. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.