### PR TITLE
Blaze: Fix flaky formatDayCount() unit test

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -171,7 +171,7 @@ private extension BlazeBudgetSettingViewModel {
     }
 
     func calculateEndDate(from startDate: Date, dayCount: Double) -> Date {
-        Date(timeInterval: Constants.oneDayInSeconds * dayCount, since: startDate)
+        Calendar.current.date(byAdding: .day, value: Int(dayCount), to: startDate) ?? startDate
     }
 
     func calculateTotalBudget(dailyBudget: Double, dayCount: Double) -> Double {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -39,19 +39,25 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
 
     func test_formatDayCount_returns_correct_content() {
         // Given
-        let initialStartDate = Date(timeIntervalSinceNow: 0)
-        let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
-                                                    dailyBudget: 11,
-                                                    isEvergreen: false,
-                                                    duration: 3,
-                                                    startDate: initialStartDate) { _, _, _, _ in }
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        // Use current timezone to match ViewModel's calendar behavior
+        dateFormatter.timeZone = .current
+
+        let startDate = dateFormatter.date(from: "2024-11-01")!
+        let viewModel = BlazeBudgetSettingViewModel(
+            siteID: 123,
+            dailyBudget: 11,
+            isEvergreen: false,
+            duration: 3,
+            startDate: startDate
+        ) { _, _, _, _ in }
 
         // When
         let content = viewModel.formatDayCount(3).string
 
         // Then
-        let endDate = initialStartDate.addingDays(3).toString(dateStyle: .medium, timeStyle: .none)
-        XCTAssertEqual(content, "3 days to \(endDate)")
+        XCTAssertEqual(content, "3 days to Nov 4, 2024")
     }
 
     func test_confirmSettings_triggers_onCompletion_with_updated_details() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -11,7 +11,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
     @MainActor
     func test_dates_for_custom_range_are_correct_for_non_custom_time_range() throws {
         // Given
-        let viewModel = StorePerformanceViewModel(siteID: 123, usageTracksEventEmitter: .init())
+        let viewModel = StorePerformanceViewModel(siteID: 123, siteTimezone: .current, usageTracksEventEmitter: .init())
 
         // When
         viewModel.didSelectTimeRange(.thisWeek)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModelTests.swift
@@ -9,7 +9,7 @@ final class TopPerformersDashboardViewModelTests: XCTestCase {
     @MainActor
     func test_dates_for_custom_range_are_correct_for_non_custom_time_range() throws {
         // Given
-        let viewModel = TopPerformersDashboardViewModel(siteID: 123, usageTracksEventEmitter: .init())
+        let viewModel = TopPerformersDashboardViewModel(siteID: 123, siteTimezone: .current, usageTracksEventEmitter: .init())
 
         // When
         viewModel.didSelectTimeRange(.thisWeek)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Fixed a flaky test in `BlazeBudgetSettingViewModelTests` by using a static date instead of the current date. The test was previously using `Date()` which could lead to inconsistent results depending on when the test was run, especially possibly during DST. 

It failed inconsistently on https://github.com/woocommerce/woocommerce-ios/pull/14279 although it then worked after a retry. Possibly similar to the issue fixed in https://github.com/woocommerce/woocommerce-ios/pull/14285

Investigation: p1730438829630369-slack-CGPNUU63E

### Previous Implementation
- Used `Date(timeIntervalSinceNow: 0)` which made the test dependent on execution time
- Compared two calculated values against each other (one in test, one in implementation)
- Could potentially pass even if both calculations were wrong in the same way

### New Implementation
- Uses a fixed date ("2024-11-01") for consistent testing
- Compares against a known, hardcoded expected string
- Maintains timezone as `.current` to match ViewModel's calendar behavior

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The CI should succeed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested the unit tests in `BlazeBudgetSettingViewModelTests` locally with a few different timezones.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.