### PR TITLE
[Shipping labels] Populate shipping label view with purchased label data

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmat.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmat.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct WooShippingHazmat: View {
+    /// Whether the interactions (navigation/setting selection) are enabled.
+    let enabled: Bool
+
     var body: some View {
         AdaptiveStack {
             Text(Localization.hazmatLabel)
@@ -8,10 +11,13 @@ struct WooShippingHazmat: View {
             Spacer()
             Text("No") // TODO: Replace with actual hazmat selection for package
                 .secondaryBodyStyle()
-            Image(uiImage: .chevronImage) // TODO: Replace with actual navigation to hazmat declaration screen
-                .secondaryBodyStyle()
+            if enabled {
+                Image(uiImage: .chevronImage) // TODO: Replace with actual navigation to hazmat declaration screen
+                    .secondaryBodyStyle()
+            }
         }
         .padding(.vertical, Layout.verticalPadding)
+        .disabled(!enabled)
     }
 }
 
@@ -29,6 +35,6 @@ private extension WooShippingHazmat {
 }
 
 #Preview {
-    WooShippingHazmat()
+    WooShippingHazmat(enabled: true)
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -44,7 +44,7 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingItems(viewModel: viewModel.items)
 
-                    WooShippingHazmat()
+                    WooShippingHazmat(enabled: !viewModel.canViewLabel)
 
                     if viewModel.hasPackage {
                         // TODO: Display package section

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -46,7 +46,9 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingHazmat(enabled: !viewModel.canViewLabel)
 
-                    if viewModel.hasPackage {
+                    if viewModel.canViewLabel {
+                        EmptyView()
+                    } else if viewModel.hasPackage {
                         // TODO: Display package section
                         // Package heading and edit button
                         // Selected package details

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -65,7 +65,7 @@ struct WooShippingCreateLabelsView: View {
                 ExpandableBottomSheet(onChangeOfExpansion: { isExpanded in
                     isShipmentDetailsExpanded = isExpanded
                 }) {
-                    if isShipmentDetailsExpanded {
+                    if isShipmentDetailsExpanded && !viewModel.canViewLabel {
                         CollapsibleHStack(spacing: Layout.bottomSheetSpacing) {
                             Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
                                 .font(.subheadline)
@@ -77,7 +77,7 @@ struct WooShippingCreateLabelsView: View {
                             Text(Localization.BottomSheet.shipmentDetails)
                                 .foregroundStyle(Color(.primary))
                                 .bold()
-                            if viewModel.hasPackage {
+                            if viewModel.hasPackage && !viewModel.canViewLabel {
                                 purchaseButton
                             }
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -191,45 +191,28 @@ private extension WooShippingCreateLabelsView {
             Text(Localization.BottomSheet.shipmentCosts)
                 .footnoteStyle()
             Group {
-                if let selectedRate = viewModel.shippingService.selectedRate {
-                    AdaptiveStack {
-                        Text(Localization.BottomSheet.rateLabel(for: selectedRate))
-                        Spacer()
-                        Text(viewModel.formatAmount(for: selectedRate.rate))
-                    }
-                    if let signature = selectedRate.signatureRate {
-                        AdaptiveStack {
-                            Text(Localization.BottomSheet.signatureRequired)
-                            Spacer()
-                            Text(viewModel.formatAmount(for: signature))
-                        }
-                    }
-                    if let adultSignature = selectedRate.adultSignatureRate {
-                        AdaptiveStack {
-                            Text(Localization.BottomSheet.adultSignatureRequired)
-                            Spacer()
-                            Text(viewModel.formatAmount(for: adultSignature))
-                        }
+                if viewModel.shippingRates.isNotEmpty {
+                    ForEach(viewModel.shippingRates, id: \.title) { rate in
+                        shippingRateRow(label: rate.title, amount: rate.amount)
                     }
                 } else {
-                    AdaptiveStack {
-                        Text(Localization.BottomSheet.subtotal)
-                        Spacer()
-                        Text("$0.00")
-                            .redacted(reason: .placeholder)
-                    }
+                    shippingRateRow(label: Localization.BottomSheet.subtotal, amount: nil)
                 }
-                AdaptiveStack {
-                    Text(Localization.BottomSheet.total)
-                        .bold()
-                    Spacer()
-                    Text(viewModel.totalCost ?? "$0.00")
-                        .if(viewModel.totalCost == nil) { total in
-                            total.redacted(reason: .placeholder)
-                        }
-                }
+                shippingRateRow(label: Localization.BottomSheet.total, amount: viewModel.totalCost)
+                    .bold()
             }
             .frame(idealHeight: Layout.rowHeight)
+        }
+    }
+
+    func shippingRateRow(label: String, amount: String?) -> some View {
+        AdaptiveStack {
+            Text(label)
+            Spacer()
+            Text(amount ?? "$0.00")
+                .if(amount == nil) { amount in
+                    amount.redacted(reason: .placeholder)
+                }
         }
     }
 
@@ -292,25 +275,6 @@ private extension WooShippingCreateLabelsView {
             static let subtotal = NSLocalizedString("wooShipping.createLabels.bottomSheet.subtotal",
                                                         value: "Subtotal",
                                                         comment: "Label for row showing the subtotal for shipment costs on the shipping label creation screen")
-            static func rateLabel(for selectedRate: WooShippingSelectedRate) -> String {
-                if selectedRate.signatureRate == nil && selectedRate.adultSignatureRate == nil {
-                    return selectedRate.rate.title
-                } else {
-                    return String.localizedStringWithFormat(baseFeeFormat, selectedRate.rate.title)
-                }
-            }
-            private static let baseFeeFormat = NSLocalizedString("wooShipping.createLabels.bottomSheet.baseFee",
-                                                                 value: "%1$@ (base fee)",
-                                                                 comment: "Label for row showing the base fee for the selected shipping service " +
-                                                                 "on the shipping label creation screen. Reads like: 'USPS - Media Mail (base fee)'")
-            static let signatureRequired = NSLocalizedString("wooShipping.createLabels.bottomSheet.signatureRequired",
-                                                             value: "Signature Required",
-                                                             comment: "Label for row showing the additional cost to require a signature " +
-                                                             "on the shipping label creation screen")
-            static let adultSignatureRequired = NSLocalizedString("wooShipping.createLabels.bottomSheet.adultSignatureRequired",
-                                                             value: "Adult Signature Required",
-                                                             comment: "Label for row showing the additional cost to require an adult signature " +
-                                                                  "on the shipping label creation screen")
             static let total = NSLocalizedString("wooShipping.createLabels.bottomSheet.total",
                                                         value: "Total",
                                                         comment: "Label for row showing the total for shipment costs on the shipping label creation screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -69,6 +69,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Purchases a shipping label with the provided label details and settings.
     func purchaseLabel() {
+        guard canPurchaseLabel else {
+            return
+        }
         // TODO: 13556 - Add action to purchase label remotely
         onLabelPurchase?(markOrderComplete) // TODO: 13556 - Only call this closure if the remote purchase is successful
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -16,10 +16,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     }
 
     /// View model for the section displayed after a shipping label is purchased.
-    var postPurchase: WooShippingPostPurchaseViewModel? {
-        guard let shippingLabel else { return nil }
-        return WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
-    }
+    @Published private(set) var postPurchase: WooShippingPostPurchaseViewModel?
 
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
@@ -90,6 +87,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.shippingLabel = shippingLabel
+        if let shippingLabel {
+            self.postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+        }
         self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase
@@ -104,7 +104,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             return
         }
         // TODO: 13556 - Add action to purchase label remotely
-        onLabelPurchase?(markOrderComplete) // TODO: 13556 - Only call this closure if the remote purchase is successful
+        // TODO: 13556 - If the remote purchase is successful:
+            onLabelPurchase?(markOrderComplete)
+        if let shippingLabel {
+            postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -8,7 +8,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
 
     /// The purchased shipping label.
-    let shippingLabel: ShippingLabel?
+    @Published private var shippingLabel: ShippingLabel?
 
     /// Whether an existing label can be viewed (and printed, tracked, refunded, etc.).
     var canViewLabel: Bool {
@@ -31,6 +31,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// View model for the label shipping service.
     let shippingService = WooShippingServiceViewModel()
 
+    /// Selected shipping rate when creating a shipping label.
+    private var selectedRate: WooShippingSelectedRate? {
+        shippingService.selectedRate
+    }
+
     /// Address to ship from (store address), formatted for display.
     let originAddress: String
 
@@ -40,14 +45,40 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Shipping lines for the order, with formatted amount.
     let shippingLines: [WooShipping_ShippingLineViewModel]
 
+    /// Shipping rates for the purchased label, with formatted amount.
+    var shippingRates: [(title: String, amount: String)] {
+        if let shippingLabel {
+            return [formatShippingRate(name: shippingLabel.serviceName, rate: shippingLabel.rate)]
+        } else if let selectedRate {
+            let baseRate = selectedRate.rate.rate
+            let formattedBaseRate = formatShippingRate(name: Localization.baseRateLabel(for: selectedRate), rate: baseRate)
+            let formattedSignatureRate = [
+                selectedRate.signatureRate.map { self.formatShippingRate(name: Localization.signatureRequired, rate: $0.rate, basedOn: baseRate) },
+                selectedRate.adultSignatureRate.map { self.formatShippingRate(name: Localization.adultSignatureRequired,
+                                                                              rate: $0.rate,
+                                                                              basedOn: baseRate) }
+            ].compacted()
+            return [formattedBaseRate] + formattedSignatureRate
+        } else {
+            return []
+        }
+    }
+
+    /// Total cost of the shipping label, formatted for display.
+    var totalCost: String? {
+        guard let amount = shippingLabel?.rate ?? selectedRate?.totalRate else {
+            return nil
+        }
+        return currencyFormatter.formatAmount(Decimal(amount))
+    }
+
     /// Whether to mark the order as complete after the label is purchased.
     @Published var markOrderComplete: Bool = false
 
     /// If the purchase button should be enabled.
-    @Published private(set) var canPurchaseLabel: Bool = false
-
-    /// Total cost of the shipping label, formatted for display.
-    @Published private(set) var totalCost: String?
+    var canPurchaseLabel: Bool {
+        selectedRate != nil && shippingLabel == nil
+    }
 
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
@@ -64,7 +95,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.originAddress = Self.formatOriginAddress(siteAddress: siteAddress)
         self.destinationAddressLines = (order.shippingAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
-        bindViewModelsToProperties()
     }
 
     /// Purchases a shipping label with the provided label details and settings.
@@ -75,31 +105,18 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         // TODO: 13556 - Add action to purchase label remotely
         onLabelPurchase?(markOrderComplete) // TODO: 13556 - Only call this closure if the remote purchase is successful
     }
-
-    /// Provides the formatted amount for the given shipping rate.
-    func formatAmount(for rate: ShippingLabelCarrierRate) -> String {
-        guard let baseRate = shippingService.selectedRate?.rate else {
-            return ""
-        }
-        let amount = rate == baseRate ? rate.rate : rate.rate - baseRate.rate
-        return currencyFormatter.formatAmount(Decimal(amount)) ?? amount.description
-    }
 }
 
 private extension WooShippingCreateLabelsViewModel {
-    func bindViewModelsToProperties() {
-        shippingService.$selectedRate
-            .map { selectedRate in
-                selectedRate != nil
+    /// Provides the formatted label and amount for a shipping rate, based on the provided base rate.
+    func formatShippingRate(name: String, rate: Double, basedOn baseRate: Double? = nil) -> (title: String, amount: String) {
+        let amount = {
+            guard let baseRate else {
+                return rate
             }
-            .assign(to: &$canPurchaseLabel)
-
-        shippingService.$selectedRate
-            .map { [weak self] selectedRate -> String? in
-                guard let self, let selectedRate else { return nil }
-                return currencyFormatter.formatAmount(Decimal(selectedRate.totalRate))
-            }
-            .assign(to: &$totalCost)
+            return rate - baseRate
+        }()
+        return (name, currencyFormatter.formatAmount(Decimal(amount)) ?? amount.description)
     }
 
     /// Formats the origin address from the provided `SiteAddress`.
@@ -117,5 +134,29 @@ private extension WooShippingCreateLabelsViewModel {
                               email: nil)
         let formattedPostalAddress = address.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ")
         return formattedPostalAddress ?? ""
+    }
+}
+
+private extension WooShippingCreateLabelsViewModel {
+    enum Localization {
+        static func baseRateLabel(for selectedRate: WooShippingSelectedRate) -> String {
+            if selectedRate.signatureRate == nil && selectedRate.adultSignatureRate == nil {
+                return selectedRate.rate.title
+            } else {
+                return String.localizedStringWithFormat(baseFeeFormat, selectedRate.rate.title)
+            }
+        }
+        private static let baseFeeFormat = NSLocalizedString("wooShipping.createLabels.bottomSheet.baseFee",
+                                                             value: "%1$@ (base fee)",
+                                                             comment: "Label for row showing the base fee for the selected shipping service " +
+                                                             "on the shipping label creation screen. Reads like: 'USPS - Media Mail (base fee)'")
+        static let signatureRequired = NSLocalizedString("wooShipping.createLabels.bottomSheet.signatureRequired",
+                                                         value: "Signature Required",
+                                                         comment: "Label for row showing the additional cost to require a signature " +
+                                                         "on the shipping label creation screen")
+        static let adultSignatureRequired = NSLocalizedString("wooShipping.createLabels.bottomSheet.adultSignatureRequired",
+                                                              value: "Adult Signature Required",
+                                                              comment: "Label for row showing the additional cost to require an adult signature " +
+                                                              "on the shipping label creation screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -10,11 +10,12 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// The purchased shipping label.
     @Published private var shippingLabel: ShippingLabel?
 
-    /// Whether an existing label can be viewed (and printed, tracked, refunded, etc.).
+    /// Whether a purchased shipping label can be viewed (and printed, tracked, refunded, etc.).
     var canViewLabel: Bool {
         shippingLabel != nil
     }
 
+    /// View model for the section displayed after a shipping label is purchased.
     var postPurchase: WooShippingPostPurchaseViewModel? {
         guard let shippingLabel else { return nil }
         return WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -116,35 +116,54 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.totalCost, "$7.53")
     }
 
-    func test_formatAmount_for_standard_shipping_rate_returns_formatted_rate() throws {
+    func test_selecting_standard_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
         let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
-        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
-        card.selectRate()
 
         // When
-        let selectedRate = try XCTUnwrap(viewModel.shippingService.selectedRate)
-        let formattedAmount = viewModel.formatAmount(for: selectedRate.rate)
+        try viewModel.selectShippingRate()
 
         // Then
-        XCTAssertEqual(formattedAmount, "$40.06")
+        XCTAssertEqual(viewModel.shippingRates.count, 1)
+        XCTAssertEqual(viewModel.shippingRates.first?.title, "USPS - Media Mail")
+        XCTAssertEqual(viewModel.shippingRates.first?.amount, "$7.53")
     }
 
-    func test_formatAmount_for_signature_shipping_rate_returns_formatted_difference_from_base_rate() throws {
+    func test_selecting_signature_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
         let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
         let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
         card.signatureRequirement = .signatureRequired
-        card.selectRate()
 
         // When
-        let signatureRate = try XCTUnwrap(viewModel.shippingService.selectedRate?.signatureRate)
-        let formattedAmount = viewModel.formatAmount(for: signatureRate)
+        card.selectRate()
 
         // Then
-        XCTAssertEqual(formattedAmount, "$2.70")
+        XCTAssertEqual(viewModel.shippingRates.count, 2)
+        XCTAssertEqual(viewModel.shippingRates[0].title, "USPS - Parcel Select Mail (base fee)")
+        XCTAssertEqual(viewModel.shippingRates[0].amount, "$40.06")
+        XCTAssertEqual(viewModel.shippingRates[1].title, "Signature Required")
+        XCTAssertEqual(viewModel.shippingRates[1].amount, "$2.70")
+    }
+
+    func test_selecting_adult_signature_shipping_rate_sets_expected_shippingRates() throws {
+        // Given
+        let order = Order.fake()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
+        card.signatureRequirement = .adultSignatureRequired
+
+        // When
+        card.selectRate()
+
+        // Then
+        XCTAssertEqual(viewModel.shippingRates.count, 2)
+        XCTAssertEqual(viewModel.shippingRates[0].title, "USPS - Parcel Select Mail (base fee)")
+        XCTAssertEqual(viewModel.shippingRates[0].amount, "$40.06")
+        XCTAssertEqual(viewModel.shippingRates[1].title, "Adult Signature Required")
+        XCTAssertEqual(viewModel.shippingRates[1].amount, "$6.90")
     }
 
     func test_canViewLabel_true_when_shipping_label_exists() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -55,15 +55,16 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(order.shippingLines.map({ $0.shippingID }), viewModel.shippingLines.map({ $0.id }))
     }
 
-    func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() {
+    func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() throws {
         // Given
         let order = Order.fake()
 
         // When
-        let markOrderComplete: Bool = waitFor { promise in
+        let markOrderComplete: Bool = try waitFor { promise in
             let viewModel = WooShippingCreateLabelsViewModel(order: order, onLabelPurchase: { complete in
                 promise(complete)
             })
+            try viewModel.selectShippingRate()
             viewModel.markOrderComplete = false
             viewModel.purchaseLabel()
         }
@@ -72,15 +73,16 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertFalse(markOrderComplete)
     }
 
-    func test_onLabelPurchase_notifies_when_order_should_be_marked_complete() {
+    func test_onLabelPurchase_notifies_when_order_should_be_marked_complete() throws {
         // Given
         let order = Order.fake()
 
         // When
-        let markOrderComplete: Bool = waitFor { promise in
+        let markOrderComplete: Bool = try waitFor { promise in
             let viewModel = WooShippingCreateLabelsViewModel(order: order, onLabelPurchase: { complete in
                 promise(complete)
             })
+            try viewModel.selectShippingRate()
             viewModel.markOrderComplete = true
             viewModel.purchaseLabel()
         }
@@ -96,8 +98,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canPurchaseLabel)
 
         // When
-        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards.first)
-        card.selectRate()
+        try viewModel.selectShippingRate()
 
         // Then
         XCTAssertTrue(viewModel.canPurchaseLabel)
@@ -109,8 +110,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
 
         // When
-        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards.first)
-        card.selectRate()
+        try viewModel.selectShippingRate()
 
         // Then
         XCTAssertEqual(viewModel.totalCost, "$7.53")
@@ -177,5 +177,13 @@ private extension WooShippingCreateLabelsViewModelTests {
     ///
     func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
         return mapGeneralSettings(from: "settings-general")
+    }
+}
+
+private extension WooShippingCreateLabelsViewModel {
+    /// Selects the first available shipping rate.
+    func selectShippingRate() throws {
+        let card = try XCTUnwrap(self.shippingService.serviceTabs.first?.cards.first)
+        card.selectRate()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 import WooFoundation
 
 final class WooShippingCreateLabelsViewModelTests: XCTestCase {
-    func test_inits_with_expected_values() {
+    func test_inits_with_expected_values_for_shipping_label_creation() {
         // Given
         let order = Order.fake()
 
@@ -15,6 +15,23 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.markOrderComplete)
         XCTAssertFalse(viewModel.canPurchaseLabel)
         XCTAssertNil(viewModel.totalCost)
+        XCTAssertFalse(viewModel.canViewLabel)
+    }
+
+    func test_inits_with_expected_values_for_viewing_purchased_label() {
+        // Given
+        let order = Order.fake()
+        let label = ShippingLabel.fake()
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingLabel: label)
+
+        // Then
+        XCTAssertNotNil(viewModel.postPurchase)
+        XCTAssertFalse(viewModel.canPurchaseLabel)
+        XCTAssertNotNil(viewModel.totalCost)
+        XCTAssertTrue(viewModel.canViewLabel)
+        XCTAssertEqual(viewModel.shippingRates.count, 1)
     }
 
     func test_site_address_converted_to_formatted_originAddress() {
@@ -164,20 +181,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingRates[0].amount, "$40.06")
         XCTAssertEqual(viewModel.shippingRates[1].title, "Adult Signature Required")
         XCTAssertEqual(viewModel.shippingRates[1].amount, "$6.90")
-    }
-
-    func test_canViewLabel_true_when_shipping_label_exists() {
-        // Given
-        let order = Order.fake()
-        let label = ShippingLabel.fake()
-
-        // When
-        let newLabelViewModel = WooShippingCreateLabelsViewModel(order: order)
-        let existingLabelViewModel = WooShippingCreateLabelsViewModel(order: order, shippingLabel: label)
-
-        // Then
-        XCTAssertFalse(newLabelViewModel.canViewLabel)
-        XCTAssertTrue(existingLabelViewModel.canViewLabel)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14242
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This populates the new Woo Shipping label view with data from the purchased shipping label, and updates the view to remove options that can't be changed after purchase:

* Hazmat selection is view-only.
* Package and rate selection are hidden.
* Purchase button and "mark as completed" button are hidden in the bottom sheet.
* Shipment costs in bottom sheet are populated with the rate from the purchased label.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: The Woo Shipping extension installed and activated, with at least one order with a purchased shipping label.

1. Check that the `revampedShippingLabelCreation` feature flag is enabled.
2. Build and run the app.
3. Open the orders tab and select an order with a purchased shipping label.
4. In the shipping labels section, tap "View purchased shipping label."
5. In the Woo Shipping label screen, confirm you can see the post-purchase section (print button, etc.), the shipment items, and the disabled hazmat section; confirm the packages and rates sections do not appear.
6. Open the bottom sheet and confirm the Shipment Costs section shows the correct shipping service name and amount.

You can also test the label creation flow (creating a new label) and confirm it works as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Before-ExistingLabel-MainScreen](https://github.com/user-attachments/assets/b04d9e74-08ee-4a19-8f6d-04831d5c91f4)|![After-ExistingLabel-MainScreen](https://github.com/user-attachments/assets/8f2dc778-7ac1-498e-8286-55063d6235ba)
![Before-ExistingLabel-BottomSheet](https://github.com/user-attachments/assets/ee8b8863-902d-429b-8736-0cd510f36939)|![After-ExistingLabel-BottomSheet](https://github.com/user-attachments/assets/111d4e35-7cb1-4828-9e8c-82a3d26bf1f0)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.