### PR TITLE
Dummy change to test https://github.com/woocommerce/woocommerce-ios/pull/14295

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 import protocol Yosemite.POSItem
 
+// Dummy change to trigger Dangermattic to test PR https://github.com/woocommerce/woocommerce-ios/pull/14295
+// Do not merge.
+
 struct CartView: View {
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
     @ObservedObject private var cartViewModel: CartViewModel


### PR DESCRIPTION
This PR is to test the Dangermattic fix in https://github.com/woocommerce/woocommerce-ios/pull/14295

Do not merge.


 - This PR's branch is currently cut from `trunk`, thus not having the Dangermattic fix yet. This is so that we first reproduce the false-negative with the old version of Dangermattic
 - After than I plan to rebase this PR on top of https://github.com/woocommerce/woocommerce-ios/pull/14295's head to get the Dangermattic update and validate it makes the false-negative disappear.

---

The below is an extract of the description of PR that triggered this false-negative in Dangermattic on a View change


### Typing invalid value

hxxps://github.com/user-attachments/axxets/8cdc7b5a-9a88-423d-bf7b-f2cf872824a6

### Scanning invalid value

hxxps://github.com/user-attachments/axxets/f3461fec-f96c-4376-9e00-f8faf65f3457
