### PR TITLE
[Watch app] opening order shows yellow warning icon

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 -----
 
 - [internal] Updated Xcode version to 16.1 [https://github.com/woocommerce/woocommerce-ios/pull/14225]
-- [**] Fixed: properly open and show order details in Watch app
+- [**] Fixed: properly open and show order details in Watch app [https://github.com/woocommerce/woocommerce-ios/pull/14306]
 
 21.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 
 - [internal] Updated Xcode version to 16.1 [https://github.com/woocommerce/woocommerce-ios/pull/14225]
+- [**] Fixed: properly open and show order details in Watch app
 
 21.0
 -----

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -116,7 +116,9 @@ struct OrdersListView: View {
     @ViewBuilder private func dataView(orders: [Order]) -> some View {
         List {
             ForEach(orders, id: \.number) { order in
-                NavigationLink(destination: OrderDetailView(order: order)) {
+                NavigationLink {
+                    OrderDetailView(order: order)
+                } label: {
                     OrderListCard(order: order)
                 }
             }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -114,16 +114,13 @@ struct OrdersListView: View {
     /// Data: List with live order content.
     ///
     @ViewBuilder private func dataView(orders: [Order]) -> some View {
-        List() {
+        List {
             ForEach(orders, id: \.number) { order in
-                NavigationLink(value: order) {
+                NavigationLink(destination: OrderDetailView(order: order)) {
                     OrderListCard(order: order)
                 }
             }
             .listRowBackground(OrderListCard.background)
-        }
-        .navigationDestination(for: Order.self) { order in
-            OrderDetailView(order: order)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14127
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When using Woo Watch app and trying to open order details, by tapping order in order list, the app would show a yellow warning icon.

When we run the app from Xcode the console shows this messages:

```
Do not put a navigation destination modifier inside a "lazy” container, like `List` or `LazyVStack`. These containers create child views only when needed to render on screen. Add the navigation destination modifier outside these containers so that the navigation stack can always see the destination. There's a misplaced `navigationDestination(for:destination:)` modifier for type `Order`. It will be ignored.
A NavigationLink is presenting a value of type “Order” but there is no matching navigationDestination declaration visible from the location of the link. The link cannot be activated.

Note: Links search for destinations in any surrounding NavigationStack, then within the same column of a NavigationSplitView.
```

After a debugging session I changed the usage of `NavigationLink` to use `NavigationLink(destination: ...)` like this:
```
NavigationLink(destination: OrderDetailView(order: order)) {
  OrderListCard(order: order)
}
```
With that change app works normally.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Install Woo from App Store, Testflight or run from `trunk`
- Open Woo app on Apple Watch
- Tap on one of the orders in the list
- You should either see a yellow warning icon or tapping one of the orders will not even do that (you will stay in the order list)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Open Woo app on Apple Watch
- Tap on one of the orders in the list
- Order details for that order should show
- Scroll order details to see if all info is shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Trunk:

https://github.com/user-attachments/assets/a0ecc26f-dd62-4640-a81a-f6b26c8ae755

### Testflight (21.0.0):

https://github.com/user-attachments/assets/b1a826a3-64cd-4863-95bf-5c39476ce3e9 

### This PR:

https://github.com/user-attachments/assets/f16f9c4c-08f0-4aaf-8401-33d17f133215

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
