### PR TITLE
[Shipping labels] Support injecting sample shipping rates to shipping service for unit tests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -9,82 +9,22 @@ final class WooShippingServiceViewModel: ObservableObject {
     @Published private(set) var selectedRate: WooShippingSelectedRate?
 
     /// Available standard shipping rates.
-    private let standardRates: [ShippingLabelCarrierRate]
+    private var standardRates: [ShippingLabelCarrierRate] = []
     /// Available shipping rates with signature required.
-    private let signatureRates: [ShippingLabelCarrierRate]
+    private var signatureRates: [ShippingLabelCarrierRate] = []
     /// Available shipping rates with adult signature required.
-    private let adultSignatureRates: [ShippingLabelCarrierRate]
+    private var adultSignatureRates: [ShippingLabelCarrierRate] = []
 
     /// Sort order for shipping services.
     @Published var sortOrder: SortOrder = .price
 
-    init() {
+    init(standardRates: [ShippingLabelCarrierRate] = [],
+         signatureRates: [ShippingLabelCarrierRate] = [],
+         adultSignatureRates: [ShippingLabelCarrierRate] = []) {
         // TODO: Replace with real data from remote
-        standardRates = [ShippingLabelCarrierRate(title: "USPS - Media Mail",
-                                              insurance: "100",
-                                              retailRate: 8,
-                                              rate: 7.53,
-                                              rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
-                                              serviceID: "",
-                                              carrierID: "usps",
-                                              shipmentID: "",
-                                              hasTracking: true,
-                                              isSelected: false,
-                                              isPickupFree: true,
-                                              deliveryDays: 7,
-                                              deliveryDateGuaranteed: false),
-                     ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                              insurance: "100",
-                                              retailRate: 40.06,
-                                              rate: 40.06,
-                                              rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
-                                              serviceID: "",
-                                              carrierID: "usps",
-                                              shipmentID: "",
-                                              hasTracking: true,
-                                              isSelected: false,
-                                              isPickupFree: true,
-                                              deliveryDays: 2,
-                                              deliveryDateGuaranteed: false),
-                     ShippingLabelCarrierRate(title: "DHL - Next Day",
-                                              insurance: "100",
-                                              retailRate: 15,
-                                              rate: 14.22,
-                                              rateID: "rate_a8a29d5f34984722942f466c30ea27eg",
-                                              serviceID: "",
-                                              carrierID: "dhlexpress",
-                                              shipmentID: "",
-                                              hasTracking: true,
-                                              isSelected: false,
-                                              isPickupFree: true,
-                                              deliveryDays: 1,
-                                              deliveryDateGuaranteed: false)]
-        signatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                       insurance: "100",
-                                                       retailRate: 42.76,
-                                                       rate: 42.76,
-                                                       rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
-                                                       serviceID: "",
-                                                       carrierID: "usps",
-                                                       shipmentID: "",
-                                                       hasTracking: true,
-                                                       isSelected: false,
-                                                       isPickupFree: true,
-                                                       deliveryDays: 2,
-                                                       deliveryDateGuaranteed: false)]
-        adultSignatureRates = [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                            insurance: "100",
-                                                            retailRate: 46.96,
-                                                            rate: 46.96,
-                                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
-                                                            serviceID: "",
-                                                            carrierID: "usps",
-                                                            shipmentID: "",
-                                                            hasTracking: true,
-                                                            isSelected: false,
-                                                            isPickupFree: true,
-                                                            deliveryDays: 2,
-                                                            deliveryDateGuaranteed: false)]
+        self.standardRates = standardRates
+        self.signatureRates = signatureRates
+        self.adultSignatureRates = adultSignatureRates
         generateServiceTabs()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -27,7 +27,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     let hasPackage: Bool = false
 
     /// View model for the label shipping service.
-    let shippingService = WooShippingServiceViewModel()
+    private(set) var shippingService: WooShippingServiceViewModel
 
     /// Selected shipping rate when creating a shipping label.
     private var selectedRate: WooShippingSelectedRate? {
@@ -85,6 +85,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          shippingLabel: ShippingLabel? = nil,
          siteAddress: SiteAddress = SiteAddress(),
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         shippingService: WooShippingServiceViewModel = WooShippingServiceViewModel(),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.shippingLabel = shippingLabel
         if let shippingLabel {
@@ -96,6 +97,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.originAddress = Self.formatOriginAddress(siteAddress: siteAddress)
         self.destinationAddressLines = (order.shippingAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
+        self.shippingService = shippingService
     }
 
     /// Purchases a shipping label with the provided label details and settings.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -78,7 +78,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // When
         let markOrderComplete: Bool = try waitFor { promise in
-            let viewModel = WooShippingCreateLabelsViewModel(order: order, onLabelPurchase: { complete in
+            let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingService: self.sampleShippingService(), onLabelPurchase: { complete in
                 promise(complete)
             })
             try viewModel.selectShippingRate()
@@ -96,7 +96,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // When
         let markOrderComplete: Bool = try waitFor { promise in
-            let viewModel = WooShippingCreateLabelsViewModel(order: order, onLabelPurchase: { complete in
+            let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingService: self.sampleShippingService(), onLabelPurchase: { complete in
                 promise(complete)
             })
             try viewModel.selectShippingRate()
@@ -111,7 +111,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_canPurchaseLabel_true_after_shipping_rate_is_selected() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order)
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingService: sampleShippingService())
         XCTAssertFalse(viewModel.canPurchaseLabel)
 
         // When
@@ -124,7 +124,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_selecting_shipping_rate_sets_totalCost() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
 
         // When
         try viewModel.selectShippingRate()
@@ -136,7 +136,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_selecting_standard_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
 
         // When
         try viewModel.selectShippingRate()
@@ -150,7 +150,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_selecting_signature_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
         let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
         card.signatureRequirement = .signatureRequired
 
@@ -168,7 +168,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_selecting_adult_signature_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings())
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
         let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
         card.signatureRequirement = .adultSignatureRequired
 
@@ -199,6 +199,74 @@ private extension WooShippingCreateLabelsViewModelTests {
     ///
     func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
         return mapGeneralSettings(from: "settings-general")
+    }
+
+    func sampleShippingService() -> WooShippingServiceViewModel {
+        WooShippingServiceViewModel(standardRates: [ShippingLabelCarrierRate(title: "USPS - Media Mail",
+                                                                             insurance: "100",
+                                                                             retailRate: 8,
+                                                                             rate: 7.53,
+                                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                                                             serviceID: "",
+                                                                             carrierID: "usps",
+                                                                             shipmentID: "",
+                                                                             hasTracking: true,
+                                                                             isSelected: false,
+                                                                             isPickupFree: true,
+                                                                             deliveryDays: 7,
+                                                                             deliveryDateGuaranteed: false),
+                                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                                             insurance: "100",
+                                                                             retailRate: 40.06,
+                                                                             rate: 40.06,
+                                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
+                                                                             serviceID: "",
+                                                                             carrierID: "usps",
+                                                                             shipmentID: "",
+                                                                             hasTracking: true,
+                                                                             isSelected: false,
+                                                                             isPickupFree: true,
+                                                                             deliveryDays: 2,
+                                                                             deliveryDateGuaranteed: false),
+                                                    ShippingLabelCarrierRate(title: "DHL - Next Day",
+                                                                             insurance: "100",
+                                                                             retailRate: 15,
+                                                                             rate: 14.22,
+                                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27eg",
+                                                                             serviceID: "",
+                                                                             carrierID: "dhlexpress",
+                                                                             shipmentID: "",
+                                                                             hasTracking: true,
+                                                                             isSelected: false,
+                                                                             isPickupFree: true,
+                                                                             deliveryDays: 1,
+                                                                             deliveryDateGuaranteed: false)],
+                                    signatureRates: [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                                              insurance: "100",
+                                                                              retailRate: 42.76,
+                                                                              rate: 42.76,
+                                                                              rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
+                                                                              serviceID: "",
+                                                                              carrierID: "usps",
+                                                                              shipmentID: "",
+                                                                              hasTracking: true,
+                                                                              isSelected: false,
+                                                                              isPickupFree: true,
+                                                                              deliveryDays: 2,
+                                                                              deliveryDateGuaranteed: false)],
+                                    adultSignatureRates: [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                                                   insurance: "100",
+                                                                                   retailRate: 46.96,
+                                                                                   rate: 46.96,
+                                                                                   rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
+                                                                                   serviceID: "",
+                                                                                   carrierID: "usps",
+                                                                                   shipmentID: "",
+                                                                                   hasTracking: true,
+                                                                                   isSelected: false,
+                                                                                   isPickupFree: true,
+                                                                                   deliveryDays: 2,
+                                                                                   deliveryDateGuaranteed: false)])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+import Yosemite
 
 final class WooShippingServiceViewModelTests: XCTestCase {
 
@@ -13,7 +14,9 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_generateServiceTabs_returns_expected_data() throws {
         // Given
-        let viewModel = WooShippingServiceViewModel()
+        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates(),
+                                                    signatureRates: sampleSignatureRates(),
+                                                    adultSignatureRates: sampleAdultSignatureRates())
 
         // Then
         XCTAssertEqual(viewModel.serviceTabs.count, 2)
@@ -65,7 +68,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_selecting_service_card_standard_rate_updates_expected_values() {
         // Given
-        let viewModel = WooShippingServiceViewModel()
+        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates())
         let card = viewModel.serviceTabs[0].cards[1]
         XCTAssertNil(viewModel.selectedRate)
         XCTAssertFalse(card.selected)
@@ -83,7 +86,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_selecting_service_card_signature_rate_updates_expected_values() {
         // Given
-        let viewModel = WooShippingServiceViewModel()
+        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates(),
+                                                    signatureRates: sampleSignatureRates())
         let card = viewModel.serviceTabs[0].cards[1]
         XCTAssertNil(viewModel.selectedRate)
         XCTAssertFalse(card.selected)
@@ -101,7 +105,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_selecting_service_card_adult_signature_rate_updates_expected_values() {
         // Given
-        let viewModel = WooShippingServiceViewModel()
+        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates(),
+                                                    adultSignatureRates: sampleAdultSignatureRates())
         let card = viewModel.serviceTabs[0].cards[1]
         XCTAssertNil(viewModel.selectedRate)
         XCTAssertFalse(card.selected)
@@ -119,7 +124,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_sortShipping_by_price_returns_sorted_list() {
         // Given
-        let viewModel = WooShippingServiceViewModel()
+        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates())
 
         // When
         viewModel.sortShipping(by: .price)
@@ -132,7 +137,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_shortShipping_by_deliveryDays_returns_sorted_list() {
         // Given
-        let viewModel = WooShippingServiceViewModel()
+        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates())
 
         // When
         viewModel.sortShipping(by: .deliveryTime)
@@ -143,4 +148,80 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(uspsCards?.first?.title, "USPS - Parcel Select Mail")
     }
 
+}
+
+private extension WooShippingServiceViewModelTests {
+    func sampleStandardRates() -> [ShippingLabelCarrierRate] {
+        [ShippingLabelCarrierRate(title: "USPS - Media Mail",
+                                  insurance: "100",
+                                  retailRate: 8,
+                                  rate: 7.53,
+                                  rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                  serviceID: "",
+                                  carrierID: "usps",
+                                  shipmentID: "",
+                                  hasTracking: true,
+                                  isSelected: false,
+                                  isPickupFree: true,
+                                  deliveryDays: 7,
+                                  deliveryDateGuaranteed: false),
+         ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                  insurance: "100",
+                                  retailRate: 40.06,
+                                  rate: 40.06,
+                                  rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
+                                  serviceID: "",
+                                  carrierID: "usps",
+                                  shipmentID: "",
+                                  hasTracking: true,
+                                  isSelected: false,
+                                  isPickupFree: true,
+                                  deliveryDays: 2,
+                                  deliveryDateGuaranteed: false),
+         ShippingLabelCarrierRate(title: "DHL - Next Day",
+                                  insurance: "100",
+                                  retailRate: 15,
+                                  rate: 14.22,
+                                  rateID: "rate_a8a29d5f34984722942f466c30ea27eg",
+                                  serviceID: "",
+                                  carrierID: "dhlexpress",
+                                  shipmentID: "",
+                                  hasTracking: true,
+                                  isSelected: false,
+                                  isPickupFree: true,
+                                  deliveryDays: 1,
+                                  deliveryDateGuaranteed: false)]
+    }
+
+    func sampleSignatureRates() -> [ShippingLabelCarrierRate] {
+        [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                  insurance: "100",
+                                  retailRate: 42.76,
+                                  rate: 42.76,
+                                  rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
+                                  serviceID: "",
+                                  carrierID: "usps",
+                                  shipmentID: "",
+                                  hasTracking: true,
+                                  isSelected: false,
+                                  isPickupFree: true,
+                                  deliveryDays: 2,
+                                  deliveryDateGuaranteed: false)]
+    }
+
+    func sampleAdultSignatureRates() -> [ShippingLabelCarrierRate] {
+        [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                  insurance: "100",
+                                  retailRate: 46.96,
+                                  rate: 46.96,
+                                  rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
+                                  serviceID: "",
+                                  carrierID: "usps",
+                                  shipmentID: "",
+                                  hasTracking: true,
+                                  isSelected: false,
+                                  isPickupFree: true,
+                                  deliveryDays: 2,
+                                  deliveryDateGuaranteed: false)]
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a small update to the shipping service view model in the new Woo Shipping label creation flow. It removes the hard-coded sample data and adds support for injecting sample rates in unit tests. This is a small step to prepare for using real data in this view model.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Confirm unit tests using this sample data continue to pass.

The shipping service section is currently not shown in the UI by default, and further testing of the view model and view will be done once we add support for real data.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.