### PR TITLE
[Core Data] Keep product image's dateCreated optional.

### DIFF
--- a/Storage/Storage/Model/ProductImage+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductImage+CoreDataProperties.swift
@@ -9,7 +9,7 @@ extension ProductImage {
     }
 
     @NSManaged public var imageID: Int64
-    @NSManaged public var dateCreated: Date
+    @NSManaged public var dateCreated: Date?
     @NSManaged public var dateModified: Date?
     @NSManaged public var src: String
     @NSManaged public var name: String?

--- a/Yosemite/Yosemite/Model/Storage/ProductImage+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductImage+ReadOnlyConvertible.swift
@@ -21,7 +21,7 @@ extension Storage.ProductImage: ReadOnlyConvertible {
     ///
     public func toReadOnly() -> Yosemite.ProductImage {
         return ProductImage(imageID: imageID,
-                            dateCreated: dateCreated,
+                            dateCreated: dateCreated ?? Date(),
                             dateModified: dateModified,
                             src: src,
                             name: name,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14312 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In https://github.com/woocommerce/woocommerce-ios/pull/14013 we made the Product object’s date and dateCreated properties optional, to avoid crashes when transforming deleted product objects in Core Data. It’s possible that (now that we aren’t crashing on the product objects) a similar crash is now happening when transforming deleted product image objects.

This PR follows the same approach from https://github.com/woocommerce/woocommerce-ios/pull/14013 and marks the `dateCreated` Swift property of `ProductImage` as optional. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Read the following excerpt from internal discussion - p91TBi-cd4-p2

```
When attempting to apply the update to the background context using persistent container’s newBackgroundContext and automaticallyMergesChangesFromParent turned off for the view context, I encountered a crash in Product+ReadOnlyConvertible when converting a product’s date and dateCreated from a storage model to a readonly object.

These attributes were declared as non-optional without any default values. A Core Data object can be deleted and there can still be a reference to it somewhere, therefore things that are marked as non-optional can be gone at runtime since Core Data can never fulfill its dynamic expectation.

The solution is to always be mindful when using non-optionals with Core Data in case we want to manually handle the merging for the view context in the future. We can set default values for the above date attributes or make them optional and set default values to them when finding nil values while converting to readonly objects.

To ensure safety, we should check all the other existing entities for non-optional attributes without default values. We should also do a thorough smoke test to see if there’s any similar crash happening anywhere else in the app.
```

Based on the above explanation, this crash is related to introducing background context to core data. This cannot be reproduced locally following a fixed set of steps. 

- Install a build from `trunk`
- Login into the app
- Switch to this branch and run the app to replace the build from trunk
- Create a product with images
- Smoke test that product image upload, viewing and deletion works as expected

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- I tested that a build from `trunk` can be replaced without any core data related crashes.
- I tested that product image upload, viewing and deletion works as expected. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-11-05 at 18 11 23](https://github.com/user-attachments/assets/b89a947e-8f03-4f50-8a00-d297546412eb)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.