### PR TITLE
[Product Global Unique Identifier] Add the global unique identifier for products in product details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -293,6 +293,11 @@ private extension DefaultProductFormTableViewModel {
             inventoryDetails.append(String.localizedStringWithFormat(Localization.skuFormat, sku))
         }
 
+        if featureFlagService.isFeatureFlagEnabled(.productGlobalUniqueIdentifierSupport),
+            let globalUniqueID = product.globalUniqueID, !globalUniqueID.isEmpty {
+            inventoryDetails.append(String.localizedStringWithFormat(Localization.globalUniqueIDFormat, globalUniqueID))
+        }
+
         if let stockQuantity = product.stockQuantity, product.manageStock {
             let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
             inventoryDetails.append(String.localizedStringWithFormat(Localization.stockQuantityFormat, localizedStockQuantity))
@@ -813,6 +818,8 @@ private extension DefaultProductFormTableViewModel.Localization {
         // Inventory
         static let skuFormat = NSLocalizedString("SKU: %@",
                                                  comment: "Format of the SKU on the Inventory Settings row")
+        static let globalUniqueIDFormat = NSLocalizedString("GTIN, UPC, EAN, ISBN: %@",
+                                             comment: "Format of the Global Unique Identifier on the Inventory Settings row")
         static let stockQuantityFormat = NSLocalizedString("Quantity: %@",
                                                            comment: "Format of the stock quantity on the Inventory Settings row")
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -65,6 +65,41 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         XCTAssertNil(inventoryViewModel?.details)
     }
 
+    func test_variable_product_inventory_row_has_details_when_passing_global_unique_identifier() {
+        // Arrange
+        let globalUniqueID = "12345"
+        let product = Product.fake().copy(productTypeKey: ProductType.variable.rawValue,
+                                          sku: "",
+                                          globalUniqueID: globalUniqueID,
+                                          manageStock: false,
+                                          stockStatusKey: ProductStockStatus.onBackOrder.rawValue)
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+
+        // Action
+        let featureFlagService = MockFeatureFlagService(isProductGlobalUniqueIdentifierSupported: true)
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "",
+                                                              isDescriptionAIEnabled: true,
+                                                              featureFlagService: featureFlagService)
+
+        // Assert
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var inventoryViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .inventory(viewModel, _) = row {
+                inventoryViewModel = viewModel
+                break
+            }
+        }
+        let expectedDetails = "GTIN, UPC, EAN, ISBN: \(globalUniqueID)"
+        XCTAssertEqual(inventoryViewModel?.details, expectedDetails)
+    }
+
     func test_variation_view_model_image_row_has_isVariation_true() {
         // Arrange
         let variation = ProductVariation.fake()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14330 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the global unique identifier information in the Product Details View

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to the Products tab
2. Tap on a product with the global unique identifier set
3. In the Inventory row, you can see the global unique identifier information

Repeat the process with a variation. Check also that nothing is shown when the global unique identifier is not set or it's empty

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
See above

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/3a3fd0b1-99df-4749-9711-c874dcf08458" width="375">
<img src="https://github.com/user-attachments/assets/0a0eb111-e82b-4f48-9fc0-b108ded6203b" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
