### PR TITLE
[Mobile Payments] Show IPP address errors when using site credentials

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1747,6 +1747,23 @@ extension Networking.Refund {
         )
     }
 }
+extension Networking.RemoteReaderLocation {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.RemoteReaderLocation {
+        .init(
+            locationID: .fake(),
+            city: .fake(),
+            country: .fake(),
+            addressLine1: .fake(),
+            addressLine2: .fake(),
+            postalCode: .fake(),
+            stateProvinceRegion: .fake(),
+            displayName: .fake(),
+            liveMode: .fake()
+        )
+    }
+}
 extension Networking.ShipmentTracking {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
+++ b/Hardware/Hardware/CardReader/CardReaderConfigProvider.swift
@@ -21,7 +21,7 @@ public protocol CardReaderConfigProvider: ReaderLocationProvider, ReaderTokenPro
 ///     May include URL for wp-admin page to update address.
 /// - invalidPostalCode: The location could not be created because the Store postal code configured for the site failed validation.
 ///
-public enum CardReaderConfigError: Error, LocalizedError {
+public enum CardReaderConfigError: Error, LocalizedError, Equatable {
     case incompleteStoreAddress(adminUrl: URL?)
     case invalidPostalCode
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -477,7 +477,7 @@ extension StripeCardReaderService: CardReaderService {
                         return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                     }
                 case .failure(let error):
-                    let underlyingError = UnderlyingError(with: error)
+                    let underlyingError = Self.logAndDecodeError(error)
                     return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                 }
             }
@@ -509,7 +509,7 @@ extension StripeCardReaderService: CardReaderService {
                         return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                     }
                 case .failure(let error):
-                    let underlyingError = UnderlyingError(with: error)
+                    let underlyingError = Self.logAndDecodeError(error)
                     return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                 }
             }
@@ -778,7 +778,7 @@ extension StripeCardReaderService {
                         self.refundCancellable = nil
                         if let error = processError {
                             promise(.failure(CardReaderServiceError.refundPayment(
-                                underlyingError: UnderlyingError(with: error),
+                                underlyingError: Self.logAndDecodeError(error),
                                 shouldRetry: self.shouldRetryRefund(after: error)
                             )))
                         } else if let refund = processedRefund {

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -847,7 +847,7 @@ extension Networking.GoogleAdsCampaign {
         rawStatus: CopiableProp<String> = .copy,
         rawType: CopiableProp<String> = .copy,
         amount: CopiableProp<Double> = .copy,
-        country: CopiableProp<String> = .copy,
+        country: NullableCopiableProp<String> = .copy,
         targetedLocations: CopiableProp<[String]> = .copy
     ) -> Networking.GoogleAdsCampaign {
         let id = id ?? self.id
@@ -2849,6 +2849,42 @@ extension Networking.Refund {
             createAutomated: createAutomated,
             items: items,
             shippingLines: shippingLines
+        )
+    }
+}
+
+extension Networking.RemoteReaderLocation {
+    public func copy(
+        locationID: CopiableProp<String> = .copy,
+        city: NullableCopiableProp<String> = .copy,
+        country: CopiableProp<String> = .copy,
+        addressLine1: CopiableProp<String> = .copy,
+        addressLine2: NullableCopiableProp<String> = .copy,
+        postalCode: NullableCopiableProp<String> = .copy,
+        stateProvinceRegion: NullableCopiableProp<String> = .copy,
+        displayName: CopiableProp<String> = .copy,
+        liveMode: CopiableProp<Bool> = .copy
+    ) -> Networking.RemoteReaderLocation {
+        let locationID = locationID ?? self.locationID
+        let city = city ?? self.city
+        let country = country ?? self.country
+        let addressLine1 = addressLine1 ?? self.addressLine1
+        let addressLine2 = addressLine2 ?? self.addressLine2
+        let postalCode = postalCode ?? self.postalCode
+        let stateProvinceRegion = stateProvinceRegion ?? self.stateProvinceRegion
+        let displayName = displayName ?? self.displayName
+        let liveMode = liveMode ?? self.liveMode
+
+        return Networking.RemoteReaderLocation(
+            locationID: locationID,
+            city: city,
+            country: country,
+            addressLine1: addressLine1,
+            addressLine2: addressLine2,
+            postalCode: postalCode,
+            stateProvinceRegion: stateProvinceRegion,
+            displayName: displayName,
+            liveMode: liveMode
         )
     }
 }

--- a/Networking/Networking/Model/RemoteReaderLocation.swift
+++ b/Networking/Networking/Model/RemoteReaderLocation.swift
@@ -1,6 +1,8 @@
 /// Represent a Remote Reader Location Entity.
 ///
-public struct RemoteReaderLocation: Decodable {
+
+import Codegen
+public struct RemoteReaderLocation: Decodable, GeneratedFakeable, GeneratedCopiable {
     public let locationID: String
     public let city: String?
     public let country: String

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 - [internal] Updated Xcode version to 16.1 [https://github.com/woocommerce/woocommerce-ios/pull/14225]
 - [**] Fixed: properly open and show order details in Watch app [https://github.com/woocommerce/woocommerce-ios/pull/14306]
+- [*] Payments: Improved error messages for reader connections when using site credentials for login [https://github.com/woocommerce/woocommerce-ios/pull/14336]
 
 21.0
 -----

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		209AD3CE2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CD2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift */; };
 		20BCF6F22B0E554500954840 /* SystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F12B0E554500954840 /* SystemStatusService.swift */; };
 		20BCF6F52B0E57AB00954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */; };
+		20D035002CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D034FF2CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift */; };
+		20D035022CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D035012CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift */; };
 		20D210C12B177EEF0099E517 /* WooPaymentsDepositServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D210C02B177EEF0099E517 /* WooPaymentsDepositServiceTests.swift */; };
 		24163B9E257F41A600F94EC3 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24163B9D257F41A600F94EC3 /* StoresManager.swift */; };
 		24163BA8257F41C500F94EC3 /* SessionManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24163BA7257F41C500F94EC3 /* SessionManagerProtocol.swift */; };
@@ -655,6 +657,8 @@
 		209AD3CD2AC1A9C200825D76 /* WooPaymentsDepositsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverview.swift; sourceTree = "<group>"; };
 		20BCF6F12B0E554500954840 /* SystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusService.swift; sourceTree = "<group>"; };
 		20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockSystemStatusService.swift; path = ../../../WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift; sourceTree = "<group>"; };
+		20D034FF2CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonReaderConfigProviderTests.swift; sourceTree = "<group>"; };
+		20D035012CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardReaderCapableRemote.swift; sourceTree = "<group>"; };
 		20D210C02B177EEF0099E517 /* WooPaymentsDepositServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositServiceTests.swift; sourceTree = "<group>"; };
 		24163B9D257F41A600F94EC3 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
 		24163BA7257F41C500F94EC3 /* SessionManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerProtocol.swift; sourceTree = "<group>"; };
@@ -1889,6 +1893,7 @@
 				022F9318257F24730011CD94 /* MockShippingLabel.swift */,
 				022F931C257F27B40011CD94 /* MockShippingLabelAddress.swift */,
 				20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */,
+				20D035012CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1966,6 +1971,7 @@
 				B54EAF2021188C470029C35E /* EntityListenerTests.swift */,
 				B5F2AE9420EBAD6000FEDC59 /* ResultsControllerTests.swift */,
 				031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */,
+				20D034FF2CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -2557,6 +2563,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4552073D25811B4E001CF873 /* ProductAttributeStoreTests.swift in Sources */,
+				20D035022CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift in Sources */,
 				458C6DE825ACC554009B300D /* AppSettingsStoreTests+ProductsSettings.swift in Sources */,
 				D88303F025E45E6F00C877F9 /* MockCardReaderService.swift in Sources */,
 				022F00C524728B0C008CD97F /* SiteNotificationCountFileContentsTests.swift in Sources */,
@@ -2603,6 +2610,7 @@
 				45ED4F16239E939A004F1BE3 /* TaxStoreTests.swift in Sources */,
 				57264572250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift in Sources */,
 				0286A1BE2A0CC4810099EF94 /* MockFeatureFlagRemote.swift in Sources */,
+				20D035002CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift in Sources */,
 				0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */,
 				D8652E4826307A5000350F37 /* MockReceiptPrinterService.swift in Sources */,
 				020B2F9623BDE4DD00BD79AD /* ProductStoreTests+Validation.swift in Sources */,

--- a/Yosemite/Yosemite/Tools/CommonReaderConfigProvider.swift
+++ b/Yosemite/Yosemite/Tools/CommonReaderConfigProvider.swift
@@ -65,18 +65,39 @@ final public class CommonReaderConfigProvider: CommonReaderConfigProviding {
 
 private extension CardReaderConfigError {
     init?(error: Error) {
-        guard let dotcomError = error as? DotcomError else {
-            return nil
-        }
-        switch dotcomError {
-        case .unknown("store_address_is_incomplete", let message):
+        switch error {
+        case DotcomError.unknown(code: "store_address_is_incomplete", let message):
             self = .incompleteStoreAddress(adminUrl: URL(string: message ?? ""))
-            return
-        case .unknown("postal_code_invalid", _):
+        case DotcomError.unknown(code: "postal_code_invalid", _):
             self = .invalidPostalCode
-            return
+        case NetworkError.unacceptableStatusCode(_, let responseData):
+            guard let responseData,
+                  let details = try? JSONDecoder().decode(CardReaderConfigNetworkErrorDetails.self, from: responseData) else {
+                return nil
+            }
+            switch details.code {
+            case .storeAddressIncomplete:
+                self = .incompleteStoreAddress(adminUrl: URL(string: details.message ?? ""))
+            case .postalCodeInvalid:
+                self = .invalidPostalCode
+            }
         default:
             return nil
         }
+    }
+}
+
+private struct CardReaderConfigNetworkErrorDetails: Decodable {
+    let code: ErrorCode
+    let message: String?
+
+    enum CodingKeys: CodingKey {
+        case code
+        case message
+    }
+
+    enum ErrorCode: String, Decodable {
+        case storeAddressIncomplete = "store_address_is_incomplete"
+        case postalCodeInvalid = "postal_code_invalid"
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/MockCardReaderCapableRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockCardReaderCapableRemote.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Yosemite
+import Networking
+import Fakes
+
+struct MockCardReaderCapableRemote: CardReaderCapableRemote {
+    func loadConnectionToken(for siteID: Int64, completion: @escaping (Result<Networking.ReaderConnectionToken, any Error>) -> Void) {
+        // no-op
+    }
+
+    var resultForDefaultReaderLocation: (Result<RemoteReaderLocation, any Error>) = .success(RemoteReaderLocation.fake())
+    func loadDefaultReaderLocation(for siteID: Int64, onCompletion: @escaping (Result<RemoteReaderLocation, any Error>) -> Void) {
+        onCompletion(resultForDefaultReaderLocation)
+    }
+    
+}

--- a/Yosemite/YosemiteTests/Mocks/MockCardReaderCapableRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockCardReaderCapableRemote.swift
@@ -12,5 +12,5 @@ struct MockCardReaderCapableRemote: CardReaderCapableRemote {
     func loadDefaultReaderLocation(for siteID: Int64, onCompletion: @escaping (Result<RemoteReaderLocation, any Error>) -> Void) {
         onCompletion(resultForDefaultReaderLocation)
     }
-    
+
 }

--- a/Yosemite/YosemiteTests/Tools/CommonReaderConfigProviderTests.swift
+++ b/Yosemite/YosemiteTests/Tools/CommonReaderConfigProviderTests.swift
@@ -1,0 +1,132 @@
+import Testing
+
+@testable import Yosemite
+import Networking
+
+struct CommonReaderConfigProviderTests {
+
+    @Test func fetchDefaultLocationID_returns_incompleteStoreAddress_error_when_jetpack_site_has_incomplete_store_address() async throws {
+        let adminURL = "https://example.com/wp-admin/set-address"
+        let mockRemote = MockCardReaderCapableRemote(
+            resultForDefaultReaderLocation: .failure(
+                DotcomError.unknown(code: "store_address_is_incomplete",
+                                    message: adminURL)))
+
+        let sut = CommonReaderConfigProvider(siteID: 123,
+                                             readerConfigRemote: mockRemote)
+
+        let expectedError = CardReaderConfigError.incompleteStoreAddress(adminUrl: URL(string: adminURL)!)
+        await #expect(throws: expectedError) {
+            try await withCheckedThrowingContinuation { continuation in
+                sut.fetchDefaultLocationID { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    @Test func fetchDefaultLocationID_returns_invalidPostalCode_error_when_jetpack_site_has_no_postcode() async throws {
+        let mockRemote = MockCardReaderCapableRemote(
+            resultForDefaultReaderLocation: .failure(
+                DotcomError.unknown(code: "postal_code_invalid",
+                                    message: "")))
+
+        let sut = CommonReaderConfigProvider(siteID: 123,
+                                             readerConfigRemote: mockRemote)
+
+        await #expect(throws: CardReaderConfigError.invalidPostalCode) {
+            try await withCheckedThrowingContinuation { continuation in
+                sut.fetchDefaultLocationID { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    @Test(
+        .bug("https://github.com/woocommerce/woocommerce-ios/issues/14333", id: "14333")
+    )
+    func fetchDefaultLocationID_returns_incompleteStoreAddress_error_when_site_has_incomplete_store_address_and_siteCredentials_used() async throws {
+        let errorResponseJSON = """
+{"code":"store_address_is_incomplete","message":"https://example.com/wp-admin/admin.php?page=wc-settings&tab=general","data":null}
+"""
+        let mockRemote = MockCardReaderCapableRemote(
+            resultForDefaultReaderLocation: .failure(
+                NetworkError.unacceptableStatusCode(
+                    statusCode: 500,
+                    response: errorResponseJSON.data(using: .utf8)
+                )
+                )
+            )
+
+        let sut = CommonReaderConfigProvider(siteID: 123,
+                                             readerConfigRemote: mockRemote)
+
+        let expectedError = CardReaderConfigError.incompleteStoreAddress(
+            adminUrl: URL(string: "https://example.com/wp-admin/admin.php?page=wc-settings&tab=general")!)
+        await #expect(throws: expectedError) {
+            try await withCheckedThrowingContinuation { continuation in
+                sut.fetchDefaultLocationID { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    @Test
+    func fetchDefaultLocationID_returns_incompleteStoreAddress_error_when_site_has_incomplete_store_address_without_url_and_siteCredentials_used() async throws {
+        let errorResponseJSON = """
+{"code":"store_address_is_incomplete","message":null,"data":null}
+"""
+        let mockRemote = MockCardReaderCapableRemote(
+            resultForDefaultReaderLocation: .failure(
+                NetworkError.unacceptableStatusCode(
+                    statusCode: 500,
+                    response: errorResponseJSON.data(using: .utf8)
+                )
+                )
+            )
+
+        let sut = CommonReaderConfigProvider(siteID: 123,
+                                             readerConfigRemote: mockRemote)
+
+        let expectedError = CardReaderConfigError.incompleteStoreAddress(adminUrl: nil)
+        await #expect(throws: expectedError) {
+            try await withCheckedThrowingContinuation { continuation in
+                sut.fetchDefaultLocationID { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    @Test(
+        .bug("https://github.com/woocommerce/woocommerce-ios/issues/14333", id: "14333")
+    )
+    func fetchDefaultLocationID_returns_invalidPostalCode_error_when_site_has_no_postcode_and_siteCredentials_used() async throws {
+        let errorResponseJSON = """
+{"code":"postal_code_invalid"}
+"""
+        let mockRemote = MockCardReaderCapableRemote(
+            resultForDefaultReaderLocation: .failure(
+                NetworkError.unacceptableStatusCode(
+                    statusCode: 500,
+                    response: errorResponseJSON.data(using: .utf8)
+                )
+                )
+            )
+
+        let sut = CommonReaderConfigProvider(siteID: 123,
+                                             readerConfigRemote: mockRemote)
+
+        let expectedError = CardReaderConfigError.invalidPostalCode
+        await #expect(throws: expectedError) {
+            try await withCheckedThrowingContinuation { continuation in
+                sut.fetchDefaultLocationID { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14333
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue found while helping a merchant through support, who couldn't connect to their readers with a new store when logged in using site credentials.

### Background
Previously, we decoded specific `DotcomError` instances to show the specific errors needed when a user hasn’t set their site address or postcode in WP-Admin, which prevents IPP reader connections from working.

These errors weren’t decoded when using site credentials to log in, as in that case a `NetworkError` is received, and our error handling didn’t decode that correctly.

This adds correct decoding and tests for the `NetworkError` variants of these issues.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Remove the Store Address or Postcode in WPAdmin settings.
2. Launch the app and log in to the site using site credentials, not Jetpack
3. Attempt to connect a card reader
4. Observe that you're shown a specific error with a button to update your address
5. Observe that specific error is logged in the console/application logs.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**Note** – I'm not able to get the postal code specific error to show; the backend doesn't appear to actually return this error, at least not for WCPay sites. It might still do it for Stripe sites, so I've covered the logic as it previously existed, and added tests, but not seen it with a real site.

Tested with an iPhone 15 Pro Max on iOS 18.0 using an M2 card reader.

I checked with both site credentials and Jetpack login.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Logs
![Console logs showing the underlying error and connection error](https://github.com/user-attachments/assets/39385577-9e0a-4e24-bcbe-b3fdb5eff05b)


### Before

https://github.com/user-attachments/assets/1cae79dc-e95d-4a80-b638-3721e22e891e



### After


https://github.com/user-attachments/assets/e0613fbf-ece5-4c8c-ad9c-40af7486fc67



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.