### PR TITLE
[Shipping labels] Add support for creating package endpoint

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2732,6 +2732,18 @@ extension Networking.WooPaymentsManualDeposit {
         )
     }
 }
+extension Networking.WooShippingCustomPackage {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingCustomPackage {
+        .init(
+            name: .fake(),
+            type: .fake(),
+            dimensions: .fake(),
+            boxWeight: .fake()
+        )
+    }
+}
 extension Networking.WordPressMedia {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2747,6 +2747,7 @@ extension Networking.WooShippingCustomPackage {
     ///
     public static func fake() -> Networking.WooShippingCustomPackage {
         .init(
+            id: .fake(),
             name: .fake(),
             type: .fake(),
             dimensions: .fake(),

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2732,6 +2732,16 @@ extension Networking.WooPaymentsManualDeposit {
         )
     }
 }
+extension Networking.WooShippingCreatePackageResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingCreatePackageResponse {
+        .init(
+            customPackages: .fake(),
+            predefinedOptions: .fake()
+        )
+    }
+}
 extension Networking.WooShippingCustomPackage {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2744,6 +2744,16 @@ extension Networking.WooShippingCustomPackage {
         )
     }
 }
+extension Networking.WooShippingPredefinedOption {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingPredefinedOption {
+        .init(
+            id: .fake(),
+            predefinedPackageIDs: .fake()
+        )
+    }
+}
 extension Networking.WordPressMedia {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -875,6 +875,7 @@
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
 		CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */; };
 		CEC7D58D2CDCEEF900111B79 /* WooShippingCustomPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D58C2CDCEEF900111B79 /* WooShippingCustomPackage.swift */; };
+		CEC7D5932CDD0D9900111B79 /* WooShippingPredefinedOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
@@ -2038,6 +2039,7 @@
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
 		CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundListMapperTests.swift; sourceTree = "<group>"; };
 		CEC7D58C2CDCEEF900111B79 /* WooShippingCustomPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomPackage.swift; sourceTree = "<group>"; };
+		CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPredefinedOption.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
@@ -2545,6 +2547,7 @@
 		451A97E3260B63030059D135 /* Predefined package */ = {
 			isa = PBXGroup;
 			children = (
+				CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */,
 				451A97E8260B657D0059D135 /* ShippingLabelPredefinedOption.swift */,
 				451A97E4260B631E0059D135 /* ShippingLabelPredefinedPackage.swift */,
 			);
@@ -4952,6 +4955,7 @@
 				CCAAD10F2683974000909664 /* ShippingLabelPackagePurchase.swift in Sources */,
 				265EFBDC285257950033BD33 /* Order+Fallbacks.swift in Sources */,
 				209AD3C32AC196E300825D76 /* WooPaymentsDepositsOverview.swift in Sources */,
+				CEC7D5932CDD0D9900111B79 /* WooShippingPredefinedOption.swift in Sources */,
 				021940E2291E3CFD0090354E /* SiteRemote.swift in Sources */,
 				B557DA0220975500005962F4 /* JetpackRequest.swift in Sources */,
 				D88E229025AC990A0023F3B1 /* OrderFeeLine.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		263E383F2641FF1600260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E383E2641FF1600260D3B /* Codegen */; };
 		263E38402641FF1600260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E383E2641FF1600260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		264541B72CA64522006C13A2 /* WooShippingRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264541B62CA644D0006C13A2 /* WooShippingRemote.swift */; };
+		264541B92CA6580E006C13A2 /* WooShippingRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264541B82CA6580E006C13A2 /* WooShippingRemoteTests.swift */; };
 		26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */; };
 		26455E2425F66982008A1D32 /* ProductAttributeTermRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08725A66AFC000DF8F6 /* ProductAttributeTermRemote.swift */; };
 		26455E2725F669EA008A1D32 /* ProductAttributeTermListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */; };
@@ -1463,6 +1464,7 @@
 		26373E282BFD0880008E6735 /* WatchOS-Models+Copiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchOS-Models+Copiable.swift"; sourceTree = "<group>"; };
 		263A6DA72BEAA0DB00C292B2 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		264541B62CA644D0006C13A2 /* WooShippingRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingRemote.swift; sourceTree = "<group>"; };
+		264541B82CA6580E006C13A2 /* WooShippingRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingRemoteTests.swift; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
 		265EFBDB285257950033BD33 /* Order+Fallbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Fallbacks.swift"; sourceTree = "<group>"; };
 		26615472242D596B00A31661 /* ProductCategoriesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoriesRemote.swift; sourceTree = "<group>"; };
@@ -2698,6 +2700,7 @@
 				026CF621237D7E61009563D4 /* ProductVariationsRemoteTests.swift */,
 				025CA2C5238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift */,
 				02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */,
+				264541B82CA6580E006C13A2 /* WooShippingRemoteTests.swift */,
 				D800DA0925EFEB9C001E13CE /* WCPayRemoteTests.swift */,
 				31A451BC2786344B00FE81AA /* StripeRemoteTests.swift */,
 				FE28F6EB268436C9004465C7 /* UserRemoteTests.swift */,
@@ -5365,6 +5368,7 @@
 				EEA658482966CBAD00112DF0 /* EntityIDMapperTests.swift in Sources */,
 				EE2C09C429AF5274009396F9 /* StoreOnboardingTaskListMapperTests.swift in Sources */,
 				DEC51AFB2769C66B009F3DF4 /* SystemStatusMapperTests.swift in Sources */,
+				264541B92CA6580E006C13A2 /* WooShippingRemoteTests.swift in Sources */,
 				CE71E2332A4C3EDD00DB5376 /* ProductsReportMapperTests.swift in Sources */,
 				DE34051F28BDFB0B00CF0D97 /* JetpackConnectionRemoteTests.swift in Sources */,
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -874,6 +874,7 @@
 		CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF90234E40B5008D9195 /* refund-single.json */; };
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
 		CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */; };
+		CEC7D58D2CDCEEF900111B79 /* WooShippingCustomPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D58C2CDCEEF900111B79 /* WooShippingCustomPackage.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
@@ -2036,6 +2037,7 @@
 		CEC4BF90234E40B5008D9195 /* refund-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single.json"; sourceTree = "<group>"; };
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
 		CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundListMapperTests.swift; sourceTree = "<group>"; };
+		CEC7D58C2CDCEEF900111B79 /* WooShippingCustomPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomPackage.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
@@ -2534,6 +2536,7 @@
 		451A97D4260A069B0059D135 /* Custom package */ = {
 			isa = PBXGroup;
 			children = (
+				CEC7D58C2CDCEEF900111B79 /* WooShippingCustomPackage.swift */,
 				451A97D0260A03900059D135 /* ShippingLabelCustomPackage.swift */,
 			);
 			path = "Custom package";
@@ -4932,6 +4935,7 @@
 				CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
 				EE1CB90E2B4BC99E00AD24D5 /* BlazeAISuggestion.swift in Sources */,
+				CEC7D58D2CDCEEF900111B79 /* WooShippingCustomPackage.swift in Sources */,
 				03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */,
 				CE6BFEE52236BF05005C79FB /* Product.swift in Sources */,
 				CE070A2A2BBC3C0A00017578 /* GiftCardStats.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		263E37D22641ACEA00260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37D12641ACEA00260D3B /* Codegen */; };
 		263E383F2641FF1600260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E383E2641FF1600260D3B /* Codegen */; };
 		263E38402641FF1600260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E383E2641FF1600260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		264541B72CA64522006C13A2 /* WooShippingRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264541B62CA644D0006C13A2 /* WooShippingRemote.swift */; };
 		26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */; };
 		26455E2425F66982008A1D32 /* ProductAttributeTermRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08725A66AFC000DF8F6 /* ProductAttributeTermRemote.swift */; };
 		26455E2725F669EA008A1D32 /* ProductAttributeTermListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */; };
@@ -1461,6 +1462,7 @@
 		263659DD2A2694A000607A0D /* IPLocationRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemoteTests.swift; sourceTree = "<group>"; };
 		26373E282BFD0880008E6735 /* WatchOS-Models+Copiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchOS-Models+Copiable.swift"; sourceTree = "<group>"; };
 		263A6DA72BEAA0DB00C292B2 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
+		264541B62CA644D0006C13A2 /* WooShippingRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingRemote.swift; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
 		265EFBDB285257950033BD33 /* Order+Fallbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Fallbacks.swift"; sourceTree = "<group>"; };
 		26615472242D596B00A31661 /* ProductCategoriesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoriesRemote.swift; sourceTree = "<group>"; };
@@ -2860,6 +2862,7 @@
 				74ABA1D0213F22CA00FFAD30 /* TopEarnersStatsRemote.swift */,
 				020D07BB23D856BF00FD9580 /* MediaRemote.swift */,
 				029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */,
+				264541B62CA644D0006C13A2 /* WooShippingRemote.swift */,
 				311D412F2783C0E200052F64 /* StripeRemote.swift */,
 				D8EDFE1D25EE87F1003D2213 /* WCPayRemote.swift */,
 				FE28F6E5268429B6004465C7 /* UserRemote.swift */,
@@ -5210,6 +5213,7 @@
 				CE43066A23465F340073CBFF /* Refund.swift in Sources */,
 				68CB800C28D87BC800E169F8 /* Customer.swift in Sources */,
 				EE1CB90A2B4BC8C500AD24D5 /* CreateBlazeCampaignMapper.swift in Sources */,
+				264541B72CA64522006C13A2 /* WooShippingRemote.swift in Sources */,
 				B96158FC2BF63B4F0080E52A /* String+MinMaxQuantities.swift in Sources */,
 				DE50295D28C6068B00551736 /* JetpackUserMapper.swift in Sources */,
 				B524194121AC60A700D6FC0A /* DotcomDevice.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -875,7 +875,9 @@
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
 		CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */; };
 		CEC7D58D2CDCEEF900111B79 /* WooShippingCustomPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D58C2CDCEEF900111B79 /* WooShippingCustomPackage.swift */; };
+		CEC7D5912CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D5902CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift */; };
 		CEC7D5932CDD0D9900111B79 /* WooShippingPredefinedOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */; };
+		CEC7D5952CDD164D00111B79 /* WooShippingCreatePackageMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
@@ -2039,7 +2041,9 @@
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
 		CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundListMapperTests.swift; sourceTree = "<group>"; };
 		CEC7D58C2CDCEEF900111B79 /* WooShippingCustomPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomPackage.swift; sourceTree = "<group>"; };
+		CEC7D5902CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreatePackageResponse.swift; sourceTree = "<group>"; };
 		CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPredefinedOption.swift; sourceTree = "<group>"; };
+		CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreatePackageMapper.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
@@ -2524,6 +2528,7 @@
 		451A97C72609FDE50059D135 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
+				CEC7D5902CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift */,
 				451A97C82609FF050059D135 /* ShippingLabelPackagesResponse.swift */,
 				451A97CC260A01A40059D135 /* ShippingLabelStoreOptions.swift */,
 				CCAAD10E2683974000909664 /* ShippingLabelPackagePurchase.swift */,
@@ -3587,6 +3592,7 @@
 				CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */,
 				CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */,
 				CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */,
+				CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */,
 				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
 				077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */,
@@ -5055,6 +5061,7 @@
 				4568E2242459D3230007E478 /* Post.swift in Sources */,
 				DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */,
 				CE606D8F2BE39426001CB424 /* ShippingMethodMapper.swift in Sources */,
+				CEC7D5912CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift in Sources */,
 				4513382427A951B300AE5E78 /* InboxNoteMapper.swift in Sources */,
 				B9CFF6522AB2118900C2F616 /* TaxRateMapper.swift in Sources */,
 				DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */,
@@ -5202,6 +5209,7 @@
 				261C466B2A6738EE00734070 /* AppicationPasswordEncoder.swift in Sources */,
 				CE606D8D2BE3927A001CB424 /* ShippingMethod.swift in Sources */,
 				DEDA8DA12B182E850076BF0F /* WordPressTheme.swift in Sources */,
+				CEC7D5952CDD164D00111B79 /* WooShippingCreatePackageMapper.swift in Sources */,
 				2665032A261F41510079A159 /* ProductAddOn.swift in Sources */,
 				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,
 				DE4C081B2C75DEC7008BC773 /* BlazeCampaignObjective.swift in Sources */,

--- a/Networking/Networking/Mapper/WooShippingCreatePackageMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingCreatePackageMapper.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+
+/// Mapper: Shipping Label Create Package response
+///
+struct WooShippingCreatePackageMapper: Mapper {
+    /// (Attempts) to convert a dictionary into WooShippingCreatePackageResponse.
+    ///
+    func map(response: Data) throws -> WooShippingCreatePackageResponse {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(WooShippingCreatePackageMapperEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode(WooShippingCreatePackageResponse.self, from: response)
+        }
+    }
+}
+
+/// WooShippingCreatePackageMapperEnvelope Disposable Entity:
+/// `Woo Shipping Packages` endpoint returns the shipping label packages in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct WooShippingCreatePackageMapperEnvelope: Decodable {
+    let data: WooShippingCreatePackageResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case data = "data"
+    }
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -847,7 +847,7 @@ extension Networking.GoogleAdsCampaign {
         rawStatus: CopiableProp<String> = .copy,
         rawType: CopiableProp<String> = .copy,
         amount: CopiableProp<Double> = .copy,
-        country: CopiableProp<String> = .copy,
+        country: NullableCopiableProp<String> = .copy,
         targetedLocations: CopiableProp<[String]> = .copy
     ) -> Networking.GoogleAdsCampaign {
         let id = id ?? self.id

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3963,6 +3963,21 @@ extension Networking.WooPaymentsManualDeposit {
     }
 }
 
+extension Networking.WooShippingCreatePackageResponse {
+    public func copy(
+        customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
+        predefinedOptions: CopiableProp<[WooShippingPredefinedOption]> = .copy
+    ) -> Networking.WooShippingCreatePackageResponse {
+        let customPackages = customPackages ?? self.customPackages
+        let predefinedOptions = predefinedOptions ?? self.predefinedOptions
+
+        return Networking.WooShippingCreatePackageResponse(
+            customPackages: customPackages,
+            predefinedOptions: predefinedOptions
+        )
+    }
+}
+
 extension Networking.WordPressMedia {
     public func copy(
         mediaID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
@@ -6,7 +6,10 @@ import WooFoundation
 ///
 public struct WooShippingCustomPackage: Equatable, GeneratedFakeable {
 
-    /// The name of the custom package, like `Krabica`. This is also the unique ID of a custom package.
+    /// The ID of the custom package.
+    public let id: String
+
+    /// The name of the custom package, like `Krabica`. This is a unique value.
     public let name: String
 
     /// Raw value of the package type (box or envelope).
@@ -28,7 +31,8 @@ public struct WooShippingCustomPackage: Equatable, GeneratedFakeable {
         PackageType(rawValue: rawType) ?? .box
     }
 
-    public init(name: String, type: String, dimensions: String, boxWeight: Double) {
+    public init(id: String, name: String, type: String, dimensions: String, boxWeight: Double) {
+        self.id = id
         self.name = name
         self.rawType = type
         self.dimensions = dimensions
@@ -56,12 +60,13 @@ extension WooShippingCustomPackage: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
+        let id = try container.decode(String.self, forKey: .id)
         let name = try container.decode(String.self, forKey: .name)
         let type = try container.decode(String.self, forKey: .type)
         let dimensions = try container.decode(String.self, forKey: .dimensions)
         let boxWeight = try container.decode(Double.self, forKey: .boxWeight)
 
-        self.init(name: name, type: type, dimensions: dimensions, boxWeight: boxWeight)
+        self.init(id: id, name: name, type: type, dimensions: dimensions, boxWeight: boxWeight)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -74,6 +79,7 @@ extension WooShippingCustomPackage: Codable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case id
         case name
         case type
         case dimensions

--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Codegen
+import WooFoundation
+
+/// Represents a custom package in Shipping Labels for the WooCommerce Shipping extension.
+///
+public struct WooShippingCustomPackage: Equatable, GeneratedFakeable {
+
+    /// The name of the custom package, like `Krabica`. This is also the unique ID of a custom package.
+    public let name: String
+
+    /// Raw value of the package type (box or envelope).
+    public let rawType: String
+
+    /// Will be a string formatted like this: `2 x 3 x 4`
+    public let dimensions: String
+
+    /// Weight of the empty package.
+    public let boxWeight: Double
+
+    public enum PackageType: String {
+        case box
+        case envelope
+    }
+
+    /// Decoded value of the package type (box or envelope).
+    public var type: PackageType {
+        PackageType(rawValue: rawType) ?? .box
+    }
+
+    public init(name: String, type: String, dimensions: String, boxWeight: Double) {
+        self.name = name
+        self.rawType = type
+        self.dimensions = dimensions
+        self.boxWeight = boxWeight
+    }
+
+    public func getLength() -> Double {
+        let firstComponent = dimensions.components(separatedBy: " x ").first ?? ""
+        return Double(firstComponent) ?? 0
+    }
+
+    public func getWidth() -> Double {
+        let secondComponent = dimensions.components(separatedBy: " x ")[safe: 1] ?? ""
+        return Double(secondComponent) ?? 0
+    }
+
+    public func getHeight() -> Double {
+        let lastComponent = dimensions.components(separatedBy: " x ").last ?? ""
+        return Double(lastComponent) ?? 0
+    }
+}
+
+// MARK: Codable
+extension WooShippingCustomPackage: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let name = try container.decode(String.self, forKey: .name)
+        let type = try container.decode(String.self, forKey: .type)
+        let dimensions = try container.decode(String.self, forKey: .dimensions)
+        let boxWeight = try container.decode(Double.self, forKey: .boxWeight)
+
+        self.init(name: name, type: type, dimensions: dimensions, boxWeight: boxWeight)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(name, forKey: .name)
+        try container.encode(type.rawValue, forKey: .type)
+        try container.encode(dimensions, forKey: .dimensions)
+        try container.encode(boxWeight, forKey: .boxWeight)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case dimensions
+        case boxWeight
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedOption.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Codegen
+
+/// Represents a predefined option in Shipping Labels for the WooCommerce Shipping extension.
+///
+public struct WooShippingPredefinedOption: Equatable, GeneratedFakeable {
+
+    /// The ID of the shipping carrier for the predefined option, e.g. "usps".
+    public let id: String
+
+    /// List of saved predefined package IDs.
+    public let predefinedPackageIDs: [String]
+
+    public init(id: String, predefinedPackageIDs: [String]) {
+        self.id = id
+        self.predefinedPackageIDs = predefinedPackageIDs
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingCreatePackageResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingCreatePackageResponse.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Codegen
+
+/// Represents a list of saved Shipping Label Packages (custom and predefined) for the WooCommerce Shipping extension.
+///
+public struct WooShippingCreatePackageResponse: Equatable, GeneratedFakeable, GeneratedCopiable {
+
+    /// Saved custom packages
+    public let customPackages: [WooShippingCustomPackage]
+
+    /// Saved (activated) predefined options
+    public let predefinedOptions: [WooShippingPredefinedOption]
+
+    public init(customPackages: [WooShippingCustomPackage],
+                predefinedOptions: [WooShippingPredefinedOption]) {
+        self.customPackages = customPackages
+        self.predefinedOptions = predefinedOptions
+    }
+}
+
+// MARK: Decodable
+extension WooShippingCreatePackageResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let customPackages = try container.decodeIfPresent([WooShippingCustomPackage].self, forKey: .custom) ?? []
+
+        // We assume that rows will always be of type `Dictionary<String:<Array<String>>>`
+        //
+        let rawPredefinedOptions: [String: [String]] = container.failsafeDecodeIfPresent([String: [String]].self, forKey: .predefined) ?? [:]
+
+        let predefinedOptions = rawPredefinedOptions.map { (carrier, packageIDs) in
+            WooShippingPredefinedOption(id: carrier, predefinedPackageIDs: packageIDs)
+        }
+
+        self.init(customPackages: customPackages,
+                  predefinedOptions: predefinedOptions)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case custom
+        case predefined
+    }
+}

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -23,7 +23,7 @@ public final class WooShippingRemote: Remote {
                 let packageIDs = predefinedOption.predefinedPackages.map({ $0.id })
                 predefinedOptionDictionary = [predefinedOption.providerID: packageIDs]
             } else {
-                throw ShippingLabelError.missingPackage
+                throw ShippingError.missingPackage
             }
 
             let parameters: [String: Any] = [
@@ -37,8 +37,17 @@ public final class WooShippingRemote: Remote {
                                          path: path,
                                          parameters: parameters,
                                          availableAsRESTRequest: true)
-            let mapper = SuccessDataResultMapper()
-            enqueue(request, mapper: mapper, completion: completion)
+
+            // Temporary mapper while we decide what data type to use here.
+            let mapper = IgnoringResponseMapper()
+
+            enqueue(request, mapper: mapper) { _, error in
+                if let error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(true))
+                }
+            }
         } catch {
             completion(.failure(error))
         }
@@ -59,7 +68,7 @@ private extension WooShippingRemote {
 
 // MARK: Errors {
 extension WooShippingRemote {
-    enum ShippingLabelError: Error {
+    enum ShippingError: Error {
         case missingPackage
     }
 }

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -1,0 +1,65 @@
+/// Shipping Labels Remote Endpoints for the WooShipping Plugin.
+///
+public final class WooShippingRemote: Remote {
+
+    /// Creates a new custom package.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site that owns the shipping label.
+    ///   - customPackage: The custom package that should be created.
+    ///   - predefinedOption: The predefined option (shipping provider and service packages) to activate.
+    ///   - completion: Closure to be executed upon completion.
+    public func createPackage(siteID: Int64,
+                              customPackage: ShippingLabelCustomPackage?,
+                              predefinedOption: ShippingLabelPredefinedOption?,
+                              completion: @escaping (Result<Bool, Error>) -> Void) {
+        do {
+            var customPackageList: [[String: Any]] = []
+            var predefinedOptionDictionary: [String: [String]] = [:]
+
+            if let customPackage = customPackage {
+                let customPackageDictionary = try customPackage.toDictionary()
+                customPackageList = [customPackageDictionary]
+            } else if let predefinedOption = predefinedOption {
+                let packageIDs = predefinedOption.predefinedPackages.map({ $0.id })
+                predefinedOptionDictionary = [predefinedOption.providerID: packageIDs]
+            } else {
+                throw ShippingLabelError.missingPackage
+            }
+
+            let parameters: [String: Any] = [
+                ParameterKey.custom: customPackageList,
+                ParameterKey.predefined: predefinedOptionDictionary
+            ]
+            let path = Path.packages
+            let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                         method: .post,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
+            let mapper = SuccessDataResultMapper()
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
+}
+
+// MARK: Constants
+private extension WooShippingRemote {
+    enum Path {
+        static let packages = "packages"
+    }
+
+    enum ParameterKey {
+        static let custom = "custom"
+        static let predefined = "predefined"
+    }
+}
+
+// MARK: Errors {
+extension WooShippingRemote {
+    enum ShippingLabelError: Error {
+        case missingPackage
+    }
+}

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -10,7 +10,7 @@ public final class WooShippingRemote: Remote {
     ///   - completion: Closure to be executed upon completion.
     public func createPackage(siteID: Int64,
                               customPackage: WooShippingCustomPackage?,
-                              predefinedOption: ShippingLabelPredefinedOption?,
+                              predefinedOption: WooShippingPredefinedOption?,
                               completion: @escaping (Result<Bool, Error>) -> Void) {
         do {
             var customPackageList: [[String: Any]] = []
@@ -20,8 +20,7 @@ public final class WooShippingRemote: Remote {
                 let customPackageDictionary = try customPackage.toDictionary()
                 customPackageList = [customPackageDictionary]
             } else if let predefinedOption {
-                let packageIDs = predefinedOption.predefinedPackages.map({ $0.id })
-                predefinedOptionDictionary = [predefinedOption.providerID: packageIDs]
+                predefinedOptionDictionary = [predefinedOption.id: predefinedOption.predefinedPackageIDs]
             } else {
                 throw ShippingError.missingPackage
             }

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -9,17 +9,17 @@ public final class WooShippingRemote: Remote {
     ///   - predefinedOption: The predefined option (shipping provider and service packages) to activate.
     ///   - completion: Closure to be executed upon completion.
     public func createPackage(siteID: Int64,
-                              customPackage: ShippingLabelCustomPackage?,
+                              customPackage: WooShippingCustomPackage?,
                               predefinedOption: ShippingLabelPredefinedOption?,
                               completion: @escaping (Result<Bool, Error>) -> Void) {
         do {
             var customPackageList: [[String: Any]] = []
             var predefinedOptionDictionary: [String: [String]] = [:]
 
-            if let customPackage = customPackage {
+            if let customPackage {
                 let customPackageDictionary = try customPackage.toDictionary()
                 customPackageList = [customPackageDictionary]
-            } else if let predefinedOption = predefinedOption {
+            } else if let predefinedOption {
                 let packageIDs = predefinedOption.predefinedPackages.map({ $0.id })
                 predefinedOptionDictionary = [predefinedOption.providerID: packageIDs]
             } else {

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -11,7 +11,7 @@ public final class WooShippingRemote: Remote {
     public func createPackage(siteID: Int64,
                               customPackage: WooShippingCustomPackage?,
                               predefinedOption: WooShippingPredefinedOption?,
-                              completion: @escaping (Result<Bool, Error>) -> Void) {
+                              completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void) {
         do {
             var customPackageList: [[String: Any]] = []
             var predefinedOptionDictionary: [String: [String]] = [:]
@@ -37,16 +37,9 @@ public final class WooShippingRemote: Remote {
                                          parameters: parameters,
                                          availableAsRESTRequest: true)
 
-            // Temporary mapper while we decide what data type to use here.
-            let mapper = IgnoringResponseMapper()
+            let mapper = WooShippingCreatePackageMapper()
 
-            enqueue(request, mapper: mapper) { _, error in
-                if let error {
-                    completion(.failure(error))
-                } else {
-                    completion(.success(true))
-                }
-            }
+            enqueue(request, mapper: mapper, completion: completion)
         } catch {
             completion(.failure(error))
         }

--- a/Networking/Networking/Settings/WooAPIVersion.swift
+++ b/Networking/Networking/Settings/WooAPIVersion.swift
@@ -46,6 +46,10 @@ public enum WooAPIVersion: String {
     ///
     case wcAdmin = "wc-admin"
 
+    /// Woo Shipping Plugin V1.
+    ///
+    case wooShipping = "wcshipping/v1"
+
     /// Returns the path for the current API Version
     ///
     var path: String {

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import TestKit
+@testable import Networking
+
+/// WooShippingTests Unit Tests
+///
+final class WooShippingRemoteTests: XCTestCase {
+    /// Dummy Network Wrapper
+    private let network = MockNetwork()
+
+    /// Dummy Site ID
+    private let sampleSiteID: Int64 = 1234
+
+    /// Dummy Order ID
+    private let sampleOrderID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network.removeAllSimulatedResponses()
+    }
+
+    func test_createPackage_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-create-package-success")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: ShippingLabelCustomPackage.fake(),
+                                 predefinedOption: ShippingLabelPredefinedOption.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let successResponse = try XCTUnwrap(result.get())
+        XCTAssertTrue(successResponse)
+    }
+
+    func test_createPackage_returns_error_on_failure() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-create-package-error")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: ShippingLabelCustomPackage.fake(),
+                                 predefinedOption: ShippingLabelPredefinedOption.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let expectedError = DotcomError
+            .unknown(code: "duplicate_custom_package_names_of_existing_packages",
+                     message: "At least one of the new custom packages has the same name as existing packages.")
+        XCTAssertEqual(result.failure as? DotcomError, expectedError)
+    }
+
+    func test_createPackage_returns_missingPackage_error_with_no_packages() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: nil,
+                                 predefinedOption: nil) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let expectedError = WooShippingRemote.ShippingError.missingPackage
+        XCTAssertEqual(result.failure as? WooShippingRemote.ShippingError, expectedError)
+    }
+}

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -25,17 +25,17 @@ final class WooShippingRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-create-package-success")
 
         // When
-        let result: Result<Bool, Error> = waitFor { promise in
+        let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             remote.createPackage(siteID: self.sampleSiteID,
-                                 customPackage: ShippingLabelCustomPackage.fake(),
-                                 predefinedOption: ShippingLabelPredefinedOption.fake()) { result in
+                                 customPackage: WooShippingCustomPackage.fake(),
+                                 predefinedOption: WooShippingPredefinedOption.fake()) { result in
                 promise(result)
             }
         }
 
         // Then
-        let successResponse = try XCTUnwrap(result.get())
-        XCTAssertTrue(successResponse)
+        let packagesResponse = try XCTUnwrap(result.get())
+        XCTAssertNotNil(packagesResponse)
     }
 
     func test_createPackage_returns_error_on_failure() throws {
@@ -44,10 +44,10 @@ final class WooShippingRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-create-package-error")
 
         // When
-        let result: Result<Bool, Error> = waitFor { promise in
+        let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             remote.createPackage(siteID: self.sampleSiteID,
-                                 customPackage: ShippingLabelCustomPackage.fake(),
-                                 predefinedOption: ShippingLabelPredefinedOption.fake()) { result in
+                                 customPackage: WooShippingCustomPackage.fake(),
+                                 predefinedOption: WooShippingPredefinedOption.fake()) { result in
                 promise(result)
             }
         }
@@ -64,7 +64,7 @@ final class WooShippingRemoteTests: XCTestCase {
         let remote = WooShippingRemote(network: network)
 
         // When
-        let result: Result<Bool, Error> = waitFor { promise in
+        let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             remote.createPackage(siteID: self.sampleSiteID,
                                  customPackage: nil,
                                  predefinedOption: nil) { result in

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -35,7 +35,8 @@ final class WooShippingRemoteTests: XCTestCase {
 
         // Then
         let packagesResponse = try XCTUnwrap(result.get())
-        XCTAssertNotNil(packagesResponse)
+        XCTAssertEqual(packagesResponse.customPackages.count, 5)
+        XCTAssertEqual(packagesResponse.predefinedOptions.count, 1)
     }
 
     func test_createPackage_returns_error_on_failure() throws {

--- a/Networking/NetworkingTests/Responses/wooshipping-create-package-error.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-create-package-error.json
@@ -1,0 +1,4 @@
+{
+    "error": "duplicate_custom_package_names_of_existing_packages",
+    "message": "At least one of the new custom packages has the same name as existing packages."
+}

--- a/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
@@ -1,0 +1,40 @@
+{
+    "data": {
+        "predefined": [],
+        "custom": [
+            {
+                "name": "Custom Package 2",
+                "length": 10,
+                "width": 5,
+                "height": 5,
+                "weight": 2,
+                "id": "59096883f6dba8b25257246069e9ba9a"
+            },
+            {
+                "name": "Custom Package 1",
+                "length": 0,
+                "width": 0,
+                "height": 5,
+                "weight": 0,
+                "id": "5b19fc63d3dc43ad25cfcb771130a0cb"
+            },
+            {
+                "name": "custom",
+                "is_letter": false,
+                "inner_dimensions": "25.0 x 25.0 x 25.0",
+                "box_weight": 0.2,
+                "is_user_defined": true,
+                "max_weight": 0,
+                "id": "8b9035807842a4e4dbe009f3f1478127"
+            },
+            {
+                "name": "Test Package E",
+                "length": 10,
+                "width": 5,
+                "height": 5,
+                "weight": 2,
+                "id": "dd018572c0a4e0b128c8f429911b12d0"
+            }
+        ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
@@ -1,39 +1,56 @@
 {
     "data": {
-        "predefined": [],
+        "predefined": {
+            "usps": [
+                "small_flat_box",
+                "flat_envelope"
+            ]
+        },
         "custom": [
             {
-                "name": "Custom Package 2",
-                "length": 10,
-                "width": 5,
-                "height": 5,
-                "weight": 2,
-                "id": "59096883f6dba8b25257246069e9ba9a"
+                "id": "69d7052f934a7c218329de9c1abe3858",
+                "name": "WCS&T Box",
+                "dimensions": "15 x 15 x 15",
+                "boxWeight": 0.25,
+                "maxWeight": 0,
+                "type": "box",
+                "is_user_defined": true
             },
             {
-                "name": "Custom Package 1",
-                "length": 0,
-                "width": 0,
-                "height": 5,
-                "weight": 0,
-                "id": "5b19fc63d3dc43ad25cfcb771130a0cb"
+                "id": "517116d2f2d929115f6e081ba780b84e",
+                "name": "WCS&T Envelope",
+                "dimensions": "30 x 10 x 1",
+                "boxWeight": 0.1,
+                "maxWeight": 0,
+                "type": "envelope",
+                "is_user_defined": true
             },
             {
-                "name": "custom",
-                "is_letter": false,
-                "inner_dimensions": "25.0 x 25.0 x 25.0",
-                "box_weight": 0.2,
-                "is_user_defined": true,
-                "max_weight": 0,
-                "id": "8b9035807842a4e4dbe009f3f1478127"
+                "id": "a344e7fa99e8bb88b15feb13141bf62c",
+                "name": "WCShip Envelope",
+                "dimensions": "100 x 10 x 1",
+                "boxWeight": 0.25,
+                "maxWeight": 0,
+                "type": "envelope",
+                "is_user_defined": true
             },
             {
-                "name": "Test Package E",
-                "length": 10,
-                "width": 5,
-                "height": 5,
-                "weight": 2,
-                "id": "dd018572c0a4e0b128c8f429911b12d0"
+                "id": "22025742fbfaf4d7e73da11caaff9a2a",
+                "name": "WCShip Box",
+                "dimensions": "10 x 10 x 10",
+                "boxWeight": 1,
+                "maxWeight": 0,
+                "type": "box",
+                "is_user_defined": true
+            },
+            {
+                "id": "dd58dcd5dc044b6c56540c557c231c4f",
+                "name": "WCShip Envelope 2",
+                "dimensions": "10 x 10 x 1",
+                "boxWeight": 1,
+                "maxWeight": 0,
+                "type": "envelope",
+                "is_user_defined": true
             }
         ]
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13552
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This builds off @Ecarrion's work in https://github.com/woocommerce/woocommerce-ios/pull/14087 to add support for creating packages with the WCShip extension. This is our first of the new endpoints in the extension, so it also adds the required support for the new API namespace.

* Adds `WooShippingRemote` with the create package request.
* Adds new types for the request/response data: `WooShippingCustomPackage`, `WooShippingPredefinedOption`, `WooShippingCreatePackageResponse`.
* Adds `WooShippingCreatePackageMapper` to map the response.
* Adds unit tests with sample error and success responses.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This endpoint isn't yet used in the app, so for now confirm unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.: 