### PR TITLE
[Woo POS] Improve itemlist state representation and fix glitches

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct PointOfSaleItemListErrorView: View {
-    private var error: ItemListViewModel.ErrorModel
+    private var error: ItemListErrorModel
     private var onRetry: (() -> Void)? = nil
 
-    init(error: ItemListViewModel.ErrorModel, onRetry: (() -> Void)? = nil) {
+    init(error: ItemListErrorModel, onRetry: (() -> Void)? = nil) {
         self.error = error
         self.onRetry = onRetry
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -131,7 +131,7 @@ private extension ItemListView {
                     })
                 }
                 GhostItemCardView()
-                    .renderedIf(viewModel.state.isLoadingNextPage)
+                    .renderedIf(viewModel.state.isLoadingAfterInitialLoad)
             }
             .frame(maxWidth: .infinity)
             .padding(.bottom, floatingControlAreaSize.height)
@@ -139,7 +139,7 @@ private extension ItemListView {
             .background(GeometryReader { proxy in
                 Color.clear
                     .onChange(of: proxy.frame(in: .global).maxY) { maxY in
-                        if viewModel.state.isLoadingNextPage {
+                        if viewModel.state.isLoadingAfterInitialLoad {
                             return
                         }
                         let viewHeight = UIScreen.main.bounds.height

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -133,6 +133,7 @@ private extension ItemListView {
                 GhostItemCardView()
                     .renderedIf(viewModel.state.isLoadingNextPage)
             }
+            .frame(maxWidth: .infinity)
             .padding(.bottom, floatingControlAreaSize.height)
             .padding(.horizontal, Constants.itemListPadding)
             .background(GeometryReader { proxy in

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -131,14 +131,14 @@ private extension ItemListView {
                     })
                 }
                 GhostItemCardView()
-                    .renderedIf(viewModel.state.isLoadingSubsequentPage)
+                    .renderedIf(viewModel.state.isLoadingNextPage)
             }
             .padding(.bottom, floatingControlAreaSize.height)
             .padding(.horizontal, Constants.itemListPadding)
             .background(GeometryReader { proxy in
                 Color.clear
                     .onChange(of: proxy.frame(in: .global).maxY) { maxY in
-                        if viewModel.state.isLoadingSubsequentPage {
+                        if viewModel.state.isLoadingNextPage {
                             return
                         }
                         let viewHeight = UIScreen.main.bounds.height

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -131,14 +131,14 @@ private extension ItemListView {
                     })
                 }
                 GhostItemCardView()
-                    .renderedIf(viewModel.state == .loading)
+                    .renderedIf(viewModel.state.isLoadingSubsequentPage)
             }
             .padding(.bottom, floatingControlAreaSize.height)
             .padding(.horizontal, Constants.itemListPadding)
             .background(GeometryReader { proxy in
                 Color.clear
                     .onChange(of: proxy.frame(in: .global).maxY) { maxY in
-                        if viewModel.state == .loading {
+                        if viewModel.state.isLoadingSubsequentPage {
                             return
                         }
                         let viewHeight = UIScreen.main.bounds.height

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -14,12 +14,12 @@ struct ItemListView: View {
         VStack {
             headerView
             switch viewModel.state {
-            case .empty, .error:
+            case .initialLoading, .empty, .error:
                 // These cases are handled directly in the dashboard, we do not render
                 // a specific view within the ItemListView to handle them
                 EmptyView()
-            case .initialLoading, .loading, .loaded:
-                listView(viewModel.items)
+            case .loading(let items), .loaded(let items):
+                listView(items)
             }
         }
         .refreshable {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -28,7 +28,7 @@ struct PointOfSaleDashboardView: View {
                 let errorContents = viewModel.itemListViewModel.state.hasError
                 PointOfSaleItemListErrorView(error: errorContents, onRetry: {
                     Task {
-                        await viewModel.itemListViewModel.reload()
+                        await viewModel.itemListViewModel.loadInitialItems()
                     }
                 })
             } else if viewModel.isEmpty {

--- a/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
@@ -1,0 +1,56 @@
+import protocol Yosemite.POSItem
+
+enum ItemListState: Equatable {
+    case empty
+    case initialLoading
+    case loading
+    case loaded([POSItem])
+    case error(ItemListErrorModel)
+
+    var isLoaded: Bool {
+        switch self {
+        case .loaded:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isLoading: Bool {
+        switch self {
+        case .initialLoading, .loading:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var hasError: ItemListErrorModel {
+        switch self {
+        case .error(let errorModel):
+            return errorModel
+        default:
+            return ItemListErrorModel(title: "Unknown error",
+                                      subtitle: "Unknown error",
+                                      buttonText: "Retry")
+        }
+    }
+
+    // Equatable conformance for testing:
+    static func == (lhs: ItemListState, rhs: ItemListState) -> Bool {
+        switch (lhs, rhs) {
+        case (.empty, .empty):
+            return true
+        case (.initialLoading, .initialLoading):
+            return true
+        case (.loading, .loading):
+            return true
+        case (.loaded(let lhsItems), .loaded(let rhsItems)):
+            return lhsItems.map { $0.itemID } == rhsItems.map { $0.itemID }
+        case (.error(let lhsError), .error(let rhsError)):
+            return lhsError == rhsError
+        default:
+            return false
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
@@ -25,7 +25,7 @@ enum ItemListState: Equatable {
         }
     }
 
-    var isLoadingSubsequentPage: Bool {
+    var isLoadingNextPage: Bool {
         switch self {
         case .loading(let currentItems):
             return currentItems.isNotEmpty

--- a/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
@@ -7,10 +7,10 @@ enum ItemListState: Equatable {
     case loaded(_ items: [POSItem])
     case error(ItemListErrorModel)
 
-    var isLoadingNextPage: Bool {
+    var isLoadingAfterInitialLoad: Bool {
         switch self {
-        case .loading(let currentItems):
-            return currentItems.isNotEmpty
+        case .loading:
+            return true
         default:
             return false
         }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
@@ -7,24 +7,6 @@ enum ItemListState: Equatable {
     case loaded(_ items: [POSItem])
     case error(ItemListErrorModel)
 
-    var isLoaded: Bool {
-        switch self {
-        case .loaded:
-            return true
-        default:
-            return false
-        }
-    }
-
-    var isLoading: Bool {
-        switch self {
-        case .initialLoading, .loading:
-            return true
-        default:
-            return false
-        }
-    }
-
     var isLoadingNextPage: Bool {
         switch self {
         case .loading(let currentItems):

--- a/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListState.swift
@@ -3,8 +3,8 @@ import protocol Yosemite.POSItem
 enum ItemListState: Equatable {
     case empty
     case initialLoading
-    case loading
-    case loaded([POSItem])
+    case loading(_ currentItems: [POSItem])
+    case loaded(_ items: [POSItem])
     case error(ItemListErrorModel)
 
     var isLoaded: Bool {
@@ -20,6 +20,15 @@ enum ItemListState: Equatable {
         switch self {
         case .initialLoading, .loading:
             return true
+        default:
+            return false
+        }
+    }
+
+    var isLoadingSubsequentPage: Bool {
+        switch self {
+        case .loading(let currentItems):
+            return currentItems.isNotEmpty
         default:
             return false
         }
@@ -43,9 +52,8 @@ enum ItemListState: Equatable {
             return true
         case (.initialLoading, .initialLoading):
             return true
-        case (.loading, .loading):
-            return true
-        case (.loaded(let lhsItems), .loaded(let rhsItems)):
+        case (.loading(let lhsItems), .loading(let rhsItems)),
+            (.loaded(let lhsItems), .loaded(let rhsItems)):
             return lhsItems.map { $0.itemID } == rhsItems.map { $0.itemID }
         case (.error(let lhsError), .error(let rhsError)):
             return lhsError == rhsError

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -26,7 +26,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     let selectedItemPublisher: AnyPublisher<POSItem, Never>
 
     var itemsPublisher: Published<[POSItem]>.Publisher { $items }
-    var statePublisher: Published<ItemListViewModel.ItemListState>.Publisher { $state }
+    var statePublisher: Published<ItemListState>.Publisher { $state }
 
     init(itemProvider: POSItemProvider) {
         self.itemProvider = itemProvider
@@ -49,7 +49,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
                 state = .loaded(items)
             }
         } catch {
-            state = .error(ErrorModel.errorOnLoadingProducts())
+            state = .error(ItemListErrorModel.errorOnLoadingProducts())
         }
     }
 
@@ -78,7 +78,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
                 currentPage = pageNumber
             }
         } catch {
-            state = .error(ErrorModel.errorOnLoadingProducts())
+            state = .error(ItemListErrorModel.errorOnLoadingProducts())
         }
     }
 
@@ -98,80 +98,19 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     }
 }
 
-extension ItemListViewModel {
-    enum ItemListState: Equatable {
-        case empty
-        case initialLoading
-        case loading
-        case loaded([POSItem])
-        case error(ErrorModel)
+struct ItemListErrorModel: Equatable {
+    let title: String
+    let subtitle: String
+    let buttonText: String
 
-        var isLoaded: Bool {
-            switch self {
-            case .loaded:
-                return true
-            default:
-                return false
-            }
-        }
-
-        var isLoading: Bool {
-            switch self {
-            case .initialLoading, .loading:
-                return true
-            default:
-                return false
-            }
-        }
-
-        var hasError: ErrorModel {
-            switch self {
-            case .error(let errorModel):
-                return errorModel
-            default:
-                return ItemListViewModel.ErrorModel(title: "Unknown error",
-                                                    subtitle: "Unknown error",
-                                                    buttonText: "Retry")
-            }
-        }
-
-        // Equatable conformance for testing:
-        static func == (lhs: ItemListViewModel.ItemListState, rhs: ItemListViewModel.ItemListState) -> Bool {
-            switch (lhs, rhs) {
-            case (.empty, .empty):
-                return true
-            case (.initialLoading, .initialLoading):
-                return true
-            case (.loading, .loading):
-                return true
-            case (.loaded(let lhsItems), .loaded(let rhsItems)):
-                return lhsItems.map { $0.itemID } == rhsItems.map { $0.itemID }
-            case (.error(let lhsError), .error(let rhsError)):
-                return lhsError == rhsError
-            default:
-                return false
-            }
-        }
-    }
-
-    struct ErrorModel: Equatable {
-        let title: String
-        let subtitle: String
-        let buttonText: String
-
-        static func errorOnLoadingProducts() -> Self {
-            ErrorModel(title: Constants.failedToLoadTitle,
-                       subtitle: Constants.failedToLoadSubtitle,
-                       buttonText: Constants.failedToLoadButtonTitle)
-        }
-    }
-
-    struct BannerState {
-        static let isSimpleProductsOnlyBannerDismissedKey = "isSimpleProductsOnlyBannerDismissed"
+    static func errorOnLoadingProducts() -> Self {
+        ItemListErrorModel(title: Constants.failedToLoadTitle,
+                           subtitle: Constants.failedToLoadSubtitle,
+                           buttonText: Constants.failedToLoadButtonTitle)
     }
 }
 
-private extension ItemListViewModel {
+private extension ItemListErrorModel {
     enum Constants {
         static let failedToLoadTitle = NSLocalizedString(
             "pos.itemList.failedToLoadTitle",
@@ -188,6 +127,17 @@ private extension ItemListViewModel {
             value: "Retry",
             comment: "Text for the button appearing on the item list screen when there's an error loading products."
         )
+    }
+}
+
+extension ItemListViewModel {
+    struct BannerState {
+        static let isSimpleProductsOnlyBannerDismissedKey = "isSimpleProductsOnlyBannerDismissed"
+    }
+}
+
+private extension ItemListViewModel {
+    enum Constants {
         static let initialPage: Int = 1
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -64,7 +64,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     @MainActor
     private func fetchPage(pageNumber: Int) async {
         do {
-            state = .loading
+            state = .loading(items)
             let newItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
             let uniqueNewItems = newItems.filter { newItem in
                 !items.contains(where: { $0.productID == newItem.productID })

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -25,7 +25,6 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     let selectedItemPublisher: AnyPublisher<POSItem, Never>
 
-    var itemsPublisher: Published<[POSItem]>.Publisher { $items }
     var statePublisher: Published<ItemListState>.Publisher { $state }
 
     init(itemProvider: POSItemProvider) {
@@ -85,7 +84,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     @MainActor
     func reload() async {
         items.removeAll()
-        await loadInitialItems()
+        await fetchPage(pageNumber: Constants.initialPage)
     }
 
     func dismissBanner() {

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -17,7 +17,15 @@ final class ItemListViewModel: ItemListViewModelProtocol {
         if UserDefaults.standard.bool(forKey: BannerState.isSimpleProductsOnlyBannerDismissedKey) == true {
             return false
         }
-        return !isHeaderBannerDismissed && (state.isLoaded || state.isLoading) && items.isNotEmpty
+        switch state {
+        case .loading,
+                .loaded:
+            return !isHeaderBannerDismissed
+        case .empty,
+            .initialLoading,
+            .error:
+            return false
+        }
     }
 
     private let itemProvider: POSItemProvider

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
@@ -4,13 +4,13 @@ import protocol Yosemite.POSItem
 
 protocol ItemListViewModelProtocol: ObservableObject {
     var items: [POSItem] { get }
-    var state: ItemListViewModel.ItemListState { get }
+    var state: ItemListState { get }
     var isHeaderBannerDismissed: Bool { get }
     var shouldShowHeaderBanner: Bool { get }
 
     var selectedItemPublisher: AnyPublisher<POSItem, Never> { get }
     var itemsPublisher: Published<[POSItem]>.Publisher { get }
-    var statePublisher: Published<ItemListViewModel.ItemListState>.Publisher { get }
+    var statePublisher: Published<ItemListState>.Publisher { get }
 
     func select(_ item: POSItem)
     func loadInitialItems() async

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
@@ -3,6 +3,7 @@ import Foundation
 import protocol Yosemite.POSItem
 
 protocol ItemListViewModelProtocol: ObservableObject {
+    @available(*, deprecated, message: "`items` is due for removal, use `state` instead.")
     var items: [POSItem] { get }
     var state: ItemListState { get }
     var isHeaderBannerDismissed: Bool { get }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
@@ -9,7 +9,6 @@ protocol ItemListViewModelProtocol: ObservableObject {
     var shouldShowHeaderBanner: Bool { get }
 
     var selectedItemPublisher: AnyPublisher<POSItem, Never> { get }
-    var itemsPublisher: Published<[POSItem]>.Publisher { get }
     var statePublisher: Published<ItemListState>.Publisher { get }
 
     func select(_ item: POSItem)

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -185,11 +185,11 @@ private extension PointOfSaleDashboardViewModel {
     }
 
     func observeItemListState() {
-        Publishers.CombineLatest(itemListViewModel.statePublisher, itemListViewModel.itemsPublisher)
-            .sink { [weak self] state, items in
+        itemListViewModel.statePublisher
+            .sink { [weak self] state in
                 guard let self = self else { return }
 
-                self.isInitialLoading = (state == .initialLoading && items.isEmpty)
+                self.isInitialLoading = state == .initialLoading
 
                 switch state {
                 case .error:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -837,6 +837,7 @@
 		20BCF6EE2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */; };
 		20BCF6F02B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */; };
 		20BCF6F72B0E5AF000954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */; };
+		20C6E7512CDE4AEA00CD124C /* ItemListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C6E7502CDE4AEA00CD124C /* ItemListState.swift */; };
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
 		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
 		20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */; };
@@ -3945,6 +3946,7 @@
 		20BCF6ED2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModel.swift; sourceTree = "<group>"; };
 		20BCF6EF2B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewViewModelTests.swift; sourceTree = "<group>"; };
 		20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusService.swift; sourceTree = "<group>"; };
+		20C6E7502CDE4AEA00CD124C /* ItemListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListState.swift; sourceTree = "<group>"; };
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
 		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -6823,6 +6825,7 @@
 				026826922BF59D830036F959 /* PointOfSaleDashboardViewModel.swift */,
 				019C5EAF2C516F7B005B82D3 /* ItemListViewModelProtocol.swift */,
 				683763152C2E44B800AD51D0 /* ItemListViewModel.swift */,
+				20C6E7502CDE4AEA00CD124C /* ItemListState.swift */,
 				C7F746C82C4868670023ADD0 /* TotalsViewModelProtocol.swift */,
 				6885E2CB2C32B14B004C8D70 /* TotalsViewModel.swift */,
 				016BCAFE2C4F907F009D8367 /* CartViewModelProtocol.swift */,
@@ -14858,6 +14861,7 @@
 				AEE2610F26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift in Sources */,
 				025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */,
 				EE9D031B2B89E4470077CED1 /* FilterOrdersByProduct+Analytics.swift in Sources */,
+				20C6E7512CDE4AEA00CD124C /* ItemListState.swift in Sources */,
 				86967D812B4E21C600C20CA8 /* BlazeAddParameterViewModel.swift in Sources */,
 				EE45E2B92A409BA40085F227 /* ProductDescriptionAITooltipUseCase.swift in Sources */,
 				DE02ABBA2B56981C008E0AC4 /* BlazeConfirmPaymentView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
@@ -5,7 +5,6 @@ import protocol Yosemite.POSItem
 
 class MockItemListViewModel: ItemListViewModelProtocol {
     @Published var items: [any Yosemite.POSItem] = []
-    var itemsPublisher: Published<[any Yosemite.POSItem]>.Publisher { $items }
 
     @Published var state: ItemListState = .initialLoading
     var statePublisher: Published<ItemListState>.Publisher { $state }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
@@ -7,7 +7,7 @@ class MockItemListViewModel: ItemListViewModelProtocol {
     @Published var items: [any Yosemite.POSItem] = []
     var itemsPublisher: Published<[any Yosemite.POSItem]>.Publisher { $items }
 
-    @Published var state: ItemListState = .loading
+    @Published var state: ItemListState = .initialLoading
     var statePublisher: Published<ItemListState>.Publisher { $state }
 
     @Published var isHeaderBannerDismissed: Bool = false

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
@@ -7,8 +7,8 @@ class MockItemListViewModel: ItemListViewModelProtocol {
     @Published var items: [any Yosemite.POSItem] = []
     var itemsPublisher: Published<[any Yosemite.POSItem]>.Publisher { $items }
 
-    @Published var state: WooCommerce.ItemListViewModel.ItemListState = .loading
-    var statePublisher: Published<WooCommerce.ItemListViewModel.ItemListState>.Publisher { $state }
+    @Published var state: ItemListState = .loading
+    var statePublisher: Published<ItemListState>.Publisher { $state }
 
     @Published var isHeaderBannerDismissed: Bool = false
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -276,7 +276,30 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.shouldShowHeaderBanner, false)
     }
 
-    func test_shouldShowHeaderBanner_when_itemListViewModel_is_initialLoading_has_items_then_returns_true() async {
+    func test_shouldShowHeaderBanner_when_itemListViewModel_is_loadingNextPage_then_returns_true() async {
+        // Given the list is already populated with items
+        await sut.loadInitialItems()
+        guard case .loaded(let items) = sut.state else {
+            return XCTFail("Expected loaded ItemList state, but got \(sut.state)")
+        }
+        XCTAssert(items.isNotEmpty)
+
+        // When we refresh the list again
+        let expectation = XCTestExpectation(description: "Expected banner to be shown when loading next item list page")
+        sut.statePublisher.sink { [unowned self] _ in
+            if case .loading = self.sut.state {
+                XCTAssertTrue(sut.shouldShowHeaderBanner)
+                expectation.fulfill()
+            }
+        }
+        .store(in: &cancellables)
+        await sut.loadNextItems()
+
+        // Then banner shoud be shown
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func test_shouldShowHeaderBanner_when_itemListViewModel_is_reloading_then_returns_true() async {
         // Given the list is already populated with items
         await sut.loadInitialItems()
         guard case .loaded(let items) = sut.state else {
@@ -287,13 +310,13 @@ final class ItemListViewModelTests: XCTestCase {
         // When we refresh the list again
         let expectation = XCTestExpectation(description: "Expected banner to be shown when reloading item list")
         sut.statePublisher.sink { [unowned self] _ in
-            if self.sut.state == .initialLoading {
+            if case .loading = self.sut.state {
                 XCTAssertTrue(sut.shouldShowHeaderBanner)
                 expectation.fulfill()
             }
         }
         .store(in: &cancellables)
-        await sut.loadInitialItems()
+        await sut.reload()
 
         // Then banner shoud be shown
         await fulfillment(of: [expectation], timeout: 1)
@@ -314,27 +337,6 @@ final class ItemListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.state, .error(expectedError))
         XCTAssertEqual(sut.shouldShowHeaderBanner, false)
-    }
-
-    func test_state_when_itemListViewModel_loaded_normally_then_returns_isLoaded_true() async {
-        // Given/When
-        await sut.loadInitialItems()
-
-        // Then
-        XCTAssertEqual(sut.state.isLoaded, true)
-    }
-
-    func test_state_when_itemListViewModel_throws_error_then_returns_isLoaded_false() async {
-        // Given
-        let itemProvider = MockPOSItemProvider()
-        itemProvider.shouldThrowError = true
-        let sut = ItemListViewModel(itemProvider: itemProvider)
-
-        // When
-        await sut.loadInitialItems()
-
-        // Then
-        XCTAssertEqual(sut.state.isLoaded, false)
     }
 
     func test_loadInitialItems_when_no_items_are_loaded_then_statePublisher_emits_expected_empty_state() async throws {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -183,9 +183,9 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
-        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
-                                                         subtitle: "Give it another go?",
-                                                         buttonText: "Retry")
+        let expectedError = ItemListErrorModel(title: "Error loading products",
+                                               subtitle: "Give it another go?",
+                                               buttonText: "Retry")
 
         XCTAssertEqual(sut.state, .initialLoading)
 
@@ -201,9 +201,9 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
-        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
-                                                         subtitle: "Give it another go?",
-                                                         buttonText: "Retry")
+        let expectedError = ItemListErrorModel(title: "Error loading products",
+                                               subtitle: "Give it another go?",
+                                               buttonText: "Retry")
 
         XCTAssertEqual(sut.state, .initialLoading)
 
@@ -231,9 +231,9 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
-        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
-                                                         subtitle: "Give it another go?",
-                                                         buttonText: "Retry")
+        let expectedError = ItemListErrorModel(title: "Error loading products",
+                                               subtitle: "Give it another go?",
+                                               buttonText: "Retry")
 
         XCTAssertEqual(sut.state, .initialLoading)
 
@@ -286,9 +286,9 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
-        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
-                                                         subtitle: "Give it another go?",
-                                                         buttonText: "Retry")
+        let expectedError = ItemListErrorModel(title: "Error loading products",
+                                               subtitle: "Give it another go?",
+                                               buttonText: "Retry")
 
         // When
         await sut.loadInitialItems()
@@ -372,7 +372,7 @@ final class ItemListViewModelTests: XCTestCase {
         let sut = ItemListViewModel(itemProvider: itemProvider)
         let expectation = XCTestExpectation(description: "Publisher should emit state changes")
 
-        var receivedStates: [ItemListViewModel.ItemListState] = []
+        var receivedStates: [ItemListState] = []
         sut.statePublisher
             .removeDuplicates()
             .sink { state in
@@ -394,7 +394,7 @@ final class ItemListViewModelTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Publisher should emit state changes")
         let items = Self.makeInitialItems()
 
-        var receivedStates: [ItemListViewModel.ItemListState] = []
+        var receivedStates: [ItemListState] = []
         sut.statePublisher
             .removeDuplicates()
             .sink { state in
@@ -415,8 +415,8 @@ final class ItemListViewModelTests: XCTestCase {
         itemProvider.shouldReturnZeroItems = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
 
-        var receivedStates: [ItemListViewModel.ItemListState] = []
-        let expectedStates: [ItemListViewModel.ItemListState] = [
+        var receivedStates: [ItemListState] = []
+        let expectedStates: [ItemListState] = [
             .initialLoading,
             .empty,
             .loading,
@@ -441,8 +441,8 @@ final class ItemListViewModelTests: XCTestCase {
     func test_sut_when_there_are_items_then_statePublisher_emits_expected_state() async {
         let items = Self.makeInitialItems()
 
-        var receivedStates: [ItemListViewModel.ItemListState] = []
-        let expectedStates: [ItemListViewModel.ItemListState] = [
+        var receivedStates: [ItemListState] = []
+        let expectedStates: [ItemListState] = [
             .initialLoading,
             .loaded(items),
             .loading,

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -152,7 +152,7 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         let initialItems = Self.makeInitialItems()
         itemProvider.items = initialItems
-        itemProvider.shouldSimulateFetchNextPage = true
+        itemProvider.shouldSimulateTwoPages = true
 
         let sut = ItemListViewModel(itemProvider: itemProvider)
 
@@ -478,7 +478,7 @@ private extension ItemListViewModelTests {
         var items: [POSItem] = []
         var shouldThrowError = false
         var shouldReturnZeroItems = false
-        var shouldSimulateFetchNextPage = false
+        var shouldSimulateTwoPages = false
 
         func providePointOfSaleItems(pageNumber: Int) async throws -> [Yosemite.POSItem] {
             if shouldThrowError {
@@ -487,7 +487,8 @@ private extension ItemListViewModelTests {
             if shouldReturnZeroItems {
                 return []
             }
-            if shouldSimulateFetchNextPage {
+            if shouldSimulateTwoPages,
+                pageNumber > 1 {
                 simulateFetchNextPage()
                 return items
             }
@@ -495,28 +496,8 @@ private extension ItemListViewModelTests {
         }
 
         func simulateFetchNextPage() {
-            let fakeUUID1 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E86D") ?? UUID()
-            let fakeUUID2 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E86F") ?? UUID()
-
-            let product1 = POSProduct(itemID: fakeUUID1,
-                                      productID: 0,
-                                      name: "Strawberry",
-                                      price: "2",
-                                      formattedPrice: "$2.00",
-                                      itemCategories: [],
-                                      productImageSource: nil,
-                                      productType: .simple)
-            items.append(product1)
-
-            let product2 = POSProduct(itemID: fakeUUID2,
-                                      productID: 1,
-                                      name: "Pistachio",
-                                      price: "3",
-                                      formattedPrice: "$3.00",
-                                      itemCategories: [],
-                                      productImageSource: nil,
-                                      productType: .simple)
-            items.append(product2)
+            items.append(contentsOf: makeSecondPageItems())
+            return
         }
     }
 
@@ -542,5 +523,29 @@ private extension ItemListViewModelTests {
                                   productImageSource: nil,
                                   productType: .simple)
         return [product1, product2]
+    }
+
+    static func makeSecondPageItems() -> [POSItem] {
+        let fakeUUID3 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E86D") ?? UUID()
+        let fakeUUID4 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E86F") ?? UUID()
+
+        let product3 = POSProduct(itemID: fakeUUID3,
+                                  productID: 2,
+                                  name: "Strawberry",
+                                  price: "2",
+                                  formattedPrice: "$2.00",
+                                  itemCategories: [],
+                                  productImageSource: nil,
+                                  productType: .simple)
+
+        let product4 = POSProduct(itemID: fakeUUID4,
+                                  productID: 4,
+                                  name: "Pistachio",
+                                  price: "3",
+                                  formattedPrice: "$3.00",
+                                  itemCategories: [],
+                                  productImageSource: nil,
+                                  productType: .simple)
+        return [product3, product4]
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -6,7 +6,7 @@ import Combine
 @testable import struct Yosemite.POSProduct
 
 final class ItemListViewModelTests: XCTestCase {
-    private var itemProvider: POSItemProvider!
+    private var itemProvider: MockPOSItemProvider!
     private var sut: ItemListViewModel!
 
     private var cancellables: Set<AnyCancellable> = []
@@ -419,7 +419,7 @@ final class ItemListViewModelTests: XCTestCase {
         let expectedStates: [ItemListState] = [
             .initialLoading,
             .empty,
-            .loading,
+            .loading([]),
             .loaded([])
         ]
 
@@ -445,8 +445,36 @@ final class ItemListViewModelTests: XCTestCase {
         let expectedStates: [ItemListState] = [
             .initialLoading,
             .loaded(items),
-            .loading,
+            .loading(items),
             .loaded(items)
+        ]
+
+        sut.statePublisher
+            .removeDuplicates()
+            .sink { state in
+                receivedStates.append(state)
+            }
+            .store(in: &cancellables)
+
+        // When
+        await sut.loadInitialItems()
+        await sut.loadNextItems()
+
+        // Then
+        XCTAssertEqual(receivedStates, expectedStates)
+    }
+
+    func test_sut_when_there_are_two_pages_of_items_then_statePublisher_emits_expected_state() async {
+        itemProvider.shouldSimulateTwoPages = true
+        let initialItems = Self.makeInitialItems()
+        let firstAndSecondPageItems = initialItems + Self.makeSecondPageItems()
+
+        var receivedStates: [ItemListState] = []
+        let expectedStates: [ItemListState] = [
+            .initialLoading,
+            .loaded(initialItems),
+            .loading(initialItems),
+            .loaded(firstAndSecondPageItems)
         ]
 
         sut.statePublisher

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -26,19 +26,22 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_itemListViewModel_when_loadInitialItems_then_items_are_populated() async {
         // Given
-        XCTAssertEqual(sut.items.count, 0)
+        XCTAssertEqual(sut.state, .initialLoading)
         let expectedItems = Self.makeInitialItems()
 
         // When
         await sut.loadInitialItems()
 
         // Then
-        XCTAssertEqual(sut.items.count, expectedItems.count)
+        guard case .loaded(let items) = sut.state else {
+            return XCTFail("Expected loaded ItemList state, but got \(sut.state)")
+        }
+        XCTAssertEqual(items.count, expectedItems.count)
     }
 
     func test_itemListViewModel_when_loadInitialItems_is_called_multiple_times_then_items_are_not_aggregated() async {
         // Given
-        XCTAssertEqual(sut.items.count, 0)
+        XCTAssertEqual(sut.state, .initialLoading)
         let expectedItems = Self.makeInitialItems()
 
         // When
@@ -47,24 +50,30 @@ final class ItemListViewModelTests: XCTestCase {
         await sut.loadInitialItems()
 
         // Then
-        XCTAssertEqual(sut.items.count, expectedItems.count)
+        guard case .loaded(let items) = sut.state else {
+            return XCTFail("Expected loaded ItemList state, but got \(sut.state)")
+        }
+        XCTAssertEqual(items.count, expectedItems.count)
     }
 
     func test_itemListViewModel_when_reload_is_called_then_items_are_populated() async {
         // Given
-        XCTAssertEqual(sut.items.count, 0)
+        XCTAssertEqual(sut.state, .initialLoading)
         let expectedItems = Self.makeInitialItems()
 
         // When
         await sut.reload()
 
         // Then
-        XCTAssertEqual(sut.items.count, expectedItems.count)
+        guard case .loaded(let items) = sut.state else {
+            return XCTFail("Expected loaded ItemList state, but got \(sut.state)")
+        }
+        XCTAssertEqual(items.count, expectedItems.count)
     }
 
     func test_itemListViewModel_when_reload_is_called_multiple_times_then_items_are_not_aggregated() async {
         // Given
-        XCTAssertEqual(sut.items.count, 0)
+        XCTAssertEqual(sut.state, .initialLoading)
         let expectedItems = Self.makeInitialItems()
 
         // When
@@ -73,7 +82,10 @@ final class ItemListViewModelTests: XCTestCase {
         await sut.reload()
 
         // Then
-        XCTAssertEqual(sut.items.count, expectedItems.count)
+        guard case .loaded(let items) = sut.state else {
+            return XCTFail("Expected loaded ItemList state, but got \(sut.state)")
+        }
+        XCTAssertEqual(items.count, expectedItems.count)
     }
 
     func test_itemListViewModel_when_select_item_then_sends_item_to_publisher() {
@@ -160,7 +172,10 @@ final class ItemListViewModelTests: XCTestCase {
         await sut.loadNextItems()
 
         // Then
-        XCTAssertEqual(sut.items.count, 4)
+        guard case .loaded(let items) = sut.state else {
+            return XCTFail("Expected loaded ItemList state, but got \(sut.state)")
+        }
+        XCTAssertEqual(items.count, 4)
     }
 
     func test_itemListViewModel_when_loadInitialItems_has_no_items_then_state_is_loaded_empty() async {
@@ -264,7 +279,10 @@ final class ItemListViewModelTests: XCTestCase {
     func test_shouldShowHeaderBanner_when_itemListViewModel_is_initialLoading_has_items_then_returns_true() async {
         // Given the list is already populated with items
         await sut.loadInitialItems()
-        XCTAssertTrue(sut.items.isNotEmpty)
+        guard case .loaded(let items) = sut.state else {
+            return XCTFail("Expected loaded ItemList state, but got \(sut.state)")
+        }
+        XCTAssert(items.isNotEmpty)
 
         // When we refresh the list again
         let expectation = XCTestExpectation(description: "Expected banner to be shown when reloading item list")
@@ -317,50 +335,6 @@ final class ItemListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sut.state.isLoaded, false)
-    }
-
-    func test_loadInitialItems_when_no_items_are_loaded_then_itemsPublisher_emits_no_items() async throws {
-        let itemProvider = MockPOSItemProvider()
-        itemProvider.shouldReturnZeroItems = true
-        let sut = ItemListViewModel(itemProvider: itemProvider)
-
-        let expectation = XCTestExpectation(description: "Publisher should emit nothing")
-        var receivedItems: [POSItem] = []
-        sut.itemsPublisher.sink { items in
-            receivedItems = items
-            expectation.fulfill()
-        }
-        .store(in: &cancellables)
-
-        // When
-        await sut.loadInitialItems()
-
-        // Then
-        XCTAssertTrue(sut.state == .empty)
-        XCTAssertTrue(receivedItems.isEmpty)
-    }
-
-    func test_loadInitialItems_when_items_are_loaded_then_itemsPublisher_emits_items() async throws {
-        // Given
-        let items = Self.makeInitialItems()
-        let expectation = XCTestExpectation(description: "Publisher should emit populated items")
-        var receivedItems: [POSItem] = []
-        sut.itemsPublisher.sink { items in
-            receivedItems = items
-            expectation.fulfill()
-        }
-        .store(in: &cancellables)
-
-        // When
-        await sut.loadInitialItems()
-        guard let firstItem = items.first, let lastItem = items.last else {
-            return XCTFail("Expected two items, got \(receivedItems).")
-        }
-
-        // Then
-        XCTAssertTrue(sut.state == .loaded(receivedItems))
-        XCTAssertEqual(receivedItems.first?.productID, firstItem.productID)
-        XCTAssertEqual(receivedItems.last?.productID, lastItem.productID)
     }
 
     func test_loadInitialItems_when_no_items_are_loaded_then_statePublisher_emits_expected_empty_state() async throws {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -300,7 +300,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
     func test_dashboard_when_item_list_loading_and_empty_then_isInitialLoading_is_false() {
         // Given
         mockItemListViewModel.items = []
-        mockItemListViewModel.state = .loading
+        mockItemListViewModel.state = .loading([])
 
         // Then
         XCTAssertFalse(sut.isInitialLoading)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14350
Closes: #14251 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes uses of the `items` array and `itemsPublisher` from the `ItemListViewModel`. This is in preparation for architecture changes to move this state to the new Aggregated Model

The only remaining use of the `items` array is from the dashboard, where it's used for creating the order. We'll remove that in a future commit.

Instead, we rely on the ItemListState, which includes items when they should be shown.

As part of this work I've had to change the various pagination/loading/refresh behaviours to use the new source of truth for items, and along the way I've fixed some glitches

- Pull to refresh now leaves the simple products banner in place (arguably the items should remain too, but I've not done that)
- There's no animation glitch on refresh #14251 
- The ghost cell does eventually go away now (though it could still do with one less load cycle)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and go to POS
2. Observe that the initial loading state is shown
3. When the items load, observe that they're shown correctly
4. Scroll to the bottom of the list; observe that the next page is loaded
5. Pull to refresh; observe that the list refreshes without glitches

Test with a site that has no simple products; observe that the full-screen empty state is shown.

Test with the products endpoint on a network breakpoint, and abort the request; observe that the error state is shown and can be refreshed correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This refactor should be limited to the display of the itemlist, but it's worth also checking a full checkout including order editing after the first checkout tap, because the `items` array is used for building the order.

I've tested this with the above scenarios on an iPad Air running iOS 17.7

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/4b2001c8-c686-4648-902b-fbffd35492a3


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.