### PR TITLE
[SiOC - customer creation] Disable feature flag as the feature is paused

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -69,7 +69,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .subscriptionsInOrderCreationUI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .subscriptionsInOrderCreationCustomers:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            // Feature paused pfoUAQ-zw-p2#comment-510.
+            return false
         case .pointOfSale:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .googleAdsCampaignCreationOnWebView:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/EditOrderFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/EditOrderFormTests.swift
@@ -18,7 +18,7 @@ final class EditOrderFormTests: XCTestCase {
         // Then
         XCTAssertNotNil(try? sut.find(button: "Add Products"))
         XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
-        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer Details"))
         XCTAssertNotNil(try? sut.find(button: "Add Note"))
         XCTAssertNotNil(try? sut.find(button: "Done"))
     }
@@ -38,7 +38,7 @@ final class EditOrderFormTests: XCTestCase {
         XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
         XCTAssertNotNil(try? sut.find(button: "Add Shipping"))
         XCTAssertNotNil(try? sut.find(button: "Add Coupon"))
-        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer Details"))
         XCTAssertNotNil(try? sut.find(button: "Add Note"))
         XCTAssertNotNil(try? sut.find(button: "Done"))
     }
@@ -56,7 +56,7 @@ final class EditOrderFormTests: XCTestCase {
 
         XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Edit amount"))
         XCTAssertNotNil(try? sut.find(button: "Add Shipping"))
-        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer Details"))
         XCTAssertNotNil(try? sut.find(button: "Add Note"))
         XCTAssertNotNil(try? sut.find(button: "Done"))
     }
@@ -74,7 +74,7 @@ final class EditOrderFormTests: XCTestCase {
         XCTAssertNotNil(try? sut.find(text: "Order total"))
 
         XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Edit shipping"))
-        XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Search customer"))
+        XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Edit Customer Details"))
 
         XCTAssertNotNil(try? sut.find(button: "Add Products"))
         XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
@@ -97,7 +97,7 @@ final class EditOrderFormTests: XCTestCase {
 
         XCTAssertNotNil(try? sut.find(button: "Add Products"))
         XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
-        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer Details"))
         XCTAssertNotNil(try? sut.find(button: "Done"))
     }
 }
@@ -107,6 +107,7 @@ private extension EditOrderFormTests {
     static func createEditView(with order: Order) -> OrderForm {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storage = MockStorageManager()
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
 
         // Insert products that relates to items into the storage.
         // This is needed by EditableOrderViewModel to properly compute its variables
@@ -118,7 +119,8 @@ private extension EditOrderFormTests {
         let viewModel = EditableOrderViewModel(siteID: order.siteID,
                                                flow: .editing(initialOrder: order),
                                                stores: stores,
-                                               storageManager: storage)
+                                               storageManager: storage,
+                                               featureFlagService: featureFlagService)
         return OrderForm(flow: .editing, viewModel: viewModel, presentProductSelector: {})
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12592
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Having a paused feature while the feature flag is still enabled in debug mode could be confusing for developers who did not know about the feature, like in p1731003005686769-slack-CGPNUU63E. As there is no plan to resume the project in the near future, the feature flag is now disabled until we make a decision on whether to continue or remove it.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Go to the orders tab
- Tap + to create an order
- Tap `Add customer details` --> a modal with a list of customers should be shown instead of a card in the order form, the same behavior as in the production version

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screenshot - iPad (10th generation) - 2024-11-11 at 08 52 22](https://github.com/user-attachments/assets/63b24c61-d9be-4473-bba0-413e98ac6094) | ![Simulator Screenshot - iPad (10th generation) - 2024-11-11 at 08 57 16](https://github.com/user-attachments/assets/d1b8ffc0-e253-4074-92dd-6aa810395f10)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.