### PR TITLE
[Beta fix] Hides `GhostItemCardView` rendering behind feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -90,6 +90,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .paymentsOnboardingInPointOfSale:
             return buildConfig == .localDeveloper
+        case .displayInfiniteScrollingUIDetailsInPointOfSale:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -196,4 +196,8 @@ public enum FeatureFlag: Int {
     /// Supports Woo Payments onboarding in POS so that merchants who have not completed onboarding can access POS.
     ///
     case paymentsOnboardingInPointOfSale
+
+    /// Enables UI-related aspects of infinite scrolling in POS. It does not affect the actual infinite scrolling behaviour.
+    ///
+    case displayInfiniteScrollingUIDetailsInPointOfSale
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -130,8 +130,10 @@ private extension ItemListView {
                         ItemCardView(item: item)
                     })
                 }
-                GhostItemCardView()
-                    .renderedIf(viewModel.state == .loading)
+                if let shouldShowGhostableItemCard = viewModel.shouldShowGhostableItemCard {
+                    GhostItemCardView()
+                        .renderedIf(shouldShowGhostableItemCard && viewModel.state == .loading)
+                }
             }
             .padding(.bottom, floatingControlAreaSize.height)
             .padding(.horizontal, Constants.itemListPadding)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -130,10 +130,8 @@ private extension ItemListView {
                         ItemCardView(item: item)
                     })
                 }
-                if let shouldShowGhostableItemCard = viewModel.shouldShowGhostableItemCard {
-                    GhostItemCardView()
-                        .renderedIf(shouldShowGhostableItemCard && viewModel.state == .loading)
-                }
+                GhostItemCardView()
+                    .renderedIf(viewModel.shouldShowGhostableItemCard && viewModel.state == .loading)
             }
             .padding(.bottom, floatingControlAreaSize.height)
             .padding(.horizontal, Constants.itemListPadding)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -26,7 +26,9 @@ struct PointOfSaleEntryPointView: View {
                                               currencyFormatter: currencyFormatter,
                                               paymentState: .acceptingCard)
         let cartViewModel = CartViewModel(analytics: analytics)
-        let itemListViewModel = ItemListViewModel(itemProvider: itemProvider)
+
+        let shouldShowGhostableItemCard = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.displayInfiniteScrollingUIDetailsInPointOfSale)
+        let itemListViewModel = ItemListViewModel(itemProvider: itemProvider, shouldShowGhostableItemCard: shouldShowGhostableItemCard)
 
         self._viewModel = StateObject(wrappedValue: PointOfSaleDashboardViewModel(
             cardPresentPaymentService: cardPresentPaymentService,

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -12,7 +12,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @Published private var currentPage: Int = Constants.initialPage
 
-    private(set) var shouldShowGhostableItemCard: Bool?
+    private(set) var shouldShowGhostableItemCard: Bool = false
 
     var shouldShowHeaderBanner: Bool {
         // The banner it's shown as long as it hasn't already been dismissed once:
@@ -30,7 +30,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     var itemsPublisher: Published<[POSItem]>.Publisher { $items }
     var statePublisher: Published<ItemListViewModel.ItemListState>.Publisher { $state }
 
-    init(itemProvider: POSItemProvider, shouldShowGhostableItemCard: Bool? = false) {
+    init(itemProvider: POSItemProvider, shouldShowGhostableItemCard: Bool = false) {
         self.itemProvider = itemProvider
         self.shouldShowGhostableItemCard = shouldShowGhostableItemCard
         selectedItemPublisher = selectedItemSubject.eraseToAnyPublisher()

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -12,6 +12,8 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     @Published private var currentPage: Int = Constants.initialPage
 
+    private(set) var shouldShowGhostableItemCard: Bool?
+
     var shouldShowHeaderBanner: Bool {
         // The banner it's shown as long as it hasn't already been dismissed once:
         if UserDefaults.standard.bool(forKey: BannerState.isSimpleProductsOnlyBannerDismissedKey) == true {
@@ -28,8 +30,9 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     var itemsPublisher: Published<[POSItem]>.Publisher { $items }
     var statePublisher: Published<ItemListViewModel.ItemListState>.Publisher { $state }
 
-    init(itemProvider: POSItemProvider) {
+    init(itemProvider: POSItemProvider, shouldShowGhostableItemCard: Bool? = false) {
         self.itemProvider = itemProvider
+        self.shouldShowGhostableItemCard = shouldShowGhostableItemCard
         selectedItemPublisher = selectedItemSubject.eraseToAnyPublisher()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
This PR hides the `GhostItemCardView` behind a feature flag, which is currently not working appropriately in beta: The GhostItemCardView will not disappear when we reach the end of the product list. 

Up until now we've relied on the remote feature flag for POS features, but this won't be enough to hide the feature if we plan to open the feature to merchants soon, as they'll use 21.1 and see the work in progress.

This only hides the cosmetic part added by the `GhostItemCardView` on loading, infinite scrolling remains untouched as it's working correctly in beta.

Before
![Simulator Screenshot - iPad mini (6th generation) - 2024-11-11 at 19 49 13](https://github.com/user-attachments/assets/ca390db0-9486-4168-858c-023cae4709d0)

After

![Simulator Screenshot - iPad mini (6th generation) - 2024-11-11 at 20 33 06](https://github.com/user-attachments/assets/985d7d12-b2e5-4734-9116-40f077dd8002)

Question: Passing the feature flag from the app as we do right now, without reaching the ServiceLocator directly is a cross-cutting concern that we'll face more often now that we cannot rely just on the remote flag. Would if be simpler to use alternatives like `if debug` pre-compiler flags? or a feature flag service specifically for POS to keep it encapsulated within the "module"?

## Steps to reproduce
You can test this with a POS eligible store with just a couple of items, or by:
- Create a jurassic ninja site
- Create 1 simple product
- For simplicity, edit `POSEligibilityChecker.isEligible` to return `Just(true).eraseToAnyPublisher()`, so we do not need to comply with other POS requirements.
- Switch the scheme to a release build
- Confirm the ghostable cell does not appear when loading products.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->


## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
