### PR TITLE
[Product • Global Unique Identifier] Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -3051,6 +3051,15 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .orderProductSearchViaSKUSuccess, properties: properties)
         }
 
+        static func productSearchViaGlobalUniqueIDSuccess(from source: String, stockManaged: Bool? = nil) -> WooAnalyticsEvent {
+            var properties = [Keys.source: source]
+
+            if let stockManaged = stockManaged {
+                properties["stock_managed"] = "\(stockManaged)"
+            }
+            return WooAnalyticsEvent(statName: .orderProductSearchViaGlobalUniqueIdentifierSuccess, properties: properties)
+        }
+
         static func productSearchViaSKUFailure(from source: String,
                                                     symbology: BarcodeSymbology? = nil,
                                                     reason: String) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -754,6 +754,7 @@ enum WooAnalyticsStat: String {
     case productInventorySettingsSKUScanned = "product_inventory_settings_sku_scanned"
     case productInventorySettingsGlobalUniqueIDScannerButtonTapped = "product_inventory_settings_global_unique_id_scanner_button_tapped"
     case productInventorySettingsGlobalUniqueIDScanned = "product_inventory_settings_global_unique_id_scanned"
+    case productInventorySettingsGlobalUniqueIDFieldEdited = "product_inventory_settings_global_unique_identifier_field_edited"
     case productDetailPreviewTapped = "product_detail_preview_tapped"
     case productDetailPreviewFailed = "product_detail_preview_failed"
     case productDetailViewBundledProductsTapped = "product_detail_view_bundled_products_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -546,6 +546,7 @@ enum WooAnalyticsStat: String {
     case barcodeScanningSuccess = "barcode_scanning_success"
     case barcodeScanningFailure = "barcode_scanning_failure"
     case orderProductSearchViaSKUSuccess = "product_search_via_sku_success"
+    case orderProductSearchViaGlobalUniqueIdentifierSuccess = "product_search_via_global_unique_identifier_success"
     case orderProductSearchViaSKUFailure = "product_search_via_sku_failure"
 
     // MARK: Tax Rate selector

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Yosemite
 import Experiments
+import WooFoundation
 
 /// Provides data needed for inventory settings.
 ///
@@ -94,6 +95,8 @@ final class ProductInventorySettingsViewModel: ProductInventorySettingsViewModel
 
     private(set) var errors: [ProductUpdateError] = []
 
+    private let analytics: Analytics
+
     // Sku validation
     private var skuIsValid: Bool = true
     private var globalUniqueIdIsValid: Bool = true
@@ -105,7 +108,8 @@ final class ProductInventorySettingsViewModel: ProductInventorySettingsViewModel
     init(formType: FormType,
          productModel: ProductFormDataModel,
          stores: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.formType = formType
         self.productModel = productModel
         self.stores = stores
@@ -122,6 +126,7 @@ final class ProductInventorySettingsViewModel: ProductInventorySettingsViewModel
 
         self.isStockStatusEnabled = productModel.isStockStatusEnabled()
         self.featureFlagService = featureFlagService
+        self.analytics = analytics
 
         reloadSections()
     }
@@ -232,6 +237,10 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
 
     func completeUpdating(onCompletion: (ProductInventoryEditableData) -> Void) {
         if skuIsValid && globalUniqueIdIsValid {
+            if globalUniqueID != productModel.globalUniqueID {
+                analytics.track(.productInventorySettingsGlobalUniqueIDFieldEdited)
+            }
+
             let data = ProductInventoryEditableData(sku: sku,
                                                     globalUniqueIdentifier: globalUniqueID,
                                                     manageStock: manageStockEnabled,

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/BarcodeScannerItemFinder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/BarcodeScannerItemFinder.swift
@@ -17,10 +17,10 @@ struct BarcodeScannerItemFinder {
     func searchByIdentifier(from barcode: ScannedBarcode,
                             siteID: Int64, source: WooAnalyticsEvent.BarcodeScanning.Source) async throws -> ItemIdentifierSearchResult {
         do {
-            let result = try await search(by: barcode.payloadStringValue, siteID: siteID)
-            analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaSKUSuccess(from: source.rawValue))
+            let (foundItem, searchSource) = try await search(by: barcode.payloadStringValue, siteID: siteID)
+            trackScanSuccess(from: searchSource, screenSource: source)
 
-            return result
+            return foundItem
         } catch {
             analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaSKUFailure(from: source.rawValue,
                                                                                             symbology: barcode.symbology,
@@ -36,20 +36,23 @@ struct BarcodeScannerItemFinder {
                 return try await searchByIdentifier(from: refinedBarcode, siteID: siteID, source: source)
             } else if let refinedBarcode = barcode.removeCheckDigitIfPossible() {
                 // Try one more time if we can remove the barcode check digit, as some merchants might have added the Identifier without it
-                return try await search(by: refinedBarcode.payloadStringValue, siteID: siteID)
+                let (foundItem, searchSource) = try await search(by: refinedBarcode.payloadStringValue, siteID: siteID)
+                trackScanSuccess(from: searchSource, screenSource: source)
+
+                return foundItem
             } else {
                 throw error
             }
         }
     }
 
-    private func search(by identifier: String, siteID: Int64) async throws -> ItemIdentifierSearchResult {
+    private func search(by identifier: String, siteID: Int64) async throws -> (ItemIdentifierSearchResult, ItemIdentifierSearchResultSource) {
         try await withCheckedThrowingContinuation { continuation in
             let action = ProductAction.retrieveFirstPurchasableItemMatchFromIdentifier(siteID: siteID,
                                                                         identifier: identifier) { result in
                 switch result {
-                case let .success(matchedProduct):
-                    continuation.resume(returning: matchedProduct)
+                case let .success(itemSourceTuple):
+                    continuation.resume(returning: itemSourceTuple)
                 case let .failure(error):
                     continuation.resume(throwing: error)
                 }
@@ -66,6 +69,15 @@ struct BarcodeScannerItemFinder {
         }
 
         return productLoadError.trackingReason
+    }
+
+    func trackScanSuccess(from searchSource: ItemIdentifierSearchResultSource, screenSource: WooAnalyticsEvent.BarcodeScanning.Source) {
+        switch searchSource {
+        case .SKU:
+            analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaSKUSuccess(from: screenSource.rawValue))
+        case .globalUniqueIdentifier:
+            analytics.track(event: WooAnalyticsEvent.BarcodeScanning.productSearchViaGlobalUniqueIDSuccess(from: screenSource.rawValue))
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2171,7 +2171,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             switch action {
             case .retrieveFirstPurchasableItemMatchFromIdentifier(_, _, let onCompletion):
                 let product = Product.fake().copy(productID: self.sampleSiteID, purchasable: true)
-                onCompletion(.success(.product(product)))
+                onCompletion(.success((.product(product), .SKU)))
             default:
                 break
             }
@@ -2216,7 +2216,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             switch action {
             case .retrieveFirstPurchasableItemMatchFromIdentifier(_, _, let onCompletion):
                 self?.storageManager.insertSampleProduct(readOnlyProduct: product)
-                onCompletion(.success(.product(product)))
+                onCompletion(.success((.product(product), .SKU)))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
@@ -398,4 +398,20 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertFalse(viewModel.hasUnsavedChanges())
     }
+
+    func test_completeUpdating_when_globalUniqueID_changes_then_it_tracks_value() {
+        // Arrange
+        let product = Product.fake().copy(globalUniqueID: "321")
+        let model = EditableProductModel(product: product)
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = ProductInventorySettingsViewModel(formType: .inventory, productModel: model, analytics: analytics)
+
+        // Act
+        viewModel.handleGlobalUniqueIdentifierChange("123", onValidation: { _, _ in })
+        viewModel.completeUpdating(onCompletion: { _ in })
+
+        // Assert
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.productInventorySettingsGlobalUniqueIDFieldEdited.rawValue)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Scanner/BarcodeScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Scanner/BarcodeScannerProductFinderTests.swift
@@ -88,6 +88,33 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["source"] as? String, source.rawValue)
     }
 
+    func test_findProduct_when_global_unique_id_matches_barcode_then_returns_product() async {
+        // Given
+        let source = WooAnalyticsEvent.BarcodeScanning.Source.orderList
+        let returningProduct = Product.fake()
+        stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
+            switch action {
+            case .retrieveFirstPurchasableItemMatchFromIdentifier(_, _, let onCompletion):
+                onCompletion(.success((.product(returningProduct), .globalUniqueIdentifier)))
+            default:
+                break
+            }
+        })
+
+        // When
+        let scannedBarcode = ScannedBarcode(payloadStringValue: "123456", symbology: .aztec)
+        let result = try? await sut.searchByIdentifier(from: scannedBarcode, siteID: 1, source: source)
+
+        guard case let .product(retrievedProduct) = result else {
+            return XCTFail("It didn't provide a product as expected")
+        }
+
+        // Then
+        XCTAssertEqual(retrievedProduct, returningProduct)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.orderProductSearchViaGlobalUniqueIdentifierSuccess.rawValue)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["source"] as? String, source.rawValue)
+    }
+
     func test_findProduct_when_barcode_has_check_digit_and_right_symbology_then_it_tries_without_it_and_returns_product() async {
 
         for symbology in [BarcodeSymbology.ean13, BarcodeSymbology.upce] {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Scanner/BarcodeScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Scanner/BarcodeScannerProductFinderTests.swift
@@ -68,7 +68,7 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
             case .retrieveFirstPurchasableItemMatchFromIdentifier(_, _, let onCompletion):
-                onCompletion(.success(.product(returningProduct)))
+                onCompletion(.success((.product(returningProduct), .SKU)))
             default:
                 break
             }
@@ -106,7 +106,7 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
             switch action {
             case let .retrieveFirstPurchasableItemMatchFromIdentifier(_, givenSKU, onCompletion):
                 if givenSKU == productSKU {
-                    onCompletion(.success(.product(returningProduct)))
+                    onCompletion(.success((.product(returningProduct), .SKU)))
                 } else {
                     onCompletion(.failure(ProductLoadError.notFound))
                 }
@@ -137,7 +137,7 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
             switch action {
             case let .retrieveFirstPurchasableItemMatchFromIdentifier(_, givenSKU, onCompletion):
                 if givenSKU == productSKU {
-                    onCompletion(.success(.product(returningProduct)))
+                    onCompletion(.success((.product(returningProduct), .SKU)))
                 } else {
                     onCompletion(.failure(ProductLoadError.notFound))
                 }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -7,7 +7,7 @@ public enum ItemIdentifierSearchResult {
 }
 
 /// Which property matched the looked identifier
-/// 
+///
 public enum ItemIdentifierSearchResultSource {
     case SKU
     case globalUniqueIdentifier

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -6,6 +6,13 @@ public enum ItemIdentifierSearchResult {
     case variation(ProductVariation)
 }
 
+/// Which property matched the looked identifier
+/// 
+public enum ItemIdentifierSearchResultSource {
+    case SKU
+    case globalUniqueIdentifier
+}
+
 /// ProductAction: Defines all of the Actions supported by the ProductStore.
 ///
 public enum ProductAction: Action {
@@ -72,7 +79,9 @@ public enum ProductAction: Action {
 
     /// Retrieves the first Product or Variation with exact-match SKU or, if that search is empty, global unique identifier
     ///
-    case retrieveFirstPurchasableItemMatchFromIdentifier(siteID: Int64, identifier: String, onCompletion: (Result<ItemIdentifierSearchResult, Error>) -> Void)
+    case retrieveFirstPurchasableItemMatchFromIdentifier(siteID: Int64,
+                                                         identifier: String,
+                                                         onCompletion: (Result<(ItemIdentifierSearchResult, ItemIdentifierSearchResultSource), Error>) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -415,7 +415,8 @@ private extension ProductStore {
     ///
     func retrieveFirstPurchasableItemMatchFromIdentifier(siteID: Int64,
                                                          identifier: String,
-                                                         onCompletion: @escaping (Result<(ItemIdentifierSearchResult, ItemIdentifierSearchResultSource), Error>) -> Void) {
+                                                         onCompletion: @escaping (Result<(ItemIdentifierSearchResult,
+                                                                                          ItemIdentifierSearchResultSource), Error>) -> Void) {
 
         guard !identifier.isEmpty else {
             return onCompletion(.failure(ProductLoadError.emptyIdentifier))

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -415,7 +415,7 @@ private extension ProductStore {
     ///
     func retrieveFirstPurchasableItemMatchFromIdentifier(siteID: Int64,
                                                          identifier: String,
-                                                         onCompletion: @escaping (Result<ItemIdentifierSearchResult, Error>) -> Void) {
+                                                         onCompletion: @escaping (Result<(ItemIdentifierSearchResult, ItemIdentifierSearchResultSource), Error>) -> Void) {
 
         guard !identifier.isEmpty else {
             return onCompletion(.failure(ProductLoadError.emptyIdentifier))
@@ -425,7 +425,7 @@ private extension ProductStore {
                                    keyword: identifier,
                                    completion: { result in
             switch result {
-            case let .success(products):
+            case let .success((products, source)):
                 let matchedProducts = products.filter { $0.sku == identifier || $0.globalUniqueID == identifier }
 
                 guard !matchedProducts.isEmpty else {
@@ -441,11 +441,11 @@ private extension ProductStore {
                                                                                                   siteID: siteID,
                                                                                                   productID: productVariation.productID,
                                                                                                   onCompletion: {
-                        onCompletion(.success(.variation(productVariation)))
+                        onCompletion(.success((.variation(productVariation), source)))
                     })
                 } else {
                     self.upsertStoredProductsInBackground(readOnlyProducts: [product], siteID: siteID, onCompletion: {
-                        onCompletion(.success(.product(product)))
+                        onCompletion(.success((.product(product), source)))
                     })
                 }
             case let .failure(error):
@@ -1278,7 +1278,7 @@ private extension ProductStore {
 }
 
 private extension ProductStore {
-    func searchProductsByIdentifier(siteID: Int64, keyword: String, completion: @escaping (Result<[Product], Error>) -> Void) {
+    func searchProductsByIdentifier(siteID: Int64, keyword: String, completion: @escaping (Result<([Product], ItemIdentifierSearchResultSource), Error>) -> Void) {
         remote.searchProductsBySKU(for: siteID,
                                    keyword: keyword,
                                    pageNumber: Remote.Default.firstPageNumber,
@@ -1298,10 +1298,15 @@ private extension ProductStore {
                                                               pageNumber: Remote.Default.firstPageNumber,
                                                               pageSize: ProductsRemote.Default.pageSize,
                                                               completion: { result in
-                    completion(result)
+                    switch result {
+                    case let .success(products):
+                        completion(.success((products, .globalUniqueIdentifier)))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
                 })
             } else {
-                completion(.success(returningResults))
+                completion(.success((returningResults, .SKU)))
             }
         })
     }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -2278,7 +2278,7 @@ final class ProductStoreTests: XCTestCase {
 
         let skuSearchResult = try XCTUnwrap(result.get())
 
-        guard case let .product(productMatch) = skuSearchResult else {
+        guard case let (.product(productMatch), _) = skuSearchResult else {
             return XCTFail("It didn't provide a product as expected")
         }
 
@@ -2310,7 +2310,7 @@ final class ProductStoreTests: XCTestCase {
 
         let identifierSearchResult = try XCTUnwrap(result.get())
 
-        guard case let .product(productMatch) = identifierSearchResult else {
+        guard case let (.product(productMatch), _) = identifierSearchResult else {
             return XCTFail("It didn't provide a product as expected")
         }
 
@@ -2342,7 +2342,7 @@ final class ProductStoreTests: XCTestCase {
 
         let skuSearchResult = try XCTUnwrap(result.get())
 
-        guard case let .variation(variationMatch) = skuSearchResult else {
+        guard case let (.variation(variationMatch), _) = skuSearchResult else {
             return XCTFail("It didn't provide a product as expected")
         }
 
@@ -2374,7 +2374,7 @@ final class ProductStoreTests: XCTestCase {
 
         let skuSearchResult = try XCTUnwrap(result.get())
 
-        guard case let .variation(variationMatch) = skuSearchResult else {
+        guard case let (.variation(variationMatch), _) = skuSearchResult else {
             return XCTFail("It didn't provide a product as expected")
         }
 
@@ -2446,7 +2446,7 @@ final class ProductStoreTests: XCTestCase {
 
         let skuSearchResult = try XCTUnwrap(result.get())
 
-        guard case let .product(productMatch) = skuSearchResult else {
+        guard case let (.product(productMatch), _) = skuSearchResult else {
             return XCTFail("It didn't provide a product as expected")
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14375 
<!-- Id number of the GitHub issue this PR addresses. -->
With this PR we add two tracking events for the Product Global Unique Identifier project:

- When editing the GTIN in the Product Inventory Settings
- When scanning a barcode that matches the GTIN

We implement the necessary infrastructure to achieve these goals.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Global unique identifier edited in Product Inventory Settings

1. Go to Products
2. Tap on a product
3. Tap on Inventory
4. Edit the Global Unique Identifier and tap on Done
5. Check that the string is tracked:

`🔵 Tracked product_inventory_settings_global_unique_identifier_field_edited, properties: [store_id: 3db14754-cf30-4c42-857d-d754bca1dac1, was_ecommerce_trial: false, is_wpcom_store: true, plan: business-bundle, site_url: https://americanwootester.wpcomstaging.com, blog_id: 214354650]`

### Product found by global unique identifier with the barcode scanner

Make sure you have a GTIN assigned to a product. Use https://barcode.tec-it.com/ to generate the barcode with that GTIN

1. Tap on Orders
2. Tap on the Barcode Scanner button (top left)
3. Scan the barcode with the assigned GTIN
4. See how this event is tracked:

`🔵 Tracked product_search_via_global_unique_identifier_success, properties: [was_ecommerce_trial: false, store_id: 3db14754-cf30-4c42-857d-d754bca1dac1, plan: business-bundle, site_url: https://americanwootester.wpcomstaging.com, blog_id: 214354650, is_wpcom_store: true, source: order_list]`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
I also tested:
- When the GTIN is not edited (e.g. editing just the SKU and tapping on Done) the event above isn't tracked
- When scanning a barcode that matches the SKU, the event above is not tracked

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
