### PR TITLE
[Tooling] Remove `BUILDKITE_` prefix from env vars

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -2,16 +2,8 @@
 
 echo "--- :git: Checkout Release Branch"
 
-# Note: `BUILDKITE_RELEASE_VERSION` is the legacy environment variable passed to Buildkite by ReleaseV2.
-# It used the `BUILDKITE_` prefix so it was not filtered out when passed to the MacOS VMs, due to how `hostmgr` works.
-# This is considered legacy: we should eventually remove all use of custom `BUILDKITE_` variables, and instead
-# resolve the value of those sooner (i.e. in the YML pipeline) then pass it as parameter to the `.sh` calls instead.
-
-# Use the provided argument if there's one, otherwise fall back to the legacy BUILDKITE_RELEASE_VERSION
-RELEASE_VERSION=${1:-$BUILDKITE_RELEASE_VERSION}
-
 if [[ -z "${RELEASE_VERSION}" ]]; then
-    echo "RELEASE_VERSION is not set and BUILDKITE_RELEASE_VERSION is not available."
+    echo "RELEASE_VERSION is not set."
     exit 1
 fi
 

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -4,11 +4,6 @@ RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
 
 echo "--- :git: Checkout Release Branch"
 
-if [[ -z "${RELEASE_VERSION}" ]]; then
-    echo "RELEASE_VERSION is not set."
-    exit 1
-fi
-
 # Buildkite, by default, checks out a specific commit. For many release actions, we need to be
 # on a release branch instead.
 BRANCH_NAME="release/${RELEASE_VERSION}"

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eu
 
+RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
+
 echo "--- :git: Checkout Release Branch"
 
 if [[ -z "${RELEASE_VERSION}" ]]; then


### PR DESCRIPTION

## Description
This PR removes the use of the `BUILDKITE_RELEASE_VERSION` env var in the CI pipeline files. They use will now use `RELEASE_VERSION` instead. There is a corresponding diff to update the release scenarios: https://code.a8c.com/D166034. I will hold off merging this one until that diff is deployed. 


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
