### PR TITLE
[Woo POS] Fix stores without the supported country/currency can still access POS

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -30,6 +30,9 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
                 .eraseToAnyPublisher()
         }
         return Publishers.CombineLatest(isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled)
+            .filter { [weak self] _ in
+                self?.isEligibleFromSiteChecks ?? false
+            }
             .map { $0 && $1 }
             .eraseToAnyPublisher()
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -101,12 +101,13 @@ final class POSEligibilityCheckerTests: XCTestCase {
             }
     }
 
-    func test_is_eligible_when_non_us_site_then_returns_false() throws {
+    func test_is_eligible_when_non_us_site_then_returns_false() {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         [Country.ca, Country.es, Country.gb].forEach { country in
             // When
             setupCountry(country: country)
+            accountWhitelistedInBackend(true)
             let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
                                                 cardPresentPaymentsOnboarding: onboardingUseCase,
                                                 siteSettings: siteSettings,
@@ -120,10 +121,48 @@ final class POSEligibilityCheckerTests: XCTestCase {
         }
     }
 
-    func test_is_eligible_when_non_usd_currency_then_returns_false() throws {
+    func test_is_eligible_when_non_us_site_then_returns_false_with_onboarding_feature_enabled() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true, paymentsOnboardingInPointOfSale: true)
+        [Country.ca, Country.es, Country.gb].forEach { country in
+            // When
+            setupCountry(country: country)
+            accountWhitelistedInBackend(true)
+            let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                                cardPresentPaymentsOnboarding: onboardingUseCase,
+                                                siteSettings: siteSettings,
+                                                currencySettings: Fixtures.usdCurrencySettings,
+                                                stores: stores,
+                                                featureFlagService: featureFlagService)
+            checker.isEligible.assign(to: &$isEligible)
+
+            // Then
+            XCTAssertFalse(isEligible)
+        }
+    }
+
+    func test_when_non_usd_currency_then_isEligible_returns_false() {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                            cardPresentPaymentsOnboarding: onboardingUseCase,
+                                            siteSettings: siteSettings,
+                                            currencySettings: Fixtures.nonUSDCurrencySettings,
+                                            stores: stores,
+                                            featureFlagService: featureFlagService)
+        checker.isEligible.assign(to: &$isEligible)
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_when_non_usd_currency_then_isEligible_returns_false_with_onboarding_feature_enabled() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true, paymentsOnboardingInPointOfSale: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
                                             cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14367 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

When the POS payments onboarding feature flag is enabled, the site checks (country and currency) function isn't invoked because it's currently under the onboarding state publisher. Therefore, stores with unsupported country/currency can still access POS when the onboarding feature flag is enabled (false in production, so the issue isn't expected to affect production users).

## How

First, test cases were added/updated so that the new cases with the payments onboarding feature flag fail without any changes. Then, the site checks are included as a filter on the returned published whenever the WC version or the remote feature flag changes.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- In wp-admin WC settings, set the country to be not in the US while the currency is USD
- In the app, go to Menu --> the POS row should **not** appear. before this PR, the POS row appears shortly
- In wp-admin WC settings, set the country back to the US
- Relaunch the app (so that the site settings are refreshed), go to Menu --> the POS row should appear shortly
- In wp-admin WC settings, set the currency to non-USD while the country is in the US
- Relaunch the app, go to Menu --> the POS row should **not** appear
- In wp-admin WC settings, set the currency back to USD
- Relaunch the app, go to Menu --> the POS row should appear shortly

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.6