### PR TITLE
[Blaze] Allow setting a CTA text when creating a campaign

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -437,7 +437,8 @@ extension Networking.CreateBlazeCampaign {
             targeting: .fake(),
             targetUrn: .fake(),
             type: .fake(),
-            objective: .fake()
+            objective: .fake(),
+            ctaText: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
@@ -95,6 +95,10 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
     ///
     public let objective: String?
 
+    /// Selected CTA text
+    ///
+    public let ctaText: String?
+
     public init(origin: String,
                 originVersion: String,
                 paymentMethodID: String,
@@ -111,7 +115,8 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
                 targeting: BlazeTargetOptions?,
                 targetUrn: String,
                 type: String,
-                objective: String?) {
+                objective: String?,
+                ctaText: String?) {
         self.origin = origin
         self.originVersion = originVersion
         self.paymentMethodID = paymentMethodID
@@ -129,5 +134,6 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
         self.targetUrn = targetUrn
         self.type = type
         self.objective = objective
+        self.ctaText = ctaText
     }
 }

--- a/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
@@ -97,7 +97,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
 
     /// Selected CTA text
     ///
-    public let ctaText: String?
+    public let ctaText: String
 
     public init(origin: String,
                 originVersion: String,
@@ -116,7 +116,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
                 targetUrn: String,
                 type: String,
                 objective: String?,
-                ctaText: String?) {
+                ctaText: String) {
         self.origin = origin
         self.originVersion = originVersion
         self.paymentMethodID = paymentMethodID

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -580,7 +580,7 @@ extension Networking.CreateBlazeCampaign {
         targetUrn: CopiableProp<String> = .copy,
         type: CopiableProp<String> = .copy,
         objective: NullableCopiableProp<String> = .copy,
-        ctaText: NullableCopiableProp<String> = .copy
+        ctaText: CopiableProp<String> = .copy
     ) -> Networking.CreateBlazeCampaign {
         let origin = origin ?? self.origin
         let originVersion = originVersion ?? self.originVersion

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -579,7 +579,8 @@ extension Networking.CreateBlazeCampaign {
         targeting: NullableCopiableProp<BlazeTargetOptions> = .copy,
         targetUrn: CopiableProp<String> = .copy,
         type: CopiableProp<String> = .copy,
-        objective: NullableCopiableProp<String> = .copy
+        objective: NullableCopiableProp<String> = .copy,
+        ctaText: NullableCopiableProp<String> = .copy
     ) -> Networking.CreateBlazeCampaign {
         let origin = origin ?? self.origin
         let originVersion = originVersion ?? self.originVersion
@@ -598,6 +599,7 @@ extension Networking.CreateBlazeCampaign {
         let targetUrn = targetUrn ?? self.targetUrn
         let type = type ?? self.type
         let objective = objective ?? self.objective
+        let ctaText = ctaText ?? self.ctaText
 
         return Networking.CreateBlazeCampaign(
             origin: origin,
@@ -616,7 +618,8 @@ extension Networking.CreateBlazeCampaign {
             targeting: targeting,
             targetUrn: targetUrn,
             type: type,
-            objective: objective
+            objective: objective,
+            ctaText: ctaText
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
@@ -7,7 +7,7 @@ struct BlazeEditAdData: Equatable {
     let image: MediaPickerImage?
     let tagline: String
     let description: String
-    let ctaText: String?
+    let ctaText: String
 }
 
 /// Hosting controller for `BlazeEditAdView`.

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
@@ -7,6 +7,7 @@ struct BlazeEditAdData: Equatable {
     let image: MediaPickerImage?
     let tagline: String
     let description: String
+    let ctaText: String?
 }
 
 /// Hosting controller for `BlazeEditAdView`.

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -6,6 +6,7 @@ struct BlazeEditAdView: View {
     private enum Field: Hashable {
         case tagline
         case description
+        case ctaText
     }
 
     @Environment(\.dismiss) private var dismiss
@@ -36,6 +37,8 @@ struct BlazeEditAdView: View {
                         tagline
 
                         description
+
+                        ctaText
 
                         suggestedByAI
                     }
@@ -157,6 +160,40 @@ private extension BlazeEditAdView {
 
             Text(viewModel.descriptionFooterText)
                 .foregroundStyle(viewModel.isDescriptionValidated ? .secondary : Color(.error))
+                .footnoteStyle()
+        }
+    }
+
+    var ctaText: some View {
+        VStack(alignment: .leading, spacing: Layout.textBlockVerticalSpacing) {
+            Text(Localization.CTAText.title)
+                .foregroundColor(Color(.label))
+                .subheadlineStyle()
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $viewModel.ctaText)
+                    .bodyStyle()
+                    .foregroundColor(.secondary)
+                    .padding(insets: Layout.textFieldContentInsets)
+                    .frame(minHeight: Layout.CTAText.minimumEditorHeight * scale, maxHeight: .infinity)
+                    .focused($focusedField, equals: .ctaText)
+
+                // Placeholder text
+                Text(Localization.CTAText.placeholder)
+                    .foregroundColor(Color(.placeholderText))
+                    .bodyStyle()
+                    .padding(insets: Layout.placeholderInsets)
+                    // Allows gestures to pass through to the `TextEditor`.
+                    .allowsHitTesting(false)
+                    .renderedIf(viewModel.ctaText.isEmpty)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                    .stroke(focusedField == .ctaText ? Color(.brand) : Color(.separator), lineWidth: Layout.strokeWidth)
+            )
+
+            Text(viewModel.ctaTextFooterText)
+                .foregroundStyle(viewModel.isCtaTextValidated ? .secondary : Color(.error))
                 .footnoteStyle()
         }
     }
@@ -292,6 +329,19 @@ private extension BlazeEditAdView {
                 comment: "Placeholder for Description text field in the Blaze Edit Ad screen."
             )
         }
+        enum CTAText {
+            static let title = NSLocalizedString(
+                "blazeEditAdView.ctaText.title",
+                value: "Call to Action",
+                comment: "CTA Text title text in the Blaze Edit Ad screen."
+            )
+
+            static let placeholder = NSLocalizedString(
+                "blazeEditAdView.ctaText.placeholder",
+                value: "CTA text",
+                comment: "Placeholder for CTA Text field in the Blaze Edit Ad screen."
+            )
+        }
         static let suggestedByAI = NSLocalizedString(
             "blazeEditAdView.suggestedByAI",
             value: "Suggested by AI",
@@ -324,6 +374,10 @@ private enum Layout {
 
     enum Description {
         static let minimumEditorHeight: CGFloat = 140
+    }
+
+    enum CTAText {
+        static let minimumEditorHeight: CGFloat = 54
     }
 
     enum SuggestedByAI {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -345,7 +345,8 @@ struct BlazeEditAdView_Previews: PreviewProvider {
                                          productID: 34,
                                          adData: .init(image: .init(image: .init(), source: .asset(asset: .init())),
                                                        tagline: "Tagline",
-                                                       description: "Description"),
+                                                       description: "Description",
+                                                       ctaText: "Shop now"),
                                          suggestions: [],
                                          onSave: { _ in })
         )

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -80,6 +80,10 @@ final class BlazeEditAdViewModel: ObservableObject {
         }
     }
 
+    var isCtaTextValidated: Bool {
+        ctaText.count <= Constants.ctaTextMaxLength
+    }
+
     @Published private var ctaTextRemainingLength: Int
     private var ctaTextLengthLimitLabel: String {
         let lengthText = String.pluralize(ctaTextRemainingLength,

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -111,7 +111,7 @@ final class BlazeEditAdViewModel: ObservableObject {
         return BlazeEditAdData(image: image,
                                tagline: tagline,
                                description: description,
-                               ctaText: ctaText.isEmpty ? nil : ctaText)
+                               ctaText: ctaText)
     }
 
     @Published private var selectedSuggestionIndex: Int?
@@ -152,7 +152,7 @@ final class BlazeEditAdViewModel: ObservableObject {
         }
         self.tagline = adData.tagline
         self.description = adData.description
-        self.ctaText = adData.ctaText ?? ""
+        self.ctaText = adData.ctaText
 
         self.onSave = onSave
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -71,10 +71,28 @@ final class BlazeEditAdViewModel: ObservableObject {
         return String(format: lengthText, descriptionRemainingLength)
     }
 
+    @Published var ctaText: String = ""
+    var ctaTextFooterText: String {
+        if ctaText.count > Constants.ctaTextMaxLength {
+            String.localizedStringWithFormat(Localization.ctaTextLengthExceedsLimit, Constants.ctaTextMaxLength)
+        } else {
+            ctaTextLengthLimitLabel
+        }
+    }
+
+    @Published private var ctaTextRemainingLength: Int
+    private var ctaTextLengthLimitLabel: String {
+        let lengthText = String.pluralize(ctaTextRemainingLength,
+                                          singular: Localization.LengthLimit.singular,
+                                          plural: Localization.LengthLimit.plural)
+        return String(format: lengthText, ctaTextRemainingLength)
+    }
+
     var isSaveButtonEnabled: Bool {
         guard let editedAdData,
                 taglineRemainingLength >= 0,
-                descriptionRemainingLength >= 0 else {
+                descriptionRemainingLength >= 0,
+                ctaTextRemainingLength >= 0 else {
             return false
         }
 
@@ -88,7 +106,8 @@ final class BlazeEditAdViewModel: ObservableObject {
         }
         return BlazeEditAdData(image: image,
                                tagline: tagline,
-                               description: description)
+                               description: description,
+                               ctaText: ctaText.isEmpty ? nil : ctaText)
     }
 
     @Published private var selectedSuggestionIndex: Int?
@@ -129,11 +148,13 @@ final class BlazeEditAdViewModel: ObservableObject {
         }
         self.tagline = adData.tagline
         self.description = adData.description
+        self.ctaText = adData.ctaText ?? ""
 
         self.onSave = onSave
         self.analytics = analytics
         self.taglineRemainingLength = Constants.taglineMaxLength
         self.descriptionRemainingLength = Constants.descriptionMaxLength
+        self.ctaTextRemainingLength = Constants.ctaTextMaxLength
 
         watchCharacterLimit()
         setSelectedSuggestionIfApplicable()
@@ -230,6 +251,12 @@ extension BlazeEditAdViewModel {
                 Constants.descriptionMaxLength - text.count
             }
             .assign(to: &$descriptionRemainingLength)
+
+        $ctaText
+            .map { text -> Int in
+                Constants.ctaTextMaxLength - text.count
+            }
+            .assign(to: &$ctaTextRemainingLength)
     }
 }
 
@@ -252,6 +279,7 @@ extension BlazeEditAdViewModel {
     enum Constants {
         static let taglineMaxLength = 32
         static let descriptionMaxLength = 140
+        static let ctaTextMaxLength = 26
     }
 
     enum Localization {
@@ -290,6 +318,11 @@ extension BlazeEditAdViewModel {
             "blazeEditAdViewModel.description.lengthExceedsLimit",
             value: "Description cannot exceed %1$d characters",
             comment: "Edit Blaze Ad screen: Error message if Description exceeds the character limit."
+        )
+        static let ctaTextLengthExceedsLimit = NSLocalizedString(
+            "blazeEditAdViewModel.ctaText.lengthExceedsLimit",
+            value: "CTA Text cannot exceed %1$d characters",
+            comment: "Edit Blaze Ad screen: Error message if CTA Text exceeds the character limit."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -293,13 +293,27 @@ private extension BlazeCampaignCreationForm {
 
                     Spacer()
 
-                    // Simulate shop button
-                    Text(Localization.shopNow)
-                        .fontWeight(.semibold)
-                        .captionStyle()
-                        .padding(Layout.contentMargin)
-                        .background(Color(uiColor: .systemGray6))
+                    if !viewModel.isLoadingAISuggestions,
+                       viewModel.ctaText.isNilOrEmpty {
+                        // Show a blue circle with an arrow if CTA is empty
+                        Image(systemName: "chevron.right.circle.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: Layout.ctaDefaultButtonSize, height: Layout.ctaDefaultButtonSize)
+                            .foregroundColor(Constants.ctaButtonColor)
+                    }
+                }
+
+                if !viewModel.isLoadingAISuggestions,
+                   viewModel.ctaText?.isNotEmpty == true {
+                    Text(viewModel.ctaText ?? "")
+                        .font(.system(size: Constants.ctaButtonFontSize))
+                        .foregroundColor(Constants.backgroundViewColor)
+                        .padding(Layout.ctaButtonPadding)
+                        .background(Constants.ctaButtonColor)
                         .cornerRadius(Layout.adButtonCornerRadius)
+                        .padding(.top, Layout.ctaButtonTopMargin)
+
                 }
             }
             .padding(Layout.contentPadding)
@@ -415,6 +429,9 @@ private extension BlazeCampaignCreationForm {
         static let shadowYOffset: CGFloat = 2
         static let maxWidth: CGFloat = 525
         static let sparkleIconSize: CGFloat = 24
+        static let ctaDefaultButtonSize: CGFloat = 40
+        static let ctaButtonPadding = EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
+        static let ctaButtonTopMargin: CGFloat = 4
     }
 
     enum Constants {
@@ -422,6 +439,11 @@ private extension BlazeCampaignCreationForm {
                                                dark: .init(uiColor: .secondarySystemBackground))
         static let cellColor = Color(light: .init(uiColor: .systemBackground),
                                      dark: .init(uiColor: .tertiarySystemBackground))
+        static let ctaButtonColor = Color(red: 0, green: 0.219, blue: 1)
+
+        static let ctaButtonTextColor = Color.white
+
+        static let ctaButtonFontSize: CGFloat = 13
 
         static let supportTag = "origin:blaze-native-campaign-creation"
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -294,7 +294,7 @@ private extension BlazeCampaignCreationForm {
                     Spacer()
 
                     if !viewModel.isLoadingAISuggestions,
-                       viewModel.ctaText.isNilOrEmpty {
+                       viewModel.ctaText.isEmpty {
                         // Show a blue circle with an arrow if CTA is empty
                         Image(systemName: "chevron.right.circle.fill")
                             .resizable()
@@ -305,8 +305,8 @@ private extension BlazeCampaignCreationForm {
                 }
 
                 if !viewModel.isLoadingAISuggestions,
-                   viewModel.ctaText?.isNotEmpty == true {
-                    Text(viewModel.ctaText ?? "")
+                   viewModel.ctaText.isNotEmpty {
+                    Text(viewModel.ctaText)
                         .font(.system(size: Constants.ctaButtonFontSize))
                         .foregroundColor(Constants.backgroundViewColor)
                         .padding(Layout.ctaButtonPadding)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -36,7 +36,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
             updateIsUsingAISuggestions()
         }
     }
-    @Published private(set) var ctaText: String? = nil
+    @Published private(set) var ctaText: String = ""
 
     // Whether the campaign should have no end date
     private var isEvergreen: Bool

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -95,6 +95,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
             self.image = adData.image
             self.tagline = adData.tagline
             self.description = adData.description
+            self.ctaText = adData.ctaText
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -36,6 +36,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
             updateIsUsingAISuggestions()
         }
     }
+    @Published private(set) var ctaText: String? = nil
 
     // Whether the campaign should have no end date
     private var isEvergreen: Bool
@@ -83,7 +84,8 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     var editAdViewModel: BlazeEditAdViewModel {
         let adData = BlazeEditAdData(image: image,
                                      tagline: tagline,
-                                     description: description)
+                                     description: description,
+                                     ctaText: ctaText)
         return BlazeEditAdViewModel(siteID: siteID,
                                     productID: productID,
                                     adData: adData,
@@ -260,7 +262,8 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                             targeting: targetOptions,
                             targetUrn: targetUrn,
                             type: Constants.campaignType,
-                            objective: campaignObjective?.id)
+                            objective: campaignObjective?.id,
+                            ctaText: ctaText)
     }
 
     private let locale: Locale

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -365,7 +365,8 @@ private extension BlazeConfirmPaymentView {
                             targeting: nil,
                             targetUrn: "",
                             type: "product",
-                            objective: "sales"),
+                            objective: "sales",
+                            ctaText: "Shop now"),
         image: .init(image: .iconBolt, source: .asset(asset: PHAsset())),
         onCompletion: {}))
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -332,7 +332,7 @@ final class BlazeEditAdViewModelTests: XCTestCase {
                                        adData: BlazeEditAdData(image: nil,
                                                                tagline: "Sample Tagline",
                                                                description: "Sample description",
-                                                               ctaText: nil),
+                                                               ctaText: "Sample CTA"),
                                        suggestions: [.fake()],
                                        onSave: { _ in })
 
@@ -425,7 +425,7 @@ final class BlazeEditAdViewModelTests: XCTestCase {
                                        adData: BlazeEditAdData(image: nil,
                                                                tagline: "Sample Tagline",
                                                                description: "Sample description",
-                                                               ctaText: nil),
+                                                               ctaText: "Sample CTA"),
                                        suggestions: [.fake()],
                                        onSave: { _ in })
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -9,7 +9,8 @@ final class BlazeEditAdViewModelTests: XCTestCase {
     private let sampleAdData = BlazeEditAdData(image: MediaPickerImage(image: UIImage.emailImage,
                                                                        source: .media(media: .fake())),
                                                tagline: "Sample Tagline",
-                                               description: "Sample description")
+                                               description: "Sample description",
+                                               ctaText: "Sample CTA")
 
     private let sampleAISuggestions = [BlazeAISuggestion(siteName: "First suggested tagline", textSnippet: "First suggested description"),
                                        BlazeAISuggestion(siteName: "Second suggested tagline", textSnippet: "Second suggested description"),
@@ -212,6 +213,84 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         XCTAssertEqual(sut.descriptionFooterText, expectedMessage)
     }
 
+    // MARK: CTA
+    func test_ctaText_footer_text_is_plural_when_multiple_characters_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       productID: 34,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+        // When
+        sut.ctaText = sampleString(length: 1)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.plural, 25)
+        XCTAssertEqual(sut.ctaTextFooterText, expectedString)
+    }
+
+    func test_ctaText_footer_text_is_singular_when_one_character_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       productID: 34,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+        // When
+        sut.ctaText = sampleString(length: 25)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.singular, 1)
+        XCTAssertEqual(sut.ctaTextFooterText, expectedString)
+    }
+
+    func test_ctaText_footer_text_is_plural_when_zero_characters_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       productID: 34,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+        // When
+        sut.ctaText = sampleString(length: 26)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.plural, 0)
+        XCTAssertEqual(sut.ctaTextFooterText, expectedString)
+    }
+
+    func test_ctaText_footer_text_is_plural_when_empty() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       productID: 34,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.ctaText = ""
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.plural, 26)
+        XCTAssertEqual(sut.ctaTextFooterText, expectedString)
+    }
+
+    func test_ctaText_footer_text_shows_error_when_tagline_exceeds_limit() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       productID: 34,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.ctaText = String(repeating: "a", count: BlazeEditAdViewModel.Constants.ctaTextMaxLength + 1)
+
+        // Then
+        let expectedMessage = String(format: BlazeEditAdViewModel.Localization.ctaTextLengthExceedsLimit, BlazeEditAdViewModel.Constants.ctaTextMaxLength)
+        XCTAssertEqual(sut.ctaTextFooterText, expectedMessage)
+    }
+
     // MARK: Save button
     func test_save_button_is_disabled_when_no_change_made_to_ad_data() {
         // Given
@@ -252,7 +331,8 @@ final class BlazeEditAdViewModelTests: XCTestCase {
                                        productID: 34,
                                        adData: BlazeEditAdData(image: nil,
                                                                tagline: "Sample Tagline",
-                                                               description: "Sample description"),
+                                                               description: "Sample description",
+                                                               ctaText: nil),
                                        suggestions: [.fake()],
                                        onSave: { _ in })
 
@@ -308,6 +388,21 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isSaveButtonEnabled)
     }
 
+    func test_save_button_is_disabled_when_cta_exceeds_character_limit() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       productID: 34,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.ctaText = String(repeating: "a", count: BlazeEditAdViewModel.Constants.ctaTextMaxLength + 1)
+
+        // Then
+        XCTAssertFalse(sut.isSaveButtonEnabled)
+    }
+
     func test_save_button_is_disabled_when_description_exceeds_character_limit() {
         // Given
         let sut = BlazeEditAdViewModel(siteID: 123,
@@ -329,7 +424,8 @@ final class BlazeEditAdViewModelTests: XCTestCase {
                                        productID: 34,
                                        adData: BlazeEditAdData(image: nil,
                                                                tagline: "Sample Tagline",
-                                                               description: "Sample description"),
+                                                               description: "Sample description",
+                                                               ctaText: nil),
                                        suggestions: [.fake()],
                                        onSave: { _ in })
 
@@ -520,7 +616,8 @@ final class BlazeEditAdViewModelTests: XCTestCase {
                                        adData: BlazeEditAdData(image: MediaPickerImage(image: UIImage.emailImage,
                                                                                        source: .media(media: .fake())),
                                                                tagline: sampleAISuggestions[1].siteName,
-                                                               description: sampleAISuggestions[1].textSnippet),
+                                                               description: sampleAISuggestions[1].textSnippet,
+                                                               ctaText: sampleAdData.ctaText),
                                        suggestions: sampleAISuggestions,
                                        onSave: { _ in })
 
@@ -594,7 +691,8 @@ final class BlazeEditAdViewModelTests: XCTestCase {
                                        adData: BlazeEditAdData(image: MediaPickerImage(image: UIImage.emailImage,
                                                                                        source: .media(media: .fake())),
                                                                tagline: sampleAISuggestions[1].siteName,
-                                                               description: sampleAISuggestions[1].textSnippet),
+                                                               description: sampleAISuggestions[1].textSnippet,
+                                                               ctaText: sampleAdData.ctaText),
                                        suggestions: sampleAISuggestions,
                                        analytics: analytics,
                                        onSave: { _ in })
@@ -619,7 +717,8 @@ final class BlazeEditAdViewModelTests: XCTestCase {
                                        adData: BlazeEditAdData(image: MediaPickerImage(image: UIImage.emailImage,
                                                                                        source: .media(media: .fake())),
                                                                tagline: sampleAISuggestions[1].siteName,
-                                                               description: sampleAISuggestions[1].textSnippet),
+                                                               description: sampleAISuggestions[1].textSnippet,
+                                                               ctaText: sampleAdData.ctaText),
                                        suggestions: sampleAISuggestions,
                                        analytics: analytics,
                                        onSave: { _ in })


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14371 
Closes: #14372 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds support for setting a CTA text on the created campaign, it updates the following:
- Adds a new field `ctaText` to the networking model.
- Updates the Ad editor screen to allow changing the CTA text value.
- Updates the Ad preview to highlight the selected CTA text, the preview is also updated to match the web design to be a more accurate representation of how the ad would look.

For now, the CTA text is empty by default, in my next PR, I'll add logic to use AI to pre-fill it like the tagline and description.

## Steps to reproduce
1. Use a site eligible for Blaze.
2. Open the app.
3. Start creating a campaign.

## Testing information
- Confirm the CTA text updates are reflected on the preview.
- Confirm how the preview looks when the CTA text is empty.
- Create a campaign, and confirm the correct CTA text in the campaign details.

## Screenshots

https://github.com/user-attachments/assets/55448d26-6bc4-4ec2-91a9-5fe0804811ab

**Web preview**
| With CTA text | Without CTA Text |
| --- | --- |
| <img width="372" alt="Screenshot 2024-11-12 at 16 02 04" src="https://github.com/user-attachments/assets/eab46e9c-2cb6-4882-b356-63349f6b563e"> | <img width="372" alt="Screenshot 2024-11-12 at 16 02 17" src="https://github.com/user-attachments/assets/c236dd80-40f3-4c42-9777-d7e120556996"> |



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.