### PR TITLE
[Woo POS] Inject POSModel through the environment

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -6,11 +6,10 @@ struct ItemListView: View {
     @Environment(\.floatingControlAreaSize) var floatingControlAreaSize: CGSize
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-    @ObservedObject var posModel: PointOfSaleAggregateModel
+    @EnvironmentObject var posModel: PointOfSaleAggregateModel
 
-    init(viewModel: ItemListViewModel, posModel: PointOfSaleAggregateModel) {
+    init(viewModel: ItemListViewModel) {
         self.viewModel = viewModel
-        self.posModel = posModel
     }
 
     var body: some View {
@@ -249,7 +248,6 @@ private extension ItemListView {
 
 #if DEBUG
 #Preview {
-    ItemListView(viewModel: ItemListViewModel(posModel: PointOfSaleAggregateModel(itemProvider: POSItemProviderPreview())),
-                 posModel: PointOfSaleAggregateModel(itemProvider: POSItemProviderPreview()))
+    ItemListView(viewModel: ItemListViewModel(posModel: PointOfSaleAggregateModel(itemProvider: POSItemProviderPreview())))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -1,18 +1,16 @@
 import SwiftUI
 
 struct PointOfSaleDashboardView: View {
-    @ObservedObject private var posModel: PointOfSaleAggregateModel
+    @EnvironmentObject private var posModel: PointOfSaleAggregateModel
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
     @ObservedObject private var totalsViewModel: TotalsViewModel
     @ObservedObject private var cartViewModel: CartViewModel
     @ObservedObject private var itemListViewModel: ItemListViewModel
 
-    init(posModel: PointOfSaleAggregateModel,
-         viewModel: PointOfSaleDashboardViewModel,
+    init(viewModel: PointOfSaleDashboardViewModel,
          totalsViewModel: TotalsViewModel,
          cartViewModel: CartViewModel,
          itemListViewModel: ItemListViewModel) {
-        self.posModel = posModel
         self.viewModel = viewModel
         self.totalsViewModel = totalsViewModel
         self.cartViewModel = cartViewModel
@@ -192,8 +190,7 @@ private extension PointOfSaleDashboardView {
     }
 
     var productListView: some View {
-        ItemListView(viewModel: itemListViewModel,
-                     posModel: posModel)
+        ItemListView(viewModel: itemListViewModel)
     }
 }
 
@@ -216,8 +213,7 @@ import class WooFoundation.MockAnalyticsProviderPreview
                                               connectivityObserver: POSConnectivityObserverPreview())
 
     return NavigationStack {
-        PointOfSaleDashboardView(posModel: PointOfSaleAggregateModel(itemProvider: POSItemProviderPreview()),
-                                 viewModel: posVM,
+        PointOfSaleDashboardView(viewModel: posVM,
                                  totalsViewModel: totalsVM,
                                  cartViewModel: cartVM,
                                  itemListViewModel: itemsListVM)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -46,12 +46,12 @@ struct PointOfSaleEntryPointView: View {
     }
 
     var body: some View {
-        PointOfSaleDashboardView(posModel: posModel,
-                                 viewModel: viewModel,
+        PointOfSaleDashboardView(viewModel: viewModel,
                                  totalsViewModel: totalsViewModel,
                                  cartViewModel: cartViewModel,
                                  itemListViewModel: itemListViewModel)
         .environmentObject(posModalManager)
+        .environmentObject(posModel)
         .onAppear {
             onPointOfSaleModeActiveStateChange(true)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the ItemList to get the POSModel from the environment, as part of the architectural changes.

The view models still need it passed in, but they won’t be around for too long with the future architectural changes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

At the moment this only has implications for the ItemList; you can simply check that CI passes and that the app doesn't crash when we get to the ItemListView (which would happen if we didn't inject the posModel into the environment from the entry view.

I've tested on an iPad Air running iOS 17.7

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.