### PR TITLE
[Shipping labels] Add support for requesting shipping rates in Networking layer

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -800,6 +800,8 @@
 		CE0A0F1B223989670075ED8D /* ProductsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1A223989670075ED8D /* ProductsRemote.swift */; };
 		CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */; };
 		CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0A0F1E223998A00075ED8D /* products-load-all.json */; };
+		CE0F4EC92CE37547006339BD /* wooshipping-get-label-rates-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0F4EC82CE3753F006339BD /* wooshipping-get-label-rates-success.json */; };
+		CE0F4ECD2CE375E4006339BD /* wooshipping-get-label-rates-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0F4ECC2CE375DD006339BD /* wooshipping-get-label-rates-error.json */; };
 		CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */; };
 		CE12AE9729F2AB3F0056DD17 /* SubscriptionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */; };
 		CE12AE9929F2AC2F0056DD17 /* subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9829F2AC2F0056DD17 /* subscription.json */; };
@@ -1966,6 +1968,8 @@
 		CE0A0F1A223989670075ED8D /* ProductsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsRemote.swift; sourceTree = "<group>"; };
 		CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMapperTests.swift; sourceTree = "<group>"; };
 		CE0A0F1E223998A00075ED8D /* products-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-load-all.json"; sourceTree = "<group>"; };
+		CE0F4EC82CE3753F006339BD /* wooshipping-get-label-rates-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-get-label-rates-success.json"; sourceTree = "<group>"; };
+		CE0F4ECC2CE375DD006339BD /* wooshipping-get-label-rates-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-get-label-rates-error.json"; sourceTree = "<group>"; };
 		CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-subscription-renewal.json"; sourceTree = "<group>"; };
 		CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionMapper.swift; sourceTree = "<group>"; };
 		CE12AE9829F2AC2F0056DD17 /* subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = subscription.json; sourceTree = "<group>"; };
@@ -3486,6 +3490,8 @@
 				453954D12C90D84200A3E64A /* meta-data-products-and-orders.json */,
 				453954D52C9193BC00A3E64A /* meta-data-products-orders-update.json */,
 				95122E3D2CB82C0A0079FF0A /* generate-product-success-wrapped.json */,
+				CE0F4EC82CE3753F006339BD /* wooshipping-get-label-rates-success.json */,
+				CE0F4ECC2CE375DD006339BD /* wooshipping-get-label-rates-error.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4237,6 +4243,7 @@
 				3158FE7C26129E2100E566B9 /* wcpay-account-restricted-pending.json in Resources */,
 				DE34051B28BDF12C00CF0D97 /* jetpack-connection-url.json in Resources */,
 				D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */,
+				CE0F4ECD2CE375E4006339BD /* wooshipping-get-label-rates-error.json in Resources */,
 				CC01CE5829B0EBED004FF537 /* product-bundle.json in Resources */,
 				4599FC5C24A6276F0056157A /* product-tags-all.json in Resources */,
 				DEA493742B3997ED00EED015 /* blaze-target-devices.json in Resources */,
@@ -4394,6 +4401,7 @@
 				0313651B28AE60E000EEE571 /* payment-gateway-cod.json in Resources */,
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
 				3158FE7426129D9F00E566B9 /* wcpay-account-rejected-other.json in Resources */,
+				CE0F4EC92CE37547006339BD /* wooshipping-get-label-rates-success.json in Resources */,
 				CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */,
 				EE57C144297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json in Resources */,
 				028CB71B290224D700331C09 /* create-account-error-username.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -802,6 +802,7 @@
 		CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0A0F1E223998A00075ED8D /* products-load-all.json */; };
 		CE0F4EC92CE37547006339BD /* wooshipping-get-label-rates-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0F4EC82CE3753F006339BD /* wooshipping-get-label-rates-success.json */; };
 		CE0F4ECD2CE375E4006339BD /* wooshipping-get-label-rates-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0F4ECC2CE375DD006339BD /* wooshipping-get-label-rates-error.json */; };
+		CE0F4ECF2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0F4ECE2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift */; };
 		CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */; };
 		CE12AE9729F2AB3F0056DD17 /* SubscriptionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */; };
 		CE12AE9929F2AC2F0056DD17 /* subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9829F2AC2F0056DD17 /* subscription.json */; };
@@ -1970,6 +1971,7 @@
 		CE0A0F1E223998A00075ED8D /* products-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-load-all.json"; sourceTree = "<group>"; };
 		CE0F4EC82CE3753F006339BD /* wooshipping-get-label-rates-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-get-label-rates-success.json"; sourceTree = "<group>"; };
 		CE0F4ECC2CE375DD006339BD /* wooshipping-get-label-rates-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-get-label-rates-error.json"; sourceTree = "<group>"; };
+		CE0F4ECE2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingLabelRatesMapper.swift; sourceTree = "<group>"; };
 		CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-subscription-renewal.json"; sourceTree = "<group>"; };
 		CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionMapper.swift; sourceTree = "<group>"; };
 		CE12AE9829F2AC2F0056DD17 /* subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = subscription.json; sourceTree = "<group>"; };
@@ -3599,6 +3601,7 @@
 				CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */,
 				CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */,
 				CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */,
+				CE0F4ECE2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift */,
 				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
 				077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */,
@@ -5164,6 +5167,7 @@
 				D8FBFF0D22D3AF4A006E3336 /* StatsGranularityV4.swift in Sources */,
 				261870782540A252006522A1 /* ShippingLineTax.swift in Sources */,
 				DEB3878C2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift in Sources */,
+				CE0F4ECF2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift in Sources */,
 				EE998150295AACE10074AE68 /* RequestConverter.swift in Sources */,
 				74046E1B217A684D007DD7BF /* SiteSettingsRemote.swift in Sources */,
 				0359EA1D27AADE000048DE2D /* WCPayChargeMapper.swift in Sources */,

--- a/Networking/Networking/Mapper/WooShippingLabelRatesMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingLabelRatesMapper.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+
+/// Mapper: WooShipping Label Rates Data
+///
+struct WooShippingLabelRatesMapper: Mapper {
+    /// (Attempts) to convert a dictionary into ShippingLabelCarriersAndRates array.
+    ///
+    func map(response: Data) throws -> [ShippingLabelCarriersAndRates] {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(ShippingLabelDataEnvelope.self, from: response).data.boxes
+        } else {
+            return try decoder.decode(ShippingLabelDefaultBoxEnvelope.self, from: response).boxes
+        }
+    }
+}
+
+/// ShippingLabelDataEnvelope Disposable Entity:
+/// `Carriers and Rates Shipping Label` endpoint returns the shipping label document under `data` -> `default_box`  key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ShippingLabelDataEnvelope: Decodable {
+    let data: ShippingLabelDefaultBoxEnvelope
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}
+
+private struct ShippingLabelDefaultBoxEnvelope: Decodable {
+    let boxes: [ShippingLabelCarriersAndRates]
+
+    init(from decoder: Decoder) throws {
+
+        let container = try decoder.singleValueContainer()
+        let dictionary = try container.decode([String: ShippingLabelCarriersAndRates].self)
+
+        boxes = dictionary.map { key, value in
+            return ShippingLabelCarriersAndRates(packageID: key,
+                                                 defaultRates: value.defaultRates,
+                                                 signatureRequired: value.signatureRequired,
+                                                 adultSignatureRequired: value.adultSignatureRequired)
+        }
+    }
+}

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -5,6 +5,12 @@ public protocol WooShippingRemoteProtocol {
                        customPackage: WooShippingCustomPackage?,
                        predefinedOption: WooShippingPredefinedOption?,
                        completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void)
+    func loadLabelRates(siteID: Int64,
+                        orderID: Int64,
+                        originAddress: ShippingLabelAddress,
+                        destinationAddress: ShippingLabelAddress,
+                        packages: [ShippingLabelPackageSelected],
+                        completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -53,17 +59,59 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    /// Loads shipping rates for a given order.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site.
+    ///   - orderID: ID of the order.
+    ///   - originAddress: the origin address entity.
+    ///   - destinationAddress: the destination address entity.
+    ///   - packages: The package previously selected with all their data.
+    ///   - completion: Closure to be executed upon completion.
+    public func loadLabelRates(siteID: Int64,
+                               orderID: Int64,
+                               originAddress: ShippingLabelAddress,
+                               destinationAddress: ShippingLabelAddress,
+                               packages: [ShippingLabelPackageSelected],
+                               completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
+        do {
+            let parameters: [String: Any] = [
+                ParameterKey.orderID: orderID,
+                ParameterKey.originAddress: try originAddress.toDictionary(),
+                ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
+                ParameterKey.packages: try packages.map { try $0.toDictionary() }
+            ]
+            let path = Path.rates
+            let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                         method: .post,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
+            let mapper = WooShippingLabelRatesMapper()
+
+            enqueue(request, mapper: mapper, completion: completion)
+        }
+        catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constants
 private extension WooShippingRemote {
     enum Path {
         static let packages = "packages"
+        static let rates = "label/rate"
     }
 
     enum ParameterKey {
         static let custom = "custom"
         static let predefined = "predefined"
+        static let orderID = "order_id"
+        static let originAddress = "origin"
+        static let destinationAddress = "destination"
+        static let packages = "packages"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -77,4 +77,62 @@ final class WooShippingRemoteTests: XCTestCase {
         let expectedError = WooShippingRemote.ShippingError.missingPackage
         XCTAssertEqual(result.failure as? WooShippingRemote.ShippingError, expectedError)
     }
+
+    func test_loadLabelRates_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/rate", filename: "wooshipping-get-label-rates-success")
+        let expectedDefaultRate = sampleLabelRate()
+
+        // When
+        let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
+            remote.loadLabelRates(siteID: self.sampleSiteID,
+                                  orderID: self.sampleOrderID,
+                                  originAddress: ShippingLabelAddress.fake(), destinationAddress: ShippingLabelAddress.fake(),
+                                  packages: [ShippingLabelPackageSelected.fake()]) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        let successResponse = try XCTUnwrap(result.get())
+        XCTAssertEqual(successResponse.first?.defaultRates.first, expectedDefaultRate)
+    }
+
+    func test_loadLabelRates_returns_error_on_failure() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/rate", filename: "generic_error")
+
+        // When
+        let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
+            remote.loadLabelRates(siteID: self.sampleSiteID,
+                                  orderID: self.sampleOrderID,
+                                  originAddress: ShippingLabelAddress.fake(), destinationAddress: ShippingLabelAddress.fake(),
+                                  packages: [ShippingLabelPackageSelected.fake()]) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
+}
+
+private extension WooShippingRemoteTests {
+    func sampleLabelRate() -> ShippingLabelCarrierRate {
+        ShippingLabelCarrierRate(title: "USPS - Media Mail",
+                                 insurance: "0.0",
+                                 retailRate: 6.13,
+                                 rate: 6.13,
+                                 rateID: "rate_fd16937cc3a14cb9b28e160a06cf3e34",
+                                 serviceID: "MediaMail",
+                                 carrierID: "usps",
+                                 shipmentID: "shp_abc123",
+                                 hasTracking: true,
+                                 isSelected: false,
+                                 isPickupFree: false,
+                                 deliveryDays: 7,
+                                 deliveryDateGuaranteed: false)
+    }
 }

--- a/Networking/NetworkingTests/Responses/wooshipping-get-label-rates-error.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-get-label-rates-error.json
@@ -1,0 +1,4 @@
+{
+    "error": "rest_missing_callback_param",
+    "message": "Missing parameter(s): order_id, origin, destination, packages"
+}

--- a/Networking/NetworkingTests/Responses/wooshipping-get-label-rates-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-get-label-rates-success.json
@@ -1,0 +1,208 @@
+{
+    "data": {
+        "default_box": {
+            "default": {
+                "rates": [
+                    {
+                        "rate_id": "rate_fd16937cc3a14cb9b28e160a06cf3e34",
+                        "service_id": "MediaMail",
+                        "carrier_id": "usps",
+                        "title": "USPS - Media Mail",
+                        "rate": 6.13,
+                        "retail_rate": 6.13,
+                        "list_rate": 6.13,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 0,
+                        "free_pickup": false,
+                        "shipment_id": "shp_abc123",
+                        "delivery_days": 7,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_82ad68eb8b8e4618a5b1d0fcac94b39c",
+                        "service_id": "GroundAdvantage",
+                        "carrier_id": "usps",
+                        "title": "USPS - Ground Advantage",
+                        "rate": 8.35,
+                        "retail_rate": 19.1,
+                        "list_rate": 8.82,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abc123",
+                        "delivery_days": 5,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_60d0fbdca8de4158b50e3b64d1d139b9",
+                        "service_id": "Priority",
+                        "carrier_id": "usps",
+                        "title": "USPS - Priority Mail",
+                        "rate": 11.55,
+                        "retail_rate": 24,
+                        "list_rate": 12.2,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abc123",
+                        "delivery_days": 2,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_7a6965218fd540be8c08cbad6a9d8668",
+                        "service_id": "Express",
+                        "carrier_id": "usps",
+                        "title": "USPS - Express Mail",
+                        "rate": 62.8,
+                        "retail_rate": 73.6,
+                        "list_rate": 62.8,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abc123",
+                        "delivery_days": 1,
+                        "delivery_date_guaranteed": true,
+                        "delivery_date": "2024-11-13T00:00:00.000Z"
+                    }
+                ],
+                "errors": []
+            },
+            "signature_required": {
+                "rates": [
+                    {
+                        "rate_id": "rate_25c158c0ea9141c8823bec1c3606cf4c",
+                        "service_id": "MediaMail",
+                        "carrier_id": "usps",
+                        "title": "USPS - Media Mail",
+                        "rate": 9.83,
+                        "retail_rate": 9.83,
+                        "list_rate": 9.83,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 0,
+                        "free_pickup": false,
+                        "shipment_id": "shp_abcd1234",
+                        "delivery_days": 7,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_ee6e04a24c2c48c9a59de29f4e6da21d",
+                        "service_id": "GroundAdvantage",
+                        "carrier_id": "usps",
+                        "title": "USPS - Ground Advantage",
+                        "rate": 12.05,
+                        "retail_rate": 23.65,
+                        "list_rate": 12.52,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abcd1234",
+                        "delivery_days": 5,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_eb9e1ef3080b41d687ed9e7d9323c50f",
+                        "service_id": "Priority",
+                        "carrier_id": "usps",
+                        "title": "USPS - Priority Mail",
+                        "rate": 15.25,
+                        "retail_rate": 28.55,
+                        "list_rate": 15.9,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abcd1234",
+                        "delivery_days": 2,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_aac28b724e674be6a54de85112a2d836",
+                        "service_id": "Express",
+                        "carrier_id": "usps",
+                        "title": "USPS - Express Mail",
+                        "rate": 62.8,
+                        "retail_rate": 73.6,
+                        "list_rate": 62.8,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abcd1234",
+                        "delivery_days": 1,
+                        "delivery_date_guaranteed": true,
+                        "delivery_date": "2024-11-13T00:00:00.000Z"
+                    }
+                ],
+                "errors": []
+            },
+            "adult_signature_required": {
+                "rates": [
+                    {
+                        "rate_id": "rate_d208059ec3514b52847cb14a5f0158c7",
+                        "service_id": "GroundAdvantage",
+                        "carrier_id": "usps",
+                        "title": "USPS - Ground Advantage",
+                        "rate": 17.7,
+                        "retail_rate": 28.45,
+                        "list_rate": 18.17,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abcde12345",
+                        "delivery_days": 5,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_7f794c69d3ab49978e285e190c4bbb81",
+                        "service_id": "Priority",
+                        "carrier_id": "usps",
+                        "title": "USPS - Priority Mail",
+                        "rate": 20.9,
+                        "retail_rate": 33.35,
+                        "list_rate": 21.55,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abcde12345",
+                        "delivery_days": 2,
+                        "delivery_date_guaranteed": false,
+                        "delivery_date": null
+                    },
+                    {
+                        "rate_id": "rate_8fa8e793820e485a957f8444a97896b2",
+                        "service_id": "Express",
+                        "carrier_id": "usps",
+                        "title": "USPS - Express Mail",
+                        "rate": 72.15,
+                        "retail_rate": 82.95,
+                        "list_rate": 72.15,
+                        "is_selected": false,
+                        "tracking": true,
+                        "insurance": 100,
+                        "free_pickup": true,
+                        "shipment_id": "shp_abcde12345",
+                        "delivery_days": 1,
+                        "delivery_date_guaranteed": true,
+                        "delivery_date": "2024-11-13T00:00:00.000Z"
+                    }
+                ],
+                "errors": []
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -37,4 +37,13 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
             }
         }
     }
+
+    func loadLabelRates(siteID: Int64,
+                        orderID: Int64,
+                        originAddress: ShippingLabelAddress,
+                        destinationAddress: ShippingLabelAddress,
+                        packages: [ShippingLabelPackageSelected],
+                        completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
+        // no-op
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14391
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Networking layer for requesting the shipping rates for a shipment in the Woo Shipping label flow, provided the order ID, origin address, destination address, and selected package(s).

The data models are unchanged from the legacy shipping label models, but along with the new endpoint in `WooShippingRemote` this introduces a new mapper for decoding the response.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This endpoint is not yet used in the app; confirm unit tests pass.

I have also tested firing a request from within the app using test code with this endpoint, and confirmed the response was decoded as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.