### PR TITLE
[Shipping labels] Add Yosemite support for loading label rates

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -200,6 +200,8 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
             case let .createPackage(_, _, _, completion):
                 completion(.success(WooShippingCreatePackageResponse(customPackages: [WooShippingCustomPackage.fake().copy(id: "1", name: packageName)],
                                                                      predefinedOptions: [])))
+            default:
+                XCTFail("Received unexpected action: \(action)")
             }
         }
 

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -7,4 +7,13 @@ public enum WooShippingAction: Action {
                        customPackage: WooShippingCustomPackage? = nil,
                        predefinedOption: WooShippingPredefinedOption? = nil,
                        completion: (Result<WooShippingCreatePackageResponse, PackageCreationError>) -> Void)
+
+    /// Fetch list of shipping label rates for the order.
+    ///
+    case loadLabelRates(siteID: Int64,
+                        orderID: Int64,
+                        originAddress: ShippingLabelAddress,
+                        destinationAddress: ShippingLabelAddress,
+                        packages: [ShippingLabelPackageSelected],
+                        completion: (Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -32,6 +32,13 @@ public final class WooShippingStore: Store {
         switch action {
         case .createPackage(let siteID, let customPackage, let predefinedOption, let completion):
             createPackage(siteID: siteID, customPackage: customPackage, predefinedOption: predefinedOption, completion: completion)
+        case .loadLabelRates(let siteID, let orderID, let originAddress, let destinationAddress, let packages, let completion):
+            loadLabelRates(siteID: siteID,
+                           orderID: orderID,
+                           originAddress: originAddress,
+                           destinationAddress: destinationAddress,
+                           packages: packages,
+                           completion: completion)
         }
     }
 }
@@ -49,5 +56,19 @@ private extension WooShippingStore {
                 completion(.failure(PackageCreationError(error: error)))
             }
         }
+    }
+
+    func loadLabelRates(siteID: Int64,
+                        orderID: Int64,
+                        originAddress: ShippingLabelAddress,
+                        destinationAddress: ShippingLabelAddress,
+                        packages: [ShippingLabelPackageSelected],
+                        completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
+        remote.loadLabelRates(siteID: siteID,
+                              orderID: orderID,
+                              originAddress: originAddress,
+                              destinationAddress: destinationAddress,
+                              packages: packages,
+                              completion: completion)
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -12,11 +12,21 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `createPackage`
     private var createPackageResults = [CreatePackageResultKey: Result<WooShippingCreatePackageResponse, Error>]()
 
+    /// The results to return based on the given arguments in `loadLabelRates`
+    private var loadLabelRatesResults = [CreatePackageResultKey: Result<[ShippingLabelCarriersAndRates], Error>]()
+
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
                            thenReturn result: Result<WooShippingCreatePackageResponse, Error>) {
         let key = CreatePackageResultKey(siteID: siteID)
         createPackageResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `loadLabelRates` is called.
+    func whenLoadLabelRates(siteID: Int64,
+                            thenReturn result: Result<[ShippingLabelCarriersAndRates], Error>) {
+        let key = CreatePackageResultKey(siteID: siteID)
+        loadLabelRatesResults[key] = result
     }
 }
 
@@ -44,6 +54,15 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                         destinationAddress: ShippingLabelAddress,
                         packages: [ShippingLabelPackageSelected],
                         completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
-        // no-op
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = CreatePackageResultKey(siteID: siteID)
+            if let result = self.loadLabelRatesResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -20,6 +20,10 @@ final class WooShippingStoreTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 123
 
+    /// Testing Order ID
+    ///
+    private let sampleOrderID: Int64 = 12
+
     override func setUp() {
         super.setUp()
         dispatcher = Dispatcher()
@@ -75,4 +79,80 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertEqual(result.failure, .duplicatePackageNames)
     }
 
+    // MARK: `loadLabelRates`
+
+    func test_loadLabelRates_returns_success_response_with_rates() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedRates = sampleLabelRates()
+        remote.whenLoadLabelRates(siteID: sampleSiteID, thenReturn: .success(expectedRates))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
+            let action = WooShippingAction.loadLabelRates(siteID: self.sampleSiteID,
+                                                          orderID: self.sampleOrderID,
+                                                          originAddress: ShippingLabelAddress.fake(),
+                                                          destinationAddress: ShippingLabelAddress.fake(),
+                                                          packages: [ShippingLabelPackageSelected.fake()]) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let rates = (try result.get())
+        XCTAssertEqual(rates, expectedRates)
+    }
+
+    func test_loadLabelRates_returns_error_on_failure() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedError = NetworkError.notFound()
+        remote.whenLoadLabelRates(siteID: sampleSiteID, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
+            let action = WooShippingAction.loadLabelRates(siteID: self.sampleSiteID,
+                                                          orderID: self.sampleOrderID,
+                                                          originAddress: ShippingLabelAddress.fake(),
+                                                          destinationAddress: ShippingLabelAddress.fake(),
+                                                          packages: [ShippingLabelPackageSelected.fake()]) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+    }
+}
+
+private extension WooShippingStoreTests {
+    func sampleLabelRates() -> [ShippingLabelCarriersAndRates] {
+        return [ShippingLabelCarriersAndRates(packageID: "123",
+                                             defaultRates: [sampleLabelRate()],
+                                             signatureRequired: [],
+                                             adultSignatureRequired: [])]
+    }
+
+    func sampleLabelRate() -> ShippingLabelCarrierRate {
+        ShippingLabelCarrierRate(title: "USPS - Media Mail",
+                                 insurance: "0.0",
+                                 retailRate: 6.13,
+                                 rate: 6.13,
+                                 rateID: "rate_fd16937cc3a14cb9b28e160a06cf3e34",
+                                 serviceID: "MediaMail",
+                                 carrierID: "usps",
+                                 shipmentID: "shp_abc123",
+                                 hasTracking: true,
+                                 isSelected: false,
+                                 isPickupFree: false,
+                                 deliveryDays: 7,
+                                 deliveryDateGuaranteed: false)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14392
⚠️ Based on #14394 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Yosemite layer for requesting the shipping rates for a shipment in the Woo Shipping label flow, provided the order ID, origin address, destination address, and selected package(s).

It adds the required action to `WooShippingAction` and method in `WooShippingStore` to fetch the label rates from remote and pass them to the UI layer for use in the Woo Shipping label flow. These rates don't need to be stored locally.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This endpoint is not yet used in the app; confirm unit tests pass.

I have also tested dispatching this action from within the app UI, and confirmed the rates were relayed as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.