### PR TITLE
Rename "deposit" to "payout": user-facing changes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Payments > About Tap To Pay > Set Up Tap To Pay on iPhone > Try a Payment: it used to be no-op with a spinner, now it navigates to a test payment for testing Tap To Pay. [https://github.com/woocommerce/woocommerce-ios/pull/14340]
 - [*] Payments onboarding: for two onboarding errors that show a wp-admin Payments setup URL in a webview ("Payments plugin not setup" and "Stripe overdue" errors that can occur to both WooPayments and Stripe Extension), the webview is now set to Payments Connect instead of Payments Overview. [https://github.com/woocommerce/woocommerce-ios/pull/14297]
 - [*] Fixed: crash for missing NSMicrophoneUsageDescription [https://github.com/woocommerce/woocommerce-ios/pull/14386]
+- [*] Menu tab > Payments: in the "deposits" summary view at the top, all mentions of "deposits/deposit/deposited" have been renamed to "payouts/payout/paid out" respectively to match the renaming in web. [https://github.com/woocommerce/woocommerce-ios/pull/14402]
 
 21.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -160,21 +160,21 @@ private extension WooPaymentsDepositsCurrencyOverviewView {
             comment: "Title for pending funds overview in WooPayments Deposits view. " +
             "This shows the balance which will be made available for pay out later.")
         static let lastDepositHeader = NSLocalizedString(
-            "deposits.currency.overview.lastDeposit",
-            value: "Last Deposit",
-            comment: "Section header for the last deposit in the WooPayments Deposits overview")
+            "payouts.currency.overview.lastPayout",
+            value: "Last Payout",
+            comment: "Section header for the last payout in the WooPayments Payout overview")
         static let learnMoreButtonText = NSLocalizedString(
             "deposits.currency.overview.learnMore",
             value: "Learn more about when you'll receive your funds",
             comment: "Button text to view more about payment schedules on the WooPayments Deposits View.")
         static let showDepositDetailAccessibilityLabel = NSLocalizedString(
-            "deposits.currency.overview.accessibility.show",
-            value: "Show deposit details",
-            comment: "Accessibility label for the expand chevron on the Deposit summary")
+            "payouts.currency.overview.accessibility.show",
+            value: "Show payout details",
+            comment: "Accessibility label for the expand chevron on the Payout summary")
         static let hideDepositDetailAccessibilityLabel = NSLocalizedString(
-            "deposits.currency.overview.accessibility.hide",
-            value: "Hide deposit details",
-            comment: "Accessibility label for the collapse chevron on the Deposit summary")
+            "payouts.currency.overview.accessibility.hide",
+            value: "Hide payout details",
+            comment: "Accessibility label for the collapse chevron on the Payout summary")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -150,12 +150,12 @@ private extension WooPaymentsDepositsCurrencyOverviewView {
 private extension WooPaymentsDepositsCurrencyOverviewView {
     enum Localization {
         static let availableFunds = NSLocalizedString(
-            "deposits.currency.overview.availableFunds",
+            "payouts.currency.overview.availableFunds",
             value: "Available funds",
             comment: "Title for available funds overview in WooPayments Deposits view. " +
             "This shows the balance which can be paid out.")
         static let pendingFunds = NSLocalizedString(
-            "deposits.currency.overview.pendingFunds",
+            "payouts.currency.overview.pendingFunds",
             value: "Pending funds",
             comment: "Title for pending funds overview in WooPayments Deposits view. " +
             "This shows the balance which will be made available for pay out later.")
@@ -164,7 +164,7 @@ private extension WooPaymentsDepositsCurrencyOverviewView {
             value: "Last Payout",
             comment: "Section header for the last payout in the WooPayments Payout overview")
         static let learnMoreButtonText = NSLocalizedString(
-            "deposits.currency.overview.learnMore",
+            "payouts.currency.overview.learnMore",
             value: "Learn more about when you'll receive your funds",
             comment: "Button text to view more about payment schedules on the WooPayments Deposits View.")
         static let showDepositDetailAccessibilityLabel = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -152,21 +152,21 @@ private extension WooPaymentsDepositsCurrencyOverviewView {
         static let availableFunds = NSLocalizedString(
             "payouts.currency.overview.availableFunds",
             value: "Available funds",
-            comment: "Title for available funds overview in WooPayments Deposits view. " +
+            comment: "Title for available funds overview in WooPayments Payouts view. " +
             "This shows the balance which can be paid out.")
         static let pendingFunds = NSLocalizedString(
             "payouts.currency.overview.pendingFunds",
             value: "Pending funds",
-            comment: "Title for pending funds overview in WooPayments Deposits view. " +
+            comment: "Title for pending funds overview in WooPayments Payouts view. " +
             "This shows the balance which will be made available for pay out later.")
         static let lastDepositHeader = NSLocalizedString(
             "payouts.currency.overview.lastPayout",
             value: "Last Payout",
-            comment: "Section header for the last payout in the WooPayments Payout overview")
+            comment: "Section header for the last payout in the WooPayments Payouts overview")
         static let learnMoreButtonText = NSLocalizedString(
             "payouts.currency.overview.learnMore",
             value: "Learn more about when you'll receive your funds",
-            comment: "Button text to view more about payment schedules on the WooPayments Deposits View.")
+            comment: "Button text to view more about payment schedules on the WooPayments Payouts View.")
         static let showDepositDetailAccessibilityLabel = NSLocalizedString(
             "payouts.currency.overview.accessibility.show",
             value: "Show payout details",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -152,13 +152,13 @@ private extension WooPaymentsDepositsCurrencyOverviewViewModel {
             comment: "Hint regarding available/pending balances shown in the WooPayments Deposits View" +
             "%1$d will be replaced by the number of days balances pend, and will be one of 2/4/5/7.")
         static let depositScheduleHintAutomatic = NSLocalizedString(
-            "Available funds are deposited automatically, %1$@.",
-            comment: "Hint showing the deposit schedule for a merchant's WooPayments account. " +
-            "e.g. Available funds are deposited automatically, every Wednesday. " +
+            "Available funds are paid out automatically, %1$@.",
+            comment: "Hint showing the payout schedule for a merchant's WooPayments account. " +
+            "e.g. Available funds are paid out automatically, every Wednesday. " +
             "%1$@ will be replaced with a translated frequency description, e.g. 'every day' or 'monthly on the 28th'")
         static let depositScheduleHintManual = NSLocalizedString(
-            "Available funds are deposited manually, on request.",
-            comment: "Hint showing the deposit schedule for a merchant's WooPayments account with a manual schedule.")
+            "Available funds are paid out manually, on request.",
+            comment: "Hint showing the payout schedule for a merchant's WooPayments account with a manual schedule.")
         static let noDateString = NSLocalizedString(
             "N/A",
             comment: "String used when there's no date available for a deposit type on the WooPayments Deposits View.")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14369
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Rename Deposits to Payouts in the user facing strings. Code-level renaming will be in a separate PR for easier review. More context paJDYF-e8c-p2.

There are 5 strings with "deposit" mentions in the English translation.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Switch to a store eligible for payout if needed
- Go to Menu > Payments --> notice that all mentions are about "payout" instead of "deposit" before

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

automatic | manual
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-11-13 at 13 59 43](https://github.com/user-attachments/assets/572c0574-741d-420d-b21a-c48d4d152420) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-11-13 at 14 09 27](https://github.com/user-attachments/assets/c122240e-fabc-492d-a28b-f54bf7e96a92)

accessibility label when showing/hiding the payout view:

<img width="1120" alt="Screenshot 2024-11-13 at 2 02 14 PM" src="https://github.com/user-attachments/assets/14e8d566-2d1e-46a5-a760-58398f8be1c4">
<img width="1126" alt="Screenshot 2024-11-13 at 2 02 23 PM" src="https://github.com/user-attachments/assets/e0534738-b513-4eb9-9911-de72e4236768">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.