### PR TITLE
[Shipping labels] Add Yosemite support for getting list of packages

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2783,14 +2783,31 @@ extension Networking.WooShippingCustomPackage {
         )
     }
 }
-extension Networking.WooShippingPredefinedOption {
+extension Networking.WooShippingPredefinedSavedOption {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> Networking.WooShippingPredefinedOption {
+    public static func fake() -> Networking.WooShippingPredefinedSavedOption {
         .init(
             id: .fake(),
             predefinedPackageIDs: .fake()
         )
+    }
+}
+extension Networking.WooShippingPredefinedPackage {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingPredefinedPackage {
+        .init(id: .fake(),
+              name: .fake(),
+              isLetter: .fake(),
+              dimensions: .fake(),
+              outerDimensions: .fake(),
+              innerDimensions: .fake(),
+              boxWeight: .fake(),
+              maxWeight: .fake(),
+              groupId: .fake(),
+              isFlatRate: .fake(),
+              canShipInternational: .fake())
     }
 }
 extension Networking.WordPressMedia {

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2759,6 +2759,17 @@ extension Networking.WooShippingCreatePackageResponse {
         )
     }
 }
+extension Networking.WooShippingPackagesResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingPackagesResponse {
+        .init(
+            storeOptions: .fake(),
+            customPackages: .fake(),
+            predefinedOptions: .fake()
+        )
+    }
+}
 extension Networking.WooShippingCustomPackage {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2768,7 +2768,8 @@ extension Networking.WooShippingPackagesResponse {
         .init(
             storeOptions: .fake(),
             customPackages: .fake(),
-            predefinedOptions: .fake()
+            savedPredefinedOptions: .fake(),
+            allPredefinedOptions: .fake()
         )
     }
 }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2786,6 +2786,17 @@ extension Networking.WooShippingCustomPackage {
         )
     }
 }
+extension Networking.WooShippingPredefinedOption {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingPredefinedOption {
+        .init(
+            title: .fake(),
+            providerID: .fake(),
+            predefinedPackages: .fake()
+        )
+    }
+}
 extension Networking.WooShippingPredefinedSavedOption {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -951,6 +951,8 @@
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
 		DAF367962CE4A9EF00D1B327 /* WooShippingPackagesMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF367952CE4A9E700D1B327 /* WooShippingPackagesMapper.swift */; };
 		DAF367982CE4AA0400D1B327 /* WooShippingPackagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF367972CE4A9FC00D1B327 /* WooShippingPackagesResponse.swift */; };
+		DAF3679A2CE6480600D1B327 /* WooShippingPredefinedPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF367992CE647FA00D1B327 /* WooShippingPredefinedPackage.swift */; };
+		DAF3679C2CE6557E00D1B327 /* WooShippingPredefinedSavedOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF3679B2CE6557C00D1B327 /* WooShippingPredefinedSavedOption.swift */; };
 		DE02ABB12B5636FC008E0AC4 /* BlazePaymentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABB02B5636FC008E0AC4 /* BlazePaymentInfo.swift */; };
 		DE02ABB32B563E61008E0AC4 /* blaze-payment-info.json in Resources */ = {isa = PBXBuildFile; fileRef = DE02ABB22B563E61008E0AC4 /* blaze-payment-info.json */; };
 		DE02ABB52B563E96008E0AC4 /* BlazePaymentInfoMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABB42B563E96008E0AC4 /* BlazePaymentInfoMapper.swift */; };
@@ -2123,6 +2125,8 @@
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
 		DAF367952CE4A9E700D1B327 /* WooShippingPackagesMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackagesMapper.swift; sourceTree = "<group>"; };
 		DAF367972CE4A9FC00D1B327 /* WooShippingPackagesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackagesResponse.swift; sourceTree = "<group>"; };
+		DAF367992CE647FA00D1B327 /* WooShippingPredefinedPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPredefinedPackage.swift; sourceTree = "<group>"; };
+		DAF3679B2CE6557C00D1B327 /* WooShippingPredefinedSavedOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPredefinedSavedOption.swift; sourceTree = "<group>"; };
 		DE02ABB02B5636FC008E0AC4 /* BlazePaymentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentInfo.swift; sourceTree = "<group>"; };
 		DE02ABB22B563E61008E0AC4 /* blaze-payment-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-payment-info.json"; sourceTree = "<group>"; };
 		DE02ABB42B563E96008E0AC4 /* BlazePaymentInfoMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentInfoMapper.swift; sourceTree = "<group>"; };
@@ -2566,6 +2570,8 @@
 			isa = PBXGroup;
 			children = (
 				CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */,
+				DAF3679B2CE6557C00D1B327 /* WooShippingPredefinedSavedOption.swift */,
+				DAF367992CE647FA00D1B327 /* WooShippingPredefinedPackage.swift */,
 				451A97E8260B657D0059D135 /* ShippingLabelPredefinedOption.swift */,
 				451A97E4260B631E0059D135 /* ShippingLabelPredefinedPackage.swift */,
 			);
@@ -5125,6 +5131,7 @@
 				D8FBFF2022D52553006E3336 /* OrderStatsV4Totals.swift in Sources */,
 				02C254B925637BA000A04423 /* OrderShippingLabelListMapper.swift in Sources */,
 				261CF1B8255AE62D0090D8D3 /* PaymentGatewayRemote.swift in Sources */,
+				DAF3679C2CE6557E00D1B327 /* WooShippingPredefinedSavedOption.swift in Sources */,
 				CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */,
 				026CF620237D69D6009563D4 /* ProductVariationsRemote.swift in Sources */,
 				03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */,
@@ -5282,6 +5289,7 @@
 				CCA1D60429437B2C00B40560 /* SiteSummaryStats.swift in Sources */,
 				451A97C92609FF050059D135 /* ShippingLabelPackagesResponse.swift in Sources */,
 				029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */,
+				DAF3679A2CE6480600D1B327 /* WooShippingPredefinedPackage.swift in Sources */,
 				B557DA0F20975E07005962F4 /* DotcomRequest.swift in Sources */,
 				AEF94585272974F2001DCCFB /* TelemetryRemote.swift in Sources */,
 				DE20046E2BFB522900660A72 /* ProductReportListMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -949,6 +949,8 @@
 		D8FBFF2422D52815006E3336 /* order-stats-v4-daily.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */; };
 		D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */; };
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
+		DAF367962CE4A9EF00D1B327 /* WooShippingPackagesMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF367952CE4A9E700D1B327 /* WooShippingPackagesMapper.swift */; };
+		DAF367982CE4AA0400D1B327 /* WooShippingPackagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF367972CE4A9FC00D1B327 /* WooShippingPackagesResponse.swift */; };
 		DE02ABB12B5636FC008E0AC4 /* BlazePaymentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABB02B5636FC008E0AC4 /* BlazePaymentInfo.swift */; };
 		DE02ABB32B563E61008E0AC4 /* blaze-payment-info.json in Resources */ = {isa = PBXBuildFile; fileRef = DE02ABB22B563E61008E0AC4 /* blaze-payment-info.json */; };
 		DE02ABB52B563E96008E0AC4 /* BlazePaymentInfoMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABB42B563E96008E0AC4 /* BlazePaymentInfoMapper.swift */; };
@@ -2119,6 +2121,8 @@
 		D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-daily.json"; sourceTree = "<group>"; };
 		D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-month.json"; sourceTree = "<group>"; };
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
+		DAF367952CE4A9E700D1B327 /* WooShippingPackagesMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackagesMapper.swift; sourceTree = "<group>"; };
+		DAF367972CE4A9FC00D1B327 /* WooShippingPackagesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackagesResponse.swift; sourceTree = "<group>"; };
 		DE02ABB02B5636FC008E0AC4 /* BlazePaymentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentInfo.swift; sourceTree = "<group>"; };
 		DE02ABB22B563E61008E0AC4 /* blaze-payment-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-payment-info.json"; sourceTree = "<group>"; };
 		DE02ABB42B563E96008E0AC4 /* BlazePaymentInfoMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentInfoMapper.swift; sourceTree = "<group>"; };
@@ -2537,6 +2541,7 @@
 			isa = PBXGroup;
 			children = (
 				CEC7D5902CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift */,
+				DAF367972CE4A9FC00D1B327 /* WooShippingPackagesResponse.swift */,
 				451A97C82609FF050059D135 /* ShippingLabelPackagesResponse.swift */,
 				451A97CC260A01A40059D135 /* ShippingLabelStoreOptions.swift */,
 				CCAAD10E2683974000909664 /* ShippingLabelPackagePurchase.swift */,
@@ -3604,6 +3609,7 @@
 				CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */,
 				CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */,
 				CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */,
+				DAF367952CE4A9E700D1B327 /* WooShippingPackagesMapper.swift */,
 				CE0F4ECE2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift */,
 				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
@@ -5012,6 +5018,7 @@
 				26615475242D7C9500A31661 /* ProductCategoryListMapper.swift in Sources */,
 				EE3D1E962B8F0CF40016B132 /* BlazeCampaignListItem.swift in Sources */,
 				3178A49F2703E5CF00A8B4CA /* RemoteReaderLocationMapper.swift in Sources */,
+				DAF367982CE4AA0400D1B327 /* WooShippingPackagesResponse.swift in Sources */,
 				45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
 				CC01CE5A29B0FD61004FF537 /* ProductBundleItem.swift in Sources */,
@@ -5163,6 +5170,7 @@
 				CE430676234BA7920073CBFF /* RefundListMapper.swift in Sources */,
 				45551F122523E7F1007EF104 /* UserAgent.swift in Sources */,
 				45CDAFAB2434CA9300F83C22 /* ProductCatalogVisibility.swift in Sources */,
+				DAF367962CE4A9EF00D1B327 /* WooShippingPackagesMapper.swift in Sources */,
 				3148977027232982007A86BD /* SystemStatus.swift in Sources */,
 				B557DA1820979D51005962F4 /* Credentials.swift in Sources */,
 				DEC51AF72769A15B009F3DF4 /* SystemStatus+Security.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -953,6 +953,7 @@
 		DAF367982CE4AA0400D1B327 /* WooShippingPackagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF367972CE4A9FC00D1B327 /* WooShippingPackagesResponse.swift */; };
 		DAF3679A2CE6480600D1B327 /* WooShippingPredefinedPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF367992CE647FA00D1B327 /* WooShippingPredefinedPackage.swift */; };
 		DAF3679C2CE6557E00D1B327 /* WooShippingPredefinedSavedOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF3679B2CE6557C00D1B327 /* WooShippingPredefinedSavedOption.swift */; };
+		DAF367A02CE65A8B00D1B327 /* wooshipping-get-packages-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DAF3679E2CE65A8B00D1B327 /* wooshipping-get-packages-success.json */; };
 		DE02ABB12B5636FC008E0AC4 /* BlazePaymentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABB02B5636FC008E0AC4 /* BlazePaymentInfo.swift */; };
 		DE02ABB32B563E61008E0AC4 /* blaze-payment-info.json in Resources */ = {isa = PBXBuildFile; fileRef = DE02ABB22B563E61008E0AC4 /* blaze-payment-info.json */; };
 		DE02ABB52B563E96008E0AC4 /* BlazePaymentInfoMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABB42B563E96008E0AC4 /* BlazePaymentInfoMapper.swift */; };
@@ -2127,6 +2128,7 @@
 		DAF367972CE4A9FC00D1B327 /* WooShippingPackagesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackagesResponse.swift; sourceTree = "<group>"; };
 		DAF367992CE647FA00D1B327 /* WooShippingPredefinedPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPredefinedPackage.swift; sourceTree = "<group>"; };
 		DAF3679B2CE6557C00D1B327 /* WooShippingPredefinedSavedOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPredefinedSavedOption.swift; sourceTree = "<group>"; };
+		DAF3679E2CE65A8B00D1B327 /* wooshipping-get-packages-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-get-packages-success.json"; sourceTree = "<group>"; };
 		DE02ABB02B5636FC008E0AC4 /* BlazePaymentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentInfo.swift; sourceTree = "<group>"; };
 		DE02ABB22B563E61008E0AC4 /* blaze-payment-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-payment-info.json"; sourceTree = "<group>"; };
 		DE02ABB42B563E96008E0AC4 /* BlazePaymentInfoMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentInfoMapper.swift; sourceTree = "<group>"; };
@@ -3507,6 +3509,7 @@
 				453954D52C9193BC00A3E64A /* meta-data-products-orders-update.json */,
 				95122E3D2CB82C0A0079FF0A /* generate-product-success-wrapped.json */,
 				CE0F4EC82CE3753F006339BD /* wooshipping-get-label-rates-success.json */,
+				DAF3679E2CE65A8B00D1B327 /* wooshipping-get-packages-success.json */,
 				CE0F4ECC2CE375DD006339BD /* wooshipping-get-label-rates-error.json */,
 			);
 			path = Responses;
@@ -4482,6 +4485,7 @@
 				EE9826902B17189B00A3F57E /* product-subscription-sync-renewals-day-month-format.json in Resources */,
 				DEB387902C2D71A10025256E /* gla-campaign-list-with-data-envelope.json in Resources */,
 				7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */,
+				DAF367A02CE65A8B00D1B327 /* wooshipping-get-packages-success.json in Resources */,
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,
 				DEC51AED2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json in Resources */,

--- a/Networking/Networking/Mapper/WooShippingPackagesMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingPackagesMapper.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct WooShippingPackagesMapper: Mapper {
+    /// (Attempts) to convert a dictionary into WooShippingPackagesResponse.
+    ///
+    func map(response: Data) throws -> WooShippingPackagesResponse {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(WooShippingPackagesMapperEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode(WooShippingPackagesResponse.self, from: response)
+        }
+    }
+}
+
+/// WooShippingPackagesMapperEnvelope Disposable Entity:
+/// `Woo Shipping Packages` endpoint returns the shipping label packages in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct WooShippingPackagesMapperEnvelope: Decodable {
+    let data: WooShippingPackagesResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case data = "data"
+    }
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -4003,7 +4003,7 @@ extension Networking.WooPaymentsManualDeposit {
 extension Networking.WooShippingCreatePackageResponse {
     public func copy(
         customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
-        predefinedOptions: CopiableProp<[WooShippingPredefinedOption]> = .copy
+        predefinedOptions: CopiableProp<[WooShippingPredefinedSavedOption]> = .copy
     ) -> Networking.WooShippingCreatePackageResponse {
         let customPackages = customPackages ?? self.customPackages
         let predefinedOptions = predefinedOptions ?? self.predefinedOptions
@@ -4019,16 +4019,19 @@ extension Networking.WooShippingPackagesResponse {
     public func copy(
         storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
         customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
-        predefinedOptions: CopiableProp<[WooShippingPredefinedOption]> = .copy
+        savedPredefinedOptions: CopiableProp<[WooShippingPredefinedSavedOption]> = .copy,
+        allPredefinedOptions: CopiableProp<[WooShippingPredefinedOption]> = .copy
     ) -> Networking.WooShippingPackagesResponse {
         let storeOptions = storeOptions ?? self.storeOptions
         let customPackages = customPackages ?? self.customPackages
-        let predefinedOptions = predefinedOptions ?? self.predefinedOptions
+        let savedPredefinedOptions = savedPredefinedOptions ?? self.savedPredefinedOptions
+        let allPredefinedOptions = allPredefinedOptions ?? self.allPredefinedOptions
 
         return Networking.WooShippingPackagesResponse(
             storeOptions: storeOptions,
             customPackages: customPackages,
-            predefinedOptions: predefinedOptions
+            savedPredefinedOptions: savedPredefinedOptions,
+            allPredefinedOptions: allPredefinedOptions
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -4015,6 +4015,24 @@ extension Networking.WooShippingCreatePackageResponse {
     }
 }
 
+extension Networking.WooShippingPackagesResponse {
+    public func copy(
+        storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
+        customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
+        predefinedOptions: CopiableProp<[WooShippingPredefinedOption]> = .copy
+    ) -> Networking.WooShippingPackagesResponse {
+        let storeOptions = storeOptions ?? self.storeOptions
+        let customPackages = customPackages ?? self.customPackages
+        let predefinedOptions = predefinedOptions ?? self.predefinedOptions
+
+        return Networking.WooShippingPackagesResponse(
+            storeOptions: storeOptions,
+            customPackages: customPackages,
+            predefinedOptions: predefinedOptions
+        )
+    }
+}
+
 extension Networking.WooShippingCustomPackage {
     public func copy(
         id: CopiableProp<String> = .copy,

--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
@@ -64,7 +64,16 @@ extension WooShippingCustomPackage: Codable {
         let name = try container.decode(String.self, forKey: .name)
         let type = try container.decode(String.self, forKey: .type)
         let dimensions = try container.decode(String.self, forKey: .dimensions)
-        let boxWeight = try container.decode(Double.self, forKey: .boxWeight)
+
+        var boxWeight: Double = 0.0
+        // Looks like some endpoints have boxWeight as String and some as Double
+        if let boxWeightDouble = try? container.decodeIfPresent(Double.self, forKey: .boxWeight) {
+            boxWeight = boxWeightDouble
+        }
+        else if let boxWeightString = try? container.decodeIfPresent(String.self, forKey: .boxWeight),
+                let boxWeightDouble = Double(boxWeightString) {
+            boxWeight = boxWeightDouble
+        }
 
         self.init(id: id, name: name, rawType: type, dimensions: dimensions, boxWeight: boxWeight)
     }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedOption.swift
@@ -5,14 +5,37 @@ import Codegen
 ///
 public struct WooShippingPredefinedOption: Equatable, GeneratedFakeable {
 
-    /// The ID of the shipping carrier for the predefined option, e.g. "usps".
-    public let id: String
+    /// The title of the predefined option. It works like an ID, and it is unique.
+    public let title: String
 
-    /// List of saved predefined package IDs.
-    public let predefinedPackageIDs: [String]
+    /// The ID of the predefined option (shipping provider), e.g. "usps". This is required for activating predefined packages remotely.
+    public let providerID: String
 
-    public init(id: String, predefinedPackageIDs: [String]) {
-        self.id = id
-        self.predefinedPackageIDs = predefinedPackageIDs
+    /// List of predefined packages
+    public let predefinedPackages: [WooShippingPredefinedPackage]
+
+    public init(title: String, providerID: String, predefinedPackages: [WooShippingPredefinedPackage]) {
+        self.title = title
+        self.providerID = providerID
+        self.predefinedPackages = predefinedPackages
+    }
+}
+
+// MARK: Decodable
+extension WooShippingPredefinedOption: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let title = try container.decode(String.self, forKey: .title)
+        let predefinedPackages = try container.decodeIfPresent([WooShippingPredefinedPackage].self, forKey: .predefinedPackages) ?? []
+        let providerID = try container.decodeIfPresent(String.self, forKey: .providerID) ?? ""
+
+        self.init(title: title, providerID: providerID, predefinedPackages: predefinedPackages)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case predefinedPackages
+        case providerID
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedPackage.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Codegen
+import WooFoundation
+
+/// Represents a predefined Shipping Label Packages for the WooCommerce Shipping extension.
+///
+public struct WooShippingPredefinedPackage: Equatable, GeneratedFakeable, Identifiable {
+
+    /// The id of the predefined package
+    public let id: String
+
+    /// The name of the package, like `USPS Priority Mail Boxes`
+    public let name: String
+
+    /// Defines if package is a box or a letter. By default is a box, so it's equal to `false`
+    public let isLetter: Bool
+
+    /// Will be a string formatted like this: `21.91 x 13.65 x 4.13`
+    public let dimensions: String
+
+    /// Will be a string formatted like this: `21.91 x 13.65 x 4.13`
+    public let outerDimensions: String
+
+    /// Will be a string formatted like this: `21.91 x 13.65 x 4.13`
+    public let innerDimensions: String
+
+    public let boxWeight: String
+
+    public let maxWeight: String
+
+    // Will be a string for the groupId, like `pri_flat_boxes`
+    public let groupId: String
+
+    public let isFlatRate: Bool?
+
+    public let canShipInternational: Bool?
+
+    public init(id: String,
+                name: String,
+                isLetter: Bool,
+                dimensions: String,
+                outerDimensions: String,
+                innerDimensions: String,
+                boxWeight: String,
+                maxWeight: String,
+                groupId: String,
+                isFlatRate: Bool?,
+                canShipInternational: Bool?) {
+        self.id = id
+        self.name = name
+        self.isLetter = isLetter
+        self.dimensions = dimensions
+        self.outerDimensions = outerDimensions
+        self.innerDimensions = innerDimensions
+        self.boxWeight = boxWeight
+        self.maxWeight = maxWeight
+        self.groupId = groupId
+        self.isFlatRate = isFlatRate
+        self.canShipInternational = canShipInternational
+    }
+
+    public func getLength() -> Double {
+        let firstComponent = dimensions.components(separatedBy: " x ").first ?? ""
+        return Double(firstComponent) ?? 0
+    }
+
+    public func getWidth() -> Double {
+        let secondComponent = dimensions.components(separatedBy: " x ")[safe: 1] ?? ""
+        return Double(secondComponent) ?? 0
+    }
+
+    public func getHeight() -> Double {
+        let lastComponent = dimensions.components(separatedBy: " x ").last ?? ""
+        return Double(lastComponent) ?? 0
+    }
+}
+
+// MARK: Decodable
+
+extension WooShippingPredefinedPackage: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let id = try container.decode(String.self, forKey: .id)
+        let name = try container.decode(String.self, forKey: .name)
+        let isLetter = try container.decodeIfPresent(Bool.self, forKey: .isLetter) ?? false
+        let dimensions = try container.decode(String.self, forKey: .dimensions)
+        let outerDimensions = try container.decode(String.self, forKey: .outerDimensions)
+        let innerDimensions = try container.decode(String.self, forKey: .innerDimensions)
+        let groupId = try container.decode(String.self, forKey: .groupId)
+        let boxWeight = try container.decode(String.self, forKey: .boxWeight)
+        let maxWeight = try container.decode(String.self, forKey: .maxWeight)
+        let isFlatRate = try container.decodeIfPresent(Bool.self, forKey: .isFlatRate)
+        let canShipInternational = try container.decodeIfPresent(Bool.self, forKey: .isFlatRate)
+
+        self.init(id: id,
+                  name: name,
+                  isLetter: isLetter,
+                  dimensions: dimensions,
+                  outerDimensions: outerDimensions,
+                  innerDimensions: innerDimensions,
+                  boxWeight: boxWeight,
+                  maxWeight: maxWeight,
+                  groupId: groupId,
+                  isFlatRate: isFlatRate,
+                  canShipInternational: canShipInternational)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case isLetter = "is_letter"
+        case dimensions
+        case outerDimensions = "outer_dimensions"
+        case innerDimensions = "inner_dimensions"
+        case groupId = "group_id"
+        case boxWeight = "box_weight"
+        case maxWeight = "max_weight"
+        case isFlatRate = "is_flat_rate"
+        case canShipInternational = "can_ship_international"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedSavedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedSavedOption.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Codegen
+
+/// Represents a predefined saved option in Shipping Labels for the WooCommerce Shipping extension.
+///
+public struct WooShippingPredefinedSavedOption: Equatable, GeneratedFakeable {
+
+    /// The ID of the shipping carrier for the predefined option, e.g. "usps".
+    public let id: String
+
+    /// List of saved predefined package IDs.
+    public let predefinedPackageIDs: [String]
+
+    public init(id: String, predefinedPackageIDs: [String]) {
+        self.id = id
+        self.predefinedPackageIDs = predefinedPackageIDs
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingCreatePackageResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingCreatePackageResponse.swift
@@ -9,10 +9,10 @@ public struct WooShippingCreatePackageResponse: Equatable, GeneratedFakeable, Ge
     public let customPackages: [WooShippingCustomPackage]
 
     /// Saved (activated) predefined options
-    public let predefinedOptions: [WooShippingPredefinedOption]
+    public let predefinedOptions: [WooShippingPredefinedSavedOption]
 
     public init(customPackages: [WooShippingCustomPackage],
-                predefinedOptions: [WooShippingPredefinedOption]) {
+                predefinedOptions: [WooShippingPredefinedSavedOption]) {
         self.customPackages = customPackages
         self.predefinedOptions = predefinedOptions
     }
@@ -30,7 +30,7 @@ extension WooShippingCreatePackageResponse: Decodable {
         let rawPredefinedOptions: [String: [String]] = container.failsafeDecodeIfPresent([String: [String]].self, forKey: .predefined) ?? [:]
 
         let predefinedOptions = rawPredefinedOptions.map { (carrier, packageIDs) in
-            WooShippingPredefinedOption(id: carrier, predefinedPackageIDs: packageIDs)
+            WooShippingPredefinedSavedOption(id: carrier, predefinedPackageIDs: packageIDs)
         }
 
         self.init(customPackages: customPackages,

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -12,14 +12,19 @@ public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, Generat
     public let customPackages: [WooShippingCustomPackage]
 
     /// Saved (activated) predefined options
-    public let predefinedOptions: [WooShippingPredefinedOption]
+    public let savedPredefinedOptions: [WooShippingPredefinedSavedOption]
+
+    /// All predefined options
+    public let allPredefinedOptions: [WooShippingPredefinedOption]
 
     public init(storeOptions: ShippingLabelStoreOptions,
                 customPackages: [WooShippingCustomPackage],
-                predefinedOptions: [WooShippingPredefinedOption]) {
+                savedPredefinedOptions: [WooShippingPredefinedSavedOption],
+                allPredefinedOptions: [WooShippingPredefinedOption]) {
         self.storeOptions = storeOptions
         self.customPackages = customPackages
-        self.predefinedOptions = predefinedOptions
+        self.savedPredefinedOptions = savedPredefinedOptions
+        self.allPredefinedOptions = allPredefinedOptions
     }
 }
 
@@ -28,34 +33,58 @@ extension WooShippingPackagesResponse: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        guard let storeOptions = try container.decodeIfPresent(ShippingLabelStoreOptions.self, forKey: .storeOptions) else {
-            throw WooShippingPackagesResponseDecodingError.missingStoreOptions
+        let storeOptions = try container.decode(ShippingLabelStoreOptions.self, forKey: .storeOptions)
+        let packagesData = try container.nestedContainer(keyedBy: PackagesKeys.self, forKey: .packages)
+
+        let savedPackagesData = try packagesData.nestedContainer(keyedBy: SavedPackagesKeys.self, forKey: .saved)
+        let customPackages = try savedPackagesData.decodeIfPresent([WooShippingCustomPackage].self, forKey: .custom) ?? []
+        let rawSavedPredefinedOptions: [String: [String]] = savedPackagesData.failsafeDecodeIfPresent([String: [String]].self, forKey: .predefined) ?? [:]
+        let savedPredefinedOptions = rawSavedPredefinedOptions.map { (carrier, packageIDs) in
+            WooShippingPredefinedSavedOption(id: carrier, predefinedPackageIDs: packageIDs)
         }
 
-        let customPackages = try container.decodeIfPresent([WooShippingCustomPackage].self, forKey: .custom) ?? []
-
-        // We assume that rows will always be of type `Dictionary<String:<Array<String>>>`
-        //
-        let rawPredefinedOptions: [String: [String]] = container.failsafeDecodeIfPresent([String: [String]].self, forKey: .predefined) ?? [:]
-
-        let predefinedOptions = rawPredefinedOptions.map { (carrier, packageIDs) in
-            WooShippingPredefinedOption(id: carrier, predefinedPackageIDs: packageIDs)
+        let allPredefinedPackagesData: [String: AnyCodable] = try packagesData.decode([String: AnyCodable].self, forKey: .predefined)
+        var allPredefinedOptions: [WooShippingPredefinedOption] = []
+        allPredefinedPackagesData.forEach { (key, value) in
+            // key is a carrier id, for example "usps"
+            if let provider: [String: Any]? = try? value.toDictionary() {
+                provider?.forEach({ (providerKey, providerValue) in
+                    // providerKey is package group id, for example "pri_flat_boxes"
+                    let providerValueDict = providerValue as? [String: Any]
+                    let title: String = providerValueDict?["title"] as? String ?? ""
+                    let packages = WooShippingPackagesResponse.getAllPredefinedPackages(packageDefinitions: providerValueDict)
+                    let option = WooShippingPredefinedOption(title: title, providerID: key, predefinedPackages: packages)
+                    allPredefinedOptions.append(option)
+                })
+            }
         }
 
         self.init(storeOptions: storeOptions,
                   customPackages: customPackages,
-                  predefinedOptions: predefinedOptions)
+                  savedPredefinedOptions: savedPredefinedOptions,
+                  allPredefinedOptions: allPredefinedOptions)
+    }
+
+    static func getAllPredefinedPackages(packageDefinitions: [String: Any]?) -> [WooShippingPredefinedPackage] {
+        guard let definitions = packageDefinitions?["definitions"], let jsonData = try? JSONSerialization.data(withJSONObject: definitions, options: []) else {
+            return []
+        }
+        return (try? JSONDecoder().decode([WooShippingPredefinedPackage].self, from: jsonData)) ?? []
     }
 
     private enum CodingKeys: String, CodingKey {
-        case custom
+        case packages
         case predefined
         case storeOptions
     }
-}
 
-// MARK: - Decoding Errors
-//
-enum WooShippingPackagesResponseDecodingError: Error {
-    case missingStoreOptions
+    private enum SavedPackagesKeys: String, CodingKey {
+        case custom
+        case predefined
+    }
+
+    private enum PackagesKeys: String, CodingKey {
+        case predefined
+        case saved
+    }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Codegen
+
+/// Represents store options, a list of saved Shipping Label Packages (custom and predefined) for the WooCommerce Shipping extension.
+///
+public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, GeneratedCopiable {
+
+    /// Store options
+    public let storeOptions: ShippingLabelStoreOptions?
+
+    /// Saved custom packages
+    public let customPackages: [WooShippingCustomPackage]
+
+    /// Saved (activated) predefined options
+    public let predefinedOptions: [WooShippingPredefinedOption]
+
+    public init(storeOptions: ShippingLabelStoreOptions?,
+                customPackages: [WooShippingCustomPackage],
+                predefinedOptions: [WooShippingPredefinedOption]) {
+        self.storeOptions = storeOptions
+        self.customPackages = customPackages
+        self.predefinedOptions = predefinedOptions
+    }
+}
+
+// MARK: Decodable
+extension WooShippingPackagesResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let storeOptions = try container.decodeIfPresent(ShippingLabelStoreOptions.self, forKey: .storeOptions)
+
+        let customPackages = try container.decodeIfPresent([WooShippingCustomPackage].self, forKey: .custom) ?? []
+
+        // We assume that rows will always be of type `Dictionary<String:<Array<String>>>`
+        //
+        let rawPredefinedOptions: [String: [String]] = container.failsafeDecodeIfPresent([String: [String]].self, forKey: .predefined) ?? [:]
+
+        let predefinedOptions = rawPredefinedOptions.map { (carrier, packageIDs) in
+            WooShippingPredefinedOption(id: carrier, predefinedPackageIDs: packageIDs)
+        }
+
+        self.init(storeOptions: storeOptions,
+                  customPackages: customPackages,
+                  predefinedOptions: predefinedOptions)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case custom
+        case predefined
+        case storeOptions
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -6,7 +6,7 @@ import Codegen
 public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// Store options
-    public let storeOptions: ShippingLabelStoreOptions?
+    public let storeOptions: ShippingLabelStoreOptions
 
     /// Saved custom packages
     public let customPackages: [WooShippingCustomPackage]
@@ -14,7 +14,7 @@ public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, Generat
     /// Saved (activated) predefined options
     public let predefinedOptions: [WooShippingPredefinedOption]
 
-    public init(storeOptions: ShippingLabelStoreOptions?,
+    public init(storeOptions: ShippingLabelStoreOptions,
                 customPackages: [WooShippingCustomPackage],
                 predefinedOptions: [WooShippingPredefinedOption]) {
         self.storeOptions = storeOptions
@@ -28,7 +28,9 @@ extension WooShippingPackagesResponse: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let storeOptions = try container.decodeIfPresent(ShippingLabelStoreOptions.self, forKey: .storeOptions)
+        guard let storeOptions = try container.decodeIfPresent(ShippingLabelStoreOptions.self, forKey: .storeOptions) else {
+            throw WooShippingPackagesResponseDecodingError.missingStoreOptions
+        }
 
         let customPackages = try container.decodeIfPresent([WooShippingCustomPackage].self, forKey: .custom) ?? []
 
@@ -50,4 +52,10 @@ extension WooShippingPackagesResponse: Decodable {
         case predefined
         case storeOptions
     }
+}
+
+// MARK: - Decoding Errors
+//
+enum WooShippingPackagesResponseDecodingError: Error {
+    case missingStoreOptions
 }

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -11,6 +11,8 @@ public protocol WooShippingRemoteProtocol {
                         destinationAddress: ShippingLabelAddress,
                         packages: [ShippingLabelPackageSelected],
                         completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
+    func loadPackages(siteID: Int64,
+                      completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -93,6 +95,28 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             enqueue(request, mapper: mapper, completion: completion)
         }
         catch {
+            completion(.failure(error))
+        }
+    }
+
+    /// Loads packages.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site.
+    ///   - completion: Closure to be executed upon completion.
+    public func loadPackages(siteID: Int64,
+                      completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void) {
+        do {
+            let path = Path.packages
+            let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                         method: .get,
+                                         siteID: siteID,
+                                         path: path,
+                                         availableAsRESTRequest: true)
+
+            let mapper = WooShippingPackagesMapper()
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
             completion(.failure(error))
         }
     }

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -3,7 +3,7 @@
 public protocol WooShippingRemoteProtocol {
     func createPackage(siteID: Int64,
                        customPackage: WooShippingCustomPackage?,
-                       predefinedOption: WooShippingPredefinedOption?,
+                       predefinedOption: WooShippingPredefinedSavedOption?,
                        completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void)
     func loadLabelRates(siteID: Int64,
                         orderID: Int64,
@@ -27,7 +27,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
     ///   - completion: Closure to be executed upon completion.
     public func createPackage(siteID: Int64,
                               customPackage: WooShippingCustomPackage?,
-                              predefinedOption: WooShippingPredefinedOption?,
+                              predefinedOption: WooShippingPredefinedSavedOption?,
                               completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void) {
         do {
             var customPackageList: [[String: Any]] = []

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -28,7 +28,7 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             remote.createPackage(siteID: self.sampleSiteID,
                                  customPackage: WooShippingCustomPackage.fake(),
-                                 predefinedOption: WooShippingPredefinedOption.fake()) { result in
+                                 predefinedOption: WooShippingPredefinedSavedOption.fake()) { result in
                 promise(result)
             }
         }
@@ -48,7 +48,7 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             remote.createPackage(siteID: self.sampleSiteID,
                                  customPackage: WooShippingCustomPackage.fake(),
-                                 predefinedOption: WooShippingPredefinedOption.fake()) { result in
+                                 predefinedOption: WooShippingPredefinedSavedOption.fake()) { result in
                 promise(result)
             }
         }

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -122,6 +122,7 @@ final class WooShippingRemoteTests: XCTestCase {
         // Given
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-get-packages-success")
+        let expectedCustomPackage = sampleCustomPackage()
 
         // When
         let result: Result<WooShippingPackagesResponse, Error> = waitFor { promise in
@@ -135,6 +136,11 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertEqual(successResponse.savedPredefinedOptions.count, 1)
         XCTAssertEqual(successResponse.savedPredefinedOptions.first?.id, "usps")
         XCTAssertEqual(successResponse.savedPredefinedOptions.first?.predefinedPackageIDs.count, 2)
+
+        XCTAssertEqual(successResponse.customPackages.count, 1)
+        XCTAssertEqual(successResponse.customPackages.first, expectedCustomPackage)
+
+        XCTAssertEqual(successResponse.allPredefinedOptions.count, 2)
     }
 
     func test_loadPackages_returns_error_on_failure() throws {
@@ -169,5 +175,13 @@ private extension WooShippingRemoteTests {
                                  isPickupFree: false,
                                  deliveryDays: 7,
                                  deliveryDateGuaranteed: false)
+    }
+
+    func sampleCustomPackage() -> WooShippingCustomPackage {
+        WooShippingCustomPackage(id: "849225dc153",
+                                 name: "Custom name",
+                                 rawType: "box",
+                                 dimensions: "12 x 12 x 12",
+                                 boxWeight: 0.01)
     }
 }

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -117,6 +117,41 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         XCTAssertNotNil(result.failure)
     }
+
+    func test_loadPackages_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-get-packages-success")
+
+        // When
+        let result: Result<WooShippingPackagesResponse, Error> = waitFor { promise in
+            remote.loadPackages(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let successResponse = try XCTUnwrap(result.get())
+        XCTAssertEqual(successResponse.savedPredefinedOptions.count, 1)
+        XCTAssertEqual(successResponse.savedPredefinedOptions.first?.id, "usps")
+        XCTAssertEqual(successResponse.savedPredefinedOptions.first?.predefinedPackageIDs.count, 2)
+    }
+
+    func test_loadPackages_returns_error_on_failure() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "generic_error")
+
+        // When
+        let result: Result<WooShippingPackagesResponse, Error> = waitFor { promise in
+            remote.loadPackages(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension WooShippingRemoteTests {

--- a/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
@@ -10,7 +10,7 @@
           "saved": {
             "custom": [
               {
-                "name": "12x12x12",
+                "name": "Custom name",
                 "boxWeight": 0.01,
                 "id": "849225dc153",
                 "type": "box",

--- a/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
@@ -1,0 +1,97 @@
+{
+    "data": {
+        "storeOptions": {
+          "currency_symbol": "$",
+          "dimension_unit": "cm",
+          "weight_unit": "kg",
+          "origin_country": "US"
+        },
+        "packages": {
+          "saved": {
+            "custom": [
+              {
+                "name": "12x12x12",
+                "boxWeight": 0.01,
+                "id": "849225dc153",
+                "type": "box",
+                "isLetter": false,
+                "dimensions": "12 x 12 x 12",
+                "is_user_defined": true
+              }
+            ],
+            "predefined": {
+              "usps": [
+                "small_flat_box",
+                "medium_flat_box_top"
+              ]
+            }
+          },
+          "predefined": {
+            "usps": {
+              "pri_flat_boxes": {
+                "title": "USPS Priority Mail Flat Rate Boxes",
+                "definitions": [
+                  {
+                    "inner_dimensions": "8.63 x 5.38 x 1.63",
+                    "outer_dimensions": "8.63 x 5.38 x 1.63",
+                    "box_weight": 0,
+                    "is_flat_rate": true,
+                    "id": "small_flat_box",
+                    "name": "Small Flat Rate Box",
+                    "dimensions": "8.63 x 5.38 x 1.63",
+                    "max_weight": 70,
+                    "is_letter": false,
+                    "group_id": "pri_flat_boxes",
+                    "can_ship_international": true
+                  },
+                  {
+                    "inner_dimensions": "11 x 8.5 x 5.5",
+                    "outer_dimensions": "11.25 x 8.75 x 6",
+                    "box_weight": 0,
+                    "is_flat_rate": true,
+                    "id": "medium_flat_box_top",
+                    "name": "Medium Flat Rate Box 1, Top Loading",
+                    "max_weight": 70,
+                    "is_letter": false,
+                    "group_id": "pri_flat_boxes",
+                    "can_ship_international": true
+                  },
+                ]
+              }
+            },
+            "fedex": {
+              "express": {
+                "title": "FedEx Express Packages",
+                "definitions": [
+                  {
+                    "inner_dimensions": "13.19 x 9.25 x 0.75",
+                    "outer_dimensions": "13.19 x 9.25 x 0.75",
+                    "box_weight": 0,
+                    "is_flat_rate": false,
+                    "id": "FedExEnvelope",
+                    "name": "Envelope",
+                    "dimensions": "13.19 x 9.25 x 0.75",
+                    "max_weight": 10,
+                    "is_letter": true,
+                    "group_id": "express"
+                  },
+                  {
+                    "inner_dimensions": "15.5 x 12 x 0.75",
+                    "outer_dimensions": "15.5 x 12 x 0.75",
+                    "box_weight": 0,
+                    "is_flat_rate": false,
+                    "id": "FedExPak",
+                    "name": "Large Pak",
+                    "dimensions": "15.5 x 12 x 0.75",
+                    "max_weight": 20,
+                    "is_letter": true,
+                    "group_id": "express"
+                  },
+                ]
+              }
+            }
+          }
+        },
+        "success": true
+      }
+}

--- a/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
@@ -11,7 +11,7 @@
             "custom": [
               {
                 "name": "Custom name",
-                "boxWeight": 0.01,
+                "boxWeight": "0.01",
                 "id": "849225dc153",
                 "type": "box",
                 "isLetter": false,

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -1,6 +1,6 @@
 import Networking
 
-public enum WooShippingAction: Action {
+public enum WooShippingAction: Action {//
     /// Creates a custom package or activated a carrier package with provided package details.
     ///
     case createPackage(siteID: Int64,
@@ -16,4 +16,9 @@ public enum WooShippingAction: Action {
                         destinationAddress: ShippingLabelAddress,
                         packages: [ShippingLabelPackageSelected],
                         completion: (Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
+
+    /// Fetch list of packages.
+    ///
+    case loadPackages(siteID: Int64,
+                      completion: (Result<WooShippingPackagesResponse, PackageCreationError>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -1,6 +1,6 @@
 import Networking
 
-public enum WooShippingAction: Action {//
+public enum WooShippingAction: Action {
     /// Creates a custom package or activated a carrier package with provided package details.
     ///
     case createPackage(siteID: Int64,
@@ -20,5 +20,5 @@ public enum WooShippingAction: Action {//
     /// Fetch list of packages.
     ///
     case loadPackages(siteID: Int64,
-                      completion: (Result<WooShippingPackagesResponse, PackageCreationError>) -> Void)
+                      completion: (Result<WooShippingPackagesResponse, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -5,7 +5,7 @@ public enum WooShippingAction: Action {
     ///
     case createPackage(siteID: Int64,
                        customPackage: WooShippingCustomPackage? = nil,
-                       predefinedOption: WooShippingPredefinedOption? = nil,
+                       predefinedOption: WooShippingPredefinedSavedOption? = nil,
                        completion: (Result<WooShippingCreatePackageResponse, PackageCreationError>) -> Void)
 
     /// Fetch list of shipping label rates for the order.

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -179,6 +179,7 @@ public typealias TopEarnerStatsItem = Networking.TopEarnerStatsItem
 public typealias User = Networking.User
 public typealias WooAPIVersion = Networking.WooAPIVersion
 public typealias WooShippingCustomPackage = Networking.WooShippingCustomPackage
+public typealias WooShippingPredefinedPackage = Networking.WooShippingPredefinedPackage
 public typealias WooShippingCreatePackageResponse = Networking.WooShippingCreatePackageResponse
 public typealias WooShippingPackagesResponse = Networking.WooShippingPackagesResponse
 public typealias WPComPlan = Networking.WPComPlan

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -180,6 +180,7 @@ public typealias User = Networking.User
 public typealias WooAPIVersion = Networking.WooAPIVersion
 public typealias WooShippingCustomPackage = Networking.WooShippingCustomPackage
 public typealias WooShippingCreatePackageResponse = Networking.WooShippingCreatePackageResponse
+public typealias WooShippingPackagesResponse = Networking.WooShippingPackagesResponse
 public typealias WPComPlan = Networking.WPComPlan
 public typealias WPComSitePlan = Networking.WPComSitePlan
 public typealias LoadSiteCurrentPlanError = Networking.LoadSiteCurrentPlanError

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -39,6 +39,8 @@ public final class WooShippingStore: Store {
                            destinationAddress: destinationAddress,
                            packages: packages,
                            completion: completion)
+        case .loadPackages(let siteID, completion: let completion):
+            loadPackages(siteID: siteID, completion: completion)
         }
     }
 }
@@ -70,5 +72,17 @@ private extension WooShippingStore {
                               destinationAddress: destinationAddress,
                               packages: packages,
                               completion: completion)
+    }
+
+    func loadPackages(siteID: Int64,
+                      completion: @escaping (Result<WooShippingPackagesResponse, PackageCreationError>) -> Void) {
+        remote.loadPackages(siteID: siteID) { result in
+            switch result {
+            case .success(let packages):
+                completion(.success(packages))
+            case .failure(let error):
+                completion(.failure(PackageCreationError(error: error)))
+            }
+        }
     }
 }

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -48,7 +48,7 @@ public final class WooShippingStore: Store {
 private extension WooShippingStore {
     func createPackage(siteID: Int64,
                        customPackage: WooShippingCustomPackage? = nil,
-                       predefinedOption: WooShippingPredefinedOption? = nil,
+                       predefinedOption: WooShippingPredefinedSavedOption? = nil,
                        completion: @escaping (Result<WooShippingCreatePackageResponse, PackageCreationError>) -> Void) {
         remote.createPackage(siteID: siteID, customPackage: customPackage, predefinedOption: predefinedOption) { result in
             switch result {

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -75,14 +75,7 @@ private extension WooShippingStore {
     }
 
     func loadPackages(siteID: Int64,
-                      completion: @escaping (Result<WooShippingPackagesResponse, PackageCreationError>) -> Void) {
-        remote.loadPackages(siteID: siteID) { result in
-            switch result {
-            case .success(let packages):
-                completion(.success(packages))
-            case .failure(let error):
-                completion(.failure(PackageCreationError(error: error)))
-            }
-        }
+                      completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void) {
+        remote.loadPackages(siteID: siteID, completion: completion)
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -44,7 +44,7 @@ final class MockWooShippingRemote {
 extension MockWooShippingRemote: WooShippingRemoteProtocol {
     func createPackage(siteID: Int64,
                        customPackage: Networking.WooShippingCustomPackage?,
-                       predefinedOption: Networking.WooShippingPredefinedOption?,
+                       predefinedOption: Networking.WooShippingPredefinedSavedOption?,
                        completion: @escaping (Result<Networking.WooShippingCreatePackageResponse, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -15,6 +15,9 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `loadLabelRates`
     private var loadLabelRatesResults = [CreatePackageResultKey: Result<[ShippingLabelCarriersAndRates], Error>]()
 
+    /// The results to return based on the given arguments in `loadLabelRates`
+    private var loadPackagesResults = [CreatePackageResultKey: Result<WooShippingPackagesResponse, Error>]()
+
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
                            thenReturn result: Result<WooShippingCreatePackageResponse, Error>) {
@@ -27,6 +30,13 @@ final class MockWooShippingRemote {
                             thenReturn result: Result<[ShippingLabelCarriersAndRates], Error>) {
         let key = CreatePackageResultKey(siteID: siteID)
         loadLabelRatesResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `loadPackages` is called.
+    func whenLoadPackages(siteID: Int64,
+                          thenReturn result: Result<WooShippingPackagesResponse, Error>) {
+        let key = CreatePackageResultKey(siteID: siteID)
+        loadPackagesResults[key] = result
     }
 }
 
@@ -59,6 +69,20 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
             let key = CreatePackageResultKey(siteID: siteID)
             if let result = self.loadLabelRatesResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func loadPackages(siteID: Int64,
+                      completion: @escaping (Result<Networking.WooShippingPackagesResponse, any Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = CreatePackageResultKey(siteID: siteID)
+            if let result = self.loadPackagesResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -130,6 +130,50 @@ final class WooShippingStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? NetworkError, expectedError)
     }
+
+    // MARK: `loadPackages`
+
+    func test_loadPackages_returns_success_response_with_rates() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let response = WooShippingPackagesResponse.fake().copy(customPackages: [WooShippingCustomPackage.fake()])
+        remote.whenLoadPackages(siteID: sampleSiteID, thenReturn: .success(response))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingPackagesResponse, Error> = waitFor { promise in
+            let action = WooShippingAction.loadPackages(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let actualResponse = try result.get()
+        XCTAssertEqual(actualResponse, response)
+    }
+
+    func test_loadPackages_returns_error_on_failure() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedError = NetworkError.notFound()
+        remote.whenLoadPackages(siteID: sampleSiteID, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingPackagesResponse, Error> = waitFor { promise in
+            let action = WooShippingAction.loadPackages(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+    }
 }
 
 private extension WooShippingStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13553
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Added networking support for getting packages using the latest plugin endpoint.
- Support is mostly added with additions to `WooShippingAction` and `WooShippingStore`

Looks like the endpoint is currently not supported.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- For now the new action isn't yet used in the app, so confirm unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
