### PR TITLE
[Woo POS] Move orderStage to aggregate model

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -5,6 +5,8 @@ import protocol Yosemite.POSItemProvider
 import protocol WooFoundation.Analytics
 
 protocol PointOfSaleAggregateModelProtocol {
+    var orderStage: PointOfSaleOrderStage { get }
+
     @available(*, deprecated, message: "`allItems` is due for removal, use `itemListState` instead.")
     var allItems: [POSItem] { get }
     var itemListState: ItemListState { get }
@@ -17,9 +19,14 @@ protocol PointOfSaleAggregateModelProtocol {
     func addToCart(_ item: POSItem)
     func remove(cartItem: CartItem)
     func removeAllItemsFromCart()
+    func submitCart()
+    func addMoreToCart()
+    func startNewCart()
 }
 
 class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProtocol {
+    @Published private(set) var orderStage: PointOfSaleOrderStage = .building
+
     @Published private(set) var allItems: [POSItem] = []
     @Published private(set) var itemListState: ItemListState = .initialLoading
 
@@ -110,6 +117,19 @@ extension PointOfSaleAggregateModel {
 
     func removeAllItemsFromCart() {
         cart.removeAll()
+    }
+
+    func submitCart() {
+        orderStage = .finalizing
+    }
+
+    func addMoreToCart() {
+        orderStage = .building
+    }
+
+    func startNewCart() {
+        removeAllItemsFromCart()
+        orderStage = .building
     }
 }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleOrderStage.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleOrderStage.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum PointOfSaleOrderStage {
+    case building
+    case finalizing
+}

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -63,7 +63,7 @@ struct CartView: View {
                             )
                     }
                     .padding(.leading, Constants.itemHorizontalPadding)
-                    .renderedIf(posModel.cart.isNotEmpty && cartViewModel.canDeleteItemsFromCart)
+                    .renderedIf(posModel.cart.isNotEmpty && posModel.orderStage == .building)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -77,7 +77,7 @@ struct CartView: View {
                         VStack(spacing: 0) {
                             ForEach(posModel.cart, id: \.id) { cartItem in
                                 ItemRowView(cartItem: cartItem,
-                                            onItemRemoveTapped: cartViewModel.canDeleteItemsFromCart ? {
+                                            onItemRemoveTapped: posModel.orderStage == .building ? {
                                     posModel.remove(cartItem: cartItem)
                                 } : nil)
                                 .id(cartItem.id)
@@ -96,7 +96,7 @@ struct CartView: View {
                     }
                     .coordinateSpace(name: Constants.scrollViewCoordinateSpaceIdentifier)
                     .onChange(of: posModel.cart.first?.id) { itemToScrollTo in
-                        if viewModel.orderStage == .building {
+                        if posModel.orderStage == .building {
                             withAnimation {
                                 proxy.scrollTo(itemToScrollTo)
                             }
@@ -105,7 +105,7 @@ struct CartView: View {
                 }
             }
             Spacer()
-            switch viewModel.orderStage {
+            switch posModel.orderStage {
             case .building:
                 if posModel.cart.isEmpty {
                     EmptyView()
@@ -195,6 +195,8 @@ private extension CartView {
 private extension CartView {
     var checkoutButton: some View {
         Button {
+            posModel.submitCart()
+            // Remove when totalsViewModel doesn't do the submission any more
             cartViewModel.submitCart()
         } label: {
             Text(Localization.checkoutButtonTitle)
@@ -204,12 +206,12 @@ private extension CartView {
 
     @ViewBuilder
     var backAddMoreButton: some View {
-        switch viewModel.orderStage {
+        switch posModel.orderStage {
         case .building:
             EmptyView()
         case .finalizing:
             Button {
-                cartViewModel.addMoreToCart()
+                posModel.addMoreToCart()
             } label: {
                 Image(systemName: Constants.backButtonSymbol)
                     .font(.posBodyEmphasized, maximumContentSizeCategory: .accessibilityLarge)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -86,12 +86,20 @@ struct PointOfSaleDashboardView: View {
         .task {
             await viewModel.itemListViewModel.loadInitialItems()
         }
+        .onChange(of: posModel.orderStage) { newValue in
+            switch newValue {
+            case .building:
+                totalsViewModel.stopShowingTotalsView()
+            case .finalizing:
+                totalsViewModel.startShowingTotalsView()
+            }
+        }
     }
 
     private var contentView: some View {
         GeometryReader { geometry in
             HStack {
-                if viewModel.orderStage == .building {
+                if posModel.orderStage == .building {
                     productListView
                         .accessibilitySortPriority(2)
                         .transition(.move(edge: .leading))
@@ -104,13 +112,13 @@ struct PointOfSaleDashboardView: View {
                         .ignoresSafeArea(edges: .bottom)
                 }
 
-                if viewModel.orderStage == .finalizing {
+                if posModel.orderStage == .finalizing {
                     totalsView
                         .accessibilitySortPriority(2)
                         .transition(.move(edge: .trailing))
                 }
             }
-            .animation(.default, value: viewModel.orderStage)
+            .animation(.default, value: posModel.orderStage)
             .animation(.default, value: viewModel.isTotalsViewFullScreen)
         }
     }

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -7,21 +7,12 @@ final class CartViewModel: CartViewModelProtocol {
     let cartSubmissionPublisher: AnyPublisher<[CartItem], Never>
     private let cartSubmissionSubject: PassthroughSubject<[CartItem], Never> = .init()
 
-    /// Emits a signal when the CTA is tapped to update the cart.
-    let addMoreToCartActionPublisher: AnyPublisher<Void, Never>
-    private let addMoreToCartActionSubject: PassthroughSubject<Void, Never> = .init()
-
-    var itemsInCartPublisher: AnyPublisher<[CartItem], Never> { posModel.$cart.eraseToAnyPublisher() }
-
-    @Published var canDeleteItemsFromCart: Bool = true
-
     let posModel: PointOfSaleAggregateModel
 
     init(posModel: PointOfSaleAggregateModel) {
         self.posModel = posModel
 
         cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
-        addMoreToCartActionPublisher = addMoreToCartActionSubject.eraseToAnyPublisher()
     }
 
     var itemsInCartLabel: String? {
@@ -36,9 +27,5 @@ final class CartViewModel: CartViewModelProtocol {
 
     func submitCart() {
         cartSubmissionSubject.send(posModel.cart)
-    }
-
-    func addMoreToCart() {
-        addMoreToCartActionSubject.send(())
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
@@ -4,13 +4,8 @@ import protocol Yosemite.POSItem
 
 protocol CartViewModelProtocol: ObservableObject {
     var cartSubmissionPublisher: AnyPublisher<[CartItem], Never> { get }
-    var addMoreToCartActionPublisher: AnyPublisher<Void, Never> { get }
-
-    var canDeleteItemsFromCart: Bool { get set }
 
     var itemsInCartLabel: String? { get }
-    var itemsInCartPublisher: AnyPublisher<[CartItem], Never> { get }
 
     func submitCart()
-    func addMoreToCart()
 }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -16,13 +16,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     let cardReaderConnectionViewModel: CardReaderConnectionViewModel
     private let connectivityObserver: ConnectivityObserver
 
-    enum OrderStage {
-        case building
-        case finalizing
-    }
-
-    @Published private(set) var orderStage: OrderStage = .building
-
     @Published private(set) var isAddMoreDisabled: Bool = false
     @Published var isExitPOSDisabled: Bool = false
     @Published var isReaderDisconnectionDisabled: Bool = false
@@ -47,24 +40,15 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         self.cartViewModel = cartViewModel
         self.connectivityObserver = connectivityObserver
 
-        observeOrderStage()
         observeSelectedItemToAddToCart()
         observeCartSubmission()
-        observeCartAddMoreAction()
-        observeCartItemsToCheckIfCartIsEmpty()
         observePaymentStateForButtonDisabledProperties()
         observeTotalsOrderActions()
         observeConnectivity()
     }
 
     private func startNewOrder() {
-        // clear cart
-        posModel.removeAllItemsFromCart()
-        orderStage = .building
-    }
-
-    private func editOrder() {
-        orderStage = .building
+        posModel.startNewCart()
     }
 
     private func cartSubmitted(cartItems: [CartItem]) {
@@ -85,26 +69,7 @@ private extension PointOfSaleDashboardViewModel {
         cartViewModel.cartSubmissionPublisher
             .sink { [weak self] cartItems in
                 guard let self else { return }
-                self.orderStage = .finalizing
                 self.cartSubmitted(cartItems: cartItems)
-            }
-            .store(in: &cancellables)
-    }
-
-    func observeCartAddMoreAction() {
-        cartViewModel.addMoreToCartActionPublisher
-            .sink { [weak self] in
-                guard let self else { return }
-                self.orderStage = .building
-            }
-            .store(in: &cancellables)
-    }
-
-    func observeCartItemsToCheckIfCartIsEmpty() {
-        cartViewModel.itemsInCartPublisher
-            .filter { $0.isEmpty }
-            .sink { [weak self] _ in
-                self?.orderStage = .building
             }
             .store(in: &cancellables)
     }
@@ -167,23 +132,6 @@ private extension PointOfSaleDashboardViewModel {
 
     }
 
-    private func observeOrderStage() {
-        $orderStage
-            .removeDuplicates()
-            .sink { [weak self] stage in
-            guard let self else { return }
-            cartViewModel.canDeleteItemsFromCart = stage == .building
-
-            switch stage {
-            case .building:
-                totalsViewModel.stopShowingTotalsView()
-            case .finalizing:
-                totalsViewModel.startShowingTotalsView()
-            }
-        }
-        .store(in: &cancellables)
-    }
-
     func observeTotalsOrderActions() {
         totalsViewModel.startNewOrderActionPublisher
             .sink { [weak self] in
@@ -195,7 +143,7 @@ private extension PointOfSaleDashboardViewModel {
         totalsViewModel.editOrderActionPublisher
             .sink { [weak self] in
                 guard let self else { return }
-                self.editOrder()
+                posModel.addMoreToCart()
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -776,6 +776,7 @@
 		203163BB2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163BA2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */; };
 		203163BD2C1C9602001C96DA /* PointOfSaleCardPresentPaymentAlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163BC2C1C9602001C96DA /* PointOfSaleCardPresentPaymentAlertType.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
+		2044158D2CE4DB480070BF54 /* PointOfSaleOrderStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2044158C2CE4DB480070BF54 /* PointOfSaleOrderStage.swift */; };
 		204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */; };
 		204CB80E2C0F8A5E000C9773 /* MockViewControllerPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */; };
 		204CB8102C10BB88000C9773 /* CardPresentPaymentPreviewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CB80F2C10BB88000C9773 /* CardPresentPaymentPreviewService.swift */; };
@@ -3890,6 +3891,7 @@
 		203163BA2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift; sourceTree = "<group>"; };
 		203163BC2C1C9602001C96DA /* PointOfSaleCardPresentPaymentAlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentAlertType.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
+		2044158C2CE4DB480070BF54 /* PointOfSaleOrderStage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderStage.swift; sourceTree = "<group>"; };
 		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
 		204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockViewControllerPresenting.swift; sourceTree = "<group>"; };
 		204CB80F2C10BB88000C9773 /* CardPresentPaymentPreviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentPreviewService.swift; sourceTree = "<group>"; };
@@ -9462,6 +9464,7 @@
 				68F151E02C0DA7910082AEC8 /* CartItem.swift */,
 				DAD988C52C4A9CF9009DE9E3 /* CartItem+Order.swift */,
 				20FCBCDC2CE223340082DCA3 /* PointOfSaleAggregateModel.swift */,
+				2044158C2CE4DB480070BF54 /* PointOfSaleOrderStage.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -15127,6 +15130,7 @@
 				318477E527A33C650058C7E9 /* CardPresentModalConnectingFailedChargeReader.swift in Sources */,
 				CEEF742A2B9A02EB00B03948 /* OrdersReportCardViewModel.swift in Sources */,
 				DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */,
+				2044158D2CE4DB480070BF54 /* PointOfSaleOrderStage.swift in Sources */,
 				68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */,
 				035DBA4B292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift in Sources */,
 				02D9EFCB2B69F91B00AE8968 /* ProductsSplitViewCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
@@ -7,27 +7,14 @@ class MockCartViewModel: CartViewModelProtocol {
     lazy var cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
     let cartSubmissionSubject: PassthroughSubject<[CartItem], Never> = .init()
 
-    lazy var addMoreToCartActionPublisher = addMoreToCartActionSubject.eraseToAnyPublisher()
-    let addMoreToCartActionSubject: PassthroughSubject<Void, Never> = .init()
-
-    lazy var itemsInCartPublisher: AnyPublisher<[CartItem], Never> = itemsInCartSubject.eraseToAnyPublisher()
-    let itemsInCartSubject: PassthroughSubject<[CartItem], Never> = .init()
-
-    var canDeleteItemsFromCart: Bool = false
     var itemsInCartLabel: String? = nil
 
     func submitCart() {
         submitCartCalled = true
     }
 
-    func addMoreToCart() {
-        addMoreToCartCalled = true
-        addMoreToCartActionSubject.send(())
-    }
-
     // Mock variables
     var submitCartCalled = false
-    var addMoreToCartCalled = false
 }
 
 // MARK: - Helpers

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -3,6 +3,8 @@ import Foundation
 import protocol Yosemite.POSItem
 
 final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
+    var orderStage: PointOfSaleOrderStage
+
     var allItems: [POSItem] {
         switch itemListState {
         case .empty,
@@ -17,8 +19,10 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
 
     var itemListState: ItemListState
 
-    init(itemListState: ItemListState = .initialLoading) {
+    init(itemListState: ItemListState = .initialLoading,
+         orderStage: PointOfSaleOrderStage = .building) {
         self.itemListState = itemListState
+        self.orderStage = orderStage
     }
 
     func loadInitialItems() async { }
@@ -37,4 +41,10 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     func removeAllItemsFromCart() {
         removeAllItemsFromCartCalled = true
     }
+
+    func submitCart() { }
+
+    func addMoreToCart() { }
+
+    func startNewCart() { }
 }

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -5,6 +5,58 @@ import protocol Yosemite.POSItem
 @testable import struct Yosemite.POSProduct
 
 struct PointOfSaleAggregateModelTests {
+    struct OrderStageTests {
+        private let sut: PointOfSaleAggregateModel
+
+        init() {
+            self.sut = PointOfSaleAggregateModel(itemProvider: MockPOSItemProvider())
+        }
+
+        @Test func inits_with_building_order_stage() async throws {
+            #expect(sut.orderStage == .building)
+        }
+
+        @Test func startNewCart_removes_all_items_from_cart_and_moves_back_to_building() async throws {
+            // Given
+            sut.addToCart(makeItem())
+            sut.submitCart()
+            try #require(sut.orderStage == .finalizing)
+            try #require(sut.cart.isNotEmpty)
+
+            // When
+            sut.startNewCart()
+
+            // Then
+            #expect(sut.orderStage == .building)
+            #expect(sut.cart.isEmpty)
+        }
+
+        @Test func submitCart_moves_to_finalizing_order_stage() async throws {
+            // Given
+            sut.addToCart(makeItem())
+
+            // When
+            sut.submitCart()
+
+            // Then
+            #expect(sut.orderStage == .finalizing)
+        }
+
+        @Test func addMoreToCart_moves_to_building_order_stage() async throws {
+            // Given
+            sut.addToCart(makeItem())
+            sut.submitCart()
+            try #require(sut.orderStage == .finalizing)
+
+            // When
+            sut.addMoreToCart()
+
+            // Then
+            #expect(sut.orderStage == .building)
+        }
+
+    }
+
     struct ItemListTests {
         private var itemProvider: MockPOSItemProvider
         private let sut: PointOfSaleAggregateModel
@@ -266,7 +318,7 @@ struct PointOfSaleAggregateModelTests {
         @Test func addItem_results_in_a_non_empty_cart() async throws {
             // Given
             try #require(sut.cart.isEmpty)
-            let item = Self.makeItem()
+            let item = makeItem()
 
             // When
             sut.addToCart(item)
@@ -277,7 +329,7 @@ struct PointOfSaleAggregateModelTests {
 
         @Test func addItem_puts_new_items_first_in_the_cart() async throws {
             // Given
-            let items = [Self.makeItem(), Self.makeItem(), Self.makeItem()]
+            let items = [makeItem(), makeItem(), makeItem()]
 
             // When
             items.forEach(sut.addToCart(_:))
@@ -288,8 +340,8 @@ struct PointOfSaleAggregateModelTests {
 
         @Test func removeItem_after_adding_two_items_removes_item_correctly() async throws {
             // Given
-            let item = Self.makeItem(name: "Item 1")
-            let anotherItem = Self.makeItem(name: "Item 2")
+            let item = makeItem(name: "Item 1")
+            let anotherItem = makeItem(name: "Item 2")
 
             sut.addToCart(item)
             sut.addToCart(anotherItem)
@@ -306,8 +358,8 @@ struct PointOfSaleAggregateModelTests {
 
         @Test func removeAllItemsFromCart_removes_everything() async throws {
             // Given
-            let item = Self.makeItem(name: "Item 1")
-            let anotherItem = Self.makeItem(name: "Item 2")
+            let item = makeItem(name: "Item 1")
+            let anotherItem = makeItem(name: "Item 2")
 
             sut.addToCart(item)
             sut.addToCart(anotherItem)
@@ -328,7 +380,7 @@ struct PointOfSaleAggregateModelTests {
             """))
         func addToCart_tracks_analytics_event() async throws {
             // Given
-            let item = Self.makeItem()
+            let item = makeItem()
 
             // When
             sut.addToCart(item)
@@ -337,16 +389,16 @@ struct PointOfSaleAggregateModelTests {
             let event = try #require(analyticsProvider.receivedEvents.first)
             #expect(event == "pos_item_added_to_cart")
         }
-
-        static func makeItem(name: String = "") -> POSItem {
-            return POSProduct(itemID: UUID(),
-                              productID: 0,
-                              name: name,
-                              price: "",
-                              formattedPrice: "",
-                              itemCategories: [],
-                              productImageSource: nil,
-                              productType: .simple)
-        }
     }
+}
+
+private func makeItem(name: String = "") -> POSItem {
+    return POSProduct(itemID: UUID(),
+                      productID: 0,
+                      name: name,
+                      price: "",
+                      formattedPrice: "",
+                      itemCategories: [],
+                      productImageSource: nil,
+                      productType: .simple)
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -49,38 +49,10 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Given
         let expectedAddMoreButtonDisabledState = false
         let expectedExitPOSButtonDisabledState = false
-        let expectedOrderStage = PointOfSaleDashboardViewModel.OrderStage.building
 
         // When/Then
-        XCTAssertEqual(sut.orderStage, expectedOrderStage)
         XCTAssertEqual(sut.isAddMoreDisabled, expectedAddMoreButtonDisabledState)
         XCTAssertEqual(sut.isExitPOSDisabled, expectedExitPOSButtonDisabledState)
-    }
-
-    func test_start_new_order() {
-        // Given
-        let expectedOrderStage = PointOfSaleDashboardViewModel.OrderStage.building
-
-        // When
-        mockTotalsViewModel.startNewOrderAction = ()
-
-        // Then
-        XCTAssertEqual(sut.orderStage, expectedOrderStage)
-        XCTAssertTrue(mockPOSModel.removeAllItemsFromCartCalled)
-    }
-
-    func test_items_added_to_cart() {
-        // Given
-        let item = Self.makeItem()
-        let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
-        let itemsAdded = true
-        let expectedOrderStage = PointOfSaleDashboardViewModel.OrderStage.building
-
-        // When
-        mockCartViewModel.itemsInCartSubject.send([cartItem])
-
-        // Then
-        XCTAssertEqual(sut.orderStage, expectedOrderStage)
     }
 
     func test_isAddMoreDisabled_is_true_when_order_is_syncing_and_paymentState_is_idle() {
@@ -208,28 +180,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func test_observeCartSubmission_updates_orderStage() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect orderStage to be .finalizing and isSyncingOrder to be true")
-        let customCartItems = [CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)]
-
-        // Attach sink to observe changes to orderStage
-        var orderStageValue: PointOfSaleDashboardViewModel.OrderStage?
-        sut.$orderStage
-            .sink { orderStage in
-                orderStageValue = orderStage
-                expectation.fulfill()
-            }
-            .store(in: &cancellables)
-
-        // When
-        mockCartViewModel.submitCart(with: customCartItems)
-
-        // Then
-        wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(orderStageValue, .finalizing)
-    }
-
     func test_observeCartSubmission_starts_syncing_order() {
         // Given
         let expectation = XCTestExpectation(description: "Expect orderStage to be .finalizing and isSyncingOrder to be true")
@@ -250,98 +200,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: 1.0)
         XCTAssertTrue(receivedIsSyncingOrder)
-    }
-
-    func test_observeCartAddMoreAction_updates_orderStage_to_building() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect orderStage to be .building when adding more to the cart")
-
-        var receivedOrderStage: PointOfSaleDashboardViewModel.OrderStage?
-        // Attach sink to observe changes to orderStage
-        sut.$orderStage
-            // Ignore the initial value of orderStage to ensure that the test only reacts to changes in the orderStage after the subscription has started.
-            .dropFirst()
-            .sink { orderStage in
-                receivedOrderStage = orderStage
-                XCTAssertEqual(receivedOrderStage, .building)
-                expectation.fulfill()
-            }
-            .store(in: &cancellables)
-
-        // When
-        mockCartViewModel.addMoreToCart()
-
-        wait(for: [expectation], timeout: 1.0)
-    }
-
-    func test_observeCartItemsToCheckIfCartIsEmpty_updates_orderStage_to_building() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect orderStage to be .building when cart becomes empty")
-        var receivedOrderStage: PointOfSaleDashboardViewModel.OrderStage?
-
-        // Attach sink to observe changes to orderStage
-        sut.$orderStage
-            .dropFirst() // Ignore the initial value. Avoids immediately fulfilling the expectation upon subscribing.
-            .sink { orderStage in
-                receivedOrderStage = orderStage
-                if orderStage == .building {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-        mockCartViewModel.itemsInCartSubject.send([]) // Trigger the empty cart condition
-
-        // Then
-        wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(receivedOrderStage, .building)
-    }
-
-    func test_cartSubmitted_sets_cartViewModel_canDeleteItems_false() {
-        // Given
-        XCTAssertTrue(mockCartViewModel.canDeleteItemsFromCart)
-
-        // When
-        mockCartViewModel.cartSubmissionSubject.send([CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)])
-
-        // Then
-        XCTAssertFalse(mockCartViewModel.canDeleteItemsFromCart)
-    }
-
-    func test_cartSubmitted_calls_totalsViewModel_startShowingTotalsView() {
-        // Given
-        mockTotalsViewModel.spyStartShowingTotalsViewCalled = false
-
-        // When
-        mockCartViewModel.cartSubmissionSubject.send([CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)])
-
-        // Then
-        XCTAssertTrue(mockTotalsViewModel.spyStartShowingTotalsViewCalled)
-    }
-
-    func test_addMoreTapped_sets_cartViewModel_canDeleteItems_true() {
-        // Given
-        mockCartViewModel.cartSubmissionSubject.send([CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)])
-        XCTAssertFalse(mockCartViewModel.canDeleteItemsFromCart)
-
-        // When
-        mockCartViewModel.addMoreToCartActionSubject.send(())
-
-        // Then
-        XCTAssertTrue(mockCartViewModel.canDeleteItemsFromCart)
-    }
-
-    func test_addMoreTapped_calls_totalsViewModel_stopShowingTotalsView() {
-        // Given the TotalsView is showing
-        mockCartViewModel.cartSubmissionSubject.send([])
-        mockTotalsViewModel.spyStopShowingTotalsViewCalled = false
-
-        // When
-        mockCartViewModel.addMoreToCartActionSubject.send(())
-
-        // Then
-        XCTAssertTrue(mockTotalsViewModel.spyStopShowingTotalsViewCalled)
     }
 
     func test_showsConnectivityError_when_nonReachable_then_shows_error() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14406
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR extracts the OrderStage to the aggregate model, and removes some cross-cutting state updates between the various views/viewModels.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This requires general smoke testing, rather than detailed repro steps.

The `OrderStage` defines which major views are shown, as well as how some of those views function.

For example, in the `building` state, we show `ItemList` and `Cart`, whereas in the `finalizing` state, we show `Totals` and (sometimes) `Cart`. (A future improvement may be to add an intervening `reviewing` stage, so that the `OrderStage` becomes the overall source of truth for which views are showing)

Beyond this it controls smaller things, like whether items can be removed from the cart; in the `building` stage, they can be, but in `finalizing`, they can't.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/fbc8abd5-8a19-4da6-93c4-ff948ff6f35a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.