### PR TITLE
[Shipping labels] Use legacy logic for setting origin and destination addresses

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -48,12 +48,12 @@ struct WooShippingCreateLabelsView: View {
 
                     if viewModel.canViewLabel {
                         EmptyView()
-                    } else if viewModel.hasPackage {
+                    } else if viewModel.hasPackage, let shippingService = viewModel.shippingService {
                         // TODO: Display package section
                         // Package heading and edit button
                         // Selected package details
                         // Total shipment weight field
-                        WooShippingServiceView(viewModel: viewModel.shippingService)
+                        WooShippingServiceView(viewModel: shippingService)
                             .padding(.horizontal, -16)
                     } else {
                         WooShippingPackageAndRatePlaceholder()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -6,6 +6,9 @@ import WooFoundation
 ///
 final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
+    private let order: Order
+    private let originSiteAddress: ShippingLabelAddress?
+    private let destinationAddress: ShippingLabelAddress?
 
     /// The purchased shipping label.
     @Published private var shippingLabel: ShippingLabel?
@@ -27,18 +30,22 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     let hasPackage: Bool = false
 
     /// View model for the label shipping service.
-    private(set) var shippingService: WooShippingServiceViewModel
+    private(set) var shippingService: WooShippingServiceViewModel?
 
     /// Selected shipping rate when creating a shipping label.
     private var selectedRate: WooShippingSelectedRate? {
-        shippingService.selectedRate
+        shippingService?.selectedRate
     }
 
     /// Address to ship from (store address), formatted for display.
-    let originAddress: String
+    private(set) lazy var originAddress: String = {
+        originSiteAddress?.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
+    }()
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
-    let destinationAddressLines: [String]
+    private(set) lazy var destinationAddressLines: [String] = {
+        (destinationAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
+    }()
 
     /// Shipping lines for the order, with formatted amount.
     let shippingLines: [WooShipping_ShippingLineViewModel]
@@ -81,23 +88,43 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
+    /// Initialize the view model without an existing shipping label.
     init(order: Order,
-         shippingLabel: ShippingLabel? = nil,
-         siteAddress: SiteAddress = SiteAddress(),
+         originAddress: SiteAddress? = nil,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingService: WooShippingServiceViewModel = WooShippingServiceViewModel(),
-         onLabelPurchase: ((Bool) -> Void)? = nil) {
-        self.shippingLabel = shippingLabel
-        if let shippingLabel {
-            self.postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
-        }
+         onLabelPurchase: ((Bool) -> Void)? = nil,
+         userDefaults: UserDefaults = .standard) {
+        self.order = order
         self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase
-        self.originAddress = Self.formatOriginAddress(siteAddress: siteAddress)
-        self.destinationAddressLines = (order.shippingAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
+        let accountSettings = Self.getStoredAccountSettings()
+        let company = ServiceLocator.stores.sessionManager.defaultSite?.name
+        let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount
+        self.originSiteAddress = Self.getDefaultOriginAddress(accountSettings: accountSettings,
+                                                              company: company,
+                                                              siteAddress: originAddress ?? SiteAddress(),
+                                                              account: defaultAccount,
+                                                              userDefaults: userDefaults)
+        self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
         self.shippingService = shippingService
+    }
+
+    /// Initialize the view model from an existing shipping label.
+    init(order: Order,
+         shippingLabel: ShippingLabel,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        self.order = order
+        self.shippingLabel = shippingLabel
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+        self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
+        self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
+        self.originSiteAddress = shippingLabel.originAddress
+        self.destinationAddress = shippingLabel.destinationAddress
+        self.onLabelPurchase = nil
     }
 
     /// Purchases a shipping label with the provided label details and settings.
@@ -114,6 +141,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     }
 }
 
+// MARK: Utils
 private extension WooShippingCreateLabelsViewModel {
     /// Provides the formatted label and amount for a shipping rate, based on the provided base rate.
     func formatShippingRate(name: String, rate: Double, basedOn baseRate: Double? = nil) -> (title: String, amount: String) {
@@ -126,21 +154,65 @@ private extension WooShippingCreateLabelsViewModel {
         return (name, currencyFormatter.formatAmount(Decimal(amount)) ?? amount.description)
     }
 
-    /// Formats the origin address from the provided `SiteAddress`.
-    static func formatOriginAddress(siteAddress: SiteAddress) -> String {
-        let address = Address(firstName: "",
-                              lastName: "",
-                              company: nil,
+    // We generate the default origin address using the information
+    // of the logged Account and of the website.
+    static func getDefaultOriginAddress(accountSettings: AccountSettings?,
+                                        company: String?,
+                                        siteAddress: SiteAddress,
+                                        account: Account?,
+                                        userDefaults: UserDefaults) -> ShippingLabelAddress? {
+        let address = Address(firstName: accountSettings?.firstName ?? "",
+                              lastName: accountSettings?.lastName ?? "",
+                              company: company ?? "",
                               address1: siteAddress.address,
                               address2: siteAddress.address2,
                               city: siteAddress.city,
                               state: siteAddress.state,
                               postcode: siteAddress.postalCode,
                               country: siteAddress.countryCode.rawValue,
-                              phone: nil,
-                              email: nil)
-        let formattedPostalAddress = address.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ")
-        return formattedPostalAddress ?? ""
+                              phone: userDefaults[.storePhoneNumber] ?? "",
+                              email: account?.email)
+        return fromAddressToShippingLabelAddress(address: address)
+    }
+
+    /// Gets the destination address as a `ShippingLabelAddress`.
+    /// The order's billing phone is used as a fallback if there is no shipping phone.
+    ///
+    static func getDestinationAddress(order: Order, address: Address?) -> ShippingLabelAddress? {
+        guard let phone = address?.phone, phone.isNotEmpty else {
+            let destinationAddress = address?.copy(phone: order.billingAddress?.phone)
+            return fromAddressToShippingLabelAddress(address: destinationAddress)
+        }
+        return fromAddressToShippingLabelAddress(address: address)
+    }
+
+    static func fromAddressToShippingLabelAddress(address: Address?) -> ShippingLabelAddress? {
+        guard let address = address else { return nil }
+
+        // In this way we support localized name correctly,
+        // because the order is often reversed in a few Asian languages.
+        var components = PersonNameComponents()
+        components.givenName = address.firstName
+        components.familyName = address.lastName
+
+        let shippingLabelAddress = ShippingLabelAddress(company: address.company ?? "",
+                                                        name: PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: []),
+                                                        phone: address.phone ?? "",
+                                                        country: address.country,
+                                                        state: address.state,
+                                                        address1: address.address1,
+                                                        address2: address.address2 ?? "",
+                                                        city: address.city,
+                                                        postcode: address.postcode)
+        return shippingLabelAddress
+    }
+
+    static func getStoredAccountSettings() -> AccountSettings? {
+        let storageManager = ServiceLocator.storageManager
+
+        let resultsController = ResultsController<StorageAccountSettings>(storageManager: storageManager, sortedBy: [])
+        try? resultsController.performFetch()
+        return resultsController.fetchedObjects.first
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -40,7 +40,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let siteAddress = SiteAddress(siteSettings: siteSettings)
 
         // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), siteAddress: siteAddress)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), originAddress: siteAddress)
 
         // Then
         XCTAssertEqual("60 29th Street #343, Auburn NY 13021, US", viewModel.originAddress)
@@ -151,7 +151,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let order = Order.fake()
         let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
-        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
+        let card = try XCTUnwrap(viewModel.shippingService?.serviceTabs.first?.cards[1])
         card.signatureRequirement = .signatureRequired
 
         // When
@@ -169,7 +169,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let order = Order.fake()
         let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
-        let card = try XCTUnwrap(viewModel.shippingService.serviceTabs.first?.cards[1])
+        let card = try XCTUnwrap(viewModel.shippingService?.serviceTabs.first?.cards[1])
         card.signatureRequirement = .adultSignatureRequired
 
         // When
@@ -273,7 +273,7 @@ private extension WooShippingCreateLabelsViewModelTests {
 private extension WooShippingCreateLabelsViewModel {
     /// Selects the first available shipping rate.
     func selectShippingRate() throws {
-        let card = try XCTUnwrap(self.shippingService.serviceTabs.first?.cards.first)
+        let card = try XCTUnwrap(self.shippingService?.serviceTabs.first?.cards.first)
         card.selectRate()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14393
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the Woo Shipping labels flow to set the origin and destination addresses in the same way as the legacy shipping labels flow. This sets up the view model to be better prepared for using these addresses in remote requests (e.g. to get label rates) and ensures consistency with the previous address behavior.

Note that in a future milestone we'll be updating how we set the origin address for the shipping label.

### How

* Uses the legacy logic to generate the origin and destination addresses as `ShippingLabelAddress` objects, and saves them as properties to use with the shipping service view model in a future PR.
* Adds an initializer for existing shipping labels, so we use the origin and destination addresses from the label itself. This initializer also skips setting properties that we don't need to existing labels (including the shipping service view model, which is now optional).

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: The Woo Shipping extension installed and activated, with at least one order with the `processing` status and a physical product.

1. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
2. Go to the Orders tab.
3. Select an order eligible for a shipping label.
4. Tap "Create Shipping Label."
5. Open the Shipment Details bottom sheet and confirm the origin and destination addresses appear as expected.

You can also check an order with a purchased shipping label:

1. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
2. Go to the Orders tab.
3. Select an order with a purchased shipping label.
4. In the shipping labels section, select "View purchased shipping label."
5. Open the Shipment Details bottom sheet and confirm the origin and destination addresses appear as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.