### PR TITLE
[Shipping labels] Load the shipping services and rates from remote in the UI layer

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3133,6 +3133,42 @@ extension Networking.ShippingLabelCustomsForm.Item {
     }
 }
 
+extension Networking.ShippingLabelPackageSelected {
+    public func copy(
+        id: CopiableProp<String> = .copy,
+        boxID: CopiableProp<String> = .copy,
+        length: CopiableProp<Double> = .copy,
+        width: CopiableProp<Double> = .copy,
+        height: CopiableProp<Double> = .copy,
+        weight: CopiableProp<Double> = .copy,
+        isLetter: CopiableProp<Bool> = .copy,
+        hazmatCategory: NullableCopiableProp<String> = .copy,
+        customsForm: NullableCopiableProp<ShippingLabelCustomsForm> = .copy
+    ) -> Networking.ShippingLabelPackageSelected {
+        let id = id ?? self.id
+        let boxID = boxID ?? self.boxID
+        let length = length ?? self.length
+        let width = width ?? self.width
+        let height = height ?? self.height
+        let weight = weight ?? self.weight
+        let isLetter = isLetter ?? self.isLetter
+        let hazmatCategory = hazmatCategory ?? self.hazmatCategory
+        let customsForm = customsForm ?? self.customsForm
+
+        return Networking.ShippingLabelPackageSelected(
+            id: id,
+            boxID: boxID,
+            length: length,
+            width: width,
+            height: height,
+            weight: weight,
+            isLetter: isLetter,
+            hazmatCategory: hazmatCategory,
+            customsForm: customsForm
+        )
+    }
+}
+
 extension Networking.ShippingLabelPackagesResponse {
     public func copy(
         storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents the package selected that will be sent in Shipping Labels Carriers and Rates endpoint.
 ///
-public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
+public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     public let id: String
     public let boxID: String

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -47,8 +47,8 @@ struct WooShippingServiceView: View {
                        tabsNameFont: .subheadline.bold(),
                        tabItemContentHorizontalPadding: 6,
                        tabItemContentVerticalPadding: 12)
-            .redacted(reason: viewModel.isLoadingRates ? .placeholder : [])
-            .shimmering(active: viewModel.isLoadingRates)
+            .redacted(reason: viewModel.loadingState == .loading ? .placeholder : [])
+            .shimmering(active: viewModel.loadingState == .loading)
         }
     }
 }
@@ -77,8 +77,4 @@ private extension WooShippingServiceView {
                                               value: "Sort by",
                                               comment: "Label for the menu to select a sort order for shipping rates in the shipping label creation screen.")
     }
-}
-
-#Preview {
-    WooShippingServiceView(viewModel: .init())
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -47,6 +47,8 @@ struct WooShippingServiceView: View {
                        tabsNameFont: .subheadline.bold(),
                        tabItemContentHorizontalPadding: 6,
                        tabItemContentVerticalPadding: 12)
+            .redacted(reason: viewModel.isLoadingRates ? .placeholder : [])
+            .shimmering(active: viewModel.isLoadingRates)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -1,6 +1,12 @@
 import Yosemite
 
 final class WooShippingServiceViewModel: ObservableObject {
+    private let siteID: Int64
+    private let orderID: Int64
+    private let originAddress: ShippingLabelAddress?
+    private let destinationAddress: ShippingLabelAddress?
+    private let stores: StoresManager
+
     /// List of tabs to display for the shipping services.
     /// Contains the data about available shipping rates, grouped by carrier.
     @Published private(set) var serviceTabs: [WooShippingServiceTab] = []
@@ -9,12 +15,7 @@ final class WooShippingServiceViewModel: ObservableObject {
     @Published private(set) var selectedRate: WooShippingSelectedRate?
 
     /// State of loading shipping rates.
-    private var loadingState: LabelRatesState = .loading
-
-    /// Whether the rates are being loaded from remote.
-    var isLoadingRates: Bool {
-        loadingState == .loading
-    }
+    private(set) var loadingState: LabelRatesState = .loading
 
     /// Available standard shipping rates.
     private var standardRates: [ShippingLabelCarrierRate] = []
@@ -26,14 +27,22 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Sort order for shipping services.
     @Published var sortOrder: SortOrder = .price
 
-    init(standardRates: [ShippingLabelCarrierRate] = placeholderRates,
-         signatureRates: [ShippingLabelCarrierRate] = [],
-         adultSignatureRates: [ShippingLabelCarrierRate] = []) {
-        // TODO: Replace with real data from remote
-        self.standardRates = standardRates
-        self.signatureRates = signatureRates
-        self.adultSignatureRates = adultSignatureRates
-        generateServiceTabs()
+    /// Closure to execute after a rate is selected.
+    let onSelectRate: ((_ selectedRate: WooShippingSelectedRate) -> Void)?
+
+    init(order: Order,
+         originAddress: ShippingLabelAddress?,
+         destinationAddress: ShippingLabelAddress?,
+         selectedPackage: ShippingLabelPackageSelected,
+         stores: StoresManager = ServiceLocator.stores,
+         onSelectRate: ((_ selectedRate: WooShippingSelectedRate) -> Void)? = nil) {
+        self.siteID = order.siteID
+        self.orderID = order.orderID
+        self.originAddress = originAddress
+        self.destinationAddress = destinationAddress
+        self.stores = stores
+        self.onSelectRate = onSelectRate
+        loadLabelRates(for: selectedPackage)
     }
 
     /// Sorts the shipping services by the provided sort order.
@@ -42,8 +51,80 @@ final class WooShippingServiceViewModel: ObservableObject {
         generateServiceTabs()
     }
 
+    /// Selects the rate with the given title and signature requirement.
+    func selectRate(_ rate: ShippingLabelCarrierRate, signatureRate: ShippingLabelCarrierRate?, adultSignatureRate: ShippingLabelCarrierRate?) {
+        let selectedRate = WooShippingSelectedRate(rate: rate, signatureRate: signatureRate, adultSignatureRate: adultSignatureRate)
+        self.selectedRate = selectedRate
+        generateServiceTabs()
+        onSelectRate?(selectedRate)
+    }
+
+    /// Retrieves shipping label rates for this shipment from remote.
+    func loadLabelRates(for selectedPackage: ShippingLabelPackageSelected) {
+        guard let originAddress, let destinationAddress else {
+            return updateLoadingState(to: .error)
+        }
+        updateLoadingState(to: .loading)
+        let action = WooShippingAction.loadLabelRates(siteID: siteID,
+                                                      orderID: orderID,
+                                                      originAddress: originAddress,
+                                                      destinationAddress: destinationAddress,
+                                                      packages: [selectedPackage]) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case let .success(rates):
+                guard let rates = rates.first(where: { $0.packageID == selectedPackage.id }) else {
+                    DDLogError("⛔️ Fetched shipping label rates for Woo Shipping do not include rates for selected package: \(selectedPackage)")
+                    updateLoadingState(to: .error)
+                    return
+                }
+                standardRates = rates.defaultRates
+                signatureRates = rates.signatureRequired
+                adultSignatureRates = rates.adultSignatureRequired
+                updateLoadingState(to: .loaded)
+            case let .failure(error):
+                DDLogError("⛔️ Error loading shipping label rates for Woo Shipping: \(error)")
+                updateLoadingState(to: .error)
+            }
+        }
+        stores.dispatch(action)
+    }
+}
+
+extension WooShippingServiceViewModel {
+    /// Holds the data needed to display a tab in `WooShippingServiceViewModel`.
+    struct WooShippingServiceTab: Identifiable {
+        let id: WooShippingCarrier
+        let cards: [WooShippingServiceCardViewModel]
+    }
+
+    /// Options for sorting available shipping services.
+    enum SortOrder: CaseIterable {
+        case price
+        case deliveryTime
+
+        var displayName: String {
+            switch self {
+            case .price:
+                Localization.sortByPrice
+            case .deliveryTime:
+                Localization.sortByDeliveryTime
+            }
+        }
+    }
+
+    /// States for label rates.
+    enum LabelRatesState {
+        case loading
+        case loaded
+        case error
+    }
+}
+
+// MARK: Utils
+private extension WooShippingServiceViewModel {
     /// Generates the data to display available shipping rates, grouped by carrier ID.
-    private func generateServiceTabs() {
+    func generateServiceTabs() {
         serviceTabs = standardRates.grouped(by: { $0.carrierID })
             .compactMap { (carrierID, rates) -> WooShippingServiceTab? in
                 guard let carrier = WooShippingCarrier(rawValue: carrierID) else {
@@ -74,47 +155,30 @@ final class WooShippingServiceViewModel: ObservableObject {
                             let signatureRate = signatureRequirement == .signatureRequired ? signatureRates.first(where: { $0.title == rateTitle }) : nil
                             let adultSignatureRate = signatureRequirement == .adultSignatureRequired ?
                                 adultSignatureRates.first(where: { $0.title == rateTitle }) : nil
-                            selectedRate = WooShippingSelectedRate(rate: rate,
-                                                                   signatureRate: signatureRate,
-                                                                   adultSignatureRate: adultSignatureRate)
-                            self.generateServiceTabs()
+                            selectRate(rate, signatureRate: signatureRate, adultSignatureRate: adultSignatureRate)
                         }
                     }
                 return WooShippingServiceTab(id: carrier, cards: cards)
             }
             .sorted(by: { $0.id < $1.id })
     }
-}
 
-extension WooShippingServiceViewModel {
-    /// Holds the data needed to display a tab in `WooShippingServiceViewModel`.
-    struct WooShippingServiceTab: Identifiable {
-        let id: WooShippingCarrier
-        let cards: [WooShippingServiceCardViewModel]
-    }
-
-    /// Options for sorting available shipping services.
-    enum SortOrder: CaseIterable {
-        case price
-        case deliveryTime
-
-        var displayName: String {
-            switch self {
-            case .price:
-                Localization.sortByPrice
-            case .deliveryTime:
-                Localization.sortByDeliveryTime
-            }
+    /// Updates view model for provided loading state.
+    func updateLoadingState(to state: LabelRatesState) {
+        switch state {
+        case .loading:
+            standardRates = Self.placeholderRates
+            generateServiceTabs()
+        case .loaded:
+            generateServiceTabs()
+        case .error:
+            serviceTabs = []
         }
-    }
-
-    /// States for label rates.
-    enum LabelRatesState {
-        case loading
-        case loaded
+        loadingState = state
     }
 }
 
+// MARK: Constants
 private extension WooShippingServiceViewModel {
     enum Localization {
         static let sortByPrice = NSLocalizedString("wooShipping.createLabels.rates.sortBy.price",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -8,6 +8,14 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Selected shipping service rate.
     @Published private(set) var selectedRate: WooShippingSelectedRate?
 
+    /// State of loading shipping rates.
+    private var loadingState: LabelRatesState = .loading
+
+    /// Whether the rates are being loaded from remote.
+    var isLoadingRates: Bool {
+        loadingState == .loading
+    }
+
     /// Available standard shipping rates.
     private var standardRates: [ShippingLabelCarrierRate] = []
     /// Available shipping rates with signature required.
@@ -18,7 +26,7 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Sort order for shipping services.
     @Published var sortOrder: SortOrder = .price
 
-    init(standardRates: [ShippingLabelCarrierRate] = [],
+    init(standardRates: [ShippingLabelCarrierRate] = placeholderRates,
          signatureRates: [ShippingLabelCarrierRate] = [],
          adultSignatureRates: [ShippingLabelCarrierRate] = []) {
         // TODO: Replace with real data from remote
@@ -99,6 +107,12 @@ extension WooShippingServiceViewModel {
             }
         }
     }
+
+    /// States for label rates.
+    enum LabelRatesState {
+        case loading
+        case loaded
+    }
 }
 
 private extension WooShippingServiceViewModel {
@@ -109,5 +123,38 @@ private extension WooShippingServiceViewModel {
         static let sortByDeliveryTime = NSLocalizedString("wooShipping.createLabels.rates.sortBy.deliveryTime",
                                                           value: "Fastest",
                                                           comment: "Option to sort shipping rates by delivery time in the shipping label creation screen.")
+    }
+}
+
+// MARK: Placeholder data
+private extension WooShippingServiceViewModel {
+    /// Placeholder data to use while loading rates from remote.
+    static var placeholderRates: [ShippingLabelCarrierRate] {
+        [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                 insurance: "100",
+                                 retailRate: 40.06,
+                                 rate: 40.06,
+                                 rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
+                                 serviceID: "",
+                                 carrierID: "usps",
+                                 shipmentID: "",
+                                 hasTracking: true,
+                                 isSelected: false,
+                                 isPickupFree: true,
+                                 deliveryDays: 2,
+                                 deliveryDateGuaranteed: false),
+         ShippingLabelCarrierRate(title: "DHL - Next Day",
+                                  insurance: "100",
+                                  retailRate: 15,
+                                  rate: 14.22,
+                                  rateID: "rate_a8a29d5f34984722942f466c30ea27eg",
+                                  serviceID: "",
+                                  carrierID: "dhlexpress",
+                                  shipmentID: "",
+                                  hasTracking: true,
+                                  isSelected: false,
+                                  isPickupFree: true,
+                                  deliveryDays: 1,
+                                  deliveryDateGuaranteed: false)]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -48,7 +48,7 @@ struct WooShippingCreateLabelsView: View {
 
                     if viewModel.canViewLabel {
                         EmptyView()
-                    } else if viewModel.hasPackage, let shippingService = viewModel.shippingService {
+                    } else if let shippingService = viewModel.shippingService {
                         // TODO: Display package section
                         // Package heading and edit button
                         // Selected package details
@@ -77,7 +77,7 @@ struct WooShippingCreateLabelsView: View {
                             Text(Localization.BottomSheet.shipmentDetails)
                                 .foregroundStyle(Color(.primary))
                                 .bold()
-                            if viewModel.hasPackage && !viewModel.canViewLabel {
+                            if viewModel.selectedPackage != nil && !viewModel.canViewLabel {
                                 purchaseButton
                             }
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -24,18 +24,25 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
-    // TODO: Update this to a property that refers to the package, when selected
-    /// Whether there is a package selected for the shipping label.
-    /// Temporary property that can be set to `true` to enable features that require a selected package, until package feature is complete.
-    let hasPackage: Bool = false
+    /// Selected package for the shipping label.
+    @Published private(set) var selectedPackage: ShippingLabelPackageSelected? {
+        didSet {
+            if let selectedPackage {
+                shippingService = WooShippingServiceViewModel(order: order,
+                                                              originAddress: originSiteAddress,
+                                                              destinationAddress: destinationAddress,
+                                                              selectedPackage: selectedPackage) { [weak self] selectedRate in
+                    self?.selectedRate = selectedRate
+                }
+            }
+        }
+    }
 
     /// View model for the label shipping service.
     private(set) var shippingService: WooShippingServiceViewModel?
 
     /// Selected shipping rate when creating a shipping label.
-    private var selectedRate: WooShippingSelectedRate? {
-        shippingService?.selectedRate
-    }
+    private var selectedRate: WooShippingSelectedRate?
 
     /// Address to ship from (store address), formatted for display.
     private(set) lazy var originAddress: String = {
@@ -91,8 +98,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Initialize the view model without an existing shipping label.
     init(order: Order,
          originAddress: SiteAddress? = nil,
+         selectedRate: WooShippingSelectedRate? = nil,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         shippingService: WooShippingServiceViewModel = WooShippingServiceViewModel(),
          onLabelPurchase: ((Bool) -> Void)? = nil,
          userDefaults: UserDefaults = .standard) {
         self.order = order
@@ -109,7 +116,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                               userDefaults: userDefaults)
         self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
-        self.shippingService = shippingService
+        self.selectedRate = selectedRate
     }
 
     /// Initialize the view model from an existing shipping label.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -72,16 +72,15 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(order.shippingLines.map({ $0.shippingID }), viewModel.shippingLines.map({ $0.id }))
     }
 
-    func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() throws {
+    func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() {
         // Given
         let order = Order.fake()
 
         // When
-        let markOrderComplete: Bool = try waitFor { promise in
-            let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingService: self.sampleShippingService(), onLabelPurchase: { complete in
+        let markOrderComplete: Bool = waitFor { promise in
+            let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate(), onLabelPurchase: { complete in
                 promise(complete)
             })
-            try viewModel.selectShippingRate()
             viewModel.markOrderComplete = false
             viewModel.purchaseLabel()
         }
@@ -90,16 +89,15 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertFalse(markOrderComplete)
     }
 
-    func test_onLabelPurchase_notifies_when_order_should_be_marked_complete() throws {
+    func test_onLabelPurchase_notifies_when_order_should_be_marked_complete() {
         // Given
         let order = Order.fake()
 
         // When
-        let markOrderComplete: Bool = try waitFor { promise in
-            let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingService: self.sampleShippingService(), onLabelPurchase: { complete in
+        let markOrderComplete: Bool = waitFor { promise in
+            let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate(), onLabelPurchase: { complete in
                 promise(complete)
             })
-            try viewModel.selectShippingRate()
             viewModel.markOrderComplete = true
             viewModel.purchaseLabel()
         }
@@ -108,54 +106,41 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertTrue(markOrderComplete)
     }
 
-    func test_canPurchaseLabel_true_after_shipping_rate_is_selected() throws {
+    func test_canPurchaseLabel_true_when_shipping_rate_is_selected() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingService: sampleShippingService())
-        XCTAssertFalse(viewModel.canPurchaseLabel)
-
-        // When
-        try viewModel.selectShippingRate()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate())
 
         // Then
         XCTAssertTrue(viewModel.canPurchaseLabel)
     }
 
-    func test_selecting_shipping_rate_sets_totalCost() throws {
+    func test_totalCost_has_expected_value_when_shipping_rate_is_set() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
-
-        // When
-        try viewModel.selectShippingRate()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate(), currencySettings: CurrencySettings())
 
         // Then
-        XCTAssertEqual(viewModel.totalCost, "$7.53")
+        XCTAssertEqual(viewModel.totalCost, "$40.06")
     }
 
     func test_selecting_standard_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
-
-        // When
-        try viewModel.selectShippingRate()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate(), currencySettings: CurrencySettings())
 
         // Then
         XCTAssertEqual(viewModel.shippingRates.count, 1)
-        XCTAssertEqual(viewModel.shippingRates.first?.title, "USPS - Media Mail")
-        XCTAssertEqual(viewModel.shippingRates.first?.amount, "$7.53")
+        XCTAssertEqual(viewModel.shippingRates.first?.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(viewModel.shippingRates.first?.amount, "$40.06")
     }
 
     func test_selecting_signature_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
-        let card = try XCTUnwrap(viewModel.shippingService?.serviceTabs.first?.cards[1])
-        card.signatureRequirement = .signatureRequired
-
-        // When
-        card.selectRate()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         selectedRate: self.sampleSelectedRate(with: .signatureRequired),
+                                                         currencySettings: CurrencySettings())
 
         // Then
         XCTAssertEqual(viewModel.shippingRates.count, 2)
@@ -168,12 +153,9 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_selecting_adult_signature_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, currencySettings: CurrencySettings(), shippingService: sampleShippingService())
-        let card = try XCTUnwrap(viewModel.shippingService?.serviceTabs.first?.cards[1])
-        card.signatureRequirement = .adultSignatureRequired
-
-        // When
-        card.selectRate()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         selectedRate: self.sampleSelectedRate(with: .adultSignatureRequired),
+                                                         currencySettings: CurrencySettings())
 
         // Then
         XCTAssertEqual(viewModel.shippingRates.count, 2)
@@ -201,79 +183,47 @@ private extension WooShippingCreateLabelsViewModelTests {
         return mapGeneralSettings(from: "settings-general")
     }
 
-    func sampleShippingService() -> WooShippingServiceViewModel {
-        WooShippingServiceViewModel(standardRates: [ShippingLabelCarrierRate(title: "USPS - Media Mail",
-                                                                             insurance: "100",
-                                                                             retailRate: 8,
-                                                                             rate: 7.53,
-                                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
-                                                                             serviceID: "",
-                                                                             carrierID: "usps",
-                                                                             shipmentID: "",
-                                                                             hasTracking: true,
-                                                                             isSelected: false,
-                                                                             isPickupFree: true,
-                                                                             deliveryDays: 7,
-                                                                             deliveryDateGuaranteed: false),
-                                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                                             insurance: "100",
-                                                                             retailRate: 40.06,
-                                                                             rate: 40.06,
-                                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
-                                                                             serviceID: "",
-                                                                             carrierID: "usps",
-                                                                             shipmentID: "",
-                                                                             hasTracking: true,
-                                                                             isSelected: false,
-                                                                             isPickupFree: true,
-                                                                             deliveryDays: 2,
-                                                                             deliveryDateGuaranteed: false),
-                                                    ShippingLabelCarrierRate(title: "DHL - Next Day",
-                                                                             insurance: "100",
-                                                                             retailRate: 15,
-                                                                             rate: 14.22,
-                                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27eg",
-                                                                             serviceID: "",
-                                                                             carrierID: "dhlexpress",
-                                                                             shipmentID: "",
-                                                                             hasTracking: true,
-                                                                             isSelected: false,
-                                                                             isPickupFree: true,
-                                                                             deliveryDays: 1,
-                                                                             deliveryDateGuaranteed: false)],
-                                    signatureRates: [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                                              insurance: "100",
-                                                                              retailRate: 42.76,
-                                                                              rate: 42.76,
-                                                                              rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
-                                                                              serviceID: "",
-                                                                              carrierID: "usps",
-                                                                              shipmentID: "",
-                                                                              hasTracking: true,
-                                                                              isSelected: false,
-                                                                              isPickupFree: true,
-                                                                              deliveryDays: 2,
-                                                                              deliveryDateGuaranteed: false)],
-                                    adultSignatureRates: [ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                                                   insurance: "100",
-                                                                                   retailRate: 46.96,
-                                                                                   rate: 46.96,
-                                                                                   rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
-                                                                                   serviceID: "",
-                                                                                   carrierID: "usps",
-                                                                                   shipmentID: "",
-                                                                                   hasTracking: true,
-                                                                                   isSelected: false,
-                                                                                   isPickupFree: true,
-                                                                                   deliveryDays: 2,
-                                                                                   deliveryDateGuaranteed: false)])
-    }
-}
-
-private extension WooShippingCreateLabelsViewModel {
-    /// Selects the first available shipping rate.
-    func selectShippingRate() throws {
-        let card = try XCTUnwrap(self.shippingService?.serviceTabs.first?.cards.first)
-        card.selectRate()
+    func sampleSelectedRate(with signatureRequirement: WooShippingServiceCardViewModel.SignatureRequirement = .none) -> WooShippingSelectedRate {
+        WooShippingSelectedRate(rate: ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                               insurance: "100",
+                                                               retailRate: 40.06,
+                                                               rate: 40.06,
+                                                               rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
+                                                               serviceID: "",
+                                                               carrierID: "usps",
+                                                               shipmentID: "",
+                                                               hasTracking: true,
+                                                               isSelected: false,
+                                                               isPickupFree: true,
+                                                               deliveryDays: 2,
+                                                               deliveryDateGuaranteed: false),
+                                signatureRate: signatureRequirement == .signatureRequired ?
+                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                             insurance: "100",
+                                                             retailRate: 42.76,
+                                                             rate: 42.76,
+                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
+                                                             serviceID: "",
+                                                             carrierID: "usps",
+                                                             shipmentID: "",
+                                                             hasTracking: true,
+                                                             isSelected: false,
+                                                             isPickupFree: true,
+                                                             deliveryDays: 2,
+                                                             deliveryDateGuaranteed: false) : nil,
+                                adultSignatureRate: signatureRequirement == .adultSignatureRequired ?
+                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                             insurance: "100",
+                                                             retailRate: 46.96,
+                                                             rate: 46.96,
+                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
+                                                             serviceID: "",
+                                                             carrierID: "usps",
+                                                             shipmentID: "",
+                                                             hasTracking: true,
+                                                             isSelected: false,
+                                                             isPickupFree: true,
+                                                             deliveryDays: 2,
+                                                             deliveryDateGuaranteed: false) : nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -10,6 +10,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNil(viewModel.selectedRate)
+        XCTAssertTrue(viewModel.isLoadingRates)
     }
 
     func test_generateServiceTabs_returns_expected_data() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -1,25 +1,53 @@
 import XCTest
 @testable import WooCommerce
 import Yosemite
+import enum Networking.NetworkError
 
 final class WooShippingServiceViewModelTests: XCTestCase {
 
+    private var stores: MockStoresManager!
+
+    private var samplePackageID = "default_box"
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, _, completion):
+                completion(.success(self.sampleLabelRates()))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+    }
+
     func test_init_sets_expected_values() {
         // Given
-        let viewModel = WooShippingServiceViewModel()
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake())
 
         // Then
         XCTAssertNil(viewModel.selectedRate)
-        XCTAssertTrue(viewModel.isLoadingRates)
+        XCTAssertEqual(viewModel.loadingState, .loading)
     }
 
-    func test_generateServiceTabs_returns_expected_data() throws {
+    func test_loadLabelRates_generates_service_tabs_with_expected_data() throws {
         // Given
-        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates(),
-                                                    signatureRates: sampleSignatureRates(),
-                                                    adultSignatureRates: sampleAdultSignatureRates())
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                    stores: stores)
+
+        // When
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake().copy(id: self.samplePackageID))
 
         // Then
+        XCTAssertEqual(viewModel.loadingState, .loaded)
+
         XCTAssertEqual(viewModel.serviceTabs.count, 2)
         XCTAssertEqual(viewModel.serviceTabs[0].cards.count, 2)
         XCTAssertEqual(viewModel.serviceTabs[1].cards.count, 1)
@@ -67,35 +95,65 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertNil(rate3.adultSignatureRequiredLabel)
     }
 
-    func test_selecting_service_card_standard_rate_updates_expected_values() {
+    func test_when_loadLabelRates_receives_error_it_sets_error_state() {
         // Given
-        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates())
-        let card = viewModel.serviceTabs[0].cards[1]
-        XCTAssertNil(viewModel.selectedRate)
-        XCTAssertFalse(card.selected)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, _, completion):
+                completion(.failure(NetworkError.timeout()))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                    stores: stores)
 
         // When
-        card.selectRate()
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake())
+
+        // Then
+        XCTAssertEqual(viewModel.loadingState, .error)
+        XCTAssertTrue(viewModel.serviceTabs.isEmpty)
+    }
+
+    func test_selecting_standard_rate_updates_expected_values() {
+        // Given
+        let standardRate = sampleStandardRates()[1]
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
+                                                    stores: stores)
+        XCTAssertNil(viewModel.selectedRate)
+        XCTAssertFalse(viewModel.serviceTabs[0].cards[1].selected)
+
+        // When
+        viewModel.selectRate(standardRate, signatureRate: nil, adultSignatureRate: nil)
 
         // Then
         XCTAssertNotNil(viewModel.selectedRate)
         XCTAssertNil(viewModel.selectedRate?.signatureRate)
         XCTAssertNil(viewModel.selectedRate?.adultSignatureRate)
-        XCTAssertEqual(viewModel.selectedRate?.rate.title, card.title)
+        XCTAssertEqual(viewModel.selectedRate?.rate.title, standardRate.title)
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 
     func test_selecting_service_card_signature_rate_updates_expected_values() {
         // Given
-        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates(),
-                                                    signatureRates: sampleSignatureRates())
-        let card = viewModel.serviceTabs[0].cards[1]
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
+                                                    stores: stores)
         XCTAssertNil(viewModel.selectedRate)
-        XCTAssertFalse(card.selected)
+        XCTAssertFalse(viewModel.serviceTabs[0].cards[1].selected)
 
         // When
-        card.signatureRequirement = .signatureRequired
-        card.selectRate()
+        viewModel.selectRate(sampleStandardRates()[1], signatureRate: sampleSignatureRates().first, adultSignatureRate: nil)
 
         // Then
         XCTAssertNotNil(viewModel.selectedRate)
@@ -106,15 +164,16 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_selecting_service_card_adult_signature_rate_updates_expected_values() {
         // Given
-        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates(),
-                                                    adultSignatureRates: sampleAdultSignatureRates())
-        let card = viewModel.serviceTabs[0].cards[1]
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
+                                                    stores: stores)
         XCTAssertNil(viewModel.selectedRate)
-        XCTAssertFalse(card.selected)
+        XCTAssertFalse(viewModel.serviceTabs[0].cards[1].selected)
 
         // When
-        card.signatureRequirement = .adultSignatureRequired
-        card.selectRate()
+        viewModel.selectRate(sampleStandardRates()[1], signatureRate: nil, adultSignatureRate: sampleAdultSignatureRates().first)
 
         // Then
         XCTAssertNotNil(viewModel.selectedRate)
@@ -123,9 +182,31 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.serviceTabs[0].cards[1].selected, true)
     }
 
+    func test_selecting_rate_calls_onSelectRate() {
+        // Given
+        var selectedRate: WooShippingSelectedRate?
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
+                                                    stores: stores) { rate in
+            selectedRate = rate
+        }
+
+        // When
+        viewModel.selectRate(sampleStandardRates()[1], signatureRate: nil, adultSignatureRate: nil)
+
+        // Then
+        XCTAssertEqual(selectedRate?.rate, sampleStandardRates()[1])
+    }
+
     func test_sortShipping_by_price_returns_sorted_list() {
         // Given
-        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates())
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
+                                                    stores: stores)
 
         // When
         viewModel.sortShipping(by: .price)
@@ -138,7 +219,11 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 
     func test_shortShipping_by_deliveryDays_returns_sorted_list() {
         // Given
-        let viewModel = WooShippingServiceViewModel(standardRates: sampleStandardRates())
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
+                                                    stores: stores)
 
         // When
         viewModel.sortShipping(by: .deliveryTime)
@@ -152,6 +237,13 @@ final class WooShippingServiceViewModelTests: XCTestCase {
 }
 
 private extension WooShippingServiceViewModelTests {
+    func sampleLabelRates() -> [ShippingLabelCarriersAndRates] {
+        [ShippingLabelCarriersAndRates(packageID: samplePackageID,
+                                       defaultRates: sampleStandardRates(),
+                                       signatureRequired: sampleSignatureRates(),
+                                       adultSignatureRequired: sampleAdultSignatureRates())]
+    }
+
     func sampleStandardRates() -> [ShippingLabelCarrierRate] {
         [ShippingLabelCarrierRate(title: "USPS - Media Mail",
                                   insurance: "100",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14393
⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/14411 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for loading the shipping label rates from remote in the Woo Shipping label flow. New behavior:

1. When the shipping service section appears, it shows a loading indicator to show that the rates are being loaded.
2. After the rates are loaded, the list of actual rates for the label are displayed.

Note that viewing the shipping service section still requires (for now) testing code to set the selected package.

### How

* `WooShippingServiceViewModel` now makes a remote request to load the label rates when it is initialized:
   * The `init` method now takes the required parameters for the remote request, and sets the loading state with placeholder values.
   * The `init` method also calls a new method to make the remote request. After receiving the response, it updates the available rates, regenerates the service tabs and rates, and sets the loading state.
* `WooShippingServiceView` now shows a shimmering, redacted placeholder view while the rates are loading.
* `WooShippingCreateLabelsViewModel` is updated to set the shipping service view model after a package is selected. This introduces a `selectedPackage` property we can set in the package selection flow.
* Updates unit tests. `ShippingLabelPackageSelected` is now copiable for ease of unit testing.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: The Woo Shipping extension installed and activated, with at least one order with the `processing` status and a physical product.

1. Update `WooShippingCreateLabelsViewModel` to provide a value for `selectedPackage` that can be used in the remote request.
2. Build and run the app with the `revampedShippingLabelCreation` feature flag enabled.
3. Go to the Orders tab.
4. Select an order eligible for a shipping label.
5. Tap "Create Shipping Label."
6. Confirm the Shipping service section is displayed with a loading view.
7. Once the request is completed, confirm a list of shipping rates is displayed, and you can sort and select the rates as expected.
8. Confirm that selecting a rate updates the shipment costs section in the "Shipment details" bottom sheet as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/5013282b-9fed-43fc-b223-3c8e5b670fdd



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.