### PR TITLE
[Woo POS] Remove `displayInfiniteScrollingUIDetailsInPointOfSale` flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,8 +91,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .paymentsOnboardingInPointOfSale:
             return buildConfig == .localDeveloper
-        case .displayInfiniteScrollingUIDetailsInPointOfSale:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -196,8 +196,4 @@ public enum FeatureFlag: Int {
     /// Supports Woo Payments onboarding in POS so that merchants who have not completed onboarding can access POS.
     ///
     case paymentsOnboardingInPointOfSale
-
-    /// Enables UI-related aspects of infinite scrolling in POS. It does not affect the actual infinite scrolling behaviour.
-    ///
-    case displayInfiniteScrollingUIDetailsInPointOfSale
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -135,7 +135,7 @@ private extension ItemListView {
                     })
                 }
                 GhostItemCardView()
-                    .renderedIf(posModel.itemListState.isLoadingAfterInitialLoad && viewModel.shouldShowGhostableItemCard)
+                    .renderedIf(posModel.itemListState.isLoadingAfterInitialLoad)
             }
             .frame(maxWidth: .infinity)
             .padding(.bottom, floatingControlAreaSize.height)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -28,8 +28,7 @@ struct PointOfSaleEntryPointView: View {
                                               currencyFormatter: currencyFormatter,
                                               paymentState: .acceptingCard)
         let cartViewModel = CartViewModel(posModel: posModel)
-        let shouldShowGhostableItemCard = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.displayInfiniteScrollingUIDetailsInPointOfSale)
-        let itemListViewModel = ItemListViewModel(posModel: posModel, shouldShowGhostableItemCard: shouldShowGhostableItemCard)
+        let itemListViewModel = ItemListViewModel(posModel: posModel)
 
         self._posModel = StateObject(wrappedValue: posModel)
         self._viewModel = StateObject(wrappedValue: PointOfSaleDashboardViewModel(

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -8,8 +8,6 @@ final class ItemListViewModel: ItemListViewModelProtocol {
     @Published private(set) var isHeaderBannerDismissed: Bool = false
     @Published var showSimpleProductsModal: Bool = false
 
-    private(set) var shouldShowGhostableItemCard: Bool = false
-
     var shouldShowHeaderBanner: Bool {
         // The banner it's shown as long as it hasn't already been dismissed once:
         if UserDefaults.standard.bool(forKey: BannerState.isSimpleProductsOnlyBannerDismissedKey) == true {
@@ -30,9 +28,8 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     let selectedItemPublisher: AnyPublisher<POSItem, Never>
 
-    init(posModel: PointOfSaleAggregateModelProtocol, shouldShowGhostableItemCard: Bool = false) {
+    init(posModel: PointOfSaleAggregateModelProtocol) {
         self.posModel = posModel
-        self.shouldShowGhostableItemCard = shouldShowGhostableItemCard
         selectedItemPublisher = selectedItemSubject.eraseToAnyPublisher()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-ios/issues/14186

## Description
We remove the feature flag `displayInfiniteScrollingUIDetailsInPointOfSale` to hide/display the `GhostItemCardView`, which was added as 21.1 beta fix.

## Testing information
- On release build configuration, load the POS and observe that the `GhostItemCardView` appears when state is loading (waiting for items from the remote).

## Screenshots

https://github.com/user-attachments/assets/12dfcdff-a627-470b-83f8-e11ef0e35b4a

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
