### PR TITLE
Exclude flaky unit tests related to dashboard cards's custom range date.

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -33,7 +33,9 @@
         "CardReaderConnectionControllerTests",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_false_when_not_entitled()",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_true_when_entitled()",
-        "StripeCardReaderIntegrationTests"
+        "StorePerformanceViewModelTests\/test_dates_for_custom_range_are_correct_for_non_custom_time_range()",
+        "StripeCardReaderIntegrationTests",
+        "TopPerformersDashboardViewModelTests\/test_dates_for_custom_range_are_correct_for_non_custom_time_range()"
       ],
       "target" : {
         "containerPath" : "container:WooCommerce.xcodeproj",


### PR DESCRIPTION
See report on https://github.com/woocommerce/woocommerce-ios/pull/14287/files#r1843059760


## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For more context, the flakiness was attempted to be fixed in a previous PR https://github.com/woocommerce/woocommerce-ios/pull/14287

It still failed on certain time, it turns out, so for now we're excluding them.

> still failing at certain time (failed [3 times](https://buildkite.com/automattic/woocommerce-ios/builds/25938#01932970-a255-40b0-928c-05b8b5033d75) 7-8AM GMT, but fixed a few hours later).

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

CI passing should be sufficient.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.