### PR TITLE
Send Receipt After Payment: Add eligibility checker

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -32,12 +32,12 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
                 return onCompletion(false)
             }
             // 2. If WooCommerce version is any of the specific API development branches, mark as eligible
-            if Constants.wcPluginDevVersion.contains(wcPlugin.version) {
+            if Constants.BackendReceipt.wcPluginDevVersion.contains(wcPlugin.version) {
                 onCompletion(true)
             } else {
                 // 3. Else, if WooCommerce version is higher than minimum required version, mark as eligible
                 let isSupported = VersionHelpers.isVersionSupported(version: wcPlugin.version,
-                                                                    minimumRequired: Constants.wcPluginMinimumVersion)
+                                                                    minimumRequired: Constants.BackendReceipt.wcPluginMinimumVersion)
                 onCompletion(isSupported)
             }
         }
@@ -45,15 +45,63 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
     }
 
     func isEligibleSendingReceiptAfterPayment(onCompletion: @escaping (Bool) -> Void) {
-        // TODO: WooCommerce 9.5.0
-        onCompletion(featureFlagService.isFeatureFlagEnabled(.sendReceiptAfterPayment))
+        guard featureFlagService.isFeatureFlagEnabled(.sendReceiptAfterPayment) else {
+            return onCompletion(false)
+        }
+
+        Task { @MainActor in
+            async let isWooCommerceSupported = isPluginSupported(Constants.wcPluginName,
+                                                                 minimumVersion: Constants.ReceiptAfterPayment.wcPluginMinimumVersion)
+            async let isWooPaymentsSupported = isPluginSupported(Constants.wcPayPluginName,
+                                                                 minimumVersion: Constants.ReceiptAfterPayment.wcPayPluginMinimumVersion)
+            let wooCommerceResult = await isWooCommerceSupported
+            let wooPaymentsResult = await isWooPaymentsSupported
+            let isSupported = wooCommerceResult && wooPaymentsResult
+
+            onCompletion(isSupported)
+        }
+    }
+}
+
+private extension ReceiptEligibilityUseCase {
+    @MainActor
+    func isPluginSupported(_ pluginName: String, minimumVersion: String) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: pluginName) { plugin in
+                // Plugin must be installed and active
+                guard let plugin, plugin.active else {
+                    return continuation.resume(returning: false)
+                }
+
+                // Checking for concrete versions to cover dev and beta versions
+                if plugin.version.contains(minimumVersion) {
+                    return continuation.resume(returning: true)
+                }
+
+                // If plugin version is higher than minimum required version, mark as eligible
+                let isSupported = VersionHelpers.isVersionSupported(version: plugin.version,
+                                                                    minimumRequired: minimumVersion)
+                continuation.resume(returning: isSupported)
+            }
+            stores.dispatch(action)
+        }
     }
 }
 
 private extension ReceiptEligibilityUseCase {
     enum Constants {
         static let wcPluginName = "WooCommerce"
-        static let wcPluginMinimumVersion = "8.7.0"
-        static let wcPluginDevVersion: [String] = ["8.7.0-dev", "8.6.0-dev"]
+        static let wcPayPluginName = "WooPayments"
+
+        enum BackendReceipt {
+            static let wcPluginMinimumVersion = "8.7.0"
+            static let wcPluginDevVersion: [String] = ["8.7.0-dev", "8.6.0-dev"]
+        }
+
+        enum ReceiptAfterPayment {
+            static let wcPluginMinimumVersion = "9.5.0"
+            static let wcPayPluginMinimumVersion = "8.6.0"
+        }
+
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -24,6 +24,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let favoriteProducts: Bool
     private let paymentsOnboardingInPointOfSale: Bool
     private let isProductGlobalUniqueIdentifierSupported: Bool
+    private let isSendReceiptAfterPaymentEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -46,7 +47,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          viewEditCustomFieldsInProductsAndOrders: Bool = false,
          favoriteProducts: Bool = false,
          paymentsOnboardingInPointOfSale: Bool = false,
-         isProductGlobalUniqueIdentifierSupported: Bool = false) {
+         isProductGlobalUniqueIdentifierSupported: Bool = false,
+         isSendReceiptAfterPaymentEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -69,6 +71,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.favoriteProducts = favoriteProducts
         self.paymentsOnboardingInPointOfSale = paymentsOnboardingInPointOfSale
         self.isProductGlobalUniqueIdentifierSupported = isProductGlobalUniqueIdentifierSupported
+        self.isSendReceiptAfterPaymentEnabled = isSendReceiptAfterPaymentEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -117,6 +120,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return paymentsOnboardingInPointOfSale
         case .productGlobalUniqueIdentifierSupport:
             return isProductGlobalUniqueIdentifierSupported
+        case .sendReceiptAfterPayment:
+            return isSendReceiptAfterPaymentEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
@@ -136,4 +136,155 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         // Then
         XCTAssertTrue(isEligible)
     }
+
+    // MARK: - Send Receipt After Payment
+
+    func test_isEligibleSendingReceiptAfterPayment_when_feature_flag_is_disabled_then_returns_false() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: false)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleSendingReceiptAfterPayment(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligibleSendingReceiptAfterPayment_when_plugins_are_inactive_then_returns_false() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.6.0", active: false)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "8.9.0", active: false)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                if systemPluginName == "WooCommerce" {
+                    onCompletion(wooCommercePlugin)
+                } else if systemPluginName == "WooPayments" {
+                    onCompletion(wooPaymentsPlugin)
+                }
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleSendingReceiptAfterPayment(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligibleSendingReceiptAfterPayment_when_plugins_are_supported_then_returns_true() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.5.0", active: true)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "8.6.0", active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                if systemPluginName == "WooCommerce" {
+                    onCompletion(wooCommercePlugin)
+                } else if systemPluginName == "WooPayments" {
+                    onCompletion(wooPaymentsPlugin)
+                }
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleSendingReceiptAfterPayment(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_isEligibleSendingReceiptAfterPayment_when_plugins_are_supported_dev_then_returns_true() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.6.0-dev-1181231238", active: true)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "8.6.0-test-1", active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                if systemPluginName == "WooCommerce" {
+                    onCompletion(wooCommercePlugin)
+                } else if systemPluginName == "WooPayments" {
+                    onCompletion(wooPaymentsPlugin)
+                }
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleSendingReceiptAfterPayment(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_isEligibleSendingReceiptAfterPayment_when_woopayments_version_is_incorrect_then_returns_false() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.5.0", active: true)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "5.0.0-dev", active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                if systemPluginName == "WooCommerce" {
+                    onCompletion(wooCommercePlugin)
+                } else if systemPluginName == "WooPayments" {
+                    onCompletion(wooPaymentsPlugin)
+                }
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleSendingReceiptAfterPayment(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Resolves: https://github.com/woocommerce/woocommerce-ios/issues/14163
Continuation of https://github.com/woocommerce/woocommerce-ios/pull/14422
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add eligibility checking logic for sending receipts after payment functionality:

- WooCommerce from 9.5 supports API calls to actions/send_order_details to trigger sending order details email
- WooPayments from 8.6 supports sending emails to attached customers when order payment fails

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The feature flag is disabled, I think it could be enough to check unit test cases to confirm that supported scenarios are handled as expected. In the final PRs, we can test the full flows.

However, if you prefer testing live:

#### Eligible site
1. Enable `sendReceiptAfterPayment` feature flag
2. Use my testing site https://lovely-aware-sturgeon.jurassic.ninja/ details: PdfdoF-5Qj-p2
3. Create an order
4. Do not attach the customer
5. Make a payment
6. Confirm "Email receipt" button appears
7. Tap on the button
8. Input email
9. Tap the CTA
10. Confirm email appears


#### Ineligible site
1. Enable `sendReceiptAfterPayment` feature flag
2. Use a testing site that has released versions of WooCommerce and WooPayments
3. Create an order
4. Do not attach the customer
5. Make a payment
6. Confirm "Email receipt" doesn't appear (or it opens native Mail client if it's installed)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Added unit tests
- Tested on my site with feature flag enabled

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.