### PR TITLE
[Woo POS] Extract payment code to aggregate model

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -24,6 +24,7 @@ protocol PointOfSaleAggregateModelProtocol {
     @available(*, deprecated, message: "`allItems` is due for removal, use `itemListState` instead.")
     var allItems: [POSItem] { get }
     var itemListState: ItemListState { get }
+    var blockReturnToItemSelection: Bool { get }
     func loadInitialItems() async
     func loadNextItems() async
     func reload() async
@@ -50,6 +51,18 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
 
     @Published private(set) var allItems: [POSItem] = []
     @Published private(set) var itemListState: ItemListState = .initialLoading
+    var blockReturnToItemSelection: Bool {
+        switch paymentState {
+        case .processingPayment,
+                .paymentError,
+                .cardPaymentSuccessful,
+                .validatingOrder,
+                .preparingReader:
+            return true
+        case .idle, .validatingOrderError, .acceptingCard:
+            return orderState.isSyncing
+        }
+    }
 
     @Published private(set) var cart: [CartItem] = []
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -371,42 +371,6 @@ private extension PointOfSaleAggregateModel {
     }
 }
 
-private extension PointOfSalePaymentState {
-    init?(from cardPaymentEvent: CardPresentPaymentEvent,
-          using paymentEventPresentationStyleDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies) {
-        switch cardPaymentEvent {
-        case .idle:
-            self = .idle
-        case .show(.validatingOrder):
-            self = .validatingOrder
-        case .show(.preparingForPayment):
-            self = .preparingReader
-        case .show(.tapSwipeOrInsertCard):
-            self = .acceptingCard
-        case .show(.processing),
-                .show(.displayReaderMessage):
-            self = .processingPayment
-        case .show(.paymentError):
-            if case let .show(eventDetails) = cardPaymentEvent,
-               case let .message(messageType) = PointOfSaleCardPresentPaymentEventPresentationStyle(
-                for: eventDetails,
-                dependencies: paymentEventPresentationStyleDependencies),
-               case .validatingOrderError = messageType {
-                self = .validatingOrderError
-            } else {
-                self = .paymentError
-            }
-        case .show(.paymentCaptureError):
-            self = .paymentError
-        case .show(.paymentSuccess):
-            self = .cardPaymentSuccessful
-        default:
-            return nil
-        }
-    }
-}
-
-
 // MARK: - Order syncing
 
 extension PointOfSaleAggregateModel {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -51,6 +51,7 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
 
     @Published private(set) var allItems: [POSItem] = []
     @Published private(set) var itemListState: ItemListState = .initialLoading
+
     var blockReturnToItemSelection: Bool {
         switch paymentState {
         case .processingPayment,

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -17,6 +17,9 @@ protocol PointOfSaleAggregateModelProtocol {
     var cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus { get }
     func connectCardReader()
     func disconnectCardReader()
+    var paymentState: PointOfSalePaymentState { get }
+    var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType? { get set }
+    var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType? { get }
 
     @available(*, deprecated, message: "`allItems` is due for removal, use `itemListState` instead.")
     var allItems: [POSItem] { get }
@@ -41,6 +44,9 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
     @Published private(set) var orderStage: PointOfSaleOrderStage = .building
 
     @Published private(set) var cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
+    @Published private(set) var paymentState: PointOfSalePaymentState
+    @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
+    @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
 
     @Published private(set) var allItems: [POSItem] = []
     @Published private(set) var itemListState: ItemListState = .initialLoading
@@ -66,13 +72,16 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderService: POSOrderServiceProtocol,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         paymentState: PointOfSalePaymentState = .idle) {
         self.itemProvider = itemProvider
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderService = orderService
         self.currencyFormatter = currencyFormatter
         self.analytics = analytics
+        self.paymentState = paymentState
         publishCardReaderConnectionStatus()
+        publishPaymentMessages()
     }
 }
 
@@ -170,13 +179,19 @@ extension PointOfSaleAggregateModel {
     }
 
     func addMoreToCart() {
-        orderStage = .building
+        setStateForEditing()
     }
 
     func startNewCart() {
         removeAllItemsFromCart()
         clearOrder()
+        setStateForEditing()
+    }
+
+    private func setStateForEditing() {
         orderStage = .building
+        paymentState = .idle
+        cardPresentPaymentInlineMessage = nil
     }
 }
 
@@ -266,6 +281,117 @@ extension PointOfSaleAggregateModel {
             }
     }
 }
+
+private extension PointOfSaleAggregateModel {
+    func publishPaymentMessages() {
+        cardPresentPaymentService.paymentEventPublisher
+            .map { [weak self] event -> PointOfSaleCardPresentPaymentAlertType? in
+                guard let self else { return nil }
+                guard case let .show(eventDetails) = event,
+                      case let .alert(alertType) = presentationStyle(for: eventDetails)
+                else {
+                    return nil
+                }
+                return alertType
+            }
+            .assign(to: &$cardPresentPaymentAlertViewModel)
+
+        cardPresentPaymentService.paymentEventPublisher
+            .map { [weak self] event -> PointOfSaleCardPresentPaymentMessageType? in
+                self?.mapCardPresentPaymentEventToMessageType(event)
+            }
+            .assign(to: &$cardPresentPaymentInlineMessage)
+
+        cardPresentPaymentService.paymentEventPublisher
+            .compactMap { [weak self] paymentEvent in
+                guard let self else { return .none }
+                return PointOfSalePaymentState(from: paymentEvent,
+                                               using: presentationStyleDeterminerDependencies)
+            }
+            .assign(to: &$paymentState)
+    }
+
+    /// Maps PaymentEvent to POSMessageType and annonates additional information if necessary
+    /// - Parameter event: CardPresentPaymentEvent
+    /// - Returns: PointOfSaleCardPresentPaymentMessageType
+    func mapCardPresentPaymentEventToMessageType(_ event: CardPresentPaymentEvent) -> PointOfSaleCardPresentPaymentMessageType? {
+        guard case let .show(eventDetails) = event,
+              case let .message(messageType) = presentationStyle(for: eventDetails) else {
+            return nil
+        }
+
+        return messageType
+    }
+
+    func presentationStyle(for eventDetails: CardPresentPaymentEventDetails) -> PointOfSaleCardPresentPaymentEventPresentationStyle? {
+        PointOfSaleCardPresentPaymentEventPresentationStyle(
+            for: eventDetails,
+            dependencies: presentationStyleDeterminerDependencies)
+    }
+
+    var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
+        let cancelThenCollectPaymentWithWeakSelf: () -> Void = { [weak self] in
+            self?.cancelThenCollectPayment()
+        }
+
+        var orderTotal: String?
+        if case .loaded(let totals) = orderState {
+            orderTotal = totals.orderTotal
+        }
+
+        return PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: cancelThenCollectPaymentWithWeakSelf,
+            nonRetryableErrorExitAction: cancelThenCollectPaymentWithWeakSelf,
+            formattedOrderTotalPrice: orderTotal,
+            paymentCaptureErrorTryAgainAction: cancelThenCollectPaymentWithWeakSelf,
+            paymentCaptureErrorNewOrderAction: { [weak self] in
+                self?.startNewCart()
+            },
+            paymentIntentCreationErrorEditOrderAction: { [weak self] in
+                self?.addMoreToCart()
+            },
+            dismissReaderConnectionModal: { [weak self] in
+                self?.cardPresentPaymentAlertViewModel = nil
+            }
+        )
+    }
+}
+
+private extension PointOfSalePaymentState {
+    init?(from cardPaymentEvent: CardPresentPaymentEvent,
+          using paymentEventPresentationStyleDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies) {
+        switch cardPaymentEvent {
+        case .idle:
+            self = .idle
+        case .show(.validatingOrder):
+            self = .validatingOrder
+        case .show(.preparingForPayment):
+            self = .preparingReader
+        case .show(.tapSwipeOrInsertCard):
+            self = .acceptingCard
+        case .show(.processing),
+                .show(.displayReaderMessage):
+            self = .processingPayment
+        case .show(.paymentError):
+            if case let .show(eventDetails) = cardPaymentEvent,
+               case let .message(messageType) = PointOfSaleCardPresentPaymentEventPresentationStyle(
+                for: eventDetails,
+                dependencies: paymentEventPresentationStyleDependencies),
+               case .validatingOrderError = messageType {
+                self = .validatingOrderError
+            } else {
+                self = .paymentError
+            }
+        case .show(.paymentCaptureError):
+            self = .paymentError
+        case .show(.paymentSuccess):
+            self = .cardPaymentSuccessful
+        default:
+            return nil
+        }
+    }
+}
+
 
 // MARK: - Order syncing
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -24,7 +24,6 @@ protocol PointOfSaleAggregateModelProtocol {
     @available(*, deprecated, message: "`allItems` is due for removal, use `itemListState` instead.")
     var allItems: [POSItem] { get }
     var itemListState: ItemListState { get }
-    var blockReturnToItemSelection: Bool { get }
     func loadInitialItems() async
     func loadNextItems() async
     func reload() async
@@ -51,19 +50,6 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
 
     @Published private(set) var allItems: [POSItem] = []
     @Published private(set) var itemListState: ItemListState = .initialLoading
-
-    var blockReturnToItemSelection: Bool {
-        switch paymentState {
-        case .processingPayment,
-                .paymentError,
-                .cardPaymentSuccessful,
-                .validatingOrder,
-                .preparingReader:
-            return true
-        case .idle, .validatingOrderError, .acceptingCard:
-            return orderState.isSyncing
-        }
-    }
 
     @Published private(set) var cart: [CartItem] = []
 

--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
@@ -10,3 +10,20 @@ enum PointOfSalePaymentState {
     case paymentError
     case cardPaymentSuccessful
 }
+
+extension PointOfSalePaymentState {
+    var shownFullScreen: Bool {
+        switch self {
+        case .processingPayment,
+                .paymentError,
+                .cardPaymentSuccessful:
+            return true
+        case .idle,
+                .validatingOrder,
+                .validatingOrderError,
+                .preparingReader,
+                .acceptingCard:
+            return false
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum PointOfSalePaymentState {
+    case idle
+    case acceptingCard
+    case validatingOrder
+    case validatingOrderError
+    case preparingReader
+    case processingPayment
+    case paymentError
+    case cardPaymentSuccessful
+}

--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
@@ -12,6 +12,39 @@ enum PointOfSalePaymentState {
 }
 
 extension PointOfSalePaymentState {
+    init?(from cardPaymentEvent: CardPresentPaymentEvent,
+          using paymentEventPresentationStyleDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies) {
+        switch cardPaymentEvent {
+        case .idle:
+            self = .idle
+        case .show(.validatingOrder):
+            self = .validatingOrder
+        case .show(.preparingForPayment):
+            self = .preparingReader
+        case .show(.tapSwipeOrInsertCard):
+            self = .acceptingCard
+        case .show(.processing),
+                .show(.displayReaderMessage):
+            self = .processingPayment
+        case .show(.paymentError):
+            if case let .show(eventDetails) = cardPaymentEvent,
+               case let .message(messageType) = PointOfSaleCardPresentPaymentEventPresentationStyle(
+                for: eventDetails,
+                dependencies: paymentEventPresentationStyleDependencies),
+               case .validatingOrderError = messageType {
+                self = .validatingOrderError
+            } else {
+                self = .paymentError
+            }
+        case .show(.paymentCaptureError):
+            self = .paymentError
+        case .show(.paymentSuccess):
+            self = .cardPaymentSuccessful
+        default:
+            return nil
+        }
+    }
+
     var shownFullScreen: Bool {
         switch self {
         case .processingPayment,

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -26,8 +26,8 @@ struct CartView: View {
             DynamicHStack(spacing: Constants.cartHeaderSpacing) {
                 HStack(spacing: Constants.cartHeaderElementSpacing) {
                     backAddMoreButton
-                        .disabled(posModel.blockReturnToItemSelection)
-                        .shimmering(active: posModel.blockReturnToItemSelection)
+                        .disabled(shouldPreventCartEditing)
+                        .shimmering(active: shouldPreventCartEditing)
 
                     HStack {
                         Text(Localization.cartTitle)
@@ -148,6 +148,13 @@ private extension CartView {
             return posModel.cart.isEmpty ? Color.posTertiaryBackground : Color.posSecondaryBackground
         }
     }
+
+    var shouldPreventCartEditing: Bool {
+        guard posModel.paymentState.allowsCartEditing else {
+            return true
+        }
+        return posModel.orderState.isSyncing
+    }
 }
 
 private extension CartView {
@@ -241,6 +248,21 @@ private extension CartView {
             Spacer()
         }
         .background(backgroundColor.ignoresSafeArea(.all))
+    }
+}
+
+private extension PointOfSalePaymentState {
+    var allowsCartEditing: Bool {
+        switch self {
+        case .processingPayment,
+                .paymentError,
+                .cardPaymentSuccessful,
+                .validatingOrder,
+                .preparingReader:
+            return false
+        case .idle, .validatingOrderError, .acceptingCard:
+            return true
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -257,8 +257,7 @@ import class WooFoundation.MockAnalyticsProviderPreview
     // TODO:
     // Simplify this by mocking `CartViewModel`
     let totalsViewModel = TotalsViewModel(posModel: posModel,
-                                          cardPresentPaymentService: CardPresentPaymentPreviewService(),
-                                          paymentState: .acceptingCard)
+                                          cardPresentPaymentService: CardPresentPaymentPreviewService())
     let cartViewModel = CartViewModel(posModel: posModel)
     let itemsListViewModel = ItemListViewModel(posModel: posModel)
     let dashboardViewModel = PointOfSaleDashboardViewModel(posModel: posModel,

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -26,8 +26,8 @@ struct CartView: View {
             DynamicHStack(spacing: Constants.cartHeaderSpacing) {
                 HStack(spacing: Constants.cartHeaderElementSpacing) {
                     backAddMoreButton
-                        .disabled(shouldPreventCartEditing)
-                        .shimmering(active: shouldPreventCartEditing)
+                        .disabled(cartViewModel.shouldPreventCartEditing(posModel: posModel))
+                        .shimmering(active: cartViewModel.shouldPreventCartEditing(posModel: posModel))
 
                     HStack {
                         Text(Localization.cartTitle)
@@ -148,13 +148,6 @@ private extension CartView {
             return posModel.cart.isEmpty ? Color.posTertiaryBackground : Color.posSecondaryBackground
         }
     }
-
-    var shouldPreventCartEditing: Bool {
-        guard posModel.paymentState.allowsCartEditing else {
-            return true
-        }
-        return posModel.orderState.isSyncing
-    }
 }
 
 private extension CartView {
@@ -248,21 +241,6 @@ private extension CartView {
             Spacer()
         }
         .background(backgroundColor.ignoresSafeArea(.all))
-    }
-}
-
-private extension PointOfSalePaymentState {
-    var allowsCartEditing: Bool {
-        switch self {
-        case .processingPayment,
-                .paymentError,
-                .cardPaymentSuccessful,
-                .validatingOrder,
-                .preparingReader:
-            return false
-        case .idle, .validatingOrderError, .acceptingCard:
-            return true
-        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -26,8 +26,8 @@ struct CartView: View {
             DynamicHStack(spacing: Constants.cartHeaderSpacing) {
                 HStack(spacing: Constants.cartHeaderElementSpacing) {
                     backAddMoreButton
-                        .disabled(viewModel.isAddMoreDisabled)
-                        .shimmering(active: viewModel.isAddMoreDisabled)
+                        .disabled(posModel.blockReturnToItemSelection)
+                        .shimmering(active: posModel.blockReturnToItemSelection)
 
                     HStack {
                         Text(Localization.cartTitle)

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -26,8 +26,8 @@ struct CartView: View {
             DynamicHStack(spacing: Constants.cartHeaderSpacing) {
                 HStack(spacing: Constants.cartHeaderElementSpacing) {
                     backAddMoreButton
-                        .disabled(cartViewModel.shouldPreventCartEditing(posModel: posModel))
-                        .shimmering(active: cartViewModel.shouldPreventCartEditing(posModel: posModel))
+                        .disabled(shouldPreventCartEditing)
+                        .shimmering(active: shouldPreventCartEditing)
 
                     HStack {
                         Text(Localization.cartTitle)
@@ -147,6 +147,12 @@ private extension CartView {
         default:
             return posModel.cart.isEmpty ? Color.posTertiaryBackground : Color.posSecondaryBackground
         }
+    }
+
+    var shouldPreventCartEditing: Bool {
+        cartViewModel.shouldPreventCartEditing(
+            orderState: posModel.orderState,
+            paymentState: posModel.paymentState)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct POSFloatingControlView: View {
     @Environment(\.posBackgroundAppearance) var backgroundAppearance
+    @EnvironmentObject private var posModel: PointOfSaleAggregateModel
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
     @Environment(\.colorScheme) var colorScheme
 
@@ -40,7 +41,7 @@ struct POSFloatingControlView: View {
             }
             .background(backgroundColor)
             .cornerRadius(Constants.cornerRadius)
-            .disabled(viewModel.isExitPOSDisabled)
+            .disabled(posModel.paymentState == .processingPayment)
 
             CardReaderConnectionStatusView()
                 .foregroundStyle(fontColor)

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -47,7 +47,7 @@ struct POSFloatingControlView: View {
                 .foregroundStyle(fontColor)
                 .background(backgroundColor)
                 .cornerRadius(Constants.cornerRadius)
-                .disabled(viewModel.isReaderDisconnectionDisabled)
+                .disabled(posModel.paymentState.shownFullScreen)
         }
         .frame(height: Constants.size)
         .background(Color.clear)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -105,7 +105,7 @@ struct PointOfSaleDashboardView: View {
                         .transition(.move(edge: .leading))
                 }
 
-                if !viewModel.isTotalsViewFullScreen {
+                if !posModel.paymentState.shownFullScreen {
                     cartView
                         .accessibilitySortPriority(1)
                         .frame(width: geometry.size.width * Constants.cartWidth)
@@ -119,7 +119,7 @@ struct PointOfSaleDashboardView: View {
                 }
             }
             .animation(.default, value: posModel.orderStage)
-            .animation(.default, value: viewModel.isTotalsViewFullScreen)
+            .animation(.default, value: posModel.paymentState.shownFullScreen)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -55,7 +55,7 @@ struct PointOfSaleDashboardView: View {
         .environment(\.floatingControlAreaSize,
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))
-        .environment(\.posBackgroundAppearance, totalsViewModel.paymentState != .processingPayment ? .primary : .secondary)
+        .environment(\.posBackgroundAppearance, posModel.paymentState != .processingPayment ? .primary : .secondary)
         .animation(.easeInOut, value: posModel.itemListState == .initialLoading)
         .animation(.easeInOut(duration: Constants.connectivityAnimationDuration), value: viewModel.showsConnectivityError)
         .background(Color.posPrimaryBackground)
@@ -65,9 +65,9 @@ struct PointOfSaleDashboardView: View {
         }) { viewModel in
             paymentsOnboardingView(from: viewModel)
         }
-        .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel,
+        .posModal(item: $posModel.cardPresentPaymentAlertViewModel,
                   onDismiss: {
-            totalsViewModel.cardPresentPaymentAlertViewModel?.onDismiss?()
+            posModel.cardPresentPaymentAlertViewModel?.onDismiss?()
         }) { alertType in
             PointOfSaleCardPresentPaymentAlert(alertType: alertType)
                 .posInteractiveDismissDisabled(alertType.isDismissDisabled)
@@ -212,8 +212,7 @@ import class WooFoundation.MockAnalyticsProviderPreview
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderService: POSOrderPreviewService())
     let totalsVM = TotalsViewModel(posModel: posModel,
-                                   cardPresentPaymentService: CardPresentPaymentPreviewService(),
-                                   paymentState: .acceptingCard)
+                                   cardPresentPaymentService: CardPresentPaymentPreviewService())
     let cartVM = CartViewModel(posModel: posModel)
     let itemsListVM = ItemListViewModel(posModel: posModel)
     let posVM = PointOfSaleDashboardViewModel(posModel: posModel,

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -26,8 +26,7 @@ struct PointOfSaleEntryPointView: View {
                                                  cardPresentPaymentService: cardPresentPaymentService,
                                                  orderService: orderService)
         let totalsViewModel = TotalsViewModel(posModel: posModel,
-                                              cardPresentPaymentService: cardPresentPaymentService,
-                                              paymentState: .acceptingCard)
+                                              cardPresentPaymentService: cardPresentPaymentService)
         let cartViewModel = CartViewModel(posModel: posModel)
         let shouldShowGhostableItemCard = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.displayInfiniteScrollingUIDetailsInPointOfSale)
         let itemListViewModel = ItemListViewModel(posModel: posModel, shouldShowGhostableItemCard: shouldShowGhostableItemCard)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -9,7 +9,13 @@ struct TotalsView: View {
     /// It allows for a simultaneous transition from the shimmering effect to the text fields,
     /// and movement from the center of the VStack to their respective positions.
     @Namespace private var totalsFieldAnimation
-    @State private var isShowingTotalsFields: Bool
+
+    // The source of truth for whether totals _are_ showing; separate from whether they
+    // _should be_ showing, so that we can animate the change.
+    @State private var isShowingTotalsFields: Bool = false
+    private var shouldShowTotalsFields: Bool {
+        viewModel.shouldShowTotalsFields(for: posModel.paymentState)
+    }
     @State private var isShowingPaymentsButtonSpacing: Bool = false
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -17,7 +23,6 @@ struct TotalsView: View {
 
     init(viewModel: TotalsViewModel) {
         self.viewModel = viewModel
-        self.isShowingTotalsFields = viewModel.isShowingTotalsFields
     }
 
     var body: some View {
@@ -50,11 +55,11 @@ struct TotalsView: View {
                             totalsFieldsView
                                 .transition(.opacity)
                                 .animation(.default, value: viewModel.isShimmering)
-                                .opacity(viewModel.isShowingTotalsFields ? 1 : 0)
+                                .opacity(viewModel.shouldShowTotalsFields(for: posModel.paymentState) ? 1 : 0)
                                 .layoutPriority(2)
                         }
                     }
-                    .animation(.default, value: viewModel.cardPresentPaymentInlineMessage)
+                    .animation(.default, value: posModel.cardPresentPaymentInlineMessage)
                     paymentsActionButtons
                     Spacer()
                 }
@@ -65,17 +70,20 @@ struct TotalsView: View {
             }
         }
         .background(backgroundColor)
-        .animation(.default, value: viewModel.paymentState)
+        .animation(.default, value: posModel.paymentState)
         .animation(.default, value: posModel.orderState.isError)
         .onDisappear {
             viewModel.onTotalsViewDisappearance()
         }
-        .onChange(of: viewModel.isShowingTotalsFields, perform: hideTotalsFieldsWithDelay)
+        .onAppear {
+            isShowingTotalsFields = shouldShowTotalsFields
+        }
+        .onChange(of: shouldShowTotalsFields, perform: hideTotalsFieldsWithDelay)
         .geometryGroupIfSupported()
     }
 
     private var backgroundColor: Color {
-        switch viewModel.paymentState {
+        switch posModel.paymentState {
         case .cardPaymentSuccessful:
             .posSecondaryBackground
         case .processingPayment:
@@ -186,7 +194,7 @@ private extension TotalsView {
     /// Hide totals fields with animation after a delay when starting to processing a payment
     /// - Parameter isShowing
     private func hideTotalsFieldsWithDelay(_ isShowing: Bool) {
-        guard !isShowing && viewModel.paymentState == .processingPayment else {
+        guard !isShowing && posModel.paymentState == .processingPayment else {
             self.isShowingTotalsFields = isShowing
             return
         }
@@ -216,7 +224,7 @@ private extension TotalsView {
 
     @ViewBuilder
     private var paymentsActionButtons: some View {
-        if viewModel.paymentState == .cardPaymentSuccessful {
+        if posModel.paymentState == .cardPaymentSuccessful {
             if isShowingPaymentsButtonSpacing {
                 Spacer().frame(height: Constants.paymentsButtonSpacing)
             }
@@ -237,7 +245,7 @@ private extension TotalsView {
     @ViewBuilder private var cardReaderView: some View {
         switch viewModel.connectionStatus {
         case .connected, .disconnecting, .cancellingConnection:
-            if let inlinePaymentMessage = viewModel.cardPresentPaymentInlineMessage {
+            if let inlinePaymentMessage = posModel.cardPresentPaymentInlineMessage {
                 HStack(alignment: .center) {
                     Spacer()
                     PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
@@ -283,7 +291,7 @@ private extension TotalsView {
             return .primary
         }
 
-        switch viewModel.paymentState {
+        switch posModel.paymentState {
         case .validatingOrderError:
             return .outlined
         case .paymentError:
@@ -401,8 +409,7 @@ private extension View {
         orderService: POSOrderPreviewService())
     let totalsVM = TotalsViewModel(
         posModel: posModel,
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        paymentState: .acceptingCard)
+        cardPresentPaymentService: CardPresentPaymentPreviewService())
     TotalsView(viewModel: totalsVM)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -34,7 +34,7 @@ struct TotalsView: View {
                         .renderedIf(cardReaderViewLayout.topPadding == nil)
 
                     VStack(alignment: .center, spacing: Constants.verticalSpacing) {
-                        if viewModel.isShowingCardReaderStatus {
+                        if isShowingCardReaderStatus {
                             cardReaderView
                                 .font(.title)
                                 .padding([.leading, .trailing],
@@ -63,7 +63,7 @@ struct TotalsView: View {
                     paymentsActionButtons
                     Spacer()
                 }
-                .animation(.default, value: viewModel.isShowingCardReaderStatus)
+                .animation(.default, value: isShowingCardReaderStatus)
             case .error(let viewModel):
                 PointOfSaleOrderSyncErrorMessageView(viewModel: viewModel)
                     .transition(.opacity)
@@ -243,7 +243,7 @@ private extension TotalsView {
     }
 
     @ViewBuilder private var cardReaderView: some View {
-        switch viewModel.connectionStatus {
+        switch posModel.cardReaderConnectionStatus {
         case .connected, .disconnecting, .cancellingConnection:
             if let inlinePaymentMessage = posModel.cardPresentPaymentInlineMessage {
                 HStack(alignment: .center) {
@@ -286,8 +286,25 @@ private extension TotalsView {
         )
     }
 
+    private var isShowingCardReaderStatus: Bool {
+        guard posModel.orderState.isLoaded else {
+            // When the order's being created or synced, we only show the shimmering totals.
+            // Before the order exists, we don’t want to show the card payment status, as it will
+            // show for a second initially, then disappear the moment we start syncing the order.
+            return false
+        }
+
+        switch posModel.cardReaderConnectionStatus {
+        case .connected, .disconnecting, .cancellingConnection:
+            return posModel.cardPresentPaymentInlineMessage != nil
+        case .disconnected:
+            // Since the reader is disconnected, this will show the "Connect your reader" CTA button view.
+            return true
+        }
+    }
+
     private var cardReaderViewLayout: CardReaderViewLayout {
-        guard viewModel.isShowingCardReaderStatus else {
+        guard isShowingCardReaderStatus else {
             return .primary
         }
 
@@ -305,7 +322,7 @@ private extension TotalsView {
             break
         }
 
-        if viewModel.connectionStatus == .disconnected {
+        if posModel.cardReaderConnectionStatus == .disconnected {
             return .outlined
         }
 

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -18,4 +18,28 @@ final class CartViewModel: CartViewModelProtocol {
                                 singular: "%1$d item",
                                 plural: "%1$d items")
     }
+
+    func shouldPreventCartEditing(posModel: PointOfSaleAggregateModel) -> Bool {
+        guard posModel.paymentState.allowsCartEditing else {
+            return true
+        }
+        return posModel.orderState.isSyncing
+    }
+}
+
+
+
+private extension PointOfSalePaymentState {
+    var allowsCartEditing: Bool {
+        switch self {
+        case .processingPayment,
+                .paymentError,
+                .cardPaymentSuccessful,
+                .validatingOrder,
+                .preparingReader:
+            return false
+        case .idle, .validatingOrderError, .acceptingCard:
+            return true
+        }
+    }
 }

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -19,11 +19,12 @@ final class CartViewModel: CartViewModelProtocol {
                                 plural: "%1$d items")
     }
 
-    func shouldPreventCartEditing(posModel: PointOfSaleAggregateModel) -> Bool {
-        guard posModel.paymentState.allowsCartEditing else {
+    func shouldPreventCartEditing(orderState: PointOfSaleOrderState,
+                                  paymentState: PointOfSalePaymentState) -> Bool {
+        guard paymentState.allowsCartEditing else {
             return true
         }
-        return posModel.orderState.isSyncing
+        return orderState.isSyncing
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
@@ -5,5 +5,6 @@ import protocol Yosemite.POSItem
 protocol CartViewModelProtocol: ObservableObject {
     var itemsInCartLabel: String? { get }
 
-    func shouldPreventCartEditing(posModel: PointOfSaleAggregateModel) -> Bool
+    func shouldPreventCartEditing(orderState: PointOfSaleOrderState,
+                                  paymentState: PointOfSalePaymentState) -> Bool
 }

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
@@ -4,4 +4,6 @@ import protocol Yosemite.POSItem
 
 protocol CartViewModelProtocol: ObservableObject {
     var itemsInCartLabel: String? { get }
+
+    func shouldPreventCartEditing(posModel: PointOfSaleAggregateModel) -> Bool
 }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -53,7 +53,7 @@ private extension PointOfSaleDashboardViewModel {
     }
 
     func observePaymentStateForButtonDisabledProperties() {
-        Publishers.CombineLatest(totalsViewModel.paymentStatePublisher, posModel.$orderState)
+        Publishers.CombineLatest(posModel.$paymentState, posModel.$orderState)
             .map { paymentState, orderState in
                 switch paymentState {
                 case .processingPayment,
@@ -68,7 +68,7 @@ private extension PointOfSaleDashboardViewModel {
             }
             .assign(to: &$isAddMoreDisabled)
 
-        totalsViewModel.paymentStatePublisher
+        posModel.$paymentState
             .map { paymentState in
                 switch paymentState {
                 case .processingPayment:
@@ -85,7 +85,7 @@ private extension PointOfSaleDashboardViewModel {
             }
             .assign(to: &$isExitPOSDisabled)
 
-        let afterCardTapPaymentStates = totalsViewModel.paymentStatePublisher
+        let afterCardTapPaymentStates = posModel.$paymentState
             .map { paymentState in
                 switch paymentState {
                 case .processingPayment,

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -15,7 +15,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     private let connectivityObserver: ConnectivityObserver
 
-    @Published var isExitPOSDisabled: Bool = false
     @Published var isReaderDisconnectionDisabled: Bool = false
     /// This boolean is used to determine if the whole totals/payments view is occupying the full screen (cart is not showed)
     @Published var isTotalsViewFullScreen: Bool = false
@@ -52,24 +51,6 @@ private extension PointOfSaleDashboardViewModel {
     }
 
     func observePaymentStateForButtonDisabledProperties() {
-
-        posModel.$paymentState
-            .map { paymentState in
-                switch paymentState {
-                case .processingPayment:
-                    return true
-                case .idle,
-                        .acceptingCard,
-                        .validatingOrder,
-                        .validatingOrderError,
-                        .preparingReader,
-                        .paymentError,
-                        .cardPaymentSuccessful:
-                    return false
-                }
-            }
-            .assign(to: &$isExitPOSDisabled)
-
         let afterCardTapPaymentStates = posModel.$paymentState
             .map { paymentState in
                 switch paymentState {

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -15,7 +15,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     private let connectivityObserver: ConnectivityObserver
 
-    @Published private(set) var isAddMoreDisabled: Bool = false
     @Published var isExitPOSDisabled: Bool = false
     @Published var isReaderDisconnectionDisabled: Bool = false
     /// This boolean is used to determine if the whole totals/payments view is occupying the full screen (cart is not showed)
@@ -53,20 +52,6 @@ private extension PointOfSaleDashboardViewModel {
     }
 
     func observePaymentStateForButtonDisabledProperties() {
-        Publishers.CombineLatest(posModel.$paymentState, posModel.$orderState)
-            .map { paymentState, orderState in
-                switch paymentState {
-                case .processingPayment,
-                        .paymentError,
-                        .cardPaymentSuccessful,
-                        .validatingOrder,
-                        .preparingReader:
-                    return true
-                case .idle, .validatingOrderError, .acceptingCard:
-                    return orderState.isSyncing
-                }
-            }
-            .assign(to: &$isAddMoreDisabled)
 
         posModel.$paymentState
             .map { paymentState in

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -15,9 +15,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     private let connectivityObserver: ConnectivityObserver
 
-    @Published var isReaderDisconnectionDisabled: Bool = false
-    /// This boolean is used to determine if the whole totals/payments view is occupying the full screen (cart is not showed)
-    @Published var isTotalsViewFullScreen: Bool = false
     @Published var showExitPOSModal: Bool = false
     @Published var showSupport: Bool = false
     @Published var showsConnectivityError: Bool = false
@@ -36,7 +33,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         self.connectivityObserver = connectivityObserver
 
         observeSelectedItemToAddToCart()
-        observePaymentStateForButtonDisabledProperties()
         observeConnectivity()
     }
 }
@@ -48,32 +44,6 @@ private extension PointOfSaleDashboardViewModel {
                 self?.posModel.addToCart(selectedItem)
             }
             .store(in: &cancellables)
-    }
-
-    func observePaymentStateForButtonDisabledProperties() {
-        let afterCardTapPaymentStates = posModel.$paymentState
-            .map { paymentState in
-                switch paymentState {
-                case .processingPayment,
-                        .paymentError,
-                        .cardPaymentSuccessful:
-                    return true
-                case .idle,
-                        .validatingOrder,
-                        .validatingOrderError,
-                        .preparingReader,
-                        .acceptingCard:
-                    return false
-                }
-            }
-            .share()
-
-        afterCardTapPaymentStates
-            .assign(to: &$isTotalsViewFullScreen)
-
-        afterCardTapPaymentStates
-            .assign(to: &$isReaderDisconnectionDisabled)
-
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -4,25 +4,9 @@ import protocol WooFoundation.Analytics
 import protocol Yosemite.POSItem
 
 final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
-    enum PaymentState {
-        case idle
-        case acceptingCard
-        case validatingOrder
-        case validatingOrderError
-        case preparingReader
-        case processingPayment
-        case paymentError
-        case cardPaymentSuccessful
-    }
-
     @Published var cardPresentPaymentOnboardingViewModel: CardPresentPaymentsOnboardingViewModel?
     private var onOnboardingCancellation: (() -> Void)?
-    @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
-    @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
     @Published private(set) var isShowingCardReaderStatus: Bool = false
-    @Published private(set) var isShowingTotalsFields: Bool = false
-
-    @Published private(set) var paymentState: PaymentState
 
     @Published private(set) var connectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
 
@@ -37,11 +21,9 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
 
     init(posModel: PointOfSaleAggregateModel,
          cardPresentPaymentService: CardPresentPaymentFacade,
-         paymentState: PaymentState,
          analytics: Analytics = ServiceLocator.analytics) {
         self.posModel = posModel
         self.cardPresentPaymentService = cardPresentPaymentService
-        self.paymentState = paymentState
         self.analytics = analytics
 
         // Initialize all properties before calling methods
@@ -49,8 +31,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         self.observeCardPresentPaymentEvents()
     }
 
-    var paymentStatePublisher: Published<PaymentState>.Publisher { $paymentState }
-    private var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { $cardPresentPaymentAlertViewModel }
     private var connectionStatusPublisher: Published<CardPresentPaymentReaderConnectionStatus>.Publisher { $connectionStatus }
 
     func connectReaderTapped() {
@@ -64,8 +44,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     }
 
     func startNewOrder() {
-        paymentState = .acceptingCard
-        cardPresentPaymentInlineMessage = nil
         posModel.startNewCart()
     }
 
@@ -89,8 +67,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     }
 
     private func editOrder() {
-        paymentState = .idle
-        cardPresentPaymentInlineMessage = nil
         posModel.addMoreToCart()
     }
 
@@ -109,6 +85,21 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     func stopShowingTotalsView() {
         posModel.cancelCardReaderPreparation()
     }
+
+    func shouldShowTotalsFields(for paymentState: PointOfSalePaymentState) -> Bool {
+        switch paymentState {
+        case .idle,
+                .acceptingCard,
+                .validatingOrder,
+                .validatingOrderError,
+                .preparingReader:
+            return true
+        case .processingPayment,
+                .paymentError,
+                .cardPaymentSuccessful:
+            return false
+        }
+    }
 }
 
 // MARK: - Payment collection
@@ -118,7 +109,7 @@ private extension TotalsViewModel {
         cardPresentPaymentService.readerConnectionStatusPublisher
             .assign(to: &$connectionStatus)
 
-        Publishers.CombineLatest3(posModel.$cardReaderConnectionStatus, posModel.$orderState, $cardPresentPaymentInlineMessage)
+        Publishers.CombineLatest3(posModel.$cardReaderConnectionStatus, posModel.$orderState, posModel.$cardPresentPaymentInlineMessage)
             .map { connectionStatus, orderState, message in
                 guard orderState.isLoaded
                         else {
@@ -150,129 +141,5 @@ private extension TotalsViewModel {
                 return viewModel
             }
             .assign(to: &$cardPresentPaymentOnboardingViewModel)
-
-        cardPresentPaymentService.paymentEventPublisher
-            .map { [weak self] event -> PointOfSaleCardPresentPaymentAlertType? in
-                guard let self else { return nil }
-                guard case let .show(eventDetails) = event,
-                      case let .alert(alertType) = presentationStyle(for: eventDetails)
-                else {
-                    return nil
-                }
-                return alertType
-            }
-            .assign(to: &$cardPresentPaymentAlertViewModel)
-
-        cardPresentPaymentService.paymentEventPublisher
-            .map { [weak self] event -> PointOfSaleCardPresentPaymentMessageType? in
-                self?.mapCardPresentPaymentEventToMessageType(event)
-            }
-            .assign(to: &$cardPresentPaymentInlineMessage)
-
-        cardPresentPaymentService.paymentEventPublisher
-            .compactMap { [weak self] paymentEvent in
-                guard let self else { return .none }
-                return PaymentState(from: paymentEvent,
-                                    using: presentationStyleDeterminerDependencies) }
-            .assign(to: &$paymentState)
-
-        paymentStatePublisher
-            .map { paymentState in
-                switch paymentState {
-                case .idle,
-                        .acceptingCard,
-                        .validatingOrder,
-                        .validatingOrderError,
-                        .preparingReader:
-                    return true
-                case .processingPayment,
-                        .paymentError,
-                        .cardPaymentSuccessful:
-                    return false
-                }
-            }
-            .assign(to: &$isShowingTotalsFields)
-    }
-}
-
-private extension TotalsViewModel {
-    /// Maps PaymentEvent to POSMessageType and annonates additional information if necessary
-    /// - Parameter event: CardPresentPaymentEvent
-    /// - Returns: PointOfSaleCardPresentPaymentMessageType
-    func mapCardPresentPaymentEventToMessageType(_ event: CardPresentPaymentEvent) -> PointOfSaleCardPresentPaymentMessageType? {
-        guard case let .show(eventDetails) = event,
-              case let .message(messageType) = presentationStyle(for: eventDetails) else {
-            return nil
-        }
-
-        return messageType
-    }
-
-    func presentationStyle(for eventDetails: CardPresentPaymentEventDetails) -> PointOfSaleCardPresentPaymentEventPresentationStyle? {
-        PointOfSaleCardPresentPaymentEventPresentationStyle(
-            for: eventDetails,
-            dependencies: presentationStyleDeterminerDependencies)
-    }
-
-    var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
-        let cancelThenCollectPaymentWithWeakSelf: () -> Void = { [weak self] in
-            self?.posModel.cancelThenCollectPayment()
-        }
-
-        var orderTotal: String?
-        if case .loaded(let totals) = posModel.orderState {
-            orderTotal = totals.orderTotal
-        }
-
-        return PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: cancelThenCollectPaymentWithWeakSelf,
-            nonRetryableErrorExitAction: cancelThenCollectPaymentWithWeakSelf,
-            formattedOrderTotalPrice: orderTotal,
-            paymentCaptureErrorTryAgainAction: cancelThenCollectPaymentWithWeakSelf,
-            paymentCaptureErrorNewOrderAction: { [weak self] in
-                self?.posModel.startNewCart()
-            },
-            paymentIntentCreationErrorEditOrderAction: { [weak self] in
-                self?.editOrder()
-            },
-            dismissReaderConnectionModal: { [weak self] in
-                self?.cardPresentPaymentAlertViewModel = nil
-            }
-        )
-    }
-}
-
-private extension TotalsViewModel.PaymentState {
-    init?(from cardPaymentEvent: CardPresentPaymentEvent,
-          using paymentEventPresentationStyleDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies) {
-        switch cardPaymentEvent {
-        case .idle:
-            self = .idle
-        case .show(.validatingOrder):
-            self = .validatingOrder
-        case .show(.preparingForPayment):
-            self = .preparingReader
-        case .show(.tapSwipeOrInsertCard):
-            self = .acceptingCard
-        case .show(.processing),
-                .show(.displayReaderMessage):
-            self = .processingPayment
-        case .show(.paymentError):
-            if case let .show(eventDetails) = cardPaymentEvent,
-               case let .message(messageType) = PointOfSaleCardPresentPaymentEventPresentationStyle(
-                for: eventDetails,
-                dependencies: paymentEventPresentationStyleDependencies),
-               case .validatingOrderError = messageType {
-                self = .validatingOrderError
-            } else {
-                self = .paymentError
-            }
-        case .show(.paymentCaptureError):
-            self = .paymentError
-        case .show(.paymentSuccess):
-            self = .cardPaymentSuccessful
-        default:
-            return nil
-        }
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -6,7 +6,6 @@ import protocol Yosemite.POSItem
 final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     @Published var cardPresentPaymentOnboardingViewModel: CardPresentPaymentsOnboardingViewModel?
     private var onOnboardingCancellation: (() -> Void)?
-    @Published private(set) var isShowingCardReaderStatus: Bool = false
 
     @Published private(set) var connectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
 
@@ -27,7 +26,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         self.analytics = analytics
 
         // Initialize all properties before calling methods
-        self.observeConnectedReaderForStatus()
         self.observeCardPresentPaymentEvents()
     }
 
@@ -105,31 +103,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
 // MARK: - Payment collection
 
 private extension TotalsViewModel {
-    func observeConnectedReaderForStatus() {
-        cardPresentPaymentService.readerConnectionStatusPublisher
-            .assign(to: &$connectionStatus)
-
-        Publishers.CombineLatest3(posModel.$cardReaderConnectionStatus, posModel.$orderState, posModel.$cardPresentPaymentInlineMessage)
-            .map { connectionStatus, orderState, message in
-                guard orderState.isLoaded
-                        else {
-                    // When the order's being created or synced, we only show the shimmering totals.
-                    // Before the order exists, we don’t want to show the card payment status, as it will
-                    // show for a second initially, then disappear the moment we start syncing the order.
-                    return false
-                }
-
-                switch connectionStatus {
-                case .connected, .disconnecting, .cancellingConnection:
-                    return message != nil
-                case .disconnected:
-                    // Since the reader is disconnected, this will show the "Connect your reader" CTA button view.
-                    return true
-                }
-            }
-            .assign(to: &$isShowingCardReaderStatus)
-    }
-
     func observeCardPresentPaymentEvents() {
         cardPresentPaymentService.paymentEventPublisher
             .map { [weak self] event -> CardPresentPaymentsOnboardingViewModel? in

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -7,8 +7,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     @Published var cardPresentPaymentOnboardingViewModel: CardPresentPaymentsOnboardingViewModel?
     private var onOnboardingCancellation: (() -> Void)?
 
-    @Published private(set) var connectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
-
     @ObservedObject var posModel: PointOfSaleAggregateModel
 
     var isShimmering: Bool {
@@ -28,8 +26,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         // Initialize all properties before calling methods
         self.observeCardPresentPaymentEvents()
     }
-
-    private var connectionStatusPublisher: Published<CardPresentPaymentReaderConnectionStatus>.Publisher { $connectionStatus }
 
     func connectReaderTapped() {
         Task { @MainActor in

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -3,12 +3,7 @@ import struct Yosemite.Order
 import protocol Yosemite.POSItem
 
 protocol TotalsViewModelProtocol {
-    var paymentState: TotalsViewModel.PaymentState { get }
     var connectionStatus: CardPresentPaymentReaderConnectionStatus { get }
-
-    var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { get }
-
-    var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType? { get }
 
     func startNewOrder()
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -3,8 +3,6 @@ import struct Yosemite.Order
 import protocol Yosemite.POSItem
 
 protocol TotalsViewModelProtocol {
-    var connectionStatus: CardPresentPaymentReaderConnectionStatus { get }
-
     func startNewOrder()
 
     func startShowingTotalsView()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -826,6 +826,7 @@
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
+		209B7A682CEB6742003BDEF0 /* PointOfSalePaymentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */; };
 		209CA0EE2B50070D0073D1AC /* WooTabContainerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */; };
 		209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EEF8F2C762ED5007969A4 /* POSModalManager.swift */; };
 		20A130EB2C5A27190058022F /* PointOfSaleAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */; };
@@ -3947,6 +3948,7 @@
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
+		209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePaymentState.swift; sourceTree = "<group>"; };
 		209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooTabContainerController.swift; sourceTree = "<group>"; };
 		209EEF8F2C762ED5007969A4 /* POSModalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalManager.swift; sourceTree = "<group>"; };
 		20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAssetsTests.swift; sourceTree = "<group>"; };
@@ -9476,6 +9478,7 @@
 				2044158C2CE4DB480070BF54 /* PointOfSaleOrderStage.swift */,
 				2044158E2CE6181E0070BF54 /* PointOfSaleOrderState.swift */,
 				204415902CE622BA0070BF54 /* PointOfSaleOrderTotals.swift */,
+				209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -16267,6 +16270,7 @@
 				AE8AEA8628084EC90054BDA2 /* MaxWidthPreference.swift in Sources */,
 				DE19BB1A26C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift in Sources */,
 				2023E2AE2C21D8EA00FC365A /* PointOfSaleCardPresentPaymentInLineMessage.swift in Sources */,
+				209B7A682CEB6742003BDEF0 /* PointOfSalePaymentState.swift in Sources */,
 				B6F3796C293794A000718561 /* AnalyticsHubYearToDateRangeData.swift in Sources */,
 				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
 				203163BB2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
@@ -15,6 +15,10 @@ class MockCartViewModel: CartViewModelProtocol {
 
     // Mock variables
     var submitCartCalled = false
+
+    func shouldPreventCartEditing(posModel: PointOfSaleAggregateModel) -> Bool {
+        return false
+    }
 }
 
 // MARK: - Helpers

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
@@ -16,7 +16,8 @@ class MockCartViewModel: CartViewModelProtocol {
     // Mock variables
     var submitCartCalled = false
 
-    func shouldPreventCartEditing(posModel: PointOfSaleAggregateModel) -> Bool {
+    func shouldPreventCartEditing(orderState: PointOfSaleOrderState,
+                                  paymentState: PointOfSalePaymentState) -> Bool {
         return false
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
@@ -2,8 +2,13 @@ import Foundation
 @testable import Yosemite
 
 class MockPOSOrderService: POSOrderServiceProtocol {
+    var simulateSyncing = false
     var orderToReturn: Order?
     func syncOrder(cart: [Yosemite.POSCartItem], order: Yosemite.Order?, allProducts: [any Yosemite.POSItem]) async throws -> Yosemite.Order {
+        if simulateSyncing {
+            try await Task.sleep(nanoseconds: UInt64(1 * Double(NSEC_PER_SEC)))
+        }
+
         guard let order = orderToReturn else {
             throw MockPOSOrderServiceError.noOrderToReturn
         }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -9,6 +9,12 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
 
     func disconnectCardReader() { }
 
+    var paymentState: WooCommerce.PointOfSalePaymentState
+
+    var cardPresentPaymentAlertViewModel: WooCommerce.PointOfSaleCardPresentPaymentAlertType?
+
+    var cardPresentPaymentInlineMessage: WooCommerce.PointOfSaleCardPresentPaymentMessageType?
+
     var orderStage: PointOfSaleOrderStage
 
     var orderState: WooCommerce.PointOfSaleOrderState
@@ -30,11 +36,13 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     init(cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected,
          itemListState: ItemListState = .initialLoading,
          orderStage: PointOfSaleOrderStage = .building,
-         orderState: PointOfSaleOrderState = .idle) {
+         orderState: PointOfSaleOrderState = .idle,
+         paymentState: PointOfSalePaymentState = .idle) {
         self.cardReaderConnectionStatus = cardReaderConnectionStatus
         self.itemListState = itemListState
         self.orderStage = orderStage
         self.orderState = orderState
+        self.paymentState = paymentState
     }
 
     func loadInitialItems() async { }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -32,6 +32,7 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     }
 
     var itemListState: ItemListState
+    var blockReturnToItemSelection: Bool = false
 
     init(cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected,
          itemListState: ItemListState = .initialLoading,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -5,8 +5,6 @@ import protocol Yosemite.POSItem
 import struct Yosemite.Order
 
 final class MockTotalsViewModel: TotalsViewModelProtocol {
-    @Published var connectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
-
     func startNewOrder() { }
 
     var spyStopShowingTotalsViewCalled = false

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -5,24 +5,9 @@ import protocol Yosemite.POSItem
 import struct Yosemite.Order
 
 final class MockTotalsViewModel: TotalsViewModelProtocol {
-
-    @Published var paymentState: TotalsViewModel.PaymentState = .idle
-
-    @Published var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
     @Published var connectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
-    @Published var editOrderAction: Void = ()
 
-    var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { $paymentState }
-    var editOrderActionPublisher: AnyPublisher<Void, Never> { $editOrderAction.eraseToAnyPublisher() }
-
-    var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType? {
-        // Provide a mock implementation if needed
-        nil
-    }
-
-    func startNewOrder() {
-        paymentState = .acceptingCard
-    }
+    func startNewOrder() { }
 
     var spyStopShowingTotalsViewCalled = false
     func stopShowingTotalsView() {

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -683,6 +683,32 @@ struct PointOfSaleAggregateModelTests {
             // When, Then
             #expect(sut.blockReturnToItemSelection == true)
         }
+
+        @Test func blockReturnToItemSelection_false_when_paymentState_acceptingCard() async throws {
+            // Given
+            cardPresentPaymentService.paymentEvent = .show(
+                eventDetails: .preparingForPayment(cancelPayment: {}))
+            try #require(sut.blockReturnToItemSelection == true)
+
+            // When
+            cardPresentPaymentService.paymentEvent = .show(
+                eventDetails: .tapSwipeOrInsertCard(inputMethods: [.tap], cancelPayment: {}))
+
+            // Then
+            #expect(sut.blockReturnToItemSelection == false)
+        }
+
+        @Test func blockReturnToItemSelection_false_when_paymentState_validatingOrderError() async throws {
+            // Given
+            cardPresentPaymentService.paymentEvent = .show(
+                eventDetails: .paymentError(
+                    error: CollectOrderPaymentUseCaseError.orderTotalChanged,
+                    retryApproach: .dontRetry,
+                    cancelPayment: {}))
+
+            // When, Then
+            #expect(sut.blockReturnToItemSelection == false)
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -650,66 +650,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentInlineMessage == nil)
         }
 
-        @Test func blockReturnToItemSelection_when_paymentState_idle_and_order_is_syncing() async throws {
-            try #require(sut.blockReturnToItemSelection == false)
-            // Given syncing will happen for 1 second on checkOut
-            orderService.simulateSyncing = true
-            sut.addToCart(makeItem())
-
-            // When syncing is ongoing on another thread
-            Task {
-                await sut.checkOut()
-            }
-            try await Task.sleep(nanoseconds: UInt64(100 * Double(NSEC_PER_MSEC)))
-
-            // Then
-            #expect(sut.blockReturnToItemSelection == true)
-        }
-
-        @Test func blockReturnToItemSelection_when_paymentState_cardPaymentSuccessful() async throws {
-            try #require(sut.blockReturnToItemSelection == false)
-            // Given
-            cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
-
-            // When, Then
-            #expect(sut.blockReturnToItemSelection == true)
-        }
-
-        @Test func blockReturnToItemSelection_when_paymentState_processingPayment() async throws {
-            try #require(sut.blockReturnToItemSelection == false)
-            // Given
-            cardPresentPaymentService.paymentEvent = .show(eventDetails: .processing)
-
-            // When, Then
-            #expect(sut.blockReturnToItemSelection == true)
-        }
-
-        @Test func blockReturnToItemSelection_false_when_paymentState_acceptingCard() async throws {
-            // Given
-            cardPresentPaymentService.paymentEvent = .show(
-                eventDetails: .preparingForPayment(cancelPayment: {}))
-            try #require(sut.blockReturnToItemSelection == true)
-
-            // When
-            cardPresentPaymentService.paymentEvent = .show(
-                eventDetails: .tapSwipeOrInsertCard(inputMethods: [.tap], cancelPayment: {}))
-
-            // Then
-            #expect(sut.blockReturnToItemSelection == false)
-        }
-
-        @Test func blockReturnToItemSelection_false_when_paymentState_validatingOrderError() async throws {
-            // Given
-            cardPresentPaymentService.paymentEvent = .show(
-                eventDetails: .paymentError(
-                    error: CollectOrderPaymentUseCaseError.orderTotalChanged,
-                    retryApproach: .dontRetry,
-                    cancelPayment: {}))
-
-            // When, Then
-            #expect(sut.blockReturnToItemSelection == false)
-        }
-
         @Test func cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async throws {
             // Given
             orderService.orderToReturn = Order.fake().copy(currency: "$", total: "52.30")

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -649,6 +649,40 @@ struct PointOfSaleAggregateModelTests {
             // Then
             #expect(sut.cardPresentPaymentInlineMessage == nil)
         }
+
+        @Test func blockReturnToItemSelection_when_paymentState_idle_and_order_is_syncing() async throws {
+            try #require(sut.blockReturnToItemSelection == false)
+            // Given syncing will happen for 1 second on checkOut
+            orderService.simulateSyncing = true
+            sut.addToCart(makeItem())
+
+            // When syncing is ongoing on another thread
+            Task {
+                await sut.checkOut()
+            }
+            try await Task.sleep(nanoseconds: UInt64(100 * Double(NSEC_PER_MSEC)))
+
+            // Then
+            #expect(sut.blockReturnToItemSelection == true)
+        }
+
+        @Test func blockReturnToItemSelection_when_paymentState_cardPaymentSuccessful() async throws {
+            try #require(sut.blockReturnToItemSelection == false)
+            // Given
+            cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+
+            // When, Then
+            #expect(sut.blockReturnToItemSelection == true)
+        }
+
+        @Test func blockReturnToItemSelection_when_paymentState_processingPayment() async throws {
+            try #require(sut.blockReturnToItemSelection == false)
+            // Given
+            cardPresentPaymentService.paymentEvent = .show(eventDetails: .processing)
+
+            // When, Then
+            #expect(sut.blockReturnToItemSelection == true)
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -709,6 +709,71 @@ struct PointOfSaleAggregateModelTests {
             // When, Then
             #expect(sut.blockReturnToItemSelection == false)
         }
+
+        @Test func cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async throws {
+            // Given
+            orderService.orderToReturn = Order.fake().copy(currency: "$", total: "52.30")
+            sut.addToCart(makeItem())
+            await sut.checkOut()
+
+            // When
+            cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+
+            // Then
+            guard case .paymentSuccess(let viewModel) = sut.cardPresentPaymentInlineMessage else {
+                Issue.record("Expected cardPresentPaymentInlineMessage to be paymentSuccess")
+                return
+            }
+            #expect(viewModel.message == "A payment of $52.30 was successfully made")
+        }
+
+        @Test func paymentIntentCreationErrorMessage_when_paymentIntentCreationError_tryAgain_cancels_payment() async throws {
+            // Given
+            struct TestError: Error {}
+            orderService.orderToReturn = Order.fake()
+            sut.addToCart(makeItem())
+            await sut.checkOut()
+
+            // When paymentIntentCreationError event is received
+            cardPresentPaymentService.paymentEvent = .show(
+                eventDetails: .paymentIntentCreationError(error: TestError(), cancelPayment: {})
+            )
+
+            // Then
+            guard case .paymentIntentCreationError(let viewModel) = sut.cardPresentPaymentInlineMessage else {
+                Issue.record("Expected cardPresentPaymentInlineMessage to be paymentIntentCreationError")
+                return
+            }
+            let tryAgainAction = viewModel.tryAgainButtonViewModel.actionHandler
+
+            tryAgainAction()
+            #expect(cardPresentPaymentService.cancelPaymentCalled == true)
+        }
+
+        @Test func paymentIntentCreationErrorMessage_when_paymentIntentCreationError_editOrder_moves_back_to_building() async throws {
+            // Given
+            struct TestError: Error {}
+            orderService.orderToReturn = Order.fake()
+            sut.addToCart(makeItem())
+            await sut.submitCart()
+
+            // When paymentIntentCreationError event is received
+            cardPresentPaymentService.paymentEvent = .show(
+                eventDetails: .paymentIntentCreationError(error: TestError(), cancelPayment: {})
+            )
+
+            // Then
+            guard case .paymentIntentCreationError(let viewModel) = sut.cardPresentPaymentInlineMessage,
+                  let editOrderAction = viewModel.editOrderButtonViewModel?.actionHandler
+            else {
+                Issue.record("Expected cardPresentPaymentInlineMessage to be paymentIntentCreationError")
+                return
+            }
+
+            try #require(sut.orderStage == .finalizing)
+            editOrderAction()
+            #expect(sut.orderStage == .building)
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -480,7 +480,7 @@ struct PointOfSaleAggregateModelTests {
             cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
 
             // Then
-            let timeout = ContinuousClock.now + .seconds(1)
+            let timeout = ContinuousClock.now + .seconds(2)
 
             while cardPresentPaymentService.collectPaymentWasCalled != true {
                 try await Task.sleep(for: .milliseconds(1))
@@ -569,16 +569,86 @@ struct PointOfSaleAggregateModelTests {
 
     struct PaymentTests {
         private let cardPresentPaymentService = MockCardPresentPaymentService()
+        private let itemProvider = MockPOSItemProvider()
+        private let orderService = MockPOSOrderService()
         private let sut: PointOfSaleAggregateModel
 
         init() {
             sut = PointOfSaleAggregateModel(
-                itemProvider: MockPOSItemProvider(),
+                itemProvider: itemProvider,
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderService: MockPOSOrderService())
+                orderService: orderService)
         }
 
+        @Test func init_sets_paymentState_to_idle() async throws {
+            // Given that we don't specify a payment state
+            // When we init
+            let sut = PointOfSaleAggregateModel(
+                itemProvider: itemProvider,
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderService: orderService)
 
+            // Then
+            #expect(sut.paymentState == .idle)
+        }
+
+        @Test func startNewCart_sets_payment_state_to_idle() async throws {
+            // Note that this previously set it to `acceptingCard`, but that seems wrong
+            // Given
+            let sut = PointOfSaleAggregateModel(
+                itemProvider: itemProvider,
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderService: orderService,
+                paymentState: .cardPaymentSuccessful)
+
+            // When
+            sut.startNewCart()
+
+            // Then
+            #expect(sut.paymentState == .idle)
+        }
+
+        @Test func startNewCart_sets_payment_message_to_nil() async throws {
+            // Given
+            cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+            try #require(sut.cardPresentPaymentInlineMessage != nil)
+
+            // When
+            sut.startNewCart()
+
+            // Then
+            #expect(sut.cardPresentPaymentInlineMessage == nil)
+        }
+
+        @Test func addMoreToCart_sets_payment_state_to_idle() async throws {
+            // Given
+            let sut = PointOfSaleAggregateModel(
+                itemProvider: itemProvider,
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderService: orderService,
+                paymentState: .cardPaymentSuccessful)
+
+            // When
+            sut.addMoreToCart()
+
+            // Then
+            #expect(sut.paymentState == .idle)
+        }
+
+        @Test func addMoreToCart_sets_payment_message_to_nil() async throws {
+            // Given
+            cardPresentPaymentService.paymentEvent = .show(
+                eventDetails: .tapSwipeOrInsertCard(
+                    inputMethods: [.tap, .swipe, .insert],
+                    cancelPayment: {}))
+            try #require(sut.cardPresentPaymentInlineMessage != nil)
+
+            // When
+            sut.addMoreToCart()
+
+            // Then
+            #expect(sut.cardPresentPaymentInlineMessage == nil)
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -1,11 +1,9 @@
 import XCTest
-import Combine
-import SwiftUI
 @testable import WooCommerce
 @testable import protocol Yosemite.POSItem
 @testable import struct Yosemite.POSProduct
 
-final class CartViewModelTests: XCTestCase {
+final class LegacyCartViewModelTests: XCTestCase {
 
     private var sut: CartViewModel!
     private var posModel: PointOfSaleAggregateModel!
@@ -36,8 +34,8 @@ final class CartViewModelTests: XCTestCase {
         XCTAssertNil(sut.itemsInCartLabel, "Initial state")
 
         // Given
-        let anItem = Self.makeItem()
-        let anotherItem = Self.makeItem()
+        let anItem = makeItem()
+        let anotherItem = makeItem()
 
         // When/Then
         posModel.addToCart(anItem)
@@ -48,15 +46,95 @@ final class CartViewModelTests: XCTestCase {
     }
 }
 
-private extension CartViewModelTests {
-    static func makeItem(name: String = "") -> POSItem {
-        return POSProduct(itemID: UUID(),
-                          productID: 0,
-                          name: name,
-                          price: "",
-                          formattedPrice: "",
-                          itemCategories: [],
-                          productImageSource: nil,
-                          productType: .simple)
+private func makeItem(name: String = "") -> POSItem {
+    return POSProduct(itemID: UUID(),
+                      productID: 0,
+                      name: name,
+                      price: "",
+                      formattedPrice: "",
+                      itemCategories: [],
+                      productImageSource: nil,
+                      productType: .simple)
+}
+
+import Testing
+
+struct CartViewModelTests {
+    let orderService: MockPOSOrderService
+    let cardPresentPaymentService: MockCardPresentPaymentService
+    let posModel: PointOfSaleAggregateModel
+    let sut: CartViewModel
+
+    init () async throws {
+        let orderService = MockPOSOrderService()
+        self.orderService = orderService
+        let cardPresentPaymentService = MockCardPresentPaymentService()
+        self.cardPresentPaymentService = cardPresentPaymentService
+        let posModel = PointOfSaleAggregateModel(itemProvider: MockPOSItemProvider(),
+                                                 cardPresentPaymentService: cardPresentPaymentService,
+                                                 orderService: orderService)
+        self.posModel = posModel
+        sut = CartViewModel(posModel: posModel)
     }
+
+    @Test func shouldPreventCartEditing_when_paymentState_idle_and_order_is_syncing() async throws {
+        try #require(sut.shouldPreventCartEditing(posModel: posModel) == false)
+        // Given syncing will happen for 1 second on checkOut
+        orderService.simulateSyncing = true
+        posModel.addToCart(makeItem())
+
+        // When syncing is ongoing on another thread
+        Task {
+            await posModel.checkOut()
+        }
+        try await Task.sleep(nanoseconds: UInt64(100 * Double(NSEC_PER_MSEC)))
+
+        // Then
+        #expect(sut.shouldPreventCartEditing(posModel: posModel) == true)
+    }
+
+    @Test func shouldPreventCartEditing_when_paymentState_cardPaymentSuccessful() async throws {
+        try #require(sut.shouldPreventCartEditing(posModel: posModel) == false)
+        // Given
+        cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+
+        // When, Then
+        #expect(sut.shouldPreventCartEditing(posModel: posModel) == true)
+    }
+
+    @Test func shouldPreventCartEditing_when_paymentState_processingPayment() async throws {
+        try #require(sut.shouldPreventCartEditing(posModel: posModel) == false)
+        // Given
+        cardPresentPaymentService.paymentEvent = .show(eventDetails: .processing)
+
+        // When, Then
+        #expect(sut.shouldPreventCartEditing(posModel: posModel) == true)
+    }
+
+    @Test func shouldPreventCartEditing_false_when_paymentState_acceptingCard() async throws {
+        // Given
+        cardPresentPaymentService.paymentEvent = .show(
+            eventDetails: .preparingForPayment(cancelPayment: {}))
+        try #require(sut.shouldPreventCartEditing(posModel: posModel) == true)
+
+        // When
+        cardPresentPaymentService.paymentEvent = .show(
+            eventDetails: .tapSwipeOrInsertCard(inputMethods: [.tap], cancelPayment: {}))
+
+        // Then
+        #expect(sut.shouldPreventCartEditing(posModel: posModel) == false)
+    }
+
+    @Test func shouldPreventCartEditing_false_when_paymentState_validatingOrderError() async throws {
+        // Given
+        cardPresentPaymentService.paymentEvent = .show(
+            eventDetails: .paymentError(
+                error: CollectOrderPaymentUseCaseError.orderTotalChanged,
+                retryApproach: .dontRetry,
+                cancelPayment: {}))
+
+        // When, Then
+        #expect(sut.shouldPreventCartEditing(posModel: posModel) == false)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -78,63 +78,59 @@ struct CartViewModelTests {
     }
 
     @Test func shouldPreventCartEditing_when_paymentState_idle_and_order_is_syncing() async throws {
-        try #require(sut.shouldPreventCartEditing(posModel: posModel) == false)
-        // Given syncing will happen for 1 second on checkOut
-        orderService.simulateSyncing = true
-        posModel.addToCart(makeItem())
+        // Given
 
-        // When syncing is ongoing on another thread
-        Task {
-            await posModel.checkOut()
-        }
-        try await Task.sleep(nanoseconds: UInt64(100 * Double(NSEC_PER_MSEC)))
-
-        // Then
-        #expect(sut.shouldPreventCartEditing(posModel: posModel) == true)
+        // When, Then
+        #expect(sut.shouldPreventCartEditing(orderState: .syncing,
+                                             paymentState: .idle) == true)
     }
 
     @Test func shouldPreventCartEditing_when_paymentState_cardPaymentSuccessful() async throws {
-        try #require(sut.shouldPreventCartEditing(posModel: posModel) == false)
         // Given
-        cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+        let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00"))
 
         // When, Then
-        #expect(sut.shouldPreventCartEditing(posModel: posModel) == true)
+        #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
+                                             paymentState: .cardPaymentSuccessful) == true)
     }
 
     @Test func shouldPreventCartEditing_when_paymentState_processingPayment() async throws {
-        try #require(sut.shouldPreventCartEditing(posModel: posModel) == false)
         // Given
-        cardPresentPaymentService.paymentEvent = .show(eventDetails: .processing)
+        let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00"))
 
         // When, Then
-        #expect(sut.shouldPreventCartEditing(posModel: posModel) == true)
+        #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
+                                             paymentState: .processingPayment) == true)
     }
 
     @Test func shouldPreventCartEditing_false_when_paymentState_acceptingCard() async throws {
         // Given
-        cardPresentPaymentService.paymentEvent = .show(
-            eventDetails: .preparingForPayment(cancelPayment: {}))
-        try #require(sut.shouldPreventCartEditing(posModel: posModel) == true)
+        let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00"))
 
-        // When
-        cardPresentPaymentService.paymentEvent = .show(
-            eventDetails: .tapSwipeOrInsertCard(inputMethods: [.tap], cancelPayment: {}))
-
-        // Then
-        #expect(sut.shouldPreventCartEditing(posModel: posModel) == false)
+        // When, Then
+        #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
+                                             paymentState: .acceptingCard) == false)
     }
 
     @Test func shouldPreventCartEditing_false_when_paymentState_validatingOrderError() async throws {
         // Given
-        cardPresentPaymentService.paymentEvent = .show(
-            eventDetails: .paymentError(
-                error: CollectOrderPaymentUseCaseError.orderTotalChanged,
-                retryApproach: .dontRetry,
-                cancelPayment: {}))
+        let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00"))
 
         // When, Then
-        #expect(sut.shouldPreventCartEditing(posModel: posModel) == false)
+        #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
+                                             paymentState: .validatingOrderError) == false)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -49,50 +49,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_viewmodel_when_loaded_then_has_expected_initial_setup() {
-        // Given
-        let expectedExitPOSButtonDisabledState = false
-
-        // When/Then
-        XCTAssertEqual(sut.isExitPOSDisabled, expectedExitPOSButtonDisabledState)
-    }
-
-    func test_isExitPOSDisabled_is_true_for_paymentState_processingPayment() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect isExitPOSDisabled to be true when paymentState is processingPayment")
-
-        sut.$isExitPOSDisabled
-            .sink { disabled in
-                if disabled {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-//        mockPOSModel.paymentState = .processingPayment
-
-        wait(for: [expectation], timeout: 1.0)
-    }
-
-    func test_isExitPOSDisabled_is_false_for_paymentState_idle() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect isExitPOSDisabled to be false when paymentState is idle")
-
-        sut.$isExitPOSDisabled
-            .sink { disabled in
-                if !disabled {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-//        mockPOSModel.paymentState = .idle
-
-        wait(for: [expectation], timeout: 1.0)
-    }
-
     func test_isTotalsViewFullScreen_is_true_for_paymentState_processingPayment() {
         // Given
         let expectation = XCTestExpectation(description: "Expect isTotalsViewFullScreen to be true when paymentState is processingPayment")

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -49,43 +49,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_isTotalsViewFullScreen_is_true_for_paymentState_processingPayment() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect isTotalsViewFullScreen to be true when paymentState is processingPayment")
-
-        sut.$isTotalsViewFullScreen
-            .dropFirst()
-            .sink { fullscreen in
-                if fullscreen {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-//        mockPOSModel.paymentState = .processingPayment
-
-        wait(for: [expectation], timeout: 1.0)
-    }
-
-    func test_isTotalsViewFullScreen_is_false_for_paymentState_idle() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect isTotalsViewFullScreen to be false when paymentState is idle")
-
-        sut.$isTotalsViewFullScreen
-            .sink { fullscreen in
-                if !fullscreen {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-//        mockPOSModel.paymentState = .idle
-
-        wait(for: [expectation], timeout: 1.0)
-    }
-
     func test_showsConnectivityError_when_nonReachable_then_shows_error() {
         // Given
         mockConnectivityObserver.setStatus(.notReachable)

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -51,67 +51,10 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
 
     func test_viewmodel_when_loaded_then_has_expected_initial_setup() {
         // Given
-        let expectedAddMoreButtonDisabledState = false
         let expectedExitPOSButtonDisabledState = false
 
         // When/Then
-        XCTAssertEqual(sut.isAddMoreDisabled, expectedAddMoreButtonDisabledState)
         XCTAssertEqual(sut.isExitPOSDisabled, expectedExitPOSButtonDisabledState)
-    }
-
-    func test_isAddMoreDisabled_is_true_when_order_is_syncing_and_paymentState_is_idle() async {
-        // Given
-        mockPOSModel.addToCart(Self.makeItem())
-        let expectation = XCTestExpectation(description: "Expect isAddMoreDisabled to be true while syncing order and payment state is idle")
-
-        await sut.$isAddMoreDisabled
-            .sink { disabled in
-                if disabled {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-        await mockPOSModel.checkOut()
-
-        await fulfillment(of: [expectation], timeout: 1.0)
-    }
-
-    func test_isAddMoreDisabled_is_true_for_collectPayment_success() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect isAddMoreDisabled to be true after successfully collecting payment")
-
-        sut.$isAddMoreDisabled
-            .sink { disabled in
-                if disabled {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-//        mockPOSModel.paymentState = .cardPaymentSuccessful
-
-        wait(for: [expectation], timeout: 2.0)
-    }
-
-    func test_isAddMoreDisabled_is_true_for_paymentState_processingPayment() {
-        // Given
-        let expectation = XCTestExpectation(description: "Expect isAddMoreDisabled to be true when paymentState is processingPayment or cardPaymentSuccessful")
-
-        sut.$isAddMoreDisabled
-            .sink { disabled in
-                if disabled {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &cancellables)
-
-        // When
-//        mockPOSModel.paymentState = .processingPayment
-
-        wait(for: [expectation], timeout: 1.0)
     }
 
     func test_isExitPOSDisabled_is_true_for_paymentState_processingPayment() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -91,7 +91,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
             .store(in: &cancellables)
 
         // When
-        mockTotalsViewModel.paymentState = .cardPaymentSuccessful
+//        mockPOSModel.paymentState = .cardPaymentSuccessful
 
         wait(for: [expectation], timeout: 2.0)
     }
@@ -109,7 +109,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
             .store(in: &cancellables)
 
         // When
-        mockTotalsViewModel.paymentState = .processingPayment
+//        mockPOSModel.paymentState = .processingPayment
 
         wait(for: [expectation], timeout: 1.0)
     }
@@ -127,7 +127,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
             .store(in: &cancellables)
 
         // When
-        mockTotalsViewModel.paymentState = .processingPayment
+//        mockPOSModel.paymentState = .processingPayment
 
         wait(for: [expectation], timeout: 1.0)
     }
@@ -145,7 +145,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
             .store(in: &cancellables)
 
         // When
-        mockTotalsViewModel.paymentState = .idle
+//        mockPOSModel.paymentState = .idle
 
         wait(for: [expectation], timeout: 1.0)
     }
@@ -164,7 +164,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
             .store(in: &cancellables)
 
         // When
-        mockTotalsViewModel.paymentState = .processingPayment
+//        mockPOSModel.paymentState = .processingPayment
 
         wait(for: [expectation], timeout: 1.0)
     }
@@ -182,7 +182,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
             .store(in: &cancellables)
 
         // When
-        mockTotalsViewModel.paymentState = .idle
+//        mockPOSModel.paymentState = .idle
 
         wait(for: [expectation], timeout: 1.0)
     }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -29,42 +29,6 @@ final class TotalsViewModelTests: XCTestCase {
         cancellables = Set()
     }
 
-    func test_isShowingCardReaderStatus_when_order_not_loaded_then_false() async {
-        // Given
-//        orderService.orderToReturn = nil
-
-        // When
-//        await sut.syncOrder(for: [], allItems: [])
-        // If this needs testing, it should rely on posModel.orderState now
-        // we can't mock posModel properties until paymentState is moved, because we currently need the published properties in TotalsViewModel
-
-        // Then
-        XCTAssertFalse(sut.isShowingCardReaderStatus)
-    }
-
-    func test_isShowingCardReaderStatus_when_connected_and_payment_message_exists_then_true() async throws {
-        // Given
-        orderService.orderToReturn = Order.fake()
-        cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
-        cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
-
-        let item = Self.makeItem()
-        posModel.addToCart(item)
-        await posModel.checkOut()
-
-        // Then
-        XCTAssertTrue(sut.isShowingCardReaderStatus)
-    }
-
-    func test_isShowingCardReaderStatus_when_connected_and_no_payment_message_then_false() {
-        // Given
-        cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
-        cardPresentPaymentService.paymentEvent = .idle
-
-        // Then
-        XCTAssertFalse(sut.isShowingCardReaderStatus)
-    }
-
     // MARK: Onboarding
 
     func test_cardPresentPaymentOnboardingViewModel_is_non_nil_when_onboarding_is_required() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -29,20 +29,6 @@ final class TotalsViewModelTests: XCTestCase {
         cancellables = Set()
     }
 
-    func test_startNewOrder_after_collecting_payment() async throws {
-        // Given
-        let item = Self.makeItem()
-
-        orderService.orderToReturn = Order.fake()
-
-        // When
-        // Lots deleted here temporarily; may need to be added back when we move paymentState and messages.
-        await sut.startNewOrder()
-
-        // Then
-//        XCTAssertNil(sut.cardPresentPaymentInlineMessage)
-    }
-
     func test_isShowingCardReaderStatus_when_order_not_loaded_then_false() async {
         // Given
 //        orderService.orderToReturn = nil
@@ -77,87 +63,6 @@ final class TotalsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(sut.isShowingCardReaderStatus)
-    }
-
-    func test_isShowingTotalsFields_when_payment_processing_then_false() {
-        cardPresentPaymentService.paymentEvent = .show(eventDetails: .processing)
-
-//        XCTAssertFalse(sut.isShowingTotalsFields)
-    }
-
-    func test_isShowingTotalsFields_when_payment_successful_then_false() {
-        cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
-
-//        XCTAssertFalse(sut.isShowingTotalsFields)
-    }
-
-    func test_isShowingTotalsFields_when_preparing_for_reader_then_true() {
-        cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
-
-//        XCTAssertTrue(sut.isShowingTotalsFields)
-    }
-
-    func test_cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async {
-        // Given
-        orderService.orderToReturn = Order.fake().copy(currency: "$", total: "52.30")
-        posModel.addToCart(Self.makeItem())
-        await posModel.checkOut()
-        // We can't actually mock this right now, but this would be the way:
-//        posModel.orderState = .loaded(.init(cartTotal: "", orderTotal: "$52.30", taxTotal: ""))
-
-        // When
-        cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: { }))
-//        let message = await sut.cardPresentPaymentInlineMessage
-//
-//        // Then
-//        if case .paymentSuccess(let viewModel) = message {
-//            XCTAssertEqual(viewModel.title, "Payment successful")
-//            XCTAssertEqual(viewModel.message, "A payment of $52.30 was successfully made")
-//        } else {
-//            XCTFail("Expected cardPresentPaymentInlineMessage to be paymentSuccess")
-//        }
-    }
-
-    func test_paymentIntentCreationErrorMessage_when_paymentIntentCreationError() async {
-        // Given
-        struct TestError: Error {}
-        orderService.orderToReturn = Order.fake()
-        posModel.addToCart(Self.makeItem())
-        await posModel.checkOut()
-
-        // When paymentIntentCreationError event is received
-        cardPresentPaymentService.paymentEvent = .show(
-            eventDetails: .paymentIntentCreationError(error: TestError(), cancelPayment: {})
-        )
-
-        // Then
-        // paymentIntentCreationError message is set
-        var editOrderAction: (() -> Void)? = nil
-        var tryAgainAction: (() -> Void)? = nil
-//        if case .paymentIntentCreationError(let viewModel) = sut.cardPresentPaymentInlineMessage {
-//            editOrderAction = viewModel.editOrderButtonViewModel?.actionHandler
-//            tryAgainAction = viewModel.tryAgainButtonViewModel.actionHandler
-//        } else {
-//            XCTFail("Expected cardPresentPaymentInlineMessage to be paymentIntentCreationError")
-//        }
-//
-//        // Try again action emits payment cancelation and collection
-//        let shouldCollectPayment = XCTestExpectation(description: "Collect payment should be called after retrying payment")
-//        cardPresentPaymentService.onCollectPaymentCalled = {
-//            shouldCollectPayment.fulfill()
-//        }
-//
-//        XCTAssertFalse(cardPresentPaymentService.cancelPaymentCalled)
-//        tryAgainAction?()
-//        XCTAssertTrue(cardPresentPaymentService.cancelPaymentCalled)
-//
-//        await fulfillment(of: [shouldCollectPayment], timeout: 3)
-
-        // Edit order action calls addMoreToCart
-        // we can't test this until we can properly mock posModel... but by then this behaviour may have moved.
-//        XCTAssertFalse(posModel.addMoreToCartWasCalled)
-//        editOrderAction?()
-//        XCTAssertTrue(posModel.addMoreToCartWasCalled)
     }
 
     // MARK: Onboarding

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -25,14 +25,12 @@ final class TotalsViewModelTests: XCTestCase {
             cardPresentPaymentService: cardPresentPaymentService,
             orderService: orderService)
         sut = TotalsViewModel(posModel: posModel,
-                              cardPresentPaymentService: cardPresentPaymentService,
-                              paymentState: .acceptingCard)
+                              cardPresentPaymentService: cardPresentPaymentService)
         cancellables = Set()
     }
 
     func test_startNewOrder_after_collecting_payment() async throws {
         // Given
-        let paymentState: TotalsViewModel.PaymentState = .acceptingCard
         let item = Self.makeItem()
 
         orderService.orderToReturn = Order.fake()
@@ -42,8 +40,7 @@ final class TotalsViewModelTests: XCTestCase {
         await sut.startNewOrder()
 
         // Then
-        XCTAssertEqual(sut.paymentState, paymentState)
-        XCTAssertNil(sut.cardPresentPaymentInlineMessage)
+//        XCTAssertNil(sut.cardPresentPaymentInlineMessage)
     }
 
     func test_isShowingCardReaderStatus_when_order_not_loaded_then_false() async {
@@ -85,19 +82,19 @@ final class TotalsViewModelTests: XCTestCase {
     func test_isShowingTotalsFields_when_payment_processing_then_false() {
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .processing)
 
-        XCTAssertFalse(sut.isShowingTotalsFields)
+//        XCTAssertFalse(sut.isShowingTotalsFields)
     }
 
     func test_isShowingTotalsFields_when_payment_successful_then_false() {
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
 
-        XCTAssertFalse(sut.isShowingTotalsFields)
+//        XCTAssertFalse(sut.isShowingTotalsFields)
     }
 
     func test_isShowingTotalsFields_when_preparing_for_reader_then_true() {
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
 
-        XCTAssertTrue(sut.isShowingTotalsFields)
+//        XCTAssertTrue(sut.isShowingTotalsFields)
     }
 
     func test_cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async {
@@ -110,15 +107,15 @@ final class TotalsViewModelTests: XCTestCase {
 
         // When
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: { }))
-        let message = await sut.cardPresentPaymentInlineMessage
-
-        // Then
-        if case .paymentSuccess(let viewModel) = message {
-            XCTAssertEqual(viewModel.title, "Payment successful")
-            XCTAssertEqual(viewModel.message, "A payment of $52.30 was successfully made")
-        } else {
-            XCTFail("Expected cardPresentPaymentInlineMessage to be paymentSuccess")
-        }
+//        let message = await sut.cardPresentPaymentInlineMessage
+//
+//        // Then
+//        if case .paymentSuccess(let viewModel) = message {
+//            XCTAssertEqual(viewModel.title, "Payment successful")
+//            XCTAssertEqual(viewModel.message, "A payment of $52.30 was successfully made")
+//        } else {
+//            XCTFail("Expected cardPresentPaymentInlineMessage to be paymentSuccess")
+//        }
     }
 
     func test_paymentIntentCreationErrorMessage_when_paymentIntentCreationError() async {
@@ -137,24 +134,24 @@ final class TotalsViewModelTests: XCTestCase {
         // paymentIntentCreationError message is set
         var editOrderAction: (() -> Void)? = nil
         var tryAgainAction: (() -> Void)? = nil
-        if case .paymentIntentCreationError(let viewModel) = sut.cardPresentPaymentInlineMessage {
-            editOrderAction = viewModel.editOrderButtonViewModel?.actionHandler
-            tryAgainAction = viewModel.tryAgainButtonViewModel.actionHandler
-        } else {
-            XCTFail("Expected cardPresentPaymentInlineMessage to be paymentIntentCreationError")
-        }
-
-        // Try again action emits payment cancelation and collection
-        let shouldCollectPayment = XCTestExpectation(description: "Collect payment should be called after retrying payment")
-        cardPresentPaymentService.onCollectPaymentCalled = {
-            shouldCollectPayment.fulfill()
-        }
-
-        XCTAssertFalse(cardPresentPaymentService.cancelPaymentCalled)
-        tryAgainAction?()
-        XCTAssertTrue(cardPresentPaymentService.cancelPaymentCalled)
-
-        await fulfillment(of: [shouldCollectPayment], timeout: 3)
+//        if case .paymentIntentCreationError(let viewModel) = sut.cardPresentPaymentInlineMessage {
+//            editOrderAction = viewModel.editOrderButtonViewModel?.actionHandler
+//            tryAgainAction = viewModel.tryAgainButtonViewModel.actionHandler
+//        } else {
+//            XCTFail("Expected cardPresentPaymentInlineMessage to be paymentIntentCreationError")
+//        }
+//
+//        // Try again action emits payment cancelation and collection
+//        let shouldCollectPayment = XCTestExpectation(description: "Collect payment should be called after retrying payment")
+//        cardPresentPaymentService.onCollectPaymentCalled = {
+//            shouldCollectPayment.fulfill()
+//        }
+//
+//        XCTAssertFalse(cardPresentPaymentService.cancelPaymentCalled)
+//        tryAgainAction?()
+//        XCTAssertTrue(cardPresentPaymentService.cancelPaymentCalled)
+//
+//        await fulfillment(of: [shouldCollectPayment], timeout: 3)
 
         // Edit order action calls addMoreToCart
         // we can't test this until we can properly mock posModel... but by then this behaviour may have moved.
@@ -186,7 +183,6 @@ final class TotalsViewModelTests: XCTestCase {
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let sut = TotalsViewModel(posModel: posModel,
                                   cardPresentPaymentService: cardPresentPaymentService,
-                                  paymentState: .acceptingCard,
                                   analytics: analytics)
         let onboardingViewModel = CardPresentPaymentsOnboardingViewModel(fixedState: .noConnectionError)
         cardPresentPaymentService.paymentEvent = .showOnboarding(onboardingViewModel: onboardingViewModel, onCancel: {})
@@ -206,7 +202,6 @@ final class TotalsViewModelTests: XCTestCase {
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let sut = TotalsViewModel(posModel: posModel,
                                   cardPresentPaymentService: cardPresentPaymentService,
-                                  paymentState: .acceptingCard,
                                   analytics: analytics)
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14407
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR moves payment related code (excluding onboarding) from the `TotalsViewModel` to the new aggregate model.

Again, apologies that this is so big... but any options to make it smaller appeared to make it less clear and testable as well.

For the most part, this was a lift-and-shift operation, but I made some changes. In particular, I :
- removed combine publisher chains (where practical.)
- replaced "should display" type flags with direct references to the relevant properties from the `View` (remember, it's better thought of as a view model!)
- added and simplified some tests.

Some things that were tested before, aren't any more. The most complex example of this is `TotalsView.isShowingCardReaderStatus` – however, it's not substantially different to the existing `cardReaderViewLayout` on the same View.

I have found that `EnvironmentObject` makes it impossible to unit test the views which rely on posModel. If we want to go down that path we can, but we'll lose the convenience of the system dependency injection. It's a shame there's no good test hook for this though.

We could potentially keep `EnvironmentObject` for use by deeply nested but simple views, and pass the posModel in to the top-level views... but it is likely to make it harder to break views in to smaller components, so I've not done it for now.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Broadly, this requires testing of payment and navigation between item list, checkout, and payment states.

That should include errors, both in fetching the order and completing the payment, and checking that editing/starting a new order works as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/2c0eb97b-eac0-4489-8adc-eb131158470d


https://github.com/user-attachments/assets/ff8ba731-f402-413c-97f2-49a8c3d54847


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.