### PR TITLE
[Woo POS] [Cash & Receipts] Feature flag & button render for sending POS receipts 

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -93,6 +93,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper
         case .sendReceiptAfterPayment:
             return false
+        case .sendReceiptsForPointOfSale:
+            return false
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -199,4 +199,8 @@ public enum FeatureFlag: Int {
 
     /// Enables sending receipt after the payment via the API
     case sendReceiptAfterPayment
+
+    /// Adds support for  sending receipts after the payment for POS
+    ///
+    case sendReceiptsForPointOfSale
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -15,6 +15,10 @@ struct TotalsView: View {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.colorScheme) var colorScheme
 
+    private var shouldShowSendReceiptButton: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sendReceiptsForPointOfSale)
+    }
+
     init(viewModel: TotalsViewModel) {
         self.viewModel = viewModel
         self.isShowingTotalsFields = viewModel.isShowingTotalsFields
@@ -202,16 +206,36 @@ private extension TotalsView {
         Button(action: {
             viewModel.startNewOrder()
         }, label: {
-            HStack(spacing: Constants.newOrderButtonSpacing) {
+            HStack(spacing: Constants.buttonSpacing) {
                 Text(Localization.newOrder)
-                    .font(Constants.newOrderButtonFont)
+                    .font(Constants.buttonFont)
             }
             .frame(minWidth: UIScreen.main.bounds.width / 2)
         })
-        .padding(Constants.newOrderButtonPadding)
+        .padding(Constants.buttonPadding)
         .foregroundColor(Constants.posPrimaryTextInverted)
         .background(Constants.posOverlayFillInverted)
-        .cornerRadius(Constants.newOrderButtonCornerRadius)
+        .cornerRadius(Constants.buttonCornerRadius)
+    }
+
+    private var sendReceiptButton: some View {
+        Button(action: {
+            // no-op
+            // https://github.com/woocommerce/woocommerce-ios/issues/14461
+        }, label: {
+            HStack(spacing: Constants.buttonSpacing) {
+                Text(Localization.sendReceipt)
+                    .font(Constants.buttonFont)
+            }
+            .frame(minWidth: UIScreen.main.bounds.width / 2)
+        })
+        .padding(Constants.buttonPadding)
+        .foregroundColor(Color.posPrimaryText)
+        .background(Color.clear)
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.buttonCornerRadius)
+                        .stroke(Color.posPrimaryText, lineWidth: 1.0)
+        }
     }
 
     @ViewBuilder
@@ -220,6 +244,8 @@ private extension TotalsView {
             if isShowingPaymentsButtonSpacing {
                 Spacer().frame(height: Constants.paymentsButtonSpacing)
             }
+            sendReceiptButton
+                .renderedIf(shouldShowSendReceiptButton)
             newOrderButton
                 .onAppear {
                     isShowingPaymentsButtonSpacing = false
@@ -308,7 +334,7 @@ private extension TotalsView {
 private extension TotalsView {
     enum Constants {
         static let pricesIdealWidth: CGFloat = 382
-        static let newOrderButtonCornerRadius: CGFloat = 8
+        static let buttonCornerRadius: CGFloat = 8
 
         static let verticalSpacing: CGFloat = 56
 
@@ -329,9 +355,9 @@ private extension TotalsView {
 
         static let paymentsButtonSpacing: CGFloat = 80
         static let paymentsButtonButtonSpacingAnimationDelay: CGFloat = 0.3
-        static let newOrderButtonSpacing: CGFloat = 12
-        static let newOrderButtonPadding: CGFloat = 32
-        static let newOrderButtonFont: POSFontStyle = .posBodyEmphasized
+        static let buttonSpacing: CGFloat = 12
+        static let buttonPadding: CGFloat = 32
+        static let buttonFont: POSFontStyle = .posBodyEmphasized
 
         /// Used for synchronizing animations of shimmeringLine and textField
         static let matchedGeometrySubtotalId: String = "pos_totals_view_subtotal_matched_geometry_id"
@@ -376,6 +402,10 @@ private extension TotalsView {
             "pos.totalsView.newOrder",
             value: "New order",
             comment: "Button title for new order button")
+        static let sendReceipt = NSLocalizedString(
+            "pos.totalsView.sendReceipt",
+            value: "Receipt",
+            comment: "Button title for the receipt button")
     }
 }
 
@@ -404,5 +434,6 @@ private extension View {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         paymentState: .acceptingCard)
     TotalsView(viewModel: totalsVM)
+        .environmentObject(posModel)
 }
 #endif


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14460
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
We add the feature flag for `.sendReceiptsForPointOfSale` as well as the initial "Receipt" button after a successful card-present payment purchase via POS. The flag is turned off by default, so changes don't show either in release nor in debug builds, as the button is still not functional.

## Steps to reproduce

1. Load POS, go through the purchase flow, and observe that there is no new button rendered at the end.
![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-11-20 at 12 42 55](https://github.com/user-attachments/assets/3ea46dc0-769a-476a-84c3-6b86d091cc23)

2. Set `.sendReceiptsForPointOfSale` to true, go through the same purchase flow, and observe the button is now present (but not functional)

| Light | Dark |
|--------|--------|
| ![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-11-20 at 12 35 44](https://github.com/user-attachments/assets/c50d1d73-48c9-4564-8ee2-ef14fe6d61c1) | ![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-11-20 at 12 36 01](https://github.com/user-attachments/assets/086b4009-cb85-4a00-b125-6ffdccd5267d) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
