### PR TITLE
[REST API] Jetpack Setup: Tracks for account creation + enable the feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,8 +95,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .sendReceiptsForPointOfSale:
             return false
-        case .jetpackSetupWPComAccountCreation:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -203,8 +203,4 @@ public enum FeatureFlag: Int {
     /// Adds support for  sending receipts after the payment for POS
     ///
     case sendReceiptsForPointOfSale
-
-    /// Enables WPCom account creation during Jetpack setup
-    ///
-    case jetpackSetupWPComAccountCreation
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 - [internal] Simplifies App Icon by only using a single image for all supported platforms. [https://github.com/woocommerce/woocommerce-ios/pull/14429]
 - [*] Dashboard: Performance card now shows cached Visitors and Conversion data correctly. [https://github.com/woocommerce/woocommerce-ios/pull/14438]
 - [internal] Updated WooCommerceScreenshot to make it work again for generating screenshots. [https://github.com/woocommerce/woocommerce-ios/pull/14335]
+- [*] Jetpack Setup: Added support for WordPress.com account creation. [https://github.com/woocommerce/woocommerce-ios/pull/14471]
 
 21.1
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+JetpackSetup.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+JetpackSetup.swift
@@ -8,6 +8,7 @@ extension WooAnalyticsEvent {
             case requiresConnectionOnly = "requires_connection_only"
             case tap
             case step
+            case isSignup = "is_signup"
         }
 
         enum LoginFlow {
@@ -41,10 +42,16 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func loginFlow(step: LoginFlow.Step, tap: LoginFlow.TapTarget? = nil, failure: Error? = nil) -> WooAnalyticsEvent {
+        static func loginFlow(step: LoginFlow.Step,
+                              isSignup: Bool? = nil,
+                              tap: LoginFlow.TapTarget? = nil,
+                              failure: Error? = nil) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Key.step.rawValue: step.rawValue]
             if let tap {
                 properties[Key.tap.rawValue] = tap.rawValue
+            }
+            if let isSignup {
+                properties[Key.isSignup.rawValue] = isSignup
             }
             return .init(statName: .jetpackSetupLoginFlow, properties: properties, error: failure)
         }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
@@ -147,7 +147,7 @@ struct WPComEmailLoginView_Previews: PreviewProvider {
                                              requiresConnectionOnly: true,
                                              allowAccountCreation: false,
                                              onPasswordUIRequest: { _ in },
-                                             onMagicLinkUIRequest: { _ in },
+                                             onMagicLinkUIRequest: { _, _ in },
                                              onError: { _ in }))
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
@@ -97,6 +97,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
             }
 
             guard email.isValidEmail() else {
+                analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
                 onError(Localization.unknownUsername)
                 return
             }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
@@ -31,7 +31,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
     private let accountService: WordPressComAccountServiceProtocol
     private let analytics: Analytics
     private let onPasswordUIRequest: (String) -> Void
-    private let onMagicLinkUIRequest: (String) -> Void
+    private let onMagicLinkUIRequest: (_ email: String, _ isSignup: Bool) -> Void
     private let onError: (String) -> Void
 
     private var emailFieldSubscription: AnyCancellable?
@@ -43,7 +43,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
          accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
          analytics: Analytics = ServiceLocator.analytics,
          onPasswordUIRequest: @escaping (String) -> Void,
-         onMagicLinkUIRequest: @escaping (String) -> Void,
+         onMagicLinkUIRequest: @escaping (String, Bool) -> Void,
          onError: @escaping (String) -> Void) {
         self.allowAccountCreation = allowAccountCreation
         self.analytics = analytics
@@ -127,10 +127,10 @@ final class WPComEmailLoginViewModel: ObservableObject {
                     continuation.resume(throwing: error)
                 })
             }
-            onMagicLinkUIRequest(email)
+            onMagicLinkUIRequest(email, forAccountCreation)
         } catch {
             onError(error.localizedDescription)
-            analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
+            analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, isSignup: forAccountCreation, failure: error))
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
@@ -116,7 +116,8 @@ private extension WPComLoginCoordinator {
     func showMagicLinkForLogin(email: String) {
         let viewController = WPComMagicLinkHostingController(email: email,
                                                              title: title,
-                                                             isJetpackSetup: isJetpackSetup)
+                                                             isJetpackSetup: isJetpackSetup,
+                                                             isSignup: false)
         navigationController.show(viewController, sender: self)
     }
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkView.swift
@@ -8,11 +8,15 @@ final class WPComMagicLinkHostingController: UIHostingController<WPComMagicLinkV
     ///
     private let isJetpackSetup: Bool
 
-    init(email: String, title: String, isJetpackSetup: Bool) {
+    private let isSignup: Bool
+
+    init(email: String, title: String, isJetpackSetup: Bool, isSignup: Bool) {
         self.isJetpackSetup = isJetpackSetup
+        self.isSignup = isSignup
         let viewModel = WPComMagicLinkViewModel(email: email)
         super.init(rootView: WPComMagicLinkView(title: title,
                                                 isJetpackSetup: isJetpackSetup,
+                                                isSignup: isSignup,
                                                 viewModel: viewModel))
         rootView.onOpenMail = {
             let linkMailPresenter = LinkMailPresenter(emailAddress: email)
@@ -34,7 +38,7 @@ final class WPComMagicLinkHostingController: UIHostingController<WPComMagicLinkV
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if isMovingFromParent, isJetpackSetup {
-            ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, tap: .dismiss))
+            ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, isSignup: isSignup, tap: .dismiss))
         }
     }
 }
@@ -49,12 +53,15 @@ struct WPComMagicLinkView: View {
     /// Whether the view is part of the login step of the Jetpack setup flow.
     private let isJetpackSetup: Bool
 
+    private let isSignup: Bool
+
     private let viewModel: WPComMagicLinkViewModel
     var onOpenMail: () -> Void = {}
 
-    init(title: String, isJetpackSetup: Bool, viewModel: WPComMagicLinkViewModel) {
+    init(title: String, isJetpackSetup: Bool, isSignup: Bool, viewModel: WPComMagicLinkViewModel) {
         self.title = title
         self.isJetpackSetup = isJetpackSetup
+        self.isSignup = isSignup
         self.viewModel = viewModel
     }
 
@@ -95,7 +102,7 @@ struct WPComMagicLinkView: View {
                 // Primary CTA
                 Button(Localization.openMail) {
                     if isJetpackSetup {
-                        ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, tap: .submit))
+                        ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, isSignup: isSignup, tap: .submit))
                     }
                     onOpenMail()
                 }
@@ -135,6 +142,7 @@ struct WPComMagicLinkView_Previews: PreviewProvider {
     static var previews: some View {
         WPComMagicLinkView(title: "Login",
                            isJetpackSetup: false,
+                           isSignup: false,
                            viewModel: .init(email: "test@example.com"))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -28,7 +28,7 @@ final class JetpackSetupCoordinator {
               requiresConnectionOnly: requiresConnectionOnly,
               allowAccountCreation: featureFlagService.isFeatureFlagEnabled(.jetpackSetupWPComAccountCreation),
               onPasswordUIRequest: showPasswordUI(email:),
-              onMagicLinkUIRequest: showMagicLinkUI(email:),
+              onMagicLinkUIRequest: showMagicLinkUI,
               onError: { [weak self] message in
             self?.showAlert(message: message)
         })
@@ -352,8 +352,8 @@ private extension JetpackSetupCoordinator {
         self.loginNavigationController = loginNavigationController
     }
 
-    func showMagicLinkUI(email: String) {
-        analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink))
+    func showMagicLinkUI(email: String, isSignup: Bool) {
+        analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, isSignup: isSignup))
         let viewController = WPComMagicLinkHostingController(email: email,
                                                              title: loginViewTitle,
                                                              isJetpackSetup: true)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -26,7 +26,7 @@ final class JetpackSetupCoordinator {
     private lazy var emailLoginViewModel: WPComEmailLoginViewModel = {
         .init(siteURL: site.url,
               requiresConnectionOnly: requiresConnectionOnly,
-              allowAccountCreation: featureFlagService.isFeatureFlagEnabled(.jetpackSetupWPComAccountCreation),
+              allowAccountCreation: true,
               onPasswordUIRequest: showPasswordUI(email:),
               onMagicLinkUIRequest: showMagicLinkUI,
               onError: { [weak self] message in

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -356,7 +356,8 @@ private extension JetpackSetupCoordinator {
         analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, isSignup: isSignup))
         let viewController = WPComMagicLinkHostingController(email: email,
                                                              title: loginViewTitle,
-                                                             isJetpackSetup: true)
+                                                             isJetpackSetup: true,
+                                                             isSignup: isSignup)
         loginNavigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
@@ -11,7 +11,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: false,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -28,7 +28,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: true,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -45,7 +45,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: false,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -62,7 +62,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: true,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -79,7 +79,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: true,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -101,7 +101,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
         // Confidence checks
         XCTAssertFalse(mockAccountService.triggeredIsPasswordlessAccount)
@@ -125,7 +125,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in triggeredOnError = true })
         // When
         await viewModel.checkWordPressComAccount(email: "mail@example.com")
@@ -144,7 +144,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in triggeredPasswordUIRequest = true },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
         // When
         await viewModel.checkWordPressComAccount(email: "mail@example.com")
@@ -162,7 +162,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in triggeredOnMagicLinkUIRequest = true },
+                                                 onMagicLinkUIRequest: { _, _ in triggeredOnMagicLinkUIRequest = true },
                                                  onError: { _ in })
         // When
         await viewModel.requestAuthenticationLink(email: "mail@example.com")
@@ -181,7 +181,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in triggeredOnError = true })
         // When
         await viewModel.requestAuthenticationLink(email: "mail@example.com")
@@ -205,7 +205,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: true,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in triggeredOnMagicLinkUIRequest = true },
+                                                 onMagicLinkUIRequest: { _, isSignup in triggeredOnMagicLinkUIRequest = isSignup },
                                                  onError: { _ in })
 
         // When
@@ -230,7 +230,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in triggeredOnError = true })
 
         // When
@@ -255,7 +255,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: true,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _ in },
+                                                 onMagicLinkUIRequest: { _, _ in },
                                                  onError: { errorMessage = $0 })
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14468 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates tracking for Jetpack setup to allow tracking signup flow, it adds a new property `is_signup` to the magic link step events.

The PR also enables the feature and removes the feature flag.

## Steps to reproduce
1. Open the app and sign using site credentials.
2. Start jetpack setup.

## Testing information
- Test magic link for both login and signup flow, and confirm the `is_signup` property is properly tracked.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.