### PR TITLE
[Shipping labels] Add support for Woo Shipping label purchase endpoint in Networking layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2786,6 +2786,17 @@ extension Networking.WooShippingCustomPackage {
         )
     }
 }
+extension Networking.WooShippingPackagePurchase {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingPackagePurchase {
+        .init(
+            package: .fake(),
+            rate: .fake(),
+            productIDs: .fake()
+        )
+    }
+}
 extension Networking.WooShippingPredefinedOption {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2751,6 +2751,16 @@ extension Networking.WooPaymentsPayoutsSchedule {
         )
     }
 }
+extension Networking.WooShippingAccountSettingsResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingAccountSettingsResponse {
+        .init(
+            storeOptions: .fake(),
+            accountSettings: .fake()
+        )
+    }
+}
 extension Networking.WooShippingCreatePackageResponse {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -2758,18 +2768,6 @@ extension Networking.WooShippingCreatePackageResponse {
         .init(
             customPackages: .fake(),
             predefinedOptions: .fake()
-        )
-    }
-}
-extension Networking.WooShippingPackagesResponse {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.WooShippingPackagesResponse {
-        .init(
-            storeOptions: .fake(),
-            customPackages: .fake(),
-            savedPredefinedPackages: .fake(),
-            allPredefinedOptions: .fake()
         )
     }
 }
@@ -2791,9 +2789,22 @@ extension Networking.WooShippingPackagePurchase {
     ///
     public static func fake() -> Networking.WooShippingPackagePurchase {
         .init(
+            shipmentID: .fake(),
             package: .fake(),
             rate: .fake(),
             productIDs: .fake()
+        )
+    }
+}
+extension Networking.WooShippingPackagesResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingPackagesResponse {
+        .init(
+            storeOptions: .fake(),
+            customPackages: .fake(),
+            savedPredefinedPackages: .fake(),
+            allPredefinedOptions: .fake()
         )
     }
 }
@@ -2808,6 +2819,20 @@ extension Networking.WooShippingPredefinedOption {
         )
     }
 }
+extension Networking.WooShippingPredefinedPackage {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingPredefinedPackage {
+        .init(
+            id: .fake(),
+            name: .fake(),
+            isLetter: .fake(),
+            dimensions: .fake(),
+            boxWeight: .fake(),
+            groupId: .fake()
+        )
+    }
+}
 extension Networking.WooShippingPredefinedSavedOption {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -2818,16 +2843,15 @@ extension Networking.WooShippingPredefinedSavedOption {
         )
     }
 }
-extension Networking.WooShippingPredefinedPackage {
+extension Networking.WooShippingSavedPredefinedPackage {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    public static func fake() -> Networking.WooShippingPredefinedPackage {
-        .init(id: .fake(),
-              name: .fake(),
-              isLetter: .fake(),
-              dimensions: .fake(),
-              boxWeight: .fake(),
-              groupId: .fake())
+    public static func fake() -> Networking.WooShippingSavedPredefinedPackage {
+        .init(
+            groupTitle: .fake(),
+            providerID: .fake(),
+            package: .fake()
+        )
     }
 }
 extension Networking.WordPressMedia {

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -819,6 +819,7 @@
 		CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */ = {isa = PBXBuildFile; fileRef = CE19CB10222486A500E8AF7A /* order-statuses.json */; };
 		CE1BE7062A2A5E9A00C6B53B /* IdentifiableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */; };
 		CE1EA4BB2CEB78F60039F477 /* wooshipping-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CE1EA4BA2CEB78F60039F477 /* wooshipping-purchase-success.json */; };
+		CE1EA4BF2CEBA0B50039F477 /* WooShippingPackagePurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1EA4BE2CEBA0AF0039F477 /* WooShippingPackagePurchase.swift */; };
 		CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = CE20179220E3EFA7005B4C18 /* broken-orders.json */; };
 		CE21FB142C2AC87000303832 /* google-ads-reports-programs-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */; };
 		CE21FB162C2AC90E00303832 /* GoogleAdsCampaignStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */; };
@@ -2000,6 +2001,7 @@
 		CE19CB10222486A500E8AF7A /* order-statuses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-statuses.json"; sourceTree = "<group>"; };
 		CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableObject.swift; sourceTree = "<group>"; };
 		CE1EA4BA2CEB78F60039F477 /* wooshipping-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-purchase-success.json"; sourceTree = "<group>"; };
+		CE1EA4BE2CEBA0AF0039F477 /* WooShippingPackagePurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackagePurchase.swift; sourceTree = "<group>"; };
 		CE20179220E3EFA7005B4C18 /* broken-orders.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "broken-orders.json"; sourceTree = "<group>"; };
 		CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs-without-data.json"; sourceTree = "<group>"; };
 		CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStats.swift; sourceTree = "<group>"; };
@@ -2561,6 +2563,7 @@
 			children = (
 				CEC7D5902CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift */,
 				DAF367A72CE75C5B00D1B327 /* WooShippingPackagesResponse.swift */,
+				CE1EA4BE2CEBA0AF0039F477 /* WooShippingPackagePurchase.swift */,
 				451A97C82609FF050059D135 /* ShippingLabelPackagesResponse.swift */,
 				451A97CC260A01A40059D135 /* ShippingLabelStoreOptions.swift */,
 				CCAAD10E2683974000909664 /* ShippingLabelPackagePurchase.swift */,
@@ -5345,6 +5348,7 @@
 				B505F6CF20BEE38B00BB1B69 /* Account.swift in Sources */,
 				743E84EA22171C5800FAC9D7 /* ShipmentsRemote.swift in Sources */,
 				45CCFCE627A2E3710012E8CB /* InboxNoteListMapper.swift in Sources */,
+				CE1EA4BF2CEBA0B50039F477 /* WooShippingPackagePurchase.swift in Sources */,
 				B59325D5217E4206000B0E8E /* NoteRange.swift in Sources */,
 				458C6DE425AC72A1009B300D /* StoredProductSettings.swift in Sources */,
 				0359EA1927AAC79E0048DE2D /* WCPayCardPresentPaymentDetails.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -818,6 +818,7 @@
 		CE17C6B1229462C000AACE1C /* ProductStockStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */; };
 		CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */ = {isa = PBXBuildFile; fileRef = CE19CB10222486A500E8AF7A /* order-statuses.json */; };
 		CE1BE7062A2A5E9A00C6B53B /* IdentifiableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */; };
+		CE1EA4BB2CEB78F60039F477 /* wooshipping-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CE1EA4BA2CEB78F60039F477 /* wooshipping-purchase-success.json */; };
 		CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = CE20179220E3EFA7005B4C18 /* broken-orders.json */; };
 		CE21FB142C2AC87000303832 /* google-ads-reports-programs-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */; };
 		CE21FB162C2AC90E00303832 /* GoogleAdsCampaignStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */; };
@@ -1998,6 +1999,7 @@
 		CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatus.swift; sourceTree = "<group>"; };
 		CE19CB10222486A500E8AF7A /* order-statuses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-statuses.json"; sourceTree = "<group>"; };
 		CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableObject.swift; sourceTree = "<group>"; };
+		CE1EA4BA2CEB78F60039F477 /* wooshipping-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-purchase-success.json"; sourceTree = "<group>"; };
 		CE20179220E3EFA7005B4C18 /* broken-orders.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "broken-orders.json"; sourceTree = "<group>"; };
 		CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs-without-data.json"; sourceTree = "<group>"; };
 		CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStats.swift; sourceTree = "<group>"; };
@@ -3524,6 +3526,7 @@
 				CE0F4ECC2CE375DD006339BD /* wooshipping-get-label-rates-error.json */,
 				DA69CC962CEDDA1200CB7CEE /* wooshipping-get-account-settings-success.json */,
 				DAA259AC2CEC86BE0035F028 /* wooshipping-get-packages-success.json */,
+				CE1EA4BA2CEB78F60039F477 /* wooshipping-purchase-success.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4325,6 +4328,7 @@
 				68BFF9042B6780AA00B15FF2 /* receipt.json in Resources */,
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
+				CE1EA4BB2CEB78F60039F477 /* wooshipping-purchase-success.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
 				EE57C140297FBEFB00BC31E7 /* product-tags-deleted-without-data.json in Resources */,
 				02B41A92296BEB3000FE3311 /* load-site-current-plan-success.json in Resources */,

--- a/Networking/Networking/Mapper/ShippingLabelCarriersAndRatesMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelCarriersAndRatesMapper.swift
@@ -8,6 +8,7 @@ struct ShippingLabelCarriersAndRatesMapper: Mapper {
     ///
     func map(response: Data) throws -> [ShippingLabelCarriersAndRates] {
         let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
         if hasDataEnvelope(in: response) {
             return try decoder.decode(ShippingLabelDataEnvelope.self, from: response).data.rates.boxes
         } else {

--- a/Networking/Networking/Mapper/WooShippingLabelRatesMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingLabelRatesMapper.swift
@@ -8,6 +8,7 @@ struct WooShippingLabelRatesMapper: Mapper {
     ///
     func map(response: Data) throws -> [ShippingLabelCarriersAndRates] {
         let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
         if hasDataEnvelope(in: response) {
             return try decoder.decode(ShippingLabelDataEnvelope.self, from: response).data.boxes
         } else {

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -4102,6 +4102,24 @@ extension Networking.WooShippingCustomPackage {
     }
 }
 
+extension Networking.WooShippingPackagePurchase {
+    public func copy(
+        package: CopiableProp<ShippingLabelPackageSelected> = .copy,
+        rate: CopiableProp<ShippingLabelCarrierRate> = .copy,
+        productIDs: CopiableProp<[Int64]> = .copy
+    ) -> Networking.WooShippingPackagePurchase {
+        let package = package ?? self.package
+        let rate = rate ?? self.rate
+        let productIDs = productIDs ?? self.productIDs
+
+        return Networking.WooShippingPackagePurchase(
+            package: package,
+            rate: rate,
+            productIDs: productIDs
+        )
+    }
+}
+
 extension Networking.WordPressMedia {
     public func copy(
         mediaID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -4042,6 +4042,21 @@ extension Networking.WooPaymentsPayoutsSchedule {
     }
 }
 
+extension Networking.WooShippingAccountSettingsResponse {
+    public func copy(
+        storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
+        accountSettings: CopiableProp<ShippingLabelAccountSettings> = .copy
+    ) -> Networking.WooShippingAccountSettingsResponse {
+        let storeOptions = storeOptions ?? self.storeOptions
+        let accountSettings = accountSettings ?? self.accountSettings
+
+        return Networking.WooShippingAccountSettingsResponse(
+            storeOptions: storeOptions,
+            accountSettings: accountSettings
+        )
+    }
+}
+
 extension Networking.WooShippingCreatePackageResponse {
     public func copy(
         customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
@@ -4053,27 +4068,6 @@ extension Networking.WooShippingCreatePackageResponse {
         return Networking.WooShippingCreatePackageResponse(
             customPackages: customPackages,
             predefinedOptions: predefinedOptions
-        )
-    }
-}
-
-extension Networking.WooShippingPackagesResponse {
-    public func copy(
-        storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
-        customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
-        savedPredefinedPackages: CopiableProp<[WooShippingSavedPredefinedPackage]> = .copy,
-        allPredefinedOptions: CopiableProp<[WooShippingPredefinedOption]> = .copy
-    ) -> Networking.WooShippingPackagesResponse {
-        let storeOptions = storeOptions ?? self.storeOptions
-        let customPackages = customPackages ?? self.customPackages
-        let savedPredefinedPackages = savedPredefinedPackages ?? self.savedPredefinedPackages
-        let allPredefinedOptions = allPredefinedOptions ?? self.allPredefinedOptions
-
-        return Networking.WooShippingPackagesResponse(
-            storeOptions: storeOptions,
-            customPackages: customPackages,
-            savedPredefinedPackages: savedPredefinedPackages,
-            allPredefinedOptions: allPredefinedOptions
         )
     }
 }
@@ -4104,18 +4098,42 @@ extension Networking.WooShippingCustomPackage {
 
 extension Networking.WooShippingPackagePurchase {
     public func copy(
+        shipmentID: CopiableProp<String> = .copy,
         package: CopiableProp<ShippingLabelPackageSelected> = .copy,
         rate: CopiableProp<ShippingLabelCarrierRate> = .copy,
         productIDs: CopiableProp<[Int64]> = .copy
     ) -> Networking.WooShippingPackagePurchase {
+        let shipmentID = shipmentID ?? self.shipmentID
         let package = package ?? self.package
         let rate = rate ?? self.rate
         let productIDs = productIDs ?? self.productIDs
 
         return Networking.WooShippingPackagePurchase(
+            shipmentID: shipmentID,
             package: package,
             rate: rate,
             productIDs: productIDs
+        )
+    }
+}
+
+extension Networking.WooShippingPackagesResponse {
+    public func copy(
+        storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
+        customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
+        savedPredefinedPackages: CopiableProp<[WooShippingSavedPredefinedPackage]> = .copy,
+        allPredefinedOptions: CopiableProp<[WooShippingPredefinedOption]> = .copy
+    ) -> Networking.WooShippingPackagesResponse {
+        let storeOptions = storeOptions ?? self.storeOptions
+        let customPackages = customPackages ?? self.customPackages
+        let savedPredefinedPackages = savedPredefinedPackages ?? self.savedPredefinedPackages
+        let allPredefinedOptions = allPredefinedOptions ?? self.allPredefinedOptions
+
+        return Networking.WooShippingPackagesResponse(
+            storeOptions: storeOptions,
+            customPackages: customPackages,
+            savedPredefinedPackages: savedPredefinedPackages,
+            allPredefinedOptions: allPredefinedOptions
         )
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
@@ -49,7 +49,7 @@ public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable {
 }
 
 // MARK: Codable
-extension ShippingLabelCarrierRate: Decodable {
+extension ShippingLabelCarrierRate: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -91,6 +91,23 @@ extension ShippingLabelCarrierRate: Decodable {
                   deliveryDateGuaranteed: deliveryDateGuaranteed)
     }
 
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(title, forKey: .title)
+        try container.encode(insurance, forKey: .insurance)
+        try container.encode(retailRate, forKey: .retailRate)
+        try container.encode(rate, forKey: .rate)
+        try container.encode(rateID, forKey: .rateId)
+        try container.encode(serviceID, forKey: .serviceId)
+        try container.encode(carrierID, forKey: .carrierId)
+        try container.encode(shipmentID, forKey: .shipmentId)
+        try container.encode(hasTracking, forKey: .tracking)
+        try container.encode(isSelected, forKey: .isSelected)
+        try container.encode(isPickupFree, forKey: .freePickup)
+        try container.encode(deliveryDays, forKey: .deliveryDays)
+        try container.encode(deliveryDateGuaranteed, forKey: .deliveryDateGuaranteed)
+    }
 
     private enum CodingKeys: String, CodingKey {
         case title

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
@@ -49,7 +49,7 @@ public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable {
 }
 
 // MARK: Codable
-extension ShippingLabelCarrierRate: Codable {
+extension ShippingLabelCarrierRate: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -65,13 +65,13 @@ extension ShippingLabelCarrierRate: Codable {
 
         let retailRate = try container.decode(Double.self, forKey: .retailRate)
         let rate = try container.decode(Double.self, forKey: .rate)
-        let rateID = try container.decode(String.self, forKey: .rateID)
-        let serviceID = try container.decode(String.self, forKey: .serviceID)
-        let carrierID = try container.decode(String.self, forKey: .carrierID)
-        let shipmentID = try container.decode(String.self, forKey: .shipmentID)
-        let hasTracking = try container.decode(Bool.self, forKey: .hasTracking)
+        let rateID = try container.decode(String.self, forKey: .rateId)
+        let serviceID = try container.decode(String.self, forKey: .serviceId)
+        let carrierID = try container.decode(String.self, forKey: .carrierId)
+        let shipmentID = try container.decode(String.self, forKey: .shipmentId)
+        let hasTracking = try container.decode(Bool.self, forKey: .tracking)
         let isSelected = try container.decode(Bool.self, forKey: .isSelected)
-        let isPickupFree = try container.decode(Bool.self, forKey: .isPickupFree)
+        let isPickupFree = try container.decode(Bool.self, forKey: .freePickup)
         let deliveryDays = try container.decodeIfPresent(Int64.self, forKey: .deliveryDays)
         let deliveryDateGuaranteed = try container.decode(Bool.self, forKey: .deliveryDateGuaranteed)
 
@@ -95,16 +95,16 @@ extension ShippingLabelCarrierRate: Codable {
     private enum CodingKeys: String, CodingKey {
         case title
         case insurance
-        case retailRate = "retail_rate"
+        case retailRate
         case rate
-        case rateID = "rate_id"
-        case serviceID = "service_id"
-        case carrierID = "carrier_id"
-        case shipmentID = "shipment_id"
-        case hasTracking = "tracking"
-        case isSelected = "is_selected"
-        case isPickupFree = "free_pickup"
-        case deliveryDays = "delivery_days"
-        case deliveryDateGuaranteed = "delivery_date_guaranteed"
+        case rateId
+        case serviceId
+        case carrierId
+        case shipmentId
+        case tracking
+        case isSelected
+        case freePickup
+        case deliveryDays
+        case deliveryDateGuaranteed
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarriersAndRates.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarriersAndRates.swift
@@ -21,7 +21,7 @@ public struct ShippingLabelCarriersAndRates: Equatable {
 }
 
 // MARK: Codable
-extension ShippingLabelCarriersAndRates: Codable {
+extension ShippingLabelCarriersAndRates: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -42,8 +42,8 @@ extension ShippingLabelCarriersAndRates: Codable {
     private enum CodingKeys: String, CodingKey {
         case packageID
         case defaultRates = "default"
-        case signatureRequired = "signature_required"
-        case adultSignatureRequired = "adult_signature_required"
+        case signatureRequired
+        case adultSignatureRequired
     }
 }
 

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingSavedPredefinedPackage.swift.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingSavedPredefinedPackage.swift.swift
@@ -12,4 +12,10 @@ public struct WooShippingSavedPredefinedPackage: Equatable, GeneratedFakeable, I
     public var id: String {
         return package.id
     }
+
+    public init(groupTitle: String, providerID: String, package: WooShippingPredefinedPackage) {
+        self.groupTitle = groupTitle
+        self.providerID = providerID
+        self.package = package
+    }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -62,6 +62,23 @@ extension WooShippingPackagePurchase: Encodable {
         ]]
     }
 
+    /// Converts the customs form to a dictionary as the API expects it.
+    /// Includes the shipment ID with the encoded customs form.
+    public func encodedCustomsForm() throws -> [String: Any] {
+        guard let form = package.customsForm else {
+            return [shipmentID: [:]]
+        }
+        return [shipmentID: [
+            CodingKeys.items: try form.items.toDictionary(),
+            CodingKeys.contentsType: form.contentsType.rawValue,
+            CodingKeys.contentsExplanation: form.contentExplanation,
+            CodingKeys.restrictionType: form.restrictionType.rawValue,
+            CodingKeys.restrictionComments: form.restrictionComments,
+            CodingKeys.isReturnToSender: form.nonDeliveryOption == .return,
+            CodingKeys.itn: form.itn
+        ]]
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case boxID = "box_id"
@@ -79,5 +96,12 @@ extension WooShippingPackagePurchase: Encodable {
         case rate
         case isHazmat
         case category
+        case contentsType
+        case contentsExplanation
+        case restrictionType
+        case restrictionComments
+        case isReturnToSender
+        case itn
+        case items
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -5,6 +5,9 @@ import Codegen
 ///
 public struct WooShippingPackagePurchase: Equatable, GeneratedFakeable, GeneratedCopiable {
 
+    /// ID for the shipment being sent in this package, e.g. `shipment_0`
+    public let shipmentID: String
+
     /// Selected package for the shipping label
     public let package: ShippingLabelPackageSelected
 
@@ -14,7 +17,8 @@ public struct WooShippingPackagePurchase: Equatable, GeneratedFakeable, Generate
     /// IDs for the products to be shipped
     public let productIDs: [Int64]
 
-    public init(package: ShippingLabelPackageSelected, rate: ShippingLabelCarrierRate, productIDs: [Int64]) {
+    public init(shipmentID: String, package: ShippingLabelPackageSelected, rate: ShippingLabelCarrierRate, productIDs: [Int64]) {
+        self.shipmentID = shipmentID
         self.package = package
         self.rate = rate
         self.productIDs = productIDs
@@ -40,6 +44,13 @@ extension WooShippingPackagePurchase: Encodable {
         try container.encode(rate.carrierID, forKey: .carrierID)
         try container.encode(rate.title, forKey: .serviceName)
         try container.encode(productIDs, forKey: .products)
+    }
+
+    /// Converts the shipment rate to a dictionary as the API expects it.
+    /// Includes the shipment ID with the encoded rate.
+    ///
+    public func encodedShipmentRate() throws -> [String: Any] {
+        [shipmentID: ["rate": try rate.toDictionary()]]
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -50,7 +50,16 @@ extension WooShippingPackagePurchase: Encodable {
     /// Includes the shipment ID with the encoded rate.
     ///
     public func encodedShipmentRate() throws -> [String: Any] {
-        [shipmentID: ["rate": try rate.toDictionary()]]
+        [shipmentID: [CodingKeys.rate: try rate.toDictionary()]]
+    }
+
+    /// Converts the hazmat settings to a dictionary as the API expects it.
+    /// Includes the shipment ID if there are hazmat settings to report.
+    public func encodedHazmat() -> [String: Any] {
+        [shipmentID: [
+            CodingKeys.isHazmat: package.hazmatCategory != nil,
+            CodingKeys.category: package.hazmatCategory ?? String()
+        ]]
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -67,5 +76,8 @@ extension WooShippingPackagePurchase: Encodable {
         case carrierID = "carrier_id"
         case serviceName = "service_name"
         case products
+        case rate
+        case isHazmat
+        case category
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Codegen
+
+/// Represents the complete package details that will be sent to the Woo Shipping Purchase endpoint.
+///
+public struct WooShippingPackagePurchase: Equatable, GeneratedFakeable, GeneratedCopiable {
+
+    /// Selected package for the shipping label
+    public let package: ShippingLabelPackageSelected
+
+    /// Selected rate for the shipping label
+    public let rate: ShippingLabelCarrierRate
+
+    /// IDs for the products to be shipped
+    public let productIDs: [Int64]
+
+    public init(package: ShippingLabelPackageSelected, rate: ShippingLabelCarrierRate, productIDs: [Int64]) {
+        self.package = package
+        self.rate = rate
+        self.productIDs = productIDs
+    }
+}
+
+// MARK: Codable
+extension WooShippingPackagePurchase: Encodable {
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(package.id, forKey: .id)
+        try container.encode(package.boxID, forKey: .boxID)
+        try container.encode(package.length, forKey: .length)
+        try container.encode(package.width, forKey: .width)
+        try container.encode(package.height, forKey: .height)
+        try container.encode(package.weight, forKey: .weight)
+        try container.encode(package.isLetter, forKey: .isLetter)
+        try container.encode(rate.shipmentID, forKey: .shipmentID)
+        try container.encode(rate.rateID, forKey: .rateID)
+        try container.encode(rate.serviceID, forKey: .serviceID)
+        try container.encode(rate.carrierID, forKey: .carrierID)
+        try container.encode(rate.title, forKey: .serviceName)
+        try container.encode(productIDs, forKey: .products)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case boxID = "box_id"
+        case length
+        case width
+        case height
+        case weight
+        case isLetter = "is_letter"
+        case shipmentID = "shipment_id"
+        case rateID = "rate_id"
+        case serviceID = "service_id"
+        case carrierID = "carrier_id"
+        case serviceName = "service_name"
+        case products
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -50,15 +50,15 @@ extension WooShippingPackagePurchase: Encodable {
     /// Includes the shipment ID with the encoded rate.
     ///
     public func encodedShipmentRate() throws -> [String: Any] {
-        [shipmentID: [CodingKeys.rate: try rate.toDictionary()]]
+        [shipmentID: [ParameterKeys.rate: try rate.toDictionary()]]
     }
 
     /// Converts the hazmat settings to a dictionary as the API expects it.
     /// Includes the shipment ID if there are hazmat settings to report.
     public func encodedHazmat() -> [String: Any] {
         [shipmentID: [
-            CodingKeys.isHazmat: package.hazmatCategory != nil,
-            CodingKeys.category: package.hazmatCategory ?? String()
+            ParameterKeys.isHazmat: package.hazmatCategory != nil,
+            ParameterKeys.category: package.hazmatCategory ?? String()
         ]]
     }
 
@@ -69,13 +69,13 @@ extension WooShippingPackagePurchase: Encodable {
             return [shipmentID: [:]]
         }
         return [shipmentID: [
-            CodingKeys.items: try form.items.toDictionary(),
-            CodingKeys.contentsType: form.contentsType.rawValue,
-            CodingKeys.contentsExplanation: form.contentExplanation,
-            CodingKeys.restrictionType: form.restrictionType.rawValue,
-            CodingKeys.restrictionComments: form.restrictionComments,
-            CodingKeys.isReturnToSender: form.nonDeliveryOption == .return,
-            CodingKeys.itn: form.itn
+            ParameterKeys.items: try form.items.map { try $0.toDictionary() },
+            ParameterKeys.contentsType: form.contentsType.rawValue,
+            ParameterKeys.contentsExplanation: form.contentExplanation,
+            ParameterKeys.restrictionType: form.restrictionType.rawValue,
+            ParameterKeys.restrictionComments: form.restrictionComments,
+            ParameterKeys.isReturnToSender: form.nonDeliveryOption == .return,
+            ParameterKeys.itn: form.itn
         ]]
     }
 
@@ -93,15 +93,18 @@ extension WooShippingPackagePurchase: Encodable {
         case carrierID = "carrier_id"
         case serviceName = "service_name"
         case products
-        case rate
-        case isHazmat
-        case category
-        case contentsType
-        case contentsExplanation
-        case restrictionType
-        case restrictionComments
-        case isReturnToSender
-        case itn
-        case items
+    }
+
+    private enum ParameterKeys {
+        static let rate = "rate"
+        static let isHazmat = "isHazmat"
+        static let category = "category"
+        static let contentsType = "contentsType"
+        static let contentsExplanation = "contentsExplanation"
+        static let restrictionType = "restrictionType"
+        static let restrictionComments = "restrictionComments"
+        static let isReturnToSender = "isReturnToSender"
+        static let itn = "itn"
+        static let items = "items"
     }
 }

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -176,7 +176,6 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.selectedRate: try package.encodedShipmentRate(),
                 ParameterKey.hazmat: {}, // Hazmat support TBD (Milestone 3)
                 ParameterKey.customs: {}, // Customs support TBD (Milestone 2)
-                ParameterKey.userMeta: {} // TODO: 13558 - Add user meta when we have account settings support
             ]
             let path = "\(Path.purchase)/\(orderID)"
             let request = JetpackRequest(wooApiVersion: .wcConnectV1,
@@ -213,7 +212,6 @@ private extension WooShippingRemote {
         static let selectedRate = "selected_rate"
         static let hazmat = "hazmat"
         static let customs = "customs"
-        static let userMeta = "user_meta"
     }
 }
 

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -175,7 +175,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.packages: [ try package.toDictionary() ],
                 ParameterKey.selectedRate: try package.encodedShipmentRate(),
                 ParameterKey.hazmat: package.encodedHazmat(),
-                ParameterKey.customs: {}, // Customs support TBD (Milestone 2)
+                ParameterKey.customs: try package.encodedCustomsForm(),
             ]
             let path = "\(Path.purchase)/\(orderID)"
             let request = JetpackRequest(wooApiVersion: .wcConnectV1,

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -17,7 +17,6 @@ public protocol WooShippingRemoteProtocol {
                              completion: @escaping (Result<WooShippingAccountSettingsResponse, Error>) -> Void)
     func purchaseShippingLabel(siteID: Int64,
                                orderID: Int64,
-                               shipmentID: String,
                                originAddress: ShippingLabelAddress,
                                destinationAddress: ShippingLabelAddress,
                                package: WooShippingPackagePurchase,
@@ -158,14 +157,12 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
     /// - Parameters:
     ///   - siteID: Remote ID of the site.
     ///   - orderID: Remote ID of the order that owns the shipping labels.
-    ///   - shipmentID: Remote ID of the shipment getting a label.
     ///   - originAddress: The origin address entity.
     ///   - destinationAddress: The destination address entity.
     ///   - package: The package previously selected with all its data.
     ///   - completion: Closure to be executed upon completion.
     public func purchaseShippingLabel(siteID: Int64,
                                       orderID: Int64,
-                                      shipmentID: String,
                                       originAddress: ShippingLabelAddress,
                                       destinationAddress: ShippingLabelAddress,
                                       package: WooShippingPackagePurchase,
@@ -176,7 +173,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.originAddress: try originAddress.toDictionary(),
                 ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
                 ParameterKey.packages: [ try package.toDictionary() ],
-                ParameterKey.selectedRate: [shipmentID: [ParameterKey.rate: try package.rate.toDictionary()]],
+                ParameterKey.selectedRate: try package.encodedShipmentRate(),
                 ParameterKey.hazmat: {}, // Hazmat support TBD (Milestone 3)
                 ParameterKey.customs: {}, // Customs support TBD (Milestone 2)
                 ParameterKey.userMeta: {} // TODO: 13558 - Add user meta when we have account settings support
@@ -214,7 +211,6 @@ private extension WooShippingRemote {
         static let packages = "packages"
         static let async = "async"
         static let selectedRate = "selected_rate"
-        static let rate = "rate"
         static let hazmat = "hazmat"
         static let customs = "customs"
         static let userMeta = "user_meta"

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -174,7 +174,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
                 ParameterKey.packages: [ try package.toDictionary() ],
                 ParameterKey.selectedRate: try package.encodedShipmentRate(),
-                ParameterKey.hazmat: {}, // Hazmat support TBD (Milestone 3)
+                ParameterKey.hazmat: package.encodedHazmat(),
                 ParameterKey.customs: {}, // Customs support TBD (Milestone 2)
             ]
             let path = "\(Path.purchase)/\(orderID)"

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -15,6 +15,13 @@ public protocol WooShippingRemoteProtocol {
                       completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void)
     func loadAccountSettings(siteID: Int64,
                              completion: @escaping (Result<WooShippingAccountSettingsResponse, Error>) -> Void)
+    func purchaseShippingLabel(siteID: Int64,
+                               orderID: Int64,
+                               shipmentID: String,
+                               originAddress: ShippingLabelAddress,
+                               destinationAddress: ShippingLabelAddress,
+                               package: WooShippingPackagePurchase,
+                               completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -106,7 +113,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
     ///   - siteID: Remote ID of the site.
     ///   - completion: Closure to be executed upon completion.
     public func loadPackages(siteID: Int64,
-                      completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void) {
+                             completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void) {
         do {
             let path = Path.packages
             let request = JetpackRequest(wooApiVersion: .wooShipping,
@@ -116,7 +123,6 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                                          availableAsRESTRequest: true)
 
             let mapper = WooShippingPackagesMapper()
-
             enqueue(request, mapper: mapper, completion: completion)
         } catch {
             completion(.failure(error))
@@ -144,6 +150,50 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    /// Initiates a shipping label purchase.
+    ///
+    /// This request returns the label purchase data, including a `PURCHASE_IN_PROGRESS` status.
+    /// After initiating the purchase, we must poll the backend for the updated label status (successful purchase or error).
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site.
+    ///   - orderID: Remote ID of the order that owns the shipping labels.
+    ///   - shipmentID: Remote ID of the shipment getting a label.
+    ///   - originAddress: The origin address entity.
+    ///   - destinationAddress: The destination address entity.
+    ///   - package: The package previously selected with all its data.
+    ///   - completion: Closure to be executed upon completion.
+    public func purchaseShippingLabel(siteID: Int64,
+                                      orderID: Int64,
+                                      shipmentID: String,
+                                      originAddress: ShippingLabelAddress,
+                                      destinationAddress: ShippingLabelAddress,
+                                      package: WooShippingPackagePurchase,
+                                      completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void) {
+        do {
+            let parameters: [String: Any] = [
+                ParameterKey.async: true,
+                ParameterKey.originAddress: try originAddress.toDictionary(),
+                ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
+                ParameterKey.packages: [ try package.toDictionary() ],
+                ParameterKey.selectedRate: [shipmentID: [ParameterKey.rate: try package.rate.toDictionary()]],
+                ParameterKey.hazmat: {}, // Hazmat support TBD (Milestone 3)
+                ParameterKey.customs: {}, // Customs support TBD (Milestone 2)
+                ParameterKey.userMeta: {} // TODO: 13558 - Add user meta when we have account settings support
+            ]
+            let path = "\(Path.purchase)/\(orderID)"
+            let request = JetpackRequest(wooApiVersion: .wcConnectV1,
+                                         method: .post,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
+            let mapper = ShippingLabelPurchaseMapper(siteID: siteID, orderID: orderID)
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constants
@@ -152,6 +202,7 @@ private extension WooShippingRemote {
         static let packages = "packages"
         static let rates = "label/rate"
         static let accountSettings = "account/settings"
+        static let purchase = "label/purchase"
     }
 
     enum ParameterKey {
@@ -161,6 +212,12 @@ private extension WooShippingRemote {
         static let originAddress = "origin"
         static let destinationAddress = "destination"
         static let packages = "packages"
+        static let async = "async"
+        static let selectedRate = "selected_rate"
+        static let rate = "rate"
+        static let hazmat = "hazmat"
+        static let customs = "customs"
+        static let userMeta = "user_meta"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -226,7 +226,6 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
             remote.purchaseShippingLabel(siteID: self.sampleSiteID,
                                          orderID: self.sampleOrderID,
-                                         shipmentID: self.sampleShipmentID,
                                          originAddress: ShippingLabelAddress.fake(),
                                          destinationAddress: ShippingLabelAddress.fake(),
                                          package: WooShippingPackagePurchase.fake()) { result in
@@ -248,7 +247,6 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
             remote.purchaseShippingLabel(siteID: self.sampleSiteID,
                                          orderID: self.sampleOrderID,
-                                         shipmentID: self.sampleShipmentID,
                                          originAddress: ShippingLabelAddress.fake(),
                                          destinationAddress: ShippingLabelAddress.fake(),
                                          package: WooShippingPackagePurchase.fake()) { result in

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -14,6 +14,9 @@ final class WooShippingRemoteTests: XCTestCase {
     /// Dummy Order ID
     private let sampleOrderID: Int64 = 1234
 
+    /// Dummy Shipment ID
+    private let sampleShipmentID: String = "shipment_0"
+
     override func setUp() {
         super.setUp()
         network.removeAllSimulatedResponses()
@@ -206,6 +209,49 @@ final class WooShippingRemoteTests: XCTestCase {
         // When
         let result: Result<WooShippingAccountSettingsResponse, Error> = waitFor { promise in
             remote.loadAccountSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
+
+    func test_purchaseShippingLabel_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/purchase/\(sampleOrderID)", filename: "wooshipping-purchase-success")
+
+        // When
+        let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
+            remote.purchaseShippingLabel(siteID: self.sampleSiteID,
+                                         orderID: self.sampleOrderID,
+                                         shipmentID: self.sampleShipmentID,
+                                         originAddress: ShippingLabelAddress.fake(),
+                                         destinationAddress: ShippingLabelAddress.fake(),
+                                         package: WooShippingPackagePurchase.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let labels = try XCTUnwrap(result.get())
+        XCTAssertEqual(labels.count, 1)
+    }
+
+    func test_purchaseShippingLabel_returns_error_on_failure() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/purchase/\(sampleOrderID)", filename: "generic_error")
+
+        // When
+        let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
+            remote.purchaseShippingLabel(siteID: self.sampleSiteID,
+                                         orderID: self.sampleOrderID,
+                                         shipmentID: self.sampleShipmentID,
+                                         originAddress: ShippingLabelAddress.fake(),
+                                         destinationAddress: ShippingLabelAddress.fake(),
+                                         package: WooShippingPackagePurchase.fake()) { result in
                 promise(result)
             }
         }

--- a/Networking/NetworkingTests/Responses/wooshipping-purchase-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-purchase-success.json
@@ -1,0 +1,155 @@
+{
+    "labels": [
+        {
+            "label_id": 4119,
+            "tracking": null,
+            "refundable_amount": 0,
+            "created": 1731599418086,
+            "carrier_id": null,
+            "service_name": "USPS - Ground Advantage",
+            "status": "PURCHASE_IN_PROGRESS",
+            "commercial_invoice_url": "",
+            "is_commercial_invoice_submitted_electronically": "",
+            "package_name": "Individual packaging",
+            "is_letter": false,
+            "product_names": [
+                "Beanie"
+            ],
+            "product_ids": [
+                19,
+                209
+            ],
+            "id": "0"
+        }
+    ],
+    "selected_rates": {
+        "shipment_0": {
+            "rate": {
+                "rateId": "rate_c84888134ca0453bad4d1b8a4493fac6",
+                "serviceId": "GroundAdvantage",
+                "carrierId": "usps",
+                "title": "USPS - Ground Advantage",
+                "rate": 7.24,
+                "retailRate": 11.8,
+                "listRate": 8.81,
+                "isSelected": false,
+                "tracking": true,
+                "insurance": 100,
+                "freePickup": true,
+                "shipmentId": "shp_33dd948486184ea09078a08be667f7b5",
+                "deliveryDays": 3,
+                "deliveryDateGuaranteed": false,
+                "deliveryDate": null
+            },
+            "parent": null
+        }
+    },
+    "selected_hazmat": {
+        "shipment_0": {
+            "isHazmat": false,
+            "category": ""
+        }
+    },
+    "selected_origin": {
+        "shipment_0": {
+            "company": "Test Store",
+            "name": "TEST MERCHANT",
+            "phone": "12345678901",
+            "country": "US",
+            "state": "CA",
+            "address": "60 29TH ST PMB 343",
+            "address_2": "",
+            "city": "SAN FRANCISCO",
+            "postcode": "94110-4929",
+            "id": "store_details",
+            "is_verified": true
+        }
+    },
+    "selected_destination": {
+        "shipment_0": {
+            "company": "",
+            "city": "ANYTOWN",
+            "state": "CA",
+            "postcode": "12345-6789",
+            "country": "US",
+            "phone": "",
+            "name": "TEST CUSTOMER",
+            "address": "1 MAIN STREET"
+        }
+    },
+    "customs_information": {
+        "shipment_0": {
+            "items": [
+                {
+                    "id": 3737,
+                    "subtotal": "20.00",
+                    "subtotal_tax": "0.00",
+                    "total": "20.00",
+                    "total_tax": "0.00",
+                    "price": "20.00",
+                    "quantity": 1,
+                    "tax_class": "clothing-20010",
+                    "name": "Beanie",
+                    "product_id": 19,
+                    "sku": "woo-beanie",
+                    "meta": {
+                        "customs_info": {
+                            "description": "Beanie",
+                            "hs_tariff_number": "392620",
+                            "origin_country": "US"
+                        }
+                    },
+                    "image": "https:\/\/example.com\/wp-content\/uploads\/2023\/01\/beanie.jpg",
+                    "weight": "1",
+                    "dimensions": {
+                        "length": "20",
+                        "width": "20",
+                        "height": "40"
+                    },
+                    "variation": [
+                        {
+                            "key": "logo",
+                            "value": "Yes",
+                            "display_key": "Logo",
+                            "display_value": "<p>Yes<\/p>\n"
+                        }
+                    ],
+                    "subItems": [
+                        {
+                            "id": "10-sub-0",
+                            "subtotal": "0.00",
+                            "subtotal_tax": "0.00",
+                            "total": "0.00",
+                            "total_tax": "0.00",
+                            "price": "0.00",
+                            "quantity": 1,
+                            "tax_class": "",
+                            "name": "Pin",
+                            "product_id": 209,
+                            "sku": "woo-pin",
+                            "meta": [],
+                            "image": "https:\/\/example.com\/wp-content\/uploads\/2023\/01\/pin.jpg",
+                            "weight": "",
+                            "dimensions": {
+                                "length": "",
+                                "width": "",
+                                "height": ""
+                            },
+                            "variation": [],
+                            "parentId": 19,
+                            "subItems": []
+                        }
+                    ],
+                    "description": "Beanie",
+                    "hsTariffNumber": "392620",
+                    "originCountry": "US"
+                }
+            ],
+            "contentsType": "merchandise",
+            "restrictionType": "none",
+            "isReturnToSender": false,
+            "itn": ""
+        }
+    },
+    "success": true
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -15,6 +15,9 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `loadLabelRates`
     private var loadLabelRatesResults = [ResultKey: Result<[ShippingLabelCarriersAndRates], Error>]()
 
+    /// The results to return based on the given arguments in `purchaseShippingLabel`
+    private var purchaseShippingLabelResults = [ResultKey: Result<[ShippingLabelPurchase], Error>]()
+
     /// The results to return based on the given arguments in `loadPackages`
     private var loadPackagesResults = [ResultKey: Result<WooShippingPackagesResponse, Error>]()
 
@@ -47,6 +50,13 @@ final class MockWooShippingRemote {
                                  thenReturn result: Result<WooShippingAccountSettingsResponse, Error>) {
         let key = ResultKey(siteID: siteID)
         loadAccountSettingsResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `purchaseShippingLabel` is called.
+    func whenPurchaseShippingLabel(siteID: Int64,
+                                   thenReturn result: Result<[ShippingLabelPurchase], Error>) {
+        let key = ResultKey(siteID: siteID)
+        purchaseShippingLabelResults[key] = result
     }
 }
 
@@ -107,6 +117,25 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
             let key = ResultKey(siteID: siteID)
             if let result = self.loadAccountSettingsResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func purchaseShippingLabel(siteID: Int64,
+                               orderID: Int64,
+                               shipmentID: String,
+                               originAddress: Networking.ShippingLabelAddress,
+                               destinationAddress: Networking.ShippingLabelAddress,
+                               package: Networking.WooShippingPackagePurchase,
+                               completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = ResultKey(siteID: siteID)
+            if let result = self.purchaseShippingLabelResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -126,7 +126,6 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
     func purchaseShippingLabel(siteID: Int64,
                                orderID: Int64,
-                               shipmentID: String,
                                originAddress: Networking.ShippingLabelAddress,
                                destinationAddress: Networking.ShippingLabelAddress,
                                package: Networking.WooShippingPackagePurchase,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14423
⚠️ Depends on #14455 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Networking layer for purchasing a label in the Woo Shipping label flow.

### How

* Adds a `WooShippingPackagePurchase` to represent the package data needed in the purchase request.
   * Includes custom encoding for the `packages` request parameter.
   * Includes custom methods to encode additional request parameters (rate, hazmat, customs) with the shipment ID.
* Updates `ShippingLabelCarrierRate` and `ShippingLabelCarriersAndRates` to handle different key strategies for decoding and encoding:
   * Previously, these were only decoded from responses, with snake case keys. (Both models were marked as `Codable` but we didn't encode them directly for any requests.) However, the purchase request requires encoding these entities with camel case keys.
   * The coding keys are now camel case by default (to support encoding), with a key decoding strategy (set in the corresponding mappers) to convert to snake case.
* Adds the purchase endpoint to `WooShippingRemote`, along with the corresponding mock response and unit tests.

A note on the number of changes in this PR: 200+ lines of changes are from testing mocks and generated fake/copy methods for unit testing. I considered trying to split up some of the changes to the networking models here into a separate PR from the WooShippingRemote changes, but I think these changes make more sense in context.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Testing steps to confirm these changes don't change the legacy shipping labels flow:

1. Disable the feature flag `revampedShippingLabelCreation`.
2. Build and run the app.
3. Go to the Orders tab and select an order eligible for shipping label creation.
4. Tap "Create Shipping Label."
5. Go through each step of the shipping label flow and purchase a shipping label, confirming there are no errors and the label can be viewed/printed as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.