### PR TITLE
Screenshot: Add Coupon Card to the My Store section of Screenshot tool 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 - [*] Receipts: Added message confirming receipt sent to customer after successful payment. [https://github.com/woocommerce/woocommerce-ios/pull/14390]
 - [internal] Simplifies App Icon by only using a single image for all supported platforms. [https://github.com/woocommerce/woocommerce-ios/pull/14429]
 - [*] Dashboard: Performance card now shows cached Visitors and Conversion data correctly. [https://github.com/woocommerce/woocommerce-ios/pull/14438]
+- [internal] Updated WooCommerceScreenshot to make it work again for generating screenshots. [https://github.com/woocommerce/woocommerce-ios/pull/14335]
 
 21.1
 -----

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		74D7F29B20F6A7FB0058B2F0 /* Order+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D7F29A20F6A7FB0058B2F0 /* Order+ReadOnlyConvertible.swift */; };
 		74D7FFFA221F01E90008CC0E /* ShipmentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D7FFF9221F01E90008CC0E /* ShipmentStore.swift */; };
 		864177A82CDBC9A1001F9640 /* MockShippingMethodActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864177A72CDBC9A1001F9640 /* MockShippingMethodActionHandler.swift */; };
+		86969E762CEEEF220032E50F /* MockCouponActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86969E752CEEEF220032E50F /* MockCouponActionHandler.swift */; };
 		86BB4C962B89FCF30096E92D /* CustomerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86BB4C952B89FCF30096E92D /* CustomerFilter.swift */; };
 		86DAA7982CD9E31E002AE55E /* MockPaymentActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DAA7972CD9E31E002AE55E /* MockPaymentActionHandler.swift */; };
 		86DAA79A2CD9E572002AE55E /* MockSiteActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DAA7992CD9E572002AE55E /* MockSiteActionHandler.swift */; };
@@ -831,6 +832,7 @@
 		79402E7AD394EEB60C39A4B8 /* Pods-YosemiteTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7F47E19203B04CF6BB5EA659 /* Pods-Yosemite.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.debug.xcconfig"; sourceTree = "<group>"; };
 		864177A72CDBC9A1001F9640 /* MockShippingMethodActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingMethodActionHandler.swift; sourceTree = "<group>"; };
+		86969E752CEEEF220032E50F /* MockCouponActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponActionHandler.swift; sourceTree = "<group>"; };
 		86BB4C952B89FCF30096E92D /* CustomerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerFilter.swift; sourceTree = "<group>"; };
 		86DAA7972CD9E31E002AE55E /* MockPaymentActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentActionHandler.swift; sourceTree = "<group>"; };
 		86DAA7992CD9E572002AE55E /* MockSiteActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSiteActionHandler.swift; sourceTree = "<group>"; };
@@ -1306,6 +1308,7 @@
 				86DAA7972CD9E31E002AE55E /* MockPaymentActionHandler.swift */,
 				86DAA7992CD9E572002AE55E /* MockSiteActionHandler.swift */,
 				86DAA79B2CD9E8C1002AE55E /* MockGoogleAdsActionHandler.swift */,
+				86969E752CEEEF220032E50F /* MockCouponActionHandler.swift */,
 				86DAA79D2CD9ED7B002AE55E /* MockJustInTimeMessageActionHandler.swift */,
 				864177A72CDBC9A1001F9640 /* MockShippingMethodActionHandler.swift */,
 			);
@@ -2577,6 +2580,7 @@
 				DEDA8DAF2B1847C80076BF0F /* WordPressThemeStore.swift in Sources */,
 				03EB99902907B97800F06A39 /* JustInTimeMessage.swift in Sources */,
 				031C1EAA27B1702800298699 /* WCPayCharge+ReadOnlyConvertible.swift in Sources */,
+				86969E762CEEEF220032E50F /* MockCouponActionHandler.swift in Sources */,
 				D8652E0D26303A8B00350F37 /* ReceiptAction.swift in Sources */,
 				0212AC62242C68B600C51F6C /* ResultsController+SortProducts.swift in Sources */,
 				741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -86,8 +86,10 @@ struct MockAppSettingsActionHandler: MockActionHandler {
         var cards = [DashboardCard]()
         // Some cards intentionally not shown here as they require further action mocking.
         cards.append(DashboardCard(type: .performance, availability: .show, enabled: true))
-        cards.append(DashboardCard(type: .reviews, availability: .show, enabled: true))
         cards.append(DashboardCard(type: .lastOrders, availability: .show, enabled: true))
+        cards.append(DashboardCard(type: .reviews, availability: .show, enabled: true))
+        // TODO: show example coupons data, for now it's empty.
+        cards.append(DashboardCard(type: .coupons, availability: .show, enabled: true))
         onCompletion(cards)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCouponActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCouponActionHandler.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Storage
+import Networking
+
+struct MockCouponActionHandler: MockActionHandler {
+
+    typealias ActionType = CouponAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+    let store: CouponStore
+
+    private var storage: StorageType! {
+        storageManager.viewStorage
+    }
+
+    init(objectGraph: MockObjectGraph, storageManager: StorageManagerType) {
+        self.objectGraph = objectGraph
+        self.storageManager = storageManager
+        self.store = CouponStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: NullNetwork())
+    }
+
+    func handle(action: ActionType) {
+        switch action {
+        case .loadMostActiveCoupons(_, _, _, _, let onCompletion):
+            onCompletion(.success(objectGraph.couponReports))
+        case .loadCoupons(_, _, let onCompletion):
+            save(mocks: objectGraph.coupons, as: StorageCoupon.self) { _ in }
+            onCompletion(.success(objectGraph.coupons))
+        default:
+            unimplementedAction(action: action)
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCouponActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockCouponActionHandler.swift
@@ -8,7 +8,6 @@ struct MockCouponActionHandler: MockActionHandler {
 
     let objectGraph: MockObjectGraph
     let storageManager: StorageManagerType
-    let store: CouponStore
 
     private var storage: StorageType! {
         storageManager.viewStorage
@@ -17,9 +16,6 @@ struct MockCouponActionHandler: MockActionHandler {
     init(objectGraph: MockObjectGraph, storageManager: StorageManagerType) {
         self.objectGraph = objectGraph
         self.storageManager = storageManager
-        self.store = CouponStore(dispatcher: Dispatcher(),
-                                 storageManager: storageManager,
-                                 network: NullNetwork())
     }
 
     func handle(action: ActionType) {

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -219,6 +219,58 @@ struct ScreenshotObjectGraph: MockObjectGraph {
 
     var googleAdsConnection = GoogleAdsConnection(id: 1234, currency: "USD", symbol: "$", rawStatus: "connected")
 
+    var couponReports = [CouponReport(couponID: 1, amount: 300, ordersCount: 32), CouponReport(couponID: 2, amount: 12, ordersCount: 21)]
+    var coupons = [
+        Coupon(couponID: 1,
+               code: "AGK32FD",
+               amount: "10.00",
+               dateCreated: Date(timeIntervalSinceNow: -1000),
+               dateModified: Date(timeIntervalSinceNow: -1000),
+               discountType: .fixedCart,
+               description: "Coupon description",
+               dateExpires: nil,
+               usageCount: 10,
+               individualUse: true,
+               productIds: [],
+               excludedProductIds: [],
+               usageLimit: 1200,
+               usageLimitPerUser: 3,
+               limitUsageToXItems: 10,
+               freeShipping: true,
+               productCategories: [],
+               excludedProductCategories: [],
+               excludeSaleItems: false,
+               minimumAmount: "5.00",
+               maximumAmount: "500.00",
+               emailRestrictions: [],
+               usedBy: []
+              ),
+        Coupon(couponID: 2,
+               code: "CRSDFE",
+               amount: "14.00",
+               dateCreated: Date(timeIntervalSinceNow: -1000),
+               dateModified: Date(timeIntervalSinceNow: -1000),
+               discountType: .fixedCart,
+               description: "Coupon description",
+               dateExpires: nil,
+               usageCount: 10,
+               individualUse: true,
+               productIds: [],
+               excludedProductIds: [],
+               usageLimit: 1200,
+               usageLimitPerUser: 3,
+               limitUsageToXItems: 10,
+               freeShipping: true,
+               productCategories: [],
+               excludedProductCategories: [],
+               excludeSaleItems: false,
+               minimumAmount: "5.00",
+               maximumAmount: "500.00",
+               emailRestrictions: [],
+               usedBy: []
+              ),
+    ]
+
     var thisMonthVisitStats: SiteVisitStats {
         Self.createVisitStats(
             siteID: 1,

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -19,6 +19,8 @@ public protocol MockObjectGraph {
 
     var taxBasedOnSetting: TaxBasedOnSetting { get }
     var googleAdsConnection: GoogleAdsConnection { get }
+    var couponReports: [CouponReport] { get }
+    var coupons: [Coupon] { get }
 
     var thisMonthOrderStats: OrderStatsV4 { get }
     var thisMonthVisitStats: SiteVisitStats { get }

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -41,6 +41,7 @@ public class MockStoresManager: StoresManager {
     private let googleAdsActionHandler: MockGoogleAdsActionHandler
     private let justInTimeMessageActionHandler: MockJustInTimeMessageActionHandler
     private let shippingMethodActionHandler: MockShippingMethodActionHandler
+    private let couponActionHandler: MockCouponActionHandler
 
 
 
@@ -76,6 +77,7 @@ public class MockStoresManager: StoresManager {
         googleAdsActionHandler = MockGoogleAdsActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         justInTimeMessageActionHandler = MockJustInTimeMessageActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         shippingMethodActionHandler = MockShippingMethodActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        couponActionHandler = MockCouponActionHandler(objectGraph: objectGraph, storageManager: storageManager)
     }
 
     /// Accessor for whether the user is logged in (spoiler: they always will be when mocking)
@@ -158,6 +160,8 @@ public class MockStoresManager: StoresManager {
             justInTimeMessageActionHandler.handle(action: action)
         case let action as ShippingMethodAction:
             shippingMethodActionHandler.handle(action: action)
+        case let action as CouponAction:
+            couponActionHandler.handle(action: action)
         default:
             fatalError("Unable to handle action: \(action.identifier) \(String(describing: action))")
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When generating screenshots on iPad device, previously My Store area might look a bit too empty because there's not enough cards on it.

This quick PR adds the Most Active Coupon card to the My Store are to fill in the space.

At the moment, the Coupon card is shown in empty state. I tried making it show mocked data, but it's non-trivial, because:

1. The card fetches data from storage based on siteID value,
2. The mocked Coupon can't have its siteID value set manually, it has to be set by its Mapper after retrieving network data:

https://github.com/woocommerce/woocommerce-ios/blob/89297f90de3c9248cbc403bedac8d599e4ce371b/Networking/Networking/Model/Coupon.swift#L11-L12

If you have suggestion on how to workaround that limitation, do let me know! At the moment I suppose it's OK because the Coupon card is not even shown fully. It's just there to help fill in the space.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set target to `WooCommerceScreenshot` and pick a tablet device (I'm using iPad Pro 12.0 2nd gen with iOS 16)
2. Build the app,
3. Compare with screenshot below in "After"

To check the "Before" screenshot, repeat the steps above on the `trunk` branch.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested this in Simulator with iPad Pro 12.0 2nd gen with iOS 16

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|-|-|
| ![Simulator Screenshot - ScreenShot iPad Pro 12 0 2nd Gen iOS 16 - 2024-11-21 at 12 24 19](https://github.com/user-attachments/assets/d84aaa6b-1076-4e5e-b65a-ce6094ddd8f7) | ![Simulator Screenshot - ScreenShot iPad Pro 12 0 2nd Gen iOS 16 - 2024-11-21 at 12 21 38](https://github.com/user-attachments/assets/e5d0447f-32c5-4425-a5db-56bb7000fa36) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.