### PR TITLE
Send receipts after failed payments via the API

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccess.swift
@@ -53,9 +53,7 @@ final class CardPresentModalBuiltInSuccess: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        viewController?.dismiss(animated: true, completion: { [weak self] in
-            self?.emailReceiptAction()
-        })
+        emailReceiptAction()
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -3,10 +3,10 @@ import UIKit
 /// Modal presented on error
 final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     /// A closure to execute when the primary button is tapped
-    private let primaryAction: () -> Void
+    private let tryAgainAction: () -> Void
 
     /// A closure to execute when the secondary button is tapped
-    private let secondaryAction: () -> Void
+    private let emailReceiptAction: () -> Void
 
     /// A closure to execute after the auxilary button is tapped to dismiss the modal
     private let dismissCompletion: () -> Void
@@ -40,25 +40,25 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     init(errorDescription: String?,
          transactionType: CardPresentTransactionType,
          image: UIImage = .paymentErrorImage,
-         primaryAction: @escaping () -> Void,
-         secondaryAction: @escaping () -> Void,
+         tryAgainAction: @escaping () -> Void,
+         emailReceiptAction: @escaping () -> Void,
          dismissCompletion: @escaping () -> Void) {
         self.topTitle = Localization.paymentFailed(transactionType: transactionType)
         self.bottomTitle = errorDescription
         self.image = image
         self.primaryButtonTitle = Localization.tryAgain(transactionType: transactionType)
         self.auxiliaryButtonTitle = Localization.noThanks(transactionType: transactionType)
-        self.primaryAction = primaryAction
-        self.secondaryAction = secondaryAction
+        self.tryAgainAction = tryAgainAction
+        self.emailReceiptAction = emailReceiptAction
         self.dismissCompletion = dismissCompletion
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        primaryAction()
+        tryAgainAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        secondaryAction()
+        emailReceiptAction()
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -5,11 +5,14 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     /// A closure to execute when the primary button is tapped
     private let primaryAction: () -> Void
 
-    /// A closure to execute after the secondary button is tapped to dismiss the modal
+    /// A closure to execute when the secondary button is tapped
+    private let secondaryAction: () -> Void
+
+    /// A closure to execute after the auxilary button is tapped to dismiss the modal
     private let dismissCompletion: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .twoAction
+    let actionsMode: PaymentsModalActionsMode = .twoActionAndAuxiliary
 
     let topTitle: String
 
@@ -19,9 +22,9 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
     let primaryButtonTitle: String?
 
-    let secondaryButtonTitle: String?
+    let secondaryButtonTitle: String? = Localization.emailReceipt
 
-    let auxiliaryButtonTitle: String? = nil
+    let auxiliaryButtonTitle: String?
 
     let bottomTitle: String?
 
@@ -38,13 +41,15 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
          transactionType: CardPresentTransactionType,
          image: UIImage = .paymentErrorImage,
          primaryAction: @escaping () -> Void,
+         secondaryAction: @escaping () -> Void,
          dismissCompletion: @escaping () -> Void) {
         self.topTitle = Localization.paymentFailed(transactionType: transactionType)
         self.bottomTitle = errorDescription
         self.image = image
         self.primaryButtonTitle = Localization.tryAgain(transactionType: transactionType)
-        self.secondaryButtonTitle = Localization.noThanks(transactionType: transactionType)
+        self.auxiliaryButtonTitle = Localization.noThanks(transactionType: transactionType)
         self.primaryAction = primaryAction
+        self.secondaryAction = secondaryAction
         self.dismissCompletion = dismissCompletion
     }
 
@@ -53,12 +58,14 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
+        secondaryAction()
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
         viewController?.dismiss(animated: true) { [weak self] in
             self?.dismissCompletion()
         }
     }
-
-    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
 extension CardPresentModalError {
@@ -112,6 +119,12 @@ extension CardPresentModalError {
             "cardPresentPaymentsModal.error.receiptMessage",
             value: "A receipt has been sent to %1$@",
             comment: "Message informing the user that a receipt has been sent to their email address. %1$@ is the email address"
+        )
+
+        static let emailReceipt = NSLocalizedString(
+            "cardPresentPaymentsModal.error.emailReceipt",
+            value: "Email receipt",
+            comment: "Button to email receipts. Presented to users after a payment has been successfully collected"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -124,7 +124,7 @@ extension CardPresentModalError {
         static let emailReceipt = NSLocalizedString(
             "cardPresentPaymentsModal.error.emailReceipt",
             value: "Email receipt",
-            comment: "Button to email receipts. Presented to users after a payment has been successfully collected"
+            comment: "Button to email receipts. Presented to users after a payment processing has failed"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorEmailSent.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Modal presented on error. Shows email address which the receipt was sent to.
 final class CardPresentModalErrorEmailSent: CardPresentPaymentsModalViewModel {
     /// A closure to execute when the primary button is tapped
-    private let primaryAction: () -> Void
+    private let tryAgainAction: () -> Void
 
     /// A closure to execute after the secondary button is tapped to dismiss the modal
     private let dismissCompletion: () -> Void
@@ -40,14 +40,14 @@ final class CardPresentModalErrorEmailSent: CardPresentPaymentsModalViewModel {
          transactionType: CardPresentTransactionType,
          image: UIImage = .paymentErrorImage,
          email: String,
-         primaryAction: @escaping () -> Void,
+         tryAgainAction: @escaping () -> Void,
          dismissCompletion: @escaping () -> Void) {
         self.topTitle = CardPresentModalError.Localization.paymentFailed(transactionType: transactionType)
         self.bottomTitle = errorDescription
         self.image = image
         self.primaryButtonTitle = CardPresentModalError.Localization.tryAgain(transactionType: transactionType)
         self.secondaryButtonTitle = CardPresentModalError.Localization.noThanks(transactionType: transactionType)
-        self.primaryAction = primaryAction
+        self.tryAgainAction = tryAgainAction
         self.dismissCompletion = dismissCompletion
 
         let formattedMessage = String(format: CardPresentModalError.Localization.receiptMessage, email)
@@ -60,7 +60,7 @@ final class CardPresentModalErrorEmailSent: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        primaryAction()
+        tryAgainAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+/// Modal presented on error
+final class CardPresentModalErrorWithoutEmail: CardPresentPaymentsModalViewModel {
+    /// A closure to execute when the primary button is tapped
+    private let primaryAction: () -> Void
+
+    /// A closure to execute after the secondary button is tapped to dismiss the modal
+    private let dismissCompletion: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .twoAction
+
+    let topTitle: String
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage
+
+    let primaryButtonTitle: String?
+
+    let secondaryButtonTitle: String?
+
+    let auxiliaryButtonTitle: String? = nil
+
+    let bottomTitle: String?
+
+    let bottomSubtitle: String? = nil
+
+    var accessibilityLabel: String? {
+        guard let bottomTitle = bottomTitle else {
+            return topTitle
+        }
+        return topTitle + bottomTitle
+    }
+
+    init(errorDescription: String?,
+         transactionType: CardPresentTransactionType,
+         image: UIImage = .paymentErrorImage,
+         primaryAction: @escaping () -> Void,
+         dismissCompletion: @escaping () -> Void) {
+        self.topTitle = CardPresentModalError.Localization.paymentFailed(transactionType: transactionType)
+        self.bottomTitle = errorDescription
+        self.image = image
+        self.primaryButtonTitle = CardPresentModalError.Localization.tryAgain(transactionType: transactionType)
+        self.secondaryButtonTitle = CardPresentModalError.Localization.noThanks(transactionType: transactionType)
+        self.primaryAction = primaryAction
+        self.dismissCompletion = dismissCompletion
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        primaryAction()
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true) { [weak self] in
+            self?.dismissCompletion()
+        }
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Modal presented on error
 final class CardPresentModalErrorWithoutEmail: CardPresentPaymentsModalViewModel {
     /// A closure to execute when the primary button is tapped
-    private let primaryAction: () -> Void
+    private let tryAgainAction: () -> Void
 
     /// A closure to execute after the secondary button is tapped to dismiss the modal
     private let dismissCompletion: () -> Void
@@ -37,19 +37,19 @@ final class CardPresentModalErrorWithoutEmail: CardPresentPaymentsModalViewModel
     init(errorDescription: String?,
          transactionType: CardPresentTransactionType,
          image: UIImage = .paymentErrorImage,
-         primaryAction: @escaping () -> Void,
+         tryAgainAction: @escaping () -> Void,
          dismissCompletion: @escaping () -> Void) {
         self.topTitle = CardPresentModalError.Localization.paymentFailed(transactionType: transactionType)
         self.bottomTitle = errorDescription
         self.image = image
         self.primaryButtonTitle = CardPresentModalError.Localization.tryAgain(transactionType: transactionType)
         self.secondaryButtonTitle = CardPresentModalError.Localization.noThanks(transactionType: transactionType)
-        self.primaryAction = primaryAction
+        self.tryAgainAction = tryAgainAction
         self.dismissCompletion = dismissCompletion
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        primaryAction()
+        tryAgainAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -9,8 +9,11 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     /// Called when the view is dismissed
     private let onDismiss: () -> Void
 
+    /// A closure to execute when the secondary button is tapped
+    private let secondaryAction: () -> Void
+
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .oneAction
+    let actionsMode: PaymentsModalActionsMode = .twoAction
 
     let topTitle: String = Localization.paymentFailed
 
@@ -22,7 +25,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
 
     let primaryButtonTitle: String? = Localization.dismiss
 
-    let secondaryButtonTitle: String? = nil
+    let secondaryButtonTitle: String? = CardPresentModalError.Localization.emailReceipt
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -41,15 +44,23 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     init(amount: String,
          errorDescription: String?,
          image: UIImage = .paymentErrorImage,
-         onDismiss: @escaping () -> Void) {
+         onDismiss: @escaping () -> Void,
+         secondaryAction: @escaping () -> Void) {
         self.amount = amount
         self.bottomTitle = errorDescription
         self.image = image
         self.onDismiss = onDismiss
+        self.secondaryAction = secondaryAction
     }
 
-    convenience init(amount: String, error: Error, onDismiss: @escaping () -> Void) {
-        self.init(amount: amount, errorDescription: error.localizedDescription, onDismiss: onDismiss)
+    convenience init(amount: String,
+                     error: Error,
+                     onDismiss: @escaping () -> Void,
+                     secondaryAction: @escaping () -> Void) {
+        self.init(amount: amount,
+                  errorDescription: error.localizedDescription,
+                  onDismiss: onDismiss,
+                  secondaryAction: secondaryAction)
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -61,7 +72,9 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
         }
     }
 
-    func didTapSecondaryButton(in viewController: UIViewController?) { }
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        secondaryAction()
+    }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -10,7 +10,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     private let onDismiss: () -> Void
 
     /// A closure to execute when the secondary button is tapped
-    private let secondaryAction: () -> Void
+    private let emailReceiptAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
     let actionsMode: PaymentsModalActionsMode = .twoAction
@@ -45,22 +45,22 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
          errorDescription: String?,
          image: UIImage = .paymentErrorImage,
          onDismiss: @escaping () -> Void,
-         secondaryAction: @escaping () -> Void) {
+         emailReceiptAction: @escaping () -> Void) {
         self.amount = amount
         self.bottomTitle = errorDescription
         self.image = image
         self.onDismiss = onDismiss
-        self.secondaryAction = secondaryAction
+        self.emailReceiptAction = emailReceiptAction
     }
 
     convenience init(amount: String,
                      error: Error,
                      onDismiss: @escaping () -> Void,
-                     secondaryAction: @escaping () -> Void) {
+                     emailReceiptAction: @escaping () -> Void) {
         self.init(amount: amount,
                   errorDescription: error.localizedDescription,
                   onDismiss: onDismiss,
-                  secondaryAction: secondaryAction)
+                  emailReceiptAction: emailReceiptAction)
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -73,7 +73,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        secondaryAction()
+        emailReceiptAction()
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+/// Modal presented on error. Does not provide a retry action.
+final class CardPresentModalNonRetryableErrorWithoutEmail: CardPresentPaymentsModalViewModel {
+
+    /// Amount charged
+    private let amount: String
+
+    /// Called when the view is dismissed
+    private let onDismiss: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .oneAction
+
+    let topTitle: String = CardPresentModalNonRetryableError.Localization.paymentFailed
+
+    var topSubtitle: String? {
+        amount
+    }
+
+    let image: UIImage
+
+    let primaryButtonTitle: String? = CardPresentModalNonRetryableError.Localization.dismiss
+
+    let secondaryButtonTitle: String? = nil
+
+    let auxiliaryButtonTitle: String? = nil
+
+    let bottomTitle: String?
+
+    let bottomSubtitle: String? = nil
+
+    var accessibilityLabel: String? {
+        guard let bottomTitle = bottomTitle else {
+            return topTitle
+        }
+
+        return topTitle + bottomTitle
+    }
+
+    init(amount: String,
+         errorDescription: String?,
+         image: UIImage = .paymentErrorImage,
+         onDismiss: @escaping () -> Void) {
+        self.amount = amount
+        self.bottomTitle = errorDescription
+        self.image = image
+        self.onDismiss = onDismiss
+    }
+
+    convenience init(amount: String, error: Error, onDismiss: @escaping () -> Void) {
+        self.init(amount: amount, errorDescription: error.localizedDescription, onDismiss: onDismiss)
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        guard let viewController else {
+            return onDismiss()
+        }
+        viewController.dismiss(animated: true) { [weak self] in
+            self?.onDismiss()
+        }
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) { }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -53,9 +53,7 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        viewController?.dismiss(animated: true, completion: { [weak self] in
-            self?.emailReceiptAction()
-        })
+        emailReceiptAction()
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -115,15 +115,22 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
         switch receiptState {
         case let .paymentSuccessEmailSent(email):
             CardPresentModalNonRetryableErrorEmailSent(amount: amount, error: error, email: email, onDismiss: dismissCompletion)
-        default:
-            CardPresentModalNonRetryableError(amount: amount, error: error, onDismiss: dismissCompletion)
+        case let .promptToSendEmailReceipt(emailReceiptAction):
+            CardPresentModalNonRetryableError(amount: amount,
+                                              error: error,
+                                              onDismiss: dismissCompletion,
+                                              secondaryAction: emailReceiptAction)
+        case .noEmailReceipt:
+            CardPresentModalNonRetryableErrorWithoutEmail(amount: amount,
+                                                          error: error,
+                                                          onDismiss: dismissCompletion)
         }
     }
 
     func cancelledOnReader() -> CardPresentPaymentsModalViewModel? {
-        CardPresentModalNonRetryableError(amount: amount,
-                                          error: CardReaderServiceError.paymentMethodCollection(underlyingError: .commandCancelled(from: .reader)),
-                                          onDismiss: { })
+        CardPresentModalNonRetryableErrorWithoutEmail(amount: amount,
+                                                      error: CardReaderServiceError.paymentMethodCollection(underlyingError: .commandCancelled(from: .reader)),
+                                                      onDismiss: { })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -94,11 +94,17 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
                                                   email: email,
                                                   primaryAction: tryAgain,
                                                   dismissCompletion: dismissCompletion)
-        default:
+        case let .promptToSendEmailReceipt(emailReceiptAction):
             return CardPresentModalError(errorDescription: errorDescription,
                                          transactionType: transactionType,
                                          primaryAction: tryAgain,
+                                         secondaryAction: emailReceiptAction,
                                          dismissCompletion: dismissCompletion)
+        case .noEmailReceipt:
+            return CardPresentModalErrorWithoutEmail(errorDescription: errorDescription,
+                                                     transactionType: transactionType,
+                                                     primaryAction: tryAgain,
+                                                     dismissCompletion: dismissCompletion)
 
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -92,7 +92,7 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
             return CardPresentModalErrorEmailSent(errorDescription: errorDescription,
                                                   transactionType: transactionType,
                                                   email: email,
-                                                  primaryAction: tryAgain,
+                                                  tryAgainAction: tryAgain,
                                                   dismissCompletion: dismissCompletion)
         case let .promptToSendEmailReceipt(emailReceiptAction):
             return CardPresentModalError(errorDescription: errorDescription,
@@ -103,7 +103,7 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
         case .noEmailReceipt:
             return CardPresentModalErrorWithoutEmail(errorDescription: errorDescription,
                                                      transactionType: transactionType,
-                                                     primaryAction: tryAgain,
+                                                     tryAgainAction: tryAgain,
                                                      dismissCompletion: dismissCompletion)
 
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -119,7 +119,7 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
             CardPresentModalNonRetryableError(amount: amount,
                                               error: error,
                                               onDismiss: dismissCompletion,
-                                              secondaryAction: emailReceiptAction)
+                                              emailReceiptAction: emailReceiptAction)
         case .noEmailReceipt:
             CardPresentModalNonRetryableErrorWithoutEmail(amount: amount,
                                                           error: error,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -97,8 +97,8 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
         case let .promptToSendEmailReceipt(emailReceiptAction):
             return CardPresentModalError(errorDescription: errorDescription,
                                          transactionType: transactionType,
-                                         primaryAction: tryAgain,
-                                         secondaryAction: emailReceiptAction,
+                                         tryAgainAction: tryAgain,
+                                         emailReceiptAction: emailReceiptAction,
                                          dismissCompletion: dismissCompletion)
         case .noEmailReceipt:
             return CardPresentModalErrorWithoutEmail(errorDescription: errorDescription,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -23,7 +23,7 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
     }
 
     func connectingFailedNonRetryable(error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalNonRetryableError(amount: "", error: error, onDismiss: close)
+        CardPresentModalNonRetryableErrorWithoutEmail(amount: "", error: error, onDismiss: close)
     }
 
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -101,7 +101,7 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                                               errorDescription: builtInReaderDescription(for: error),
                                               image: .builtInReaderError,
                                               onDismiss: dismissCompletion,
-                                              secondaryAction: emailReceiptAction)
+                                              emailReceiptAction: emailReceiptAction)
         case .noEmailReceipt:
             CardPresentModalNonRetryableErrorWithoutEmail(amount: amount,
                                                           errorDescription: builtInReaderDescription(for: error),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -44,15 +44,15 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
     func success(receiptState: CardReaderTransactionAlertReceiptState) -> CardPresentPaymentsModalViewModel {
         switch receiptState {
         case let .paymentSuccessEmailSent(email, printReceiptAction, noReceiptAction):
-            return CardPresentModalSuccessEmailSent(printReceipt: printReceiptAction,
-                                                    noReceiptAction: noReceiptAction,
-                                                    email: email)
+            return CardPresentModalBuiltInSuccessEmailSent(printReceipt: printReceiptAction,
+                                                           noReceiptAction: noReceiptAction,
+                                                           email: email)
         case let .promptToSendEmailReceipt(printReceiptAction, emailReceiptAction, noReceiptAction):
-            return CardPresentModalSuccess(printReceipt: printReceiptAction,
-                                           emailReceipt: emailReceiptAction,
-                                           noReceiptAction: noReceiptAction)
+            return CardPresentModalBuiltInSuccess(printReceipt: printReceiptAction,
+                                                  emailReceipt: emailReceiptAction,
+                                                  noReceiptAction: noReceiptAction)
         case let .emailSendingNotSupported(printReceiptAction, noReceiptAction):
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceiptAction, noReceiptAction: noReceiptAction)
+            return CardPresentModalBuiltInSuccessWithoutEmail(printReceipt: printReceiptAction, noReceiptAction: noReceiptAction)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -68,7 +68,7 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                                                   transactionType: .collectPayment,
                                                   image: .builtInReaderError,
                                                   email: email,
-                                                  primaryAction: tryAgain,
+                                                  tryAgainAction: tryAgain,
                                                   dismissCompletion: dismissCompletion)
         case let .promptToSendEmailReceipt(emailReceiptAction):
             return CardPresentModalError(errorDescription: builtInReaderDescription(for: error),
@@ -81,7 +81,7 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
             return CardPresentModalErrorWithoutEmail(errorDescription: builtInReaderDescription(for: error),
                                                      transactionType: .collectPayment,
                                                      image: .builtInReaderError,
-                                                     primaryAction: tryAgain,
+                                                     tryAgainAction: tryAgain,
                                                      dismissCompletion: dismissCompletion)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -96,11 +96,17 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                                                        image: .builtInReaderError,
                                                        email: email,
                                                        onDismiss: dismissCompletion)
-        default:
+        case let .promptToSendEmailReceipt(emailReceiptAction):
             CardPresentModalNonRetryableError(amount: amount,
                                               errorDescription: builtInReaderDescription(for: error),
                                               image: .builtInReaderError,
-                                              onDismiss: dismissCompletion)
+                                              onDismiss: dismissCompletion,
+                                              secondaryAction: emailReceiptAction)
+        case .noEmailReceipt:
+            CardPresentModalNonRetryableErrorWithoutEmail(amount: amount,
+                                                          errorDescription: builtInReaderDescription(for: error),
+                                                          image: .builtInReaderError,
+                                                          onDismiss: dismissCompletion)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -74,8 +74,8 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
             return CardPresentModalError(errorDescription: builtInReaderDescription(for: error),
                                          transactionType: .collectPayment,
                                          image: .builtInReaderError,
-                                         primaryAction: tryAgain,
-                                         secondaryAction: emailReceiptAction,
+                                         tryAgainAction: tryAgain,
+                                         emailReceiptAction: emailReceiptAction,
                                          dismissCompletion: dismissCompletion)
         case .noEmailReceipt:
             return CardPresentModalErrorWithoutEmail(errorDescription: builtInReaderDescription(for: error),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -70,12 +70,19 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                                                   email: email,
                                                   primaryAction: tryAgain,
                                                   dismissCompletion: dismissCompletion)
-        default:
+        case let .promptToSendEmailReceipt(emailReceiptAction):
             return CardPresentModalError(errorDescription: builtInReaderDescription(for: error),
                                          transactionType: .collectPayment,
                                          image: .builtInReaderError,
                                          primaryAction: tryAgain,
+                                         secondaryAction: emailReceiptAction,
                                          dismissCompletion: dismissCompletion)
+        case .noEmailReceipt:
+            return CardPresentModalErrorWithoutEmail(errorDescription: builtInReaderDescription(for: error),
+                                                     transactionType: .collectPayment,
+                                                     image: .builtInReaderError,
+                                                     primaryAction: tryAgain,
+                                                     dismissCompletion: dismissCompletion)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import Yosemite
 import MessageUI
+import WordPressUI
 import WooFoundation
 import protocol Storage.StorageManagerType
 //TODO: Move to alertprovider (and ideally, remove from this target or translate through Yosemite)
@@ -455,7 +456,8 @@ private extension CollectOrderPaymentUseCase {
                                                paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                                paymentGatewayAccount: PaymentGatewayAccount,
                                                onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        receiptStateForFailedPayment(error: error) { [weak self] receiptState in
+        receiptStateForFailedPayment(error: error,
+                                     receiptStateCompletion: { [weak self] receiptState in
             guard let self else { return }
             alertsPresenter.present(
                 viewModel: paymentAlerts.error(error: error,
@@ -484,14 +486,21 @@ private extension CollectOrderPaymentUseCase {
                                                    onCompletion(.failure(error))
                                                })
             )
-        }
+        },
+                                     emailPromptCompletion: { [weak self] in
+            self?.presentRetryByRestartingError(error: error,
+                                                paymentAlerts: paymentAlerts,
+                                                paymentGatewayAccount: paymentGatewayAccount,
+                                                onCompletion: onCompletion)
+        })
     }
 
     private func presentRetryWithoutRestartingError(error: Error,
                                                     paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                                     paymentGatewayAccount: PaymentGatewayAccount,
                                                     onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        receiptStateForFailedPayment(error: error) { [weak self] receiptState in
+        receiptStateForFailedPayment(error: error,
+                                     receiptStateCompletion: { [weak self] receiptState in
             guard let self else { return }
 
             alertsPresenter.present(
@@ -535,13 +544,20 @@ private extension CollectOrderPaymentUseCase {
                         onCompletion(.failure(error))
                     })
             )
-        }
+        },
+                                     emailPromptCompletion: { [weak self] in
+            self?.presentRetryWithoutRestartingError(error: error,
+                                                     paymentAlerts: paymentAlerts,
+                                                     paymentGatewayAccount: paymentGatewayAccount,
+                                                     onCompletion: onCompletion)
+        })
     }
 
     private func presentNonRetryableError(error: Error,
                                           paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        receiptStateForFailedPayment(error: error) { [weak self] receiptState in
+        receiptStateForFailedPayment(error: error,
+                                     receiptStateCompletion: { [weak self] receiptState in
             guard let self else { return }
 
             alertsPresenter.present(
@@ -550,7 +566,10 @@ private extension CollectOrderPaymentUseCase {
                                                            dismissCompletion: {
                                                                onCompletion(.failure(error))
                                                            }))
-        }
+        },
+                                     emailPromptCompletion: { [weak self] in
+            self?.presentNonRetryableError(error: error, paymentAlerts: paymentAlerts, onCompletion: onCompletion)
+        })
     }
 
     /// Cancels payment and record analytics.
@@ -583,7 +602,9 @@ private extension CollectOrderPaymentUseCase {
             }
             // Sends receipt via API
             let addCustomerEmailAndSendReceiptCompletionAction: () -> Void = { [weak self] in
-                self?.presentSendReceiptAfterPayment(onCompleted: onCompleted)
+                self?.presentSendReceiptAfterPayment { _ in
+                    onCompleted()
+                }
             }
 
             let noReceiptAction: () -> Void = { onCompleted() }
@@ -711,17 +732,23 @@ private extension CollectOrderPaymentUseCase {
     }
 }
 
+
 // MARK: - Collect customer email and send receipt after payment presentation
 private extension CollectOrderPaymentUseCase {
-    func presentSendReceiptAfterPayment(onCompleted: @escaping (() -> Void)) {
-        let receiptEmailViewController = ReceiptEmailViewHostingController(order: order) { _ in
-            onCompleted()
+    func presentSendReceiptAfterPayment(onCompleted: @escaping ((Order?) -> Void)) {
+        let receiptEmailViewController = ReceiptEmailViewHostingController(order: order) { order in
+            onCompleted(order)
         }
-        rootViewController.present(receiptEmailViewController, animated: true)
+
+        // Support opening receipt modal on top of a presented alert if needed
+        let viewController = rootViewController.presentedViewController ?? rootViewController
+        viewController.present(receiptEmailViewController, animated: true)
     }
 
+
     private func receiptStateForFailedPayment(error: Error,
-                                              _ completion: @escaping (CardReaderTransactionFailureAlertReceiptState) -> Void) {
+                                              receiptStateCompletion: @escaping (CardReaderTransactionFailureAlertReceiptState) -> Void,
+                                              emailPromptCompletion: @escaping () -> Void) {
 
         let isErrorEligibleForSendingFailureReceiptAfterPayment: Bool = {
             switch error {
@@ -737,7 +764,7 @@ private extension CollectOrderPaymentUseCase {
 
         // Order only fails when the payment is declined by the payment processor, other types of failure don't produce failure states and receipts.
         guard isErrorEligibleForSendingFailureReceiptAfterPayment else {
-            return completion(.noEmailReceipt)
+            return receiptStateCompletion(.noEmailReceipt)
         }
 
         receiptEligibilityUseCase.isEligibleSendingReceiptAfterPayment { [weak self] isEligible in
@@ -748,14 +775,20 @@ private extension CollectOrderPaymentUseCase {
                 if let email = order.billingAddress?.email, email.isNotEmpty {
                     receiptState = .paymentSuccessEmailSent(email: email)
                 } else {
-                    receiptState = .promptToSendEmailReceipt(emailReceiptAction: {
-                        // TODO
+                    receiptState = .promptToSendEmailReceipt(emailReceiptAction: { [weak self] in
+                        guard let self else { return }
+                        presentSendReceiptAfterPayment { order in
+                            if let order {
+                                self.order = order
+                            }
+                            emailPromptCompletion()
+                        }
                     })
                 }
             } else {
                 receiptState = .noEmailReceipt
             }
-            completion(receiptState)
+            receiptStateCompletion(receiptState)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -567,54 +567,34 @@ private extension CollectOrderPaymentUseCase {
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
     ///
-    func presentBackendReceiptAlert(
-        alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
-        onCompleted: @escaping () -> ()) {
-            // Handles receipt presentation for both print and email actions
-            let receiptPresentationCompletionAction: () -> Void = { [weak self] in
+    func presentBackendReceiptAlert(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
+                                    onCompleted: @escaping () -> ()) {
+        // Handles receipt presentation for both print and native iOS client email actions
+        let presentBackendReceiptAction: () -> Void = { [weak self] in
+            guard let self else { return }
+
+            alertsPresenter.dismiss()
+            paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { [weak self] result in
                 guard let self else { return }
-                self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { [weak self] result in
-                    guard let self else { return }
-                    switch result {
-                    case let .success(receipt):
-                        self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
-                    case let .failure(error):
-                        self.presentReceiptFailedNotice(with: error, onCompleted: onCompleted)
-                    }
-                })
-            }
-            // Sends receipt via API
-            let addCustomerEmailAndSendReceiptCompletionAction: () -> Void = { [weak self] in
-                self?.presentSendReceiptAfterPayment { _ in
-                    onCompleted()
+
+                switch result {
+                case let .success(receipt):
+                    presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
+                case let .failure(error):
+                    presentReceiptFailedNotice(with: error, onCompleted: onCompleted)
                 }
-            }
-
-            let noReceiptAction: () -> Void = { onCompleted() }
-
-            // Presents receipt alert
-            receiptEligibilityUseCase.isEligibleSendingReceiptAfterPayment { isEligibleSendingReceiptAfterPayment in
-                let receiptState: CardReaderTransactionAlertReceiptState
-
-                if let email = self.order.billingAddress?.email, email.isNotEmpty {
-                    receiptState = .paymentSuccessEmailSent(email: email,
-                                                            printReceiptAction: receiptPresentationCompletionAction,
-                                                            noReceiptAction: noReceiptAction)
-                } else if isEligibleSendingReceiptAfterPayment {
-                    receiptState = .promptToSendEmailReceipt(printReceiptAction: receiptPresentationCompletionAction,
-                                                             emailReceiptAction: addCustomerEmailAndSendReceiptCompletionAction,
-                                                             noReceiptAction: noReceiptAction)
-                } else if MFMailComposeViewController.canSendMail() {
-                    receiptState = .promptToSendEmailReceipt(printReceiptAction: receiptPresentationCompletionAction,
-                                                             emailReceiptAction: receiptPresentationCompletionAction,
-                                                             noReceiptAction: noReceiptAction)
-                } else {
-                    receiptState = .emailSendingNotSupported(printReceiptAction: receiptPresentationCompletionAction,
-                                                             noReceiptAction: noReceiptAction)
-                }
-                self.alertsPresenter.present(viewModel: paymentAlerts.success(receiptState: receiptState))
-            }
+            })
         }
+
+        getReceiptStateForSuccessPayment(presentBackendReceiptAction: presentBackendReceiptAction,
+                                         noReceiptAction: onCompleted,
+                                         completion: { [weak self] receiptState in
+            guard let self else { return }
+
+            alertsPresenter.present(viewModel: paymentAlerts.success(receiptState: receiptState))
+        })
+    }
+
 
     /// Allow merchants to print or email locally-generated receipts.
     ///
@@ -644,6 +624,8 @@ private extension CollectOrderPaymentUseCase {
             }
         }, emailReceipt: { [order, analyticsTracker, paymentOrchestrator, weak self] in
             guard let self = self else { return }
+
+            alertsPresenter.dismiss()
 
             analyticsTracker.trackEmailTapped()
 
@@ -728,6 +710,43 @@ private extension CollectOrderPaymentUseCase {
         viewController.present(receiptEmailViewController, animated: true)
     }
 
+    private func getReceiptStateForSuccessPayment(
+        presentBackendReceiptAction: @escaping () -> Void,
+        noReceiptAction: @escaping () -> Void,
+        completion: @escaping (CardReaderTransactionAlertReceiptState) -> Void) {
+        receiptEligibilityUseCase.isEligibleSendingReceiptAfterPayment { isEligibleSendingReceiptAfterPayment in
+            let receiptState: CardReaderTransactionAlertReceiptState
+
+            if let email = self.order.billingAddress?.email, email.isNotEmpty {
+                receiptState = .paymentSuccessEmailSent(email: email,
+                                                        printReceiptAction: presentBackendReceiptAction,
+                                                        noReceiptAction: noReceiptAction)
+            } else if isEligibleSendingReceiptAfterPayment {
+                receiptState = .promptToSendEmailReceipt(printReceiptAction: presentBackendReceiptAction,
+                                                         emailReceiptAction: { [weak self] in
+                    guard let self else { return }
+                    self.presentSendReceiptAfterPayment { order in
+                        if let order  = order, let email = order.billingAddress?.email, email.isNotEmpty {
+                            self.order = order
+                            completion(.paymentSuccessEmailSent(email: email,
+                                                                printReceiptAction: presentBackendReceiptAction,
+                                                                noReceiptAction: noReceiptAction))
+                        }
+                    }
+                },
+                                                         noReceiptAction: noReceiptAction)
+            } else if MFMailComposeViewController.canSendMail() {
+                receiptState = .promptToSendEmailReceipt(printReceiptAction: presentBackendReceiptAction,
+                                                         emailReceiptAction: presentBackendReceiptAction,
+                                                         noReceiptAction: noReceiptAction)
+            } else {
+                receiptState = .emailSendingNotSupported(printReceiptAction: presentBackendReceiptAction,
+                                                         noReceiptAction: noReceiptAction)
+            }
+
+            completion(receiptState)
+        }
+    }
 
     private func getReceiptStateForFailedPayment(error: Error,
                                                  completion: @escaping (CardReaderTransactionFailureAlertReceiptState) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -777,7 +777,8 @@ private extension CollectOrderPaymentUseCase {
                 } else {
                     receiptState = .promptToSendEmailReceipt(emailReceiptAction: { [weak self] in
                         guard let self else { return }
-                        presentSendReceiptAfterPayment { order in
+                        presentSendReceiptAfterPayment { [weak self] order in
+                            guard let self else { return }
                             if let order {
                                 self.order = order
                             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -429,147 +429,130 @@ private extension CollectOrderPaymentUseCase {
 
         analyticsTracker.trackPaymentFailure(with: error)
 
-        guard let retryableError = error as? CardPaymentErrorProtocol else {
-            return presentNonRetryableError(error: error,
-                                            paymentAlerts: paymentAlerts,
-                                            onCompletion: onCompletion)
+        let presentErrorAlert: (CardReaderTransactionFailureAlertReceiptState) -> Void = { [weak self] receiptState in
+            guard let self else { return }
+            guard let retryableError = error as? CardPaymentErrorProtocol else {
+                return presentNonRetryableError(error: error,
+                                                paymentAlerts: paymentAlerts,
+                                                receiptState: receiptState,
+                                                onCompletion: onCompletion)
+            }
+
+            switch retryableError.retryApproach {
+            case .restart:
+                presentRetryByRestartingError(error: error,
+                                              paymentAlerts: paymentAlerts,
+                                              paymentGatewayAccount: paymentGatewayAccount,
+                                              receiptState: receiptState,
+                                              onCompletion: onCompletion)
+            case .reuseIntent:
+                presentRetryWithoutRestartingError(error: error,
+                                                   paymentAlerts: paymentAlerts,
+                                                   paymentGatewayAccount: paymentGatewayAccount,
+                                                   receiptState: receiptState,
+                                                   onCompletion: onCompletion)
+            case .dontRetry:
+                presentNonRetryableError(error: error,
+                                         paymentAlerts: paymentAlerts,
+                                         receiptState: receiptState,
+                                         onCompletion: onCompletion)
+            }
         }
-        switch retryableError.retryApproach {
-        case .restart:
-            presentRetryByRestartingError(error: error,
-                                          paymentAlerts: paymentAlerts,
-                                          paymentGatewayAccount: paymentGatewayAccount,
-                                          onCompletion: onCompletion)
-        case .reuseIntent:
-            presentRetryWithoutRestartingError(error: error,
-                                               paymentAlerts: paymentAlerts,
-                                               paymentGatewayAccount: paymentGatewayAccount,
-                                               onCompletion: onCompletion)
-        case .dontRetry:
-            presentNonRetryableError(error: error,
-                                     paymentAlerts: paymentAlerts,
-                                     onCompletion: onCompletion)
-        }
+
+        getReceiptStateForFailedPayment(error: error, completion: presentErrorAlert)
     }
 
     private func presentRetryByRestartingError(error: Error,
                                                paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                                paymentGatewayAccount: PaymentGatewayAccount,
+                                               receiptState: CardReaderTransactionFailureAlertReceiptState,
                                                onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        receiptStateForFailedPayment(error: error,
-                                     receiptStateCompletion: { [weak self] receiptState in
-            guard let self else { return }
-            alertsPresenter.present(
-                viewModel: paymentAlerts.error(error: error,
-                                               receiptState: receiptState,
-                                               tryAgain: { [weak self] in
-                                                   // Cancel current payment
-                                                   self?.paymentOrchestrator.cancelPayment() { [weak self] result in
-                                                       guard let self = self else { return }
+        alertsPresenter.present(
+            viewModel: paymentAlerts.error(error: error,
+                                           receiptState: receiptState,
+                                           tryAgain: { [weak self] in
+                                               // Cancel current payment
+                                               self?.paymentOrchestrator.cancelPayment() { [weak self] result in
+                                                   guard let self = self else { return }
 
-                                                       switch result {
-                                                       case .success, .failure(CardReaderServiceError.paymentCancellation(.noActivePaymentIntent)):
-                                                           // Retry payment
-                                                           self.attemptPayment(alertProvider: paymentAlerts,
-                                                                               paymentGatewayAccount: paymentGatewayAccount,
-                                                                               onCompletion: onCompletion)
-                                                       case .failure(let cancelError):
-                                                           // Inform that payment can't be retried.
-                                                           self.alertsPresenter.present(
-                                                            viewModel: paymentAlerts.nonRetryableError(error: cancelError,
-                                                                                                       receiptState: receiptState) {
-                                                                                                           onCompletion(.failure(error))
-                                                                                                       })
-                                                       }
+                                                   switch result {
+                                                   case .success, .failure(CardReaderServiceError.paymentCancellation(.noActivePaymentIntent)):
+                                                       // Retry payment
+                                                       self.attemptPayment(alertProvider: paymentAlerts,
+                                                                           paymentGatewayAccount: paymentGatewayAccount,
+                                                                           onCompletion: onCompletion)
+                                                   case .failure(let cancelError):
+                                                       // Inform that payment can't be retried.
+                                                       self.alertsPresenter.present(
+                                                        viewModel: paymentAlerts.nonRetryableError(error: cancelError,
+                                                                                                   receiptState: receiptState) {
+                                                                                                       onCompletion(.failure(error))
+                                                                                                   })
                                                    }
-                                               }, dismissCompletion: {
-                                                   onCompletion(.failure(error))
-                                               })
-            )
-        },
-                                     emailPromptCompletion: { [weak self] in
-            self?.presentRetryByRestartingError(error: error,
-                                                paymentAlerts: paymentAlerts,
-                                                paymentGatewayAccount: paymentGatewayAccount,
-                                                onCompletion: onCompletion)
-        })
+                                               }
+                                           }, dismissCompletion: {
+                                               onCompletion(.failure(error))
+                                           })
+        )
     }
 
     private func presentRetryWithoutRestartingError(error: Error,
                                                     paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                                     paymentGatewayAccount: PaymentGatewayAccount,
+                                                    receiptState: CardReaderTransactionFailureAlertReceiptState,
                                                     onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        receiptStateForFailedPayment(error: error,
-                                     receiptStateCompletion: { [weak self] receiptState in
-            guard let self else { return }
-
-            alertsPresenter.present(
-                viewModel: paymentAlerts.error(
-                    error: error,
-                    receiptState: receiptState,
-                    tryAgain: { [weak self] in
-                        guard let self = self else { return }
-                        self.checkOrderIsStillEligibleForPayment(alertProvider: paymentAlerts, onPaymentCompletion: onCompletion) { result in
-                            switch result {
-                            case .failure(let error):
-                                return self.checkThenHandlePaymentFailureAndRetryPayment(error,
-                                                                                         alertProvider: paymentAlerts,
-                                                                                         paymentGatewayAccount: paymentGatewayAccount,
-                                                                                         onCompletion: onCompletion)
-                            case .success:
-                                self.paymentOrchestrator.retryPayment(for: self.order) { [weak self] result in
-                                    guard let self = self else { return }
-                                    switch result {
-                                    case .success(let capturedPaymentData):
-                                        self.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
-                                        onCompletion(.success(capturedPaymentData))
-                                    case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
-                                        switch cancellationSource {
-                                        case .reader:
-                                            self.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
-                                        default:
-                                            self.handlePaymentCancellation(from: .other)
-                                        }
-                                    case .failure(let error):
-                                        let retryError = CollectOrderPaymentUseCaseError.alreadyRetried(error)
-                                        self.checkThenHandlePaymentFailureAndRetryPayment(retryError,
-                                                                                          alertProvider: paymentAlerts,
-                                                                                          paymentGatewayAccount: paymentGatewayAccount,
-                                                                                          onCompletion: onCompletion)
+        alertsPresenter.present(
+            viewModel: paymentAlerts.error(
+                error: error,
+                receiptState: receiptState,
+                tryAgain: { [weak self] in
+                    guard let self = self else { return }
+                    self.checkOrderIsStillEligibleForPayment(alertProvider: paymentAlerts, onPaymentCompletion: onCompletion) { result in
+                        switch result {
+                        case .failure(let error):
+                            return self.checkThenHandlePaymentFailureAndRetryPayment(error,
+                                                                                     alertProvider: paymentAlerts,
+                                                                                     paymentGatewayAccount: paymentGatewayAccount,
+                                                                                     onCompletion: onCompletion)
+                        case .success:
+                            self.paymentOrchestrator.retryPayment(for: self.order) { [weak self] result in
+                                guard let self = self else { return }
+                                switch result {
+                                case .success(let capturedPaymentData):
+                                    self.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
+                                    onCompletion(.success(capturedPaymentData))
+                                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
+                                    switch cancellationSource {
+                                    case .reader:
+                                        self.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
+                                    default:
+                                        self.handlePaymentCancellation(from: .other)
                                     }
+                                case .failure(let error):
+                                    let retryError = CollectOrderPaymentUseCaseError.alreadyRetried(error)
+                                    self.checkThenHandlePaymentFailureAndRetryPayment(retryError,
+                                                                                      alertProvider: paymentAlerts,
+                                                                                      paymentGatewayAccount: paymentGatewayAccount,
+                                                                                      onCompletion: onCompletion)
                                 }
                             }
                         }
-                    }, dismissCompletion: {
-                        onCompletion(.failure(error))
-                    })
-            )
-        },
-                                     emailPromptCompletion: { [weak self] in
-            self?.presentRetryWithoutRestartingError(error: error,
-                                                     paymentAlerts: paymentAlerts,
-                                                     paymentGatewayAccount: paymentGatewayAccount,
-                                                     onCompletion: onCompletion)
-        })
+                    }
+                }, dismissCompletion: {
+                    onCompletion(.failure(error))
+                })
+        )
     }
 
     private func presentNonRetryableError(error: Error,
                                           paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
+                                          receiptState: CardReaderTransactionFailureAlertReceiptState,
                                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        receiptStateForFailedPayment(error: error,
-                                     receiptStateCompletion: { [weak self] receiptState in
-            guard let self else { return }
-
-            alertsPresenter.present(
-                viewModel: paymentAlerts.nonRetryableError(error: error,
-                                                           receiptState: receiptState,
-                                                           dismissCompletion: {
-                                                               onCompletion(.failure(error))
-                                                           }))
-        },
-                                     emailPromptCompletion: { [weak self] in
-            self?.presentNonRetryableError(error: error, paymentAlerts: paymentAlerts, onCompletion: onCompletion)
-        })
+        alertsPresenter.present(viewModel: paymentAlerts.nonRetryableError(error: error,
+                                                                           receiptState: receiptState,
+                                                                           dismissCompletion: {
+            onCompletion(.failure(error))
+        }))
     }
 
     /// Cancels payment and record analytics.
@@ -746,10 +729,8 @@ private extension CollectOrderPaymentUseCase {
     }
 
 
-    private func receiptStateForFailedPayment(error: Error,
-                                              receiptStateCompletion: @escaping (CardReaderTransactionFailureAlertReceiptState) -> Void,
-                                              emailPromptCompletion: @escaping () -> Void) {
-
+    private func getReceiptStateForFailedPayment(error: Error,
+                                                 completion: @escaping (CardReaderTransactionFailureAlertReceiptState) -> Void) {
         let isErrorEligibleForSendingFailureReceiptAfterPayment: Bool = {
             switch error {
             case CardReaderServiceError.paymentCaptureWithPaymentMethod(.paymentDeclinedByPaymentProcessorAPI, _),
@@ -764,7 +745,7 @@ private extension CollectOrderPaymentUseCase {
 
         // Order only fails when the payment is declined by the payment processor, other types of failure don't produce failure states and receipts.
         guard isErrorEligibleForSendingFailureReceiptAfterPayment else {
-            return receiptStateCompletion(.noEmailReceipt)
+            return completion(.noEmailReceipt)
         }
 
         receiptEligibilityUseCase.isEligibleSendingReceiptAfterPayment { [weak self] isEligible in
@@ -779,17 +760,17 @@ private extension CollectOrderPaymentUseCase {
                         guard let self else { return }
                         presentSendReceiptAfterPayment { [weak self] order in
                             guard let self else { return }
-                            if let order {
+                            if let order, let email = order.billingAddress?.email, email.isNotEmpty {
                                 self.order = order
+                                completion(.paymentSuccessEmailSent(email: email))
                             }
-                            emailPromptCompletion()
                         }
                     })
                 }
             } else {
                 receiptState = .noEmailReceipt
             }
-            receiptStateCompletion(receiptState)
+            completion(receiptState)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptEmail/ReceiptEmailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptEmail/ReceiptEmailView.swift
@@ -39,7 +39,7 @@ struct ReceiptEmailView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.cancel, action: {
-                        viewModel.onDismiss(false)
+                        viewModel.onDismiss(nil)
                     })
                 }
             }
@@ -86,20 +86,20 @@ private enum Localization {
 }
 
 final class ReceiptEmailViewHostingController: UIHostingController<ReceiptEmailView>, UIAdaptivePresentationControllerDelegate {
-    private var onDismiss: ((Bool) -> Void)
+    private var onDismiss: ((Order?) -> Void)
 
     init(order: Order,
          stores: StoresManager = ServiceLocator.stores,
          systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
-         onDismiss: @escaping (Bool) -> Void) {
+         onDismiss: @escaping (Order?) -> Void) {
 
         self.onDismiss = onDismiss
         let viewModel = ReceiptEmailViewModel(order: order, stores: stores, onDismiss: onDismiss)
         super.init(rootView: ReceiptEmailView(viewModel: viewModel))
 
-        viewModel.onDismiss = { [weak self] success in
+        viewModel.onDismiss = { [weak self] order in
             self?.dismiss(animated: true, completion: nil)
-            onDismiss(success)
+            onDismiss(order)
         }
 
         presentationController?.delegate = self
@@ -111,6 +111,6 @@ final class ReceiptEmailViewHostingController: UIHostingController<ReceiptEmailV
     }
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        onDismiss(false)
+        onDismiss(nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptEmail/ReceiptEmailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptEmail/ReceiptEmailViewModel.swift
@@ -10,12 +10,12 @@ final class ReceiptEmailViewModel: ObservableObject {
     private let stores: StoresManager
     var noticePresenter: NoticePresenter
     var emailValidator: (String) -> Bool = EmailFormatValidator.validate
-    var onDismiss: (Bool) -> Void
+    var onDismiss: (Order?) -> Void
 
     init(order: Order,
          stores: StoresManager,
          noticesPresenter: NoticePresenter = DefaultNoticePresenter(),
-         onDismiss: @escaping (Bool) -> Void = { _ in }) {
+         onDismiss: @escaping (Order?) -> Void = { _ in }) {
         self.order = order
         self.stores = stores
         self.noticePresenter = noticesPresenter
@@ -33,10 +33,10 @@ final class ReceiptEmailViewModel: ObservableObject {
                 guard let self else { return }
                 self.state = .idle
                 switch result {
-                case .success:
+                case let .success(order):
                     self.state = .success
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                        self.onDismiss(true)
+                        self.onDismiss(order)
                     }
                 case let .failure(error):
                     DDLogError("Sending email receipt failed: \(error.localizedDescription)")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		0188CA0F2C65622A0051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0188CA0E2C65622A0051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel.swift */; };
 		0188CA112C6565320051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0188CA102C6565320051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift */; };
 		018D5C7E2CA6B4A60085EBEE /* CurrencySettings+Sanitized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018D5C7D2CA6B49D0085EBEE /* CurrencySettings+Sanitized.swift */; };
+		01929C342CEF6354006C79ED /* CardPresentModalErrorWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01929C332CEF634E006C79ED /* CardPresentModalErrorWithoutEmail.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
 		01ADC1382C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */; };
 		01BD77442C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD77432C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift */; };
@@ -3158,6 +3159,7 @@
 		0188CA0E2C65622A0051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		0188CA102C6565320051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift; sourceTree = "<group>"; };
 		018D5C7D2CA6B49D0085EBEE /* CurrencySettings+Sanitized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrencySettings+Sanitized.swift"; sourceTree = "<group>"; };
+		01929C332CEF634E006C79ED /* CardPresentModalErrorWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalErrorWithoutEmail.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift; sourceTree = "<group>"; };
 		01BD77432C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentProcessingMessageView.swift; sourceTree = "<group>"; };
@@ -12456,6 +12458,7 @@
 				03E471DB29424EC9001A58AD /* CardPresentModalBuiltInSuccessWithoutEmail.swift */,
 				D8815B122638686200EDAD62 /* CardPresentModalError.swift */,
 				011D7A342CEC87B60007C187 /* CardPresentModalErrorEmailSent.swift */,
+				01929C332CEF634E006C79ED /* CardPresentModalErrorWithoutEmail.swift */,
 				D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */,
 				011D7A322CEC87770007C187 /* CardPresentModalNonRetryableErrorEmailSent.swift */,
 				03E471CD293F63B4001A58AD /* PaymentCaptureOrchestrator.swift */,
@@ -15425,6 +15428,7 @@
 				4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */,
 				DE4B3B5626A68DD000EEF2D8 /* View+InsetPaddings.swift in Sources */,
 				B59D1EEC2190B08B009D1978 /* Age.swift in Sources */,
+				01929C342CEF6354006C79ED /* CardPresentModalErrorWithoutEmail.swift in Sources */,
 				CE27257C21924A8C002B22EB /* HelpAndSupportViewController.swift in Sources */,
 				025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */,
 				DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		0188CA112C6565320051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0188CA102C6565320051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift */; };
 		018D5C7E2CA6B4A60085EBEE /* CurrencySettings+Sanitized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018D5C7D2CA6B49D0085EBEE /* CurrencySettings+Sanitized.swift */; };
 		01929C342CEF6354006C79ED /* CardPresentModalErrorWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01929C332CEF634E006C79ED /* CardPresentModalErrorWithoutEmail.swift */; };
+		01929C362CEF6D6E006C79ED /* CardPresentModalNonRetryableErrorWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01929C352CEF6D6A006C79ED /* CardPresentModalNonRetryableErrorWithoutEmail.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
 		01ADC1382C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */; };
 		01BD77442C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD77432C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift */; };
@@ -3160,6 +3161,7 @@
 		0188CA102C6565320051BF1C /* PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift; sourceTree = "<group>"; };
 		018D5C7D2CA6B49D0085EBEE /* CurrencySettings+Sanitized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrencySettings+Sanitized.swift"; sourceTree = "<group>"; };
 		01929C332CEF634E006C79ED /* CardPresentModalErrorWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalErrorWithoutEmail.swift; sourceTree = "<group>"; };
+		01929C352CEF6D6A006C79ED /* CardPresentModalNonRetryableErrorWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableErrorWithoutEmail.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift; sourceTree = "<group>"; };
 		01BD77432C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentProcessingMessageView.swift; sourceTree = "<group>"; };
@@ -12460,6 +12462,7 @@
 				011D7A342CEC87B60007C187 /* CardPresentModalErrorEmailSent.swift */,
 				01929C332CEF634E006C79ED /* CardPresentModalErrorWithoutEmail.swift */,
 				D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */,
+				01929C352CEF6D6A006C79ED /* CardPresentModalNonRetryableErrorWithoutEmail.swift */,
 				011D7A322CEC87770007C187 /* CardPresentModalNonRetryableErrorEmailSent.swift */,
 				03E471CD293F63B4001A58AD /* PaymentCaptureOrchestrator.swift */,
 				B9C4AB2628002AF3007008B8 /* PaymentReceiptEmailParameterDeterminer.swift */,
@@ -16557,6 +16560,7 @@
 				ABC3521A374A2355001E3CD6 /* CardReaderSettingsSearchingViewController.swift in Sources */,
 				2004E2E52C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift in Sources */,
 				B9F1489A2AD586E5008FC795 /* FormattableAmountTextFieldViewModel.swift in Sources */,
+				01929C362CEF6D6E006C79ED /* CardPresentModalNonRetryableErrorWithoutEmail.swift in Sources */,
 				532842FC64B572D4545BD98E /* OrderFormCustomerNoteViewModel.swift in Sources */,
 				532846FAFFFCA93169B5E0BC /* WaitingTimeTracker.swift in Sources */,
 				53284E9AB1C65FD79E803694 /* EUShippingNoticeTopBannerFactory.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -10,8 +10,8 @@ final class CardPresentModalErrorTests: XCTestCase {
         closures = Closures()
         viewModel = CardPresentModalError(errorDescription: Expectations.error.localizedDescription,
                                           transactionType: .collectPayment,
-                                          primaryAction: closures.primaryAction(),
-                                          secondaryAction: closures.secondaryAction(),
+                                          tryAgainAction: closures.primaryAction(),
+                                          emailReceiptAction: closures.secondaryAction(),
                                           dismissCompletion: closures.dismissCompletion())
     }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -11,6 +11,7 @@ final class CardPresentModalErrorTests: XCTestCase {
         viewModel = CardPresentModalError(errorDescription: Expectations.error.localizedDescription,
                                           transactionType: .collectPayment,
                                           primaryAction: closures.primaryAction(),
+                                          secondaryAction: closures.secondaryAction(),
                                           dismissCompletion: closures.dismissCompletion())
     }
 
@@ -40,6 +41,10 @@ final class CardPresentModalErrorTests: XCTestCase {
         XCTAssertNotNil(viewModel.secondaryButtonTitle)
     }
 
+    func test_auxiliary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.auxiliaryButtonTitle)
+    }
+
     func test_bottom_title_is_not_nil() {
         XCTAssertNotNil(viewModel.bottomTitle)
     }
@@ -66,11 +71,18 @@ private extension CardPresentModalErrorTests {
 
 private final class Closures {
     var didTapPrimary = false
+    var didTapSecondary = false
     var didDismiss = false
 
     func primaryAction() -> () -> Void {
         return {[weak self] in
             self?.didTapPrimary = true
+        }
+    }
+
+    func secondaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapSecondary = true
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorTests.swift
@@ -6,7 +6,7 @@ final class CardPresentModalNonRetryableErrorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        viewModel = CardPresentModalNonRetryableError(amount: Expectations.amount, error: Expectations.error, onDismiss: {})
+        viewModel = CardPresentModalNonRetryableError(amount: Expectations.amount, error: Expectations.error, onDismiss: {}, secondaryAction: {})
     }
 
     override func tearDown() {
@@ -31,7 +31,7 @@ final class CardPresentModalNonRetryableErrorTests: XCTestCase {
     }
 
     func test_secondary_button_title_is_nil() {
-        XCTAssertNil(viewModel.secondaryButtonTitle)
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
     }
 
     func test_auxiliary_button_title_is_nil() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorTests.swift
@@ -6,7 +6,10 @@ final class CardPresentModalNonRetryableErrorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        viewModel = CardPresentModalNonRetryableError(amount: Expectations.amount, error: Expectations.error, onDismiss: {}, secondaryAction: {})
+        viewModel = CardPresentModalNonRetryableError(amount: Expectations.amount,
+                                                      error: Expectations.error,
+                                                      onDismiss: {},
+                                                      emailReceiptAction: {})
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -151,10 +151,10 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         }
 
         // When
-        let errorAlert: CardPresentModalNonRetryableError = waitFor { [weak self] promise in
+        let errorAlert: CardPresentModalNonRetryableErrorWithoutEmail = waitFor { [weak self] promise in
             guard let self = self else { return }
             self.alertsPresenter.onPresentCalled = { viewModel in
-                guard let viewModel = viewModel as? CardPresentModalNonRetryableError else {
+                guard let viewModel = viewModel as? CardPresentModalNonRetryableErrorWithoutEmail else {
                     return
                 }
                 promise(viewModel)
@@ -284,6 +284,40 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         let interacPaymentMethod = PaymentMethod.interacPresent(details: .fake())
         let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: interacPaymentMethod)])
         let error = CardReaderServiceError.disconnection(underlyingError: .bluetoothDisconnected)
+        mockFailedCardPresentPaymentActions(intent: intent,
+                                            error: error)
+        receiptEligibilityUseCase.isEligibleSendingReceiptAfterPayment = true
+
+        // When we make a payment thar results in card reader disconnection
+        waitFor { promise in
+            self.alertsPresenter.onPresentCalled = { viewModel in
+                if viewModel is CardPresentModalErrorWithoutEmail {
+                    promise(())
+                }
+            }
+            self.useCase.collectPayment(using: .bluetoothScan,
+                                        onFailure: { _ in },
+                                        onCancel: {},
+                                        onPaymentCompletion: {},
+                                        onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then we should present a default modal without the email
+        let lastAlert = alertsPresenter.spyPresentedAlertViewModels.last as? CardPresentModalErrorWithoutEmail
+        XCTAssertNotNil(lastAlert)
+    }
+
+    func test_collectPayment_payment_error_without_customer_then_default_modal_presented() async throws {
+        // Given we have an order withour a customer email
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5", billingAddress: Address.fake())
+
+        setUpUseCase(order: order)
+        let interacPaymentMethod = PaymentMethod.interacPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: interacPaymentMethod)])
+        let error = CardReaderServiceError.paymentCapture(
+            underlyingError: .paymentDeclinedByPaymentProcessorAPI(declineReason: .insufficientFunds)
+        )
         mockFailedCardPresentPaymentActions(intent: intent,
                                             error: error)
         receiptEligibilityUseCase.isEligibleSendingReceiptAfterPayment = true

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -288,7 +288,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
                                             error: error)
         receiptEligibilityUseCase.isEligibleSendingReceiptAfterPayment = true
 
-        // When we make a payment thar results in card reader disconnection
+        // When we make a payment that results in card reader disconnection
         waitFor { promise in
             self.alertsPresenter.onPresentCalled = { viewModel in
                 if viewModel is CardPresentModalErrorWithoutEmail {

--- a/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEmailViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEmailViewModelTests.swift
@@ -42,7 +42,7 @@ struct ReceiptEmailViewModelTests {
         }
 
         // Then
-        #expect(completionResult == true)
+        #expect(completionResult != nil)
     }
 
     @Test func sendReceipt_when_action_fails() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14163
Wraps up the work from: 
- https://github.com/woocommerce/woocommerce-ios/pull/14422 
- https://github.com/woocommerce/woocommerce-ios/pull/14446 
- https://github.com/woocommerce/woocommerce-ios/pull/14475
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Allow inputting and sending receipts after failed payments. Equivalent changes to https://github.com/woocommerce/woocommerce-ios/pull/14422 but for failed payments.

I will enable feature flag only when both WooCommerce and WooPayments versions are officially released and additional CFT is performed.

## Solution

1. To be consistent, now we have three types of alerts:
- **EmailSent** (email sent message): CardPresentModalSuccessEmailSent, CardPresentModalErrorEmailSent, CardPresentModalNonRetryableErrorEmailSent
- **WithoutEmail** (no email information) : CardPresentModalSuccessWithoutEmail, CardPresentModalErrorWithoutEmail, CardPresentModalNonRetryableErrorWithoutEmail
- **Default** (with email receipt button): CardPresentModalSuccess, CardPresentModalError, CardPresentModalNonRetryableError

2. Since payment failure alert allows to retry the payment, when `ReceiptEmailViewController` is present, do not automatically dismiss the alert. If email is sent, update the alert to show `Email sent` message created in the previous PR.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Before testing:
1. Enable `sendReceiptAfterPayment` in `DefaultFeatureFlagService`
2. Use my testing site https://lovely-aware-sturgeon.jurassic.ninja/ details: PdfdoF-5Qj-p2

#### Main scenario: No customer + Failed Payment + Input Email

1. Order
2. [Set a failure amount](https://docs.stripe.com/terminal/references/testing#physical-test-cards)
3. Make Card Reader / TTP payment
4. Confirm Payment failed modal appears with "Email receipt option"
5. Click "Email receipt"
6. Confirm a new modal appears
7. Input a valid email
8. Tap "Email receipt"
9. Confirm email modal is dismissed, payment failure alert is updated with an email sent message
10 Confirm email arrives
11. Tap `Try collecting again'
12. Confirm email sent message is shown

#### 2nd scenario: No customer + Failed Payment + Retry + Input email

1. Repeat steps 1-4 until failure modal appears
2. Tap 'Try collecting again'
3. Confirm 'Email Receipt' and 'Dismiss' options are shown
4. Click "Email receipt", enter valid email, confirm
5. Confirm email modal is dismissed, payment failure alert is updated with an email sent message
6. Confirm email sent message is shown

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I additionally tested:
- Feature flag enabled/disabled
- Dismissing receipt email modal via cancel button or dismiss gesture
- Making payments with customer, without customer, retrying payments later, attaching customer later etc...
- iPad and iPhone
- Tap to Pay and Card Reader
- Success

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Card Reader + Failed Payment + Input email

https://github.com/user-attachments/assets/81f5be07-25e7-477c-916a-5b09c2c896ea

### TTP + Failed Payment + Retry + Input email

https://github.com/user-attachments/assets/f9f592ab-bb76-4e06-98ff-23bdb4d6f9ff

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.m