### PR TITLE
[Shipping labels] Add networking layer support for label status endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -867,6 +867,7 @@
 		CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */; };
 		CE865AA32A4207A50049B03C /* date-modified-gmt-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */; };
 		CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */; };
+		CE90E99C2CEFCAB00068D852 /* wooshipping-label-status-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CE90E99B2CEFCAA50068D852 /* wooshipping-label-status-success.json */; };
 		CEA455B72BB2D64400D932CF /* product-bundle-top-bundles.json in Resources */ = {isa = PBXBuildFile; fileRef = CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */; };
 		CEB9BF2F2BB18F430007978A /* ProductBundleStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */; };
 		CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF302BB190590007978A /* product-bundle-stats.json */; };
@@ -2049,6 +2050,7 @@
 		CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt.json"; sourceTree = "<group>"; };
 		CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt-without-data.json"; sourceTree = "<group>"; };
 		CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapperTests.swift; sourceTree = "<group>"; };
+		CE90E99B2CEFCAA50068D852 /* wooshipping-label-status-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-label-status-success.json"; sourceTree = "<group>"; };
 		CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-top-bundles.json"; sourceTree = "<group>"; };
 		CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsRemoteTests.swift; sourceTree = "<group>"; };
 		CEB9BF302BB190590007978A /* product-bundle-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats.json"; sourceTree = "<group>"; };
@@ -3530,6 +3532,7 @@
 				DA69CC962CEDDA1200CB7CEE /* wooshipping-get-account-settings-success.json */,
 				DAA259AC2CEC86BE0035F028 /* wooshipping-get-packages-success.json */,
 				CE1EA4BA2CEB78F60039F477 /* wooshipping-purchase-success.json */,
+				CE90E99B2CEFCAA50068D852 /* wooshipping-label-status-success.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4375,6 +4378,7 @@
 				CEF2DD8C2B559C6E00A3DD0B /* jetpack-settings-success.json in Resources */,
 				02AAFCD42A13517800F05E60 /* dotcom-plugins.json in Resources */,
 				31A451D827863A2E00FE81AA /* stripe-account-restricted-overdue.json in Resources */,
+				CE90E99C2CEFCAB00068D852 /* wooshipping-label-status-success.json in Resources */,
 				D865CE69278CA245002C8520 /* stripe-payment-intent-unknown-status.json in Resources */,
 				DE66C5572976913C00DAA978 /* wcpay-charge-card-present-without-data.json in Resources */,
 				EE4D51B62ACD331300783D77 /* product-categories-created-without-data.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -868,6 +868,7 @@
 		CE865AA32A4207A50049B03C /* date-modified-gmt-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */; };
 		CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */; };
 		CE90E99C2CEFCAB00068D852 /* wooshipping-label-status-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CE90E99B2CEFCAA50068D852 /* wooshipping-label-status-success.json */; };
+		CE90E99E2CEFCB170068D852 /* WooShippingStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE90E99D2CEFCB100068D852 /* WooShippingStatusMapper.swift */; };
 		CEA455B72BB2D64400D932CF /* product-bundle-top-bundles.json in Resources */ = {isa = PBXBuildFile; fileRef = CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */; };
 		CEB9BF2F2BB18F430007978A /* ProductBundleStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */; };
 		CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF302BB190590007978A /* product-bundle-stats.json */; };
@@ -2051,6 +2052,7 @@
 		CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt-without-data.json"; sourceTree = "<group>"; };
 		CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapperTests.swift; sourceTree = "<group>"; };
 		CE90E99B2CEFCAA50068D852 /* wooshipping-label-status-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-label-status-success.json"; sourceTree = "<group>"; };
+		CE90E99D2CEFCB100068D852 /* WooShippingStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingStatusMapper.swift; sourceTree = "<group>"; };
 		CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-top-bundles.json"; sourceTree = "<group>"; };
 		CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsRemoteTests.swift; sourceTree = "<group>"; };
 		CEB9BF302BB190590007978A /* product-bundle-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats.json"; sourceTree = "<group>"; };
@@ -3643,6 +3645,7 @@
 				CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */,
 				CE0F4ECE2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift */,
 				DAF367A12CE75B9D00D1B327 /* WooShippingPackagesMapper.swift */,
+				CE90E99D2CEFCB100068D852 /* WooShippingStatusMapper.swift */,
 				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
 				077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */,
@@ -4960,6 +4963,7 @@
 				263659DC2A264A3E00607A0D /* IPLocationRemote.swift in Sources */,
 				CEB9BF432BB199600007978A /* ProductBundleStatsMapper.swift in Sources */,
 				02C2548425635BD000A04423 /* ShippingLabelPaperSize.swift in Sources */,
+				CE90E99E2CEFCB170068D852 /* WooShippingStatusMapper.swift in Sources */,
 				B9DFE4BE2AA2057B00174004 /* TaxRateListMapper.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
 				DE66C5532976508300DAA978 /* CookieNonceAuthenticator.swift in Sources */,

--- a/Networking/Networking/Mapper/WooShippingStatusMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingStatusMapper.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Mapper: Check Status of Shipping Labels in Woo Shipping extension
+///
+struct WooShippingStatusMapper: Mapper {
+    /// Site ID associated to the shipping labels that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the shipping label endpoints.
+    ///
+    let siteID: Int64
+
+    /// Order ID associated to the shipping labels that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because OrderID is not returned in any of the shipping label endpoints.
+    ///
+    let orderID: Int64
+
+    /// (Attempts) to convert a dictionary into `ShippingLabelStatusPollingResponse`.
+    ///
+    func map(response: Data) throws -> ShippingLabelStatusPollingResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        decoder.userInfo = [
+            .siteID: siteID,
+            .orderID: orderID
+        ]
+
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(WooShippingStatusResponse.self, from: response).data.label
+        } else {
+            return try decoder.decode(WooShippingStatusEnvelope.self, from: response).label
+        }
+    }
+}
+
+/// ShippingLabelPurchaseResponse Disposable Entity
+///
+/// `Check Shipping Labels Status` endpoint returns the data wrapper in the `data` key.
+///
+private struct WooShippingStatusResponse: Decodable {
+    let data: WooShippingStatusEnvelope
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}
+
+/// ShippingLabelPurchaseEnvelope Disposable Entity
+///
+/// `Check Shipping Labels Status` endpoint returns the shipping label purchase in the `data.label` key.
+///
+private struct WooShippingStatusEnvelope: Decodable {
+    let label: ShippingLabelStatusPollingResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case label
+    }
+}

--- a/Networking/Networking/Mapper/WooShippingStatusMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingStatusMapper.swift
@@ -33,9 +33,9 @@ struct WooShippingStatusMapper: Mapper {
     }
 }
 
-/// ShippingLabelPurchaseResponse Disposable Entity
+/// WooShippingStatusResponse Disposable Entity
 ///
-/// `Check Shipping Labels Status` endpoint returns the data wrapper in the `data` key.
+/// `Check Label Status` endpoint returns the data wrapper in the `data` key.
 ///
 private struct WooShippingStatusResponse: Decodable {
     let data: WooShippingStatusEnvelope
@@ -45,9 +45,9 @@ private struct WooShippingStatusResponse: Decodable {
     }
 }
 
-/// ShippingLabelPurchaseEnvelope Disposable Entity
+/// WooShippingStatusEnvelope Disposable Entity
 ///
-/// `Check Shipping Labels Status` endpoint returns the shipping label purchase in the `data.label` key.
+/// `Check Label Status` endpoint returns the shipping label purchase in the `data.label` key.
 ///
 private struct WooShippingStatusEnvelope: Decodable {
     let label: ShippingLabelStatusPollingResponse

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -176,7 +176,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.customs: try package.encodedCustomsForm(),
             ]
             let path = "\(Path.purchase)/\(orderID)"
-            let request = JetpackRequest(wooApiVersion: .wcConnectV1,
+            let request = JetpackRequest(wooApiVersion: .wooShipping,
                                          method: .post,
                                          siteID: siteID,
                                          path: path,

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -21,6 +21,10 @@ public protocol WooShippingRemoteProtocol {
                                destinationAddress: ShippingLabelAddress,
                                package: WooShippingPackagePurchase,
                                completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void)
+    func checkLabelStatus(siteID: Int64,
+                          orderID: Int64,
+                          labelID: Int64,
+                          completion: @escaping (Result<ShippingLabelStatusPollingResponse, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -188,6 +192,29 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    /// Checks the shipping label status
+    ///
+    /// Used after purchasing a shipping label, to check for errors or confirm a successful purchase.
+    /// This is used instead of loading all purchased labels for the order to ensure up-to-date (non-cached) results.
+    /// - Parameters:
+    ///     - siteID: Remote ID of the site.
+    ///     - orderID: Remote ID of the order that owns the shipping labels.
+    ///     - labelID: Remote ID of the label to check the status of.
+    ///     - completion: Closure to be executed upon completion.
+    public func checkLabelStatus(siteID: Int64,
+                                 orderID: Int64,
+                                 labelID: Int64,
+                                 completion: @escaping (Result<ShippingLabelStatusPollingResponse, Error>) -> Void) {
+        let path = "\(Path.status)/\(orderID)/\(labelID)"
+        let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     availableAsRESTRequest: true)
+        let mapper = WooShippingStatusMapper(siteID: siteID, orderID: orderID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: Constants
@@ -197,6 +224,7 @@ private extension WooShippingRemote {
         static let rates = "label/rate"
         static let accountSettings = "account/settings"
         static let purchase = "label/purchase"
+        static let status = "label/status"
     }
 
     enum ParameterKey {

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -257,6 +257,46 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         XCTAssertNotNil(result.failure)
     }
+
+    func test_checkLabelStatus_parses_success_response() throws {
+        // Given
+        let sampleLabelID: Int64 = 4321
+        let expectedLabelStatus = ShippingLabel.fake().status
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/status/\(sampleOrderID)/\(sampleLabelID)", filename: "wooshipping-label-status-success")
+
+        // When
+        let result: Result<ShippingLabelStatusPollingResponse, Error> = waitFor { promise in
+            remote.checkLabelStatus(siteID: self.sampleSiteID,
+                                    orderID: self.sampleOrderID,
+                                    labelID: sampleLabelID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let label = try XCTUnwrap(result.get())
+        XCTAssertEqual(label.status, expectedLabelStatus)
+    }
+
+    func test_checkLabelStatus_returns_error_on_failure() throws {
+        // Given
+        let sampleLabelID: Int64 = 4321
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/status/\(sampleOrderID)/\(sampleLabelID)", filename: "generic_error")
+
+        // When
+        let result: Result<ShippingLabelStatusPollingResponse, Error> = waitFor { promise in
+            remote.checkLabelStatus(siteID: self.sampleSiteID,
+                                    orderID: self.sampleOrderID,
+                                    labelID: sampleLabelID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension WooShippingRemoteTests {

--- a/Networking/NetworkingTests/Responses/wooshipping-label-status-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-label-status-success.json
@@ -1,0 +1,30 @@
+{
+    "data": {
+        "success": true,
+        "label": {
+            "label_id": 4145,
+            "tracking": "9449000106025109444563",
+            "refundable_amount": 6.13,
+            "created": 1732200776893,
+            "carrier_id": "usps",
+            "service_name": "USPS - Media Mail",
+            "status": "PURCHASED",
+            "commercial_invoice_url": "",
+            "is_commercial_invoice_submitted_electronically": false,
+            "package_name": "Custom Box",
+            "is_letter": false,
+            "product_names": [
+                "Beanie"
+            ],
+            "product_ids": [
+                19
+            ],
+            "receipt_item_id": 25040494,
+            "created_date": 1732200780000,
+            "expiry_date": 1747752780000,
+            "main_receipt_id": 20268581,
+            "rate": 6.13,
+            "currency": "USD"
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -24,6 +24,9 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `loadAccountSettings`
     private var loadAccountSettingsResults = [ResultKey: Result<WooShippingAccountSettingsResponse, Error>]()
 
+    /// The results to return based on the given arguments in `checkLabelStatus`
+    private var checkLabelStatus = [ResultKey: Result<ShippingLabelStatusPollingResponse, Error>]()
+
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
                            thenReturn result: Result<WooShippingCreatePackageResponse, Error>) {
@@ -57,6 +60,13 @@ final class MockWooShippingRemote {
                                    thenReturn result: Result<[ShippingLabelPurchase], Error>) {
         let key = ResultKey(siteID: siteID)
         purchaseShippingLabelResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `checkLabelStatus` is called.
+    func whenCheckLabelStatus(siteID: Int64,
+                              thenReturn result: Result<ShippingLabelStatusPollingResponse, Error>) {
+        let key = ResultKey(siteID: siteID)
+        checkLabelStatus[key] = result
     }
 }
 
@@ -135,6 +145,22 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
             let key = ResultKey(siteID: siteID)
             if let result = self.purchaseShippingLabelResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func checkLabelStatus(siteID: Int64,
+                          orderID: Int64,
+                          labelID: Int64,
+                          completion: @escaping (Result<ShippingLabelStatusPollingResponse, any Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = ResultKey(siteID: siteID)
+            if let result = self.checkLabelStatus[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14053
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the Networking layer support for checking the status of a label after purchasing it. It can be used immediately after the purchase request to poll for the completed purchase.

### How

* The response can be decoded as the existing `ShippingLabelStatusPollingResponse`, so we keep using that model.
* Introduces a new mapper because the new endpoint only returns a single label's status at a time.
* Introduces the new endpoint in `WooShippingRemote`.
* Adds a mock response and unit test support.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This endpoint is not yet used in the app; confirm unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.