### PR TITLE
Screenshot: More flakiness fixes and fastlane update

### DIFF
--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -42,7 +42,6 @@ class WooCommerceScreenshots: XCTestCase {
 
             return false
         }
-        app.tap()
 
         try MyStoreScreen()
 

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockActionHandler.swift
@@ -38,27 +38,22 @@ extension MockActionHandler {
     /// A helper for saving mock objects into Core Data
     func save<T, U>(mocks: [T], as dataType: U.Type, onCompletion: @escaping (Error?) -> ()) where U: ReadOnlyConvertible & NSManagedObject {
 
-        var error: Error?
-
-        let storage = storageManager.viewStorage
-
-        storage.perform {
+        storageManager.performAndSave({ storage in
             let objects: [NSManagedObject] = mocks.map {
                 let newObject = storage.insertNewObject(ofType: U.self)
                 newObject.update(with: $0 as! U.ReadOnlyType)
                 return newObject
             }
 
-            do {
-                try storage.obtainPermanentIDs(for: objects)
+            // Obtain permanent IDs inside the same block
+            try storage.obtainPermanentIDs(for: objects)
+        }, completion: { result in
+            switch result {
+            case .success:
+                onCompletion(nil)
+            case .failure(let error):
+                onCompletion(error)
             }
-            catch let err {
-                error = err
-            }
-        }
-
-        storageManager.saveDerivedType(derivedStorage: storage) {
-            onCompletion(error)
-        }
+        }, on: .main)
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,7 @@ FASTLANE_METADATA_FOLDER = File.join(FASTLANE_DIR, 'metadata')
 WORKSPACE_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce.xcworkspace')
 BUILDKITE_RELEASE_PIPELINE = 'release-builds.yml'
 IOS_LOCALES = %w[ar de-DE en-US es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant].freeze
-SIMULATOR_VERSION = '15.5' # For screenshots
+SIMULATOR_VERSION = '16.0' # For screenshots
 SCREENSHOTS_SCHEME = 'WooCommerceScreenshots'
 SCREENSHOT_DEVICES = [
   'iPhone 11 Pro Max',

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -63,7 +63,7 @@
 			"filename": "iPhone 11 Pro Max-01.png",
 			"background": "#674399",
 			"screenshot": "iPhone 11 Pro Max-1-dark-order-dashboard.png",
-			"text": "metadata/{locale}/app_store_screenshot_1.txt"
+			"text": "metadata/{locale}/promo_screenshot_1.txt"
 		},
 		// Create orders on the fly
 		{
@@ -71,7 +71,7 @@
 			"filename": "iPhone 11 Pro Max-02.png",
 			"background": "#C9356E",
 			"screenshot": "iPhone 11 Pro Max-2-light-order-creation.png",
-			"text": "metadata/{locale}/app_store_screenshot_2.txt"
+			"text": "metadata/{locale}/promo_screenshot_2.txt"
 		},
 		// Take payments in person
 		{
@@ -79,7 +79,7 @@
 			"filename": "iPhone 11 Pro Max-03.png",
 			"background": "#674399",
 			"screenshot": "iPhone 11 Pro Max-3-dark-order-payment.png",
-			"text": "metadata/{locale}/app_store_screenshot_3.txt"
+			"text": "metadata/{locale}/promo_screenshot_3.txt"
 		},
 		// Add and edit products with a touch
 		{
@@ -87,7 +87,7 @@
 			"filename": "iPhone 11 Pro Max-04.png",
 			"background": "#C9356E",
 			"screenshot": "iPhone 11 Pro Max-4-light-product-add.png",
-			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+			"text": "metadata/{locale}/promo_screenshot_4.txt"
 		},
 		// Get notified of every sale
 		{
@@ -95,7 +95,7 @@
 			"filename": "iPhone 11 Pro Max-05.png",
 			"background": "#674399",
 			"screenshot": "iPhone 11 Pro Max-5-dark-order-notification.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
+			"text": "metadata/{locale}/promo_screenshot_5.txt"
 		},
 
 		// iPhone 8 Plus
@@ -105,7 +105,7 @@
 			"filename": "iPhone 8 Plus-01.png",
 			"background": "#674399",
 			"screenshot": "iPhone 8 Plus-1-dark-order-dashboard.png",
-			"text": "metadata/{locale}/app_store_screenshot_1.txt"
+			"text": "metadata/{locale}/promo_screenshot_1.txt"
 		},
 		// Create orders on the fly
 		{
@@ -113,7 +113,7 @@
 			"filename": "iPhone 8 Plus-02.png",
 			"background": "#C9356E",
 			"screenshot": "iPhone 8 Plus-2-light-order-creation.png",
-			"text": "metadata/{locale}/app_store_screenshot_2.txt"
+			"text": "metadata/{locale}/promo_screenshot_2.txt"
 		},
 		// Take payments in person
 		{
@@ -121,7 +121,7 @@
 			"filename": "iPhone 8 Plus-03.png",
 			"background": "#674399",
 			"screenshot": "iPhone 8 Plus-3-dark-order-payment.png",
-			"text": "metadata/{locale}/app_store_screenshot_3.txt"
+			"text": "metadata/{locale}/promo_screenshot_3.txt"
 		},
 		// Add and edit products with a touch
 		{
@@ -129,7 +129,7 @@
 			"filename": "iPhone 8 Plus-04.png",
 			"background": "#C9356E",
 			"screenshot": "iPhone 8 Plus-4-light-product-add.png",
-			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+			"text": "metadata/{locale}/promo_screenshot_4.txt"
 		},
 		// Get notified of every sale
 		{
@@ -137,7 +137,7 @@
 			"filename": "iPhone 8 Plus-05.png",
 			"background": "#674399",
 			"screenshot": "iPhone 8 Plus-5-dark-order-notification.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
+			"text": "metadata/{locale}/promo_screenshot_5.txt"
 		},
 
 
@@ -148,7 +148,7 @@
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-01.png",
 			"background": "#674399",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-1-dark-order-dashboard.png",
-			"text": "metadata/{locale}/app_store_screenshot_1.txt"
+			"text": "metadata/{locale}/promo_screenshot_1.txt"
 		},
 		// Create orders on the fly
 		{
@@ -156,7 +156,7 @@
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-02.png",
 			"background": "#C9356E",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-2-light-order-creation.png",
-			"text": "metadata/{locale}/app_store_screenshot_2.txt"
+			"text": "metadata/{locale}/promo_screenshot_2.txt"
 		},
 		// Take payments in person
 		{
@@ -164,7 +164,7 @@
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-03.png",
 			"background": "#674399",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-dark-order-payment.png",
-			"text": "metadata/{locale}/app_store_screenshot_3.txt"
+			"text": "metadata/{locale}/promo_screenshot_3.txt"
 		},
 		// Add and edit products with a touch
 		{
@@ -172,7 +172,7 @@
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-04.png",
 			"background": "#C9356E",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-4-light-product-add.png",
-			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+			"text": "metadata/{locale}/promo_screenshot_4.txt"
 		},
 		// Get notified of every sale
 		{
@@ -180,7 +180,7 @@
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-05.png",
 			"background": "#674399",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-dark-order-notification.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
+			"text": "metadata/{locale}/promo_screenshot_5.txt"
 		},
 
 		/// iPad Pro 12.9 (3rd Generation)
@@ -190,7 +190,7 @@
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-01.png",
 			"background": "#674399",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-1-dark-order-dashboard.png",
-			"text": "metadata/{locale}/app_store_screenshot_1.txt"
+			"text": "metadata/{locale}/promo_screenshot_1.txt"
 		},
 		// Create orders on the fly
 		{
@@ -198,7 +198,7 @@
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-02.png",
 			"background": "#C9356E",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-2-light-order-creation.png",
-			"text": "metadata/{locale}/app_store_screenshot_2.txt"
+			"text": "metadata/{locale}/promo_screenshot_2.txt"
 		},
 		// Take payments in person
 		{
@@ -206,7 +206,7 @@
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-03.png",
 			"background": "#674399",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-dark-order-payment.png",
-			"text": "metadata/{locale}/app_store_screenshot_3.txt"
+			"text": "metadata/{locale}/promo_screenshot_3.txt"
 		},
 		// Add and edit products with a touch
 		{
@@ -214,7 +214,7 @@
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-04.png",
 			"background": "#C9356E",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-4-light-product-add.png",
-			"text": "metadata/{locale}/app_store_screenshot_4.txt"
+			"text": "metadata/{locale}/promo_screenshot_4.txt"
 		},
 		// Get notified of every sale
 		{
@@ -222,7 +222,7 @@
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-05.png",
 			"background": "#674399",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-dark-order-notification.png",
-			"text": "metadata/{locale}/app_store_screenshot_5.txt"
+			"text": "metadata/{locale}/promo_screenshot_5.txt"
 		}
 	]
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Various notes:

This PR depends on #14487, which contains Ruby Gem updates with fixes to promo screenshot generation.
Our initial plan is to have that and this PR to be included in 21.2 release so we can test sending updated screenshots, so it's a do not merge for now.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces some fixes related to getting fastlane to generate screenshots properly. 

Previously there's already [a PR](https://github.com/woocommerce/woocommerce-ios/pull/14335) that made `WooCommerceScreenshot` work in the context of running the test directly inside Xcode. However, when run in fastlane to both generate raw screenshot and promo screenshot, I encountered various flakiness and issues. This PR is meant to handle those issues, more details follows.

1. https://github.com/woocommerce/woocommerce-ios/pull/14492/commits/3c503c10afe2de201d066e5569ebe25676f13197 This simply bumps the Simulator used to 16.0, matching the minimum deploy target. 
2. 31e0fae7628da69374a9e1d7b40ce7e81c56a70b As tested with @irfano in Slack p1732085614299129/1732038668.400999-slack-C03L1NF1EA3, when generating promo screenshots, I found that fastlane was unable to find the right translation files. This commit updates the right names to be used.
3. 833c0b38a29a503c9ff6f0aabadb161020026f25 During fastlane testing, I found that `app.tap()` sometimes caused a random tap in the app, which changed the screen and caused the automated test to be unable to proceed. Paired with using iOS 16, it looks like the tapping is not needed anymore, and can be removed safely.
4. 77a89990a3dc79912e4ec86f22fb2011b54c8132 The main flakiness issue I encountered was on this part of the test:

```
        .tapCollectPaymentButton()

        .tapCardPresentPayment()
        .thenTakeScreenshot(named: "order-payment")
```

For `tapCardPresentPayment()` to work, the option to pay with card must exist. However, occasionally, this option did not appear, and only "Cash" option is presented, making the test fail. From debugging in Slack p1732190657647519/1732160573.962259-slack-CGPNUU63E , it failed with `SiteAddress` was empty when checking for IPP support (it needs to check country). `SiteAddress` is injected as part of `SiteSettings` by the mock, though, so my hunch is maybe there was a race condition between the saving and the part of the code that fetches the value from DB.

With this commit I updated the saving method to use the newly introduced `performAndSave()` method. After multiple testings this seem to get rid of the flakiness. Although given my experience with CoreData so far, I would love to get a second eye on this @selanthiraiyan 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

#### General test for `WooCommerceScreenshots`

1. Select WooCommerceScreenshots as target and pick an iPhone,
2. Go to Test Navigator, search for testScreenshots()
3. Run testScreenshots(), ensure that this opens the Simulator and starts going through screens automatically, and it finishes completely with the test passing.
4. Check [homedir]/Library/Caches/tools.fastlane/screenshots and ensure there are generated screenshots there. You might need to create this directory first if you don't have it.
5. Restart the same steps with an iPad.

#### Fastlane test

You can use the guide for more details P91TBi-8Pt-p2

Ideally you want to try:
1. Generating raw screenshots generating. I would recommend trying to generate just for one language: `bundle exec fastlane take_screenshotslocales:en-US`
2. Generating promo screenshots generating

Reminder that these are long processes that can be complicated. Please ping me in Slack for any questions.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested the above (both `WooCommerceScreenshots` and fastlane) on Simulators, iPad and iPhones on iO 16:
```
  'iPhone 11 Pro Max',
  'iPhone 8 Plus',
  'iPad Pro (12.9-inch) (2nd generation)',
  'iPad Pro (12.9-inch) (3rd generation)'
```

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.