### PR TITLE
[REST API] Fix magic link handling on cold start

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
+21.3
+-----
+- [*] Jetpack Setup: Fixed an issue with magic link handling when the app is cold started. [https://github.com/woocommerce/woocommerce-ios/pull/14502]
 
 21.2
 -----

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -1,10 +1,12 @@
 import UIKit
+import Combine
 import Storage
 import class Networking.UserAgent
 import Experiments
 import class WidgetKit.WidgetCenter
 import protocol WooFoundation.Analytics
 import protocol Yosemite.StoresManager
+import struct Yosemite.Site
 
 import CocoaLumberjack
 import KeychainAccess
@@ -60,6 +62,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// Handles events to background refresh the app.
     ///
     private let appRefreshHandler = BackgroundTaskRefreshDispatcher()
+
+    private var subscriptions: Set<AnyCancellable> = []
 
     // MARK: - AppDelegate Methods
 
@@ -135,17 +139,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             fatalError()
         }
 
-        if ServiceLocator.stores.isAuthenticatedWithoutWPCom,
-           let site = ServiceLocator.stores.sessionManager.defaultSite {
-            let coordinator = JetpackSetupCoordinator(site: site, rootViewController: rootViewController)
-            jetpackSetupCoordinator = coordinator
-            return coordinator.handleAuthenticationUrl(url)
-        }
         if let universalLinkRouter, universalLinkRouter.canHandle(url: url) {
             universalLinkRouter.handle(url: url)
             return true
         }
-        return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
+
+        return handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -575,6 +574,44 @@ private extension AppDelegate {
         }
 
         universalLinkRouter?.handle(url: linkURL)
+    }
+}
+
+// MARK: - Magic link
+private extension AppDelegate {
+    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
+        return if ServiceLocator.stores.isAuthenticatedWithoutWPCom {
+            handleAuthenticationUrlForJetpackSetup(url, rootViewController: rootViewController)
+        } else {
+            ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
+        }
+    }
+
+    func handleAuthenticationUrlForJetpackSetup(_ url: URL, rootViewController: UIViewController) -> Bool {
+        if let site = ServiceLocator.stores.sessionManager.defaultSite {
+            return handleAuthenticationUrlForJetpackSetup(with: site, url: url, rootViewController: rootViewController)
+        } else {
+            // Wait for the site to be available before handling the magic link
+            ServiceLocator.stores.sessionManager.defaultSitePublisher
+                .timeout(.seconds(30), scheduler: DispatchQueue.main)
+                .first(where: { $0 != nil })
+                .sink { site in
+                    guard let site = site else {
+                        return
+                    }
+                    _ = self.handleAuthenticationUrlForJetpackSetup(with: site, url: url, rootViewController: rootViewController)
+                }
+                .store(in: &subscriptions)
+
+            // Assume that we will handle the URL
+            return true
+        }
+    }
+
+    func handleAuthenticationUrlForJetpackSetup(with site: Site, url: URL, rootViewController: UIViewController) -> Bool {
+        let coordinator = JetpackSetupCoordinator(site: site, rootViewController: rootViewController)
+        jetpackSetupCoordinator = coordinator
+        return coordinator.handleAuthenticationUrl(url)
     }
 }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -597,6 +597,7 @@ private extension AppDelegate {
                 .first(where: { $0 != nil })
                 .sink { site in
                     guard let site else {
+                        // This should never happen as we filter out nil values
                         return
                     }
                     _ = self.handleAuthenticationUrlForJetpackSetup(with: site, url: url, rootViewController: rootViewController)

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -595,12 +595,12 @@ private extension AppDelegate {
             ServiceLocator.stores.sessionManager.defaultSitePublisher
                 .timeout(.seconds(30), scheduler: DispatchQueue.main)
                 .first(where: { $0 != nil })
-                .sink { site in
+                .sink { [weak self] site in
                     guard let site else {
                         // This should never happen as we filter out nil values
                         return
                     }
-                    _ = self.handleAuthenticationUrlForJetpackSetup(with: site, url: url, rootViewController: rootViewController)
+                    _ = self?.handleAuthenticationUrlForJetpackSetup(with: site, url: url, rootViewController: rootViewController)
                 }
                 .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -596,7 +596,7 @@ private extension AppDelegate {
                 .timeout(.seconds(30), scheduler: DispatchQueue.main)
                 .first(where: { $0 != nil })
                 .sink { site in
-                    guard let site = site else {
+                    guard let site else {
                         return
                     }
                     _ = self.handleAuthenticationUrlForJetpackSetup(with: site, url: url, rootViewController: rootViewController)


### PR DESCRIPTION
Closes: #14470 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds a fix for the case where we receive a magic link to continue the Jetpack setup, and the app is launched from cold, previously this led to launching the site picker, as we fail to get the selected site.

With this PR, we will know wait for the site to be available before trying to handle the URL.

**Note:**
Personally I think this is just a workaround, because ideally we should be caching the site for REST API just like we [do](https://github.com/woocommerce/woocommerce-ios/blob/0f6ad4ba2a24ecbaf55b41cb4caa4950f5249c46/Yosemite/Yosemite/Stores/AccountStore.swift#L106-L108) for WordPress.com, and if we were doing this, then the `defaultSite` could be loaded synchronously during URL launches.
The lack of cache leads to some other issues, if we launch the app and the fetching [failed](https://github.com/woocommerce/woocommerce-ios/blob/0f6ad4ba2a24ecbaf55b41cb4caa4950f5249c46/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L680), the app will stay broken until it's force closed.
Adding the local cache and updating the logic will take a significant effort though.

## Steps to reproduce
1. Use a self-hosted site.
2. Sign in to the site using site credentials.
3. Start Jetpack setup.
4. Optionally:
   - Use magic link to sign in to an existing account.
   - Enter a new email to start signup.
5. Close the app.
6. Tap on the magic link.

## Testing information
- The app should be able to handle the magic link even though it was closed.

Tested magic link handling for both login and signup using iPhone 16 Simulator iOS 18.0

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
