### PR TITLE
[Woo POS] Remove itemlist dependency for order sync

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -185,6 +185,8 @@
 		209AD3C52AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3C42AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift */; };
 		20D210C32B1780CE0099E517 /* deposits-overview-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 20D210C22B1780CE0099E517 /* deposits-overview-all.json */; };
 		20D210C52B1788E60099E517 /* deposits-overview-all-no-default-currency.json in Resources */ = {isa = PBXBuildFile; fileRef = 20D210C42B1788E60099E517 /* deposits-overview-all-no-default-currency.json */; };
+		20F616482CF4B74600F9FA2A /* POSOrdersRemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F616472CF4B74600F9FA2A /* POSOrdersRemoteProtocol.swift */; };
+		20F616492CF4B8CD00F9FA2A /* POSOrdersRemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F616472CF4B74600F9FA2A /* POSOrdersRemoteProtocol.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagRemote.swift */; };
 		24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C5D2502EDCF00F49B68 /* BundleWooTests.swift */; };
@@ -1468,6 +1470,7 @@
 		209AD3C42AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewMapper.swift; sourceTree = "<group>"; };
 		20D210C22B1780CE0099E517 /* deposits-overview-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deposits-overview-all.json"; sourceTree = "<group>"; };
 		20D210C42B1788E60099E517 /* deposits-overview-all-no-default-currency.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deposits-overview-all-no-default-currency.json"; sourceTree = "<group>"; };
+		20F616472CF4B74600F9FA2A /* POSOrdersRemoteProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSOrdersRemoteProtocol.swift; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemote.swift; sourceTree = "<group>"; };
 		24F98C5D2502EDCF00F49B68 /* BundleWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleWooTests.swift; sourceTree = "<group>"; };
 		24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemoteTests.swift; sourceTree = "<group>"; };
@@ -2887,6 +2890,7 @@
 				03EB99872906A78400F06A39 /* JustInTimeMessagesRemote.swift */,
 				B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */,
 				B557DA0120975500005962F4 /* OrdersRemote.swift */,
+				20F616472CF4B74600F9FA2A /* POSOrdersRemoteProtocol.swift */,
 				D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */,
 				261CF1B7255AE62D0090D8D3 /* PaymentGatewayRemote.swift */,
 				45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */,
@@ -4818,6 +4822,7 @@
 				263A6DBE2BEAA4A900C292B2 /* MIContainer.swift in Sources */,
 				263A6DBB2BEAA49B00C292B2 /* AnyCodable.swift in Sources */,
 				26373E0D2BFCEAFB008E6735 /* Address.swift in Sources */,
+				20F616492CF4B8CD00F9FA2A /* POSOrdersRemoteProtocol.swift in Sources */,
 				26373E2A2BFD08AF008E6735 /* WatchOS-Models+Copiable.swift in Sources */,
 				263A6DBC2BEAA49B00C292B2 /* AnyDecodable.swift in Sources */,
 				263A6DBD2BEAA49B00C292B2 /* AnyEncodable.swift in Sources */,
@@ -5076,6 +5081,7 @@
 				933A2732222234F800C2143A /* Logging.swift in Sources */,
 				CE50346021B5799F007573C6 /* SitePlan.swift in Sources */,
 				EE1CB9092B4BC8C500AD24D5 /* BlazeTargetOptionMappers.swift in Sources */,
+				20F616482CF4B74600F9FA2A /* POSOrdersRemoteProtocol.swift in Sources */,
 				DE2E8E9F295310C5002E4B14 /* WordPressSiteMapper.swift in Sources */,
 				B59325CC217E2B4C000B0E8E /* NoteListMapper.swift in Sources */,
 				B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */,

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -220,19 +220,6 @@ public class OrdersRemote: Remote {
         }
     }
 
-    public func createPOSOrder(siteID: Int64, order: Order, fields: [CreateOrderField]) async throws -> Order {
-        return try await withCheckedThrowingContinuation { continuation in
-            createOrder(siteID: siteID, order: order, giftCard: nil, fields: fields) { result in
-                switch result {
-                case let .success(order):
-                    continuation.resume(returning: order)
-                case let .failure(error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
-
     /// Updates the `OrderStatus` of a given Order.
     ///
     /// - Parameters:
@@ -325,19 +312,6 @@ public class OrdersRemote: Remote {
         }
     }
 
-    public func updatePOSOrder(siteID: Int64, order: Order, fields: [UpdateOrderField]) async throws -> Order {
-        return try await withCheckedThrowingContinuation { continuation in
-            updateOrder(from: siteID, order: order, giftCard: nil, fields: fields) { result in
-                switch result {
-                case let .success(order):
-                    continuation.resume(returning: order)
-                case let .failure(error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
-
     /// Adds an order note to a specific Order.
     ///
     /// - Parameters:
@@ -408,6 +382,34 @@ public class OrdersRemote: Remote {
         let mapper = EntityDateModifiedMapper()
 
         return try await enqueue(request, mapper: mapper)
+    }
+}
+
+extension OrdersRemote: POSOrdersRemoteProtocol {
+    public func createPOSOrder(siteID: Int64, order: Order, fields: [CreateOrderField]) async throws -> Order {
+        return try await withCheckedThrowingContinuation { continuation in
+            createOrder(siteID: siteID, order: order, giftCard: nil, fields: fields) { result in
+                switch result {
+                case let .success(order):
+                    continuation.resume(returning: order)
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    public func updatePOSOrder(siteID: Int64, order: Order, fields: [UpdateOrderField]) async throws -> Order {
+        return try await withCheckedThrowingContinuation { continuation in
+            updateOrder(from: siteID, order: order, giftCard: nil, fields: fields) { result in
+                switch result {
+                case let .success(order):
+                    continuation.resume(returning: order)
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 }
 

--- a/Networking/Networking/Remote/POSOrdersRemoteProtocol.swift
+++ b/Networking/Networking/Remote/POSOrdersRemoteProtocol.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public protocol POSOrdersRemoteProtocol {
+    func updatePOSOrder(siteID: Int64,
+                        order: Order,
+                        fields: [OrdersRemote.UpdateOrderField]) async throws -> Order
+
+    func createPOSOrder(siteID: Int64,
+                        order: Order,
+                        fields: [OrdersRemote.CreateOrderField]) async throws -> Order
+}

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -371,7 +371,7 @@ extension PointOfSaleAggregateModel {
         }
         orderState = .syncing
         let cart = cartProducts.map {
-            POSCartItem(itemID: nil, product: $0.item, quantity: Decimal($0.quantity))
+            POSCartItem(product: $0.item, quantity: Decimal($0.quantity))
         }
 
         do {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -361,11 +361,11 @@ extension PointOfSaleAggregateModel {
             return
         }
         // calculate totals and sync order if there was a change in the cart
-        await syncOrder(for: cart, allItems: itemsService.allItems)
+        await syncOrder(for: cart)
     }
 
     @MainActor
-    private func syncOrder(for cartProducts: [CartItem], allItems: [POSItem]) async {
+    private func syncOrder(for cartProducts: [CartItem]) async {
         guard orderState.isSyncing == false else {
             return
         }
@@ -375,7 +375,7 @@ extension PointOfSaleAggregateModel {
         }
 
         do {
-            let syncedOrder = try await orderService.syncOrder(cart: cart, order: order, allProducts: allItems)
+            let syncedOrder = try await orderService.syncOrder(cart: cart, order: order)
             self.order = syncedOrder
             orderState = .loaded(totals(for: syncedOrder))
             await startPaymentWhenCardReaderConnected()
@@ -386,7 +386,7 @@ extension PointOfSaleAggregateModel {
             // Consider removing error or handle specific errors with our own formatting and localization
             orderState = .error(.init(message: error.localizedDescription, handler: { [weak self] in
                 Task {
-                    await self?.syncOrder(for: cartProducts, allItems: allItems)
+                    await self?.syncOrder(for: cartProducts)
                 }
             }))
         }

--- a/WooCommerce/Classes/POS/Services/PointOfSaleItemsService.swift
+++ b/WooCommerce/Classes/POS/Services/PointOfSaleItemsService.swift
@@ -6,8 +6,6 @@ import enum Yosemite.POSProductProviderError
 
 protocol PointOfSaleItemsServiceProtocol {
     var itemListStatePublisher: any Publisher<ItemListState, Never> { get }
-    @available(*, deprecated, message: "allItems will be removed in a future release. Use itemListState's associated value instead")
-    var allItems: [POSItem] { get }
     func loadInitialItems() async
     func loadNextItems() async
     func reload() async
@@ -16,7 +14,7 @@ protocol PointOfSaleItemsServiceProtocol {
 class PointOfSaleItemsService: PointOfSaleItemsServiceProtocol {
     private(set) var itemListStatePublisher: any Publisher<ItemListState, Never>
     private var itemListStateSubject: PassthroughSubject<ItemListState, Never> = .init()
-    private(set) var allItems: [POSItem] = []
+    private var allItems: [POSItem] = []
     private var currentPage: Int = Constants.initialPage
     private var mightHaveMorePages: Bool = true
     private let itemProvider: POSItemProvider

--- a/WooCommerce/Classes/POS/Utils/POSOrderPreviewService.swift
+++ b/WooCommerce/Classes/POS/Utils/POSOrderPreviewService.swift
@@ -7,7 +7,7 @@ import enum Yosemite.OrderFactory
 import struct Yosemite.Order
 
 class POSOrderPreviewService: POSOrderServiceProtocol {
-    func syncOrder(cart: [POSCartItem], order: Order?, allProducts: [any POSItem]) async throws -> Order {
+    func syncOrder(cart: [POSCartItem], order: Order?) async throws -> Order {
         OrderFactory.emptyNewOrder
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
@@ -4,7 +4,7 @@ import Foundation
 class MockPOSOrderService: POSOrderServiceProtocol {
     var simulateSyncing = false
     var orderToReturn: Order?
-    func syncOrder(cart: [Yosemite.POSCartItem], order: Yosemite.Order?, allProducts: [any Yosemite.POSItem]) async throws -> Yosemite.Order {
+    func syncOrder(cart: [Yosemite.POSCartItem], order: Yosemite.Order?) async throws -> Yosemite.Order {
         if simulateSyncing {
             try await Task.sleep(nanoseconds: UInt64(1 * Double(NSEC_PER_SEC)))
         }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -147,9 +147,11 @@
 		209AD3CE2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */; };
 		20BCF6F22B0E554500954840 /* SystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F12B0E554500954840 /* SystemStatusService.swift */; };
 		20BCF6F52B0E57AB00954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */; };
+		20CF75B82CF4C3B900ACCF4A /* MockPOSOrdersRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */; };
 		20D035002CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D034FF2CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift */; };
 		20D035022CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D035012CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift */; };
 		20D210C12B177EEF0099E517 /* WooPaymentsPayoutServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D210C02B177EEF0099E517 /* WooPaymentsPayoutServiceTests.swift */; };
+		20F616462CF4B4E500F9FA2A /* POSOrderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F616452CF4B4DE00F9FA2A /* POSOrderServiceTests.swift */; };
 		24163B9E257F41A600F94EC3 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24163B9D257F41A600F94EC3 /* StoresManager.swift */; };
 		24163BA8257F41C500F94EC3 /* SessionManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24163BA7257F41C500F94EC3 /* SessionManagerProtocol.swift */; };
 		247CE7AB2582DB9300F9D9D1 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247CE7AA2582DB9300F9D9D1 /* String+Extensions.swift */; };
@@ -667,9 +669,11 @@
 		209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverview.swift; sourceTree = "<group>"; };
 		20BCF6F12B0E554500954840 /* SystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusService.swift; sourceTree = "<group>"; };
 		20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockSystemStatusService.swift; path = ../../../WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift; sourceTree = "<group>"; };
+		20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrdersRemote.swift; sourceTree = "<group>"; };
 		20D034FF2CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonReaderConfigProviderTests.swift; sourceTree = "<group>"; };
 		20D035012CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardReaderCapableRemote.swift; sourceTree = "<group>"; };
 		20D210C02B177EEF0099E517 /* WooPaymentsPayoutServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutServiceTests.swift; sourceTree = "<group>"; };
+		20F616452CF4B4DE00F9FA2A /* POSOrderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSOrderServiceTests.swift; sourceTree = "<group>"; };
 		24163B9D257F41A600F94EC3 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
 		24163BA7257F41C500F94EC3 /* SessionManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerProtocol.swift; sourceTree = "<group>"; };
 		247CE7AA2582DB9300F9D9D1 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
@@ -1255,6 +1259,14 @@
 				20D210C02B177EEF0099E517 /* WooPaymentsPayoutServiceTests.swift */,
 			);
 			path = Payments;
+			sourceTree = "<group>";
+		};
+		20F616442CF4B4D800F9FA2A /* POS */ = {
+			isa = PBXGroup;
+			children = (
+				20F616452CF4B4DE00F9FA2A /* POSOrderServiceTests.swift */,
+			);
+			path = POS;
 			sourceTree = "<group>";
 		};
 		247CE7AF2582DBD000F9D9D1 /* Mocks */ = {
@@ -1904,6 +1916,7 @@
 		B5C9DE1D2087FF20006B910A /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */,
 				D88303EE25E45E5500C877F9 /* CardPresentPayments */,
 				578CE7892475E78C00492EBF /* Networking */,
 				D8BD6A4B229D07C8007CAD6C /* custom-shipment-provider.plist */,
@@ -1993,6 +2006,7 @@
 		B5F2AE9320EBAD5200FEDC59 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				20F616442CF4B4D800F9FA2A /* POS */,
 				20D210BF2B177EDB0099E517 /* Payments */,
 				E18FDAFF28F98360008519BA /* InAppPurchases */,
 				02FF055723D984500058E6E7 /* Media */,
@@ -2659,6 +2673,7 @@
 				0391C13D29CC5E14008A3E86 /* OrderCardPresentPaymentEligibilityStoreTests.swift in Sources */,
 				B5C9DE222087FF20006B910A /* DispatcherTests.swift in Sources */,
 				DEDA8DB32B184B950076BF0F /* WordPressThemeStoreTests.swift in Sources */,
+				20CF75B82CF4C3B900ACCF4A /* MockPOSOrdersRemote.swift in Sources */,
 				45182D2327B55F9C00B4C05C /* InboxNotesStoreTests.swift in Sources */,
 				03FBDA2A263296C400ACE257 /* CouponStoreTests.swift in Sources */,
 				DAD988C42C4A5147009DE9E3 /* LocalIDStoreTests.swift in Sources */,
@@ -2710,6 +2725,7 @@
 				02DAE7FA291A9F36009342B7 /* MockDomainRemote.swift in Sources */,
 				741F34842195F752005F5BD9 /* CommentStoreTests.swift in Sources */,
 				B5C9DE282087FF20006B910A /* MockSiteStore.swift in Sources */,
+				20F616462CF4B4E500F9FA2A /* POSOrderServiceTests.swift in Sources */,
 				FEEB2F5F268A1C5E0075A6E0 /* User+RolesTests.swift in Sources */,
 				DEB387882C2C09FC0025256E /* MockGoogleListingsAndAdsRemote.swift in Sources */,
 				B5BC736820D1AA8F00B5B6FA /* AccountStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -22,9 +22,8 @@ public protocol POSOrderServiceProtocol {
     /// - Parameters:
     ///   - cart: Cart with optional items (product & quantity).
     ///   - order: Optional latest remotely synced order. Nil when syncing order for the first time.
-    ///   - allProducts: Necessary for removing existing order items with products that have been removed from the cart.
     /// - Returns: Order from the remote sync.
-    func syncOrder(cart: [POSCartItem], order: Order?, allProducts: [POSItem]) async throws -> Order
+    func syncOrder(cart: [POSCartItem], order: Order?) async throws -> Order
 }
 
 public final class POSOrderService: POSOrderServiceProtocol {
@@ -50,9 +49,9 @@ public final class POSOrderService: POSOrderServiceProtocol {
 
     // MARK: - Protocol conformance
 
-    public func syncOrder(cart: [POSCartItem], order posOrder: Order?, allProducts: [POSItem]) async throws -> Order {
+    public func syncOrder(cart: [POSCartItem], order posOrder: Order?) async throws -> Order {
         let initialOrder: Order = posOrder ?? OrderFactory.emptyNewOrder.copy(siteID: siteID, status: .autoDraft)
-        let order = updateOrder(initialOrder, cart: cart, allProducts: allProducts).sanitizingLocalItems()
+        let order = updateOrder(initialOrder, cart: cart).sanitizingLocalItems()
         let syncedOrder: Order
         if posOrder != nil {
             syncedOrder = try await ordersRemote.updatePOSOrder(siteID: siteID, order: order, fields: [.items])
@@ -79,17 +78,14 @@ private struct POSOrderSyncProductType: OrderSyncProductTypeProtocol {
 }
 
 private extension POSOrderService {
-    func updateOrder(_ order: Order, cart: [POSCartItem], allProducts: [POSItem]) -> Order {
+    func updateOrder(_ order: Order, cart: [POSCartItem]) -> Order {
         let cartProducts = cart.map { POSOrderSyncProductType(productID: $0.product.productID,
                                                               price: $0.product.price,
                                                               productType: $0.product.productType) }
-        let allProducts = allProducts.map { POSOrderSyncProductType(productID: $0.productID,
-                                                                    price: $0.price,
-                                                                    productType: $0.productType) }
 
         // Removes all existing items by setting quantity to 0.
         let itemsToRemove = order.items.compactMap {
-            ProductInputTransformer.createUpdateProductInput(item: $0, quantity: 0, allProducts: allProducts, allProductVariations: [], defaultDiscount: 0)
+            Self.removalProductInput(item: $0)
         }
 
         // Adds items from the latest cart grouping cart items of the same product.
@@ -101,7 +97,7 @@ private extension POSOrderService {
         }
         let itemsToAdd: [OrderSyncProductInput] = productIDsSortedByOrderInCart.compactMap { productID in
             guard let quantity = quantitiesByProductID[productID],
-                  let product = allProducts.first(where: { $0.productID == productID }) else {
+                  let product = cartProducts.first(where: { $0.productID == productID }) else {
                 return nil
             }
             return OrderSyncProductInput(product: .product(product), quantity: quantity)
@@ -121,5 +117,23 @@ private extension POSOrderService {
             }
             return result
         }
+    }
+
+    /// Creates a new `OrderSyncProductInput` type meant to remove an existing item from `OrderSynchronizer`
+    ///
+    static func removalProductInput(item: OrderItem) -> OrderSyncProductInput? {
+        let productForRemoval = POSProductForRemoval(productID: item.productID)
+        // Return a new input with the new quantity but with the same item id to properly reference the update.
+        return OrderSyncProductInput(id: item.itemID,
+                                     product: .product(productForRemoval),
+                                     quantity: 0)
+    }
+
+    /// A simplified product struct, intended to contain only the `productID`
+    struct POSProductForRemoval: OrderSyncProductTypeProtocol {
+        var price: String = ""
+        var productID: Int64
+        var productType: ProductType = .simple
+        var bundledItems: [ProductBundleItem] = []
     }
 }

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -5,13 +5,10 @@ import class WooFoundation.CurrencyFormatter
 /// POSCartItem is different from the CartItem in the POS app layer.
 /// - The POS cart UI might show the cart items differently from how they appear in an order in wp-admin.
 public struct POSCartItem {
-    /// Nil when the cart item is local and has not been synced remotely.
-    let itemID: Int64?
     let product: POSItem
     let quantity: Decimal
 
-    public init(itemID: Int64?, product: POSItem, quantity: Decimal) {
-        self.itemID = itemID
+    public init(product: POSItem, quantity: Decimal) {
         self.product = product
         self.quantity = quantity
     }

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -30,7 +30,7 @@ public final class POSOrderService: POSOrderServiceProtocol {
     // MARK: - Properties
 
     private let siteID: Int64
-    private let ordersRemote: OrdersRemote
+    private let ordersRemote: POSOrdersRemoteProtocol
 
     // MARK: - Initialization
 
@@ -39,12 +39,13 @@ public final class POSOrderService: POSOrderServiceProtocol {
             DDLogError("⛔️ Could not create POSOrderService due to not finding credentials")
             return nil
         }
-        self.init(siteID: siteID, network: AlamofireNetwork(credentials: credentials))
+        self.init(siteID: siteID,
+                  ordersRemote: OrdersRemote(network: AlamofireNetwork(credentials: credentials)))
     }
 
-    public init(siteID: Int64, network: Network) {
+    public init(siteID: Int64, ordersRemote: POSOrdersRemoteProtocol) {
         self.siteID = siteID
-        self.ordersRemote = OrdersRemote(network: network)
+        self.ordersRemote = ordersRemote
     }
 
     // MARK: - Protocol conformance

--- a/Yosemite/YosemiteTests/Mocks/MockPOSOrdersRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockPOSOrdersRemote.swift
@@ -1,0 +1,21 @@
+import Networking
+
+final class MockPOSOrdersRemote: POSOrdersRemoteProtocol {
+    var updatePOSOrderCalled: Bool = false
+    var spyUpdatePOSOrder: Order?
+    func updatePOSOrder(siteID: Int64,
+                        order: Order,
+                        fields: [OrdersRemote.UpdateOrderField]) async throws -> Order {
+        updatePOSOrderCalled = true
+        spyUpdatePOSOrder = order
+        return Order.fake()
+    }
+
+    var createPOSOrderCalled: Bool = false
+    func createPOSOrder(siteID: Int64,
+                        order: Networking.Order,
+                        fields: [OrdersRemote.CreateOrderField]) async throws -> Order {
+        createPOSOrderCalled = true
+        return Order.fake()
+    }
+}

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -44,8 +44,8 @@ struct POSOrderServiceTests {
 
         // When
         let cart: [POSCartItem] = [
-            makePOSCartItem(cartItemID: 1008, productID: 100, quantity: 2),
-            makePOSCartItem(cartItemID: 1009, productID: 102, quantity: 1)
+            makePOSCartItem(productID: 100, quantity: 2),
+            makePOSCartItem(productID: 102, quantity: 1)
         ]
         _ = try await sut.syncOrder(cart: cart, order: order)
 
@@ -66,7 +66,7 @@ struct POSOrderServiceTests {
 
         // When
         let cart: [POSCartItem] = [
-            makePOSCartItem(cartItemID: 1009, productID: 102, quantity: 1)
+            makePOSCartItem(productID: 102, quantity: 1)
         ]
         _ = try await sut.syncOrder(cart: cart, order: order)
 
@@ -88,11 +88,9 @@ struct POSOrderServiceTests {
 }
 
 private func makePOSCartItem(
-    cartItemID: Int64?,
     productID: Int64,
     quantity: Decimal) -> POSCartItem {
         return POSCartItem(
-            itemID: cartItemID,
             product: POSProduct(
                 itemID: UUID(),
                 productID: productID,
@@ -105,4 +103,3 @@ private func makePOSCartItem(
             quantity: quantity
         )
     }
-

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -56,6 +56,35 @@ struct POSOrderServiceTests {
                     "Items should be deleted (quantity 0) or new (itemID 0)")
         }
     }
+
+    @Test func syncOrder_after_removing_item_from_cart_deletes_it_from_the_order() async throws {
+        // Given
+        let orderItems: [OrderItem] = [
+            .fake().copy(itemID: 1, name: "Item 1", productID: 100, quantity: 1),
+            .fake().copy(itemID: 2, name: "Item 2", productID: 102, quantity: 5)]
+        let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems)
+
+        // When
+        let cart: [POSCartItem] = [
+            makePOSCartItem(cartItemID: 1009, productID: 102, quantity: 1)
+        ]
+        _ = try await sut.syncOrder(cart: cart, order: order)
+
+        // Then
+        let updatedOrderItems = try #require(mockOrdersRemote.spyUpdatePOSOrder?.items)
+
+        #expect(updatedOrderItems.contains(where: { item in
+            item.itemID == 1 && item.quantity == 0
+        }), "Item 1 should be deleted")
+
+        #expect(!updatedOrderItems.contains(where: { item in
+            item.productID == 100 && item.quantity > 0
+        }), "Product for item 1 should not be re-added")
+
+        #expect(updatedOrderItems.contains(where: { item in
+            item.productID == 102 && item.quantity > 0
+        }), "Product for item 2 should be re-added")
+    }
 }
 
 private func makePOSCartItem(

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -85,6 +85,28 @@ struct POSOrderServiceTests {
             item.productID == 102 && item.quantity > 0
         }), "Product for item 2 should be re-added")
     }
+
+    @Test func syncOrder_after_adding_to_cart_adds_it_to_the_order() async throws {
+        // Given
+        let orderItems: [OrderItem] = [
+            .fake().copy(itemID: 1, name: "Item 1", productID: 100, quantity: 1)
+        ]
+        let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems)
+
+        // When
+        let cart: [POSCartItem] = [
+            makePOSCartItem(productID: 100, quantity: 1),
+            makePOSCartItem(productID: 102, quantity: 5)
+        ]
+        _ = try await sut.syncOrder(cart: cart, order: order)
+
+        // Then
+        let updatedOrderItems = try #require(mockOrdersRemote.spyUpdatePOSOrder?.items)
+
+        #expect(updatedOrderItems.contains(where: { item in
+            item.productID == 102 && item.quantity == 5
+        }), "Item for product 102 should be added")
+    }
 }
 
 private func makePOSCartItem(

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import Yosemite
+
+struct POSOrderServiceTests {
+    let sut: POSOrderService
+    let mockOrdersRemote: MockPOSOrdersRemote
+
+    init() {
+        let mockOrdersRemote = MockPOSOrdersRemote()
+        self.mockOrdersRemote = mockOrdersRemote
+        self.sut = POSOrderService(siteID: 123, ordersRemote: mockOrdersRemote)
+    }
+
+    @Test
+    func syncOrder_without_passing_an_order_creates_a_new_order() async throws {
+        // Given
+
+        // When
+        _ = try await sut.syncOrder(cart: [], order: nil)
+
+        // Then
+        #expect(mockOrdersRemote.createPOSOrderCalled == true)
+    }
+
+    @Test
+    func syncOrder_with_an_existing_order_updates_it() async throws {
+        // Given
+        let order = Order.fake().copy(siteID: 123, orderID: 456)
+
+        // When
+        _ = try await sut.syncOrder(cart: [], order: order)
+
+        // Then
+        #expect(mockOrdersRemote.updatePOSOrderCalled == true)
+        #expect(mockOrdersRemote.spyUpdatePOSOrder == order)
+    }
+
+    @Test func syncOrder_updates_by_deleting_existing_items_and_adding_everything_from_the_cart() async throws {
+        // Given
+        let orderItems: [OrderItem] = [
+            .fake().copy(itemID: 1, name: "Item 1", productID: 100, quantity: 1),
+            .fake().copy(itemID: 2, name: "Item 2", productID: 102, quantity: 5)]
+        let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems)
+
+        // When
+        let cart: [POSCartItem] = [
+            makePOSCartItem(cartItemID: 1008, productID: 100, quantity: 2),
+            makePOSCartItem(cartItemID: 1009, productID: 102, quantity: 1)
+        ]
+        _ = try await sut.syncOrder(cart: cart, order: order)
+
+        // Then
+        let updatedOrderItems = try #require(mockOrdersRemote.spyUpdatePOSOrder?.items)
+        for item in updatedOrderItems {
+            #expect(item.itemID == 0 || item.quantity == 0,
+                    "Items should be deleted (quantity 0) or new (itemID 0)")
+        }
+    }
+}
+
+private func makePOSCartItem(
+    cartItemID: Int64?,
+    productID: Int64,
+    quantity: Decimal) -> POSCartItem {
+        return POSCartItem(
+            itemID: cartItemID,
+            product: POSProduct(
+                itemID: UUID(),
+                productID: productID,
+                name: "",
+                price: "",
+                formattedPrice: "",
+                itemCategories: [],
+                productImageSource: nil,
+                productType: .simple),
+            quantity: quantity
+        )
+    }
+


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14505
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes the need to pass in the list of all the items when syncing the order.

The `allItems` list was only used for deleting order items from the list, and only to match product IDs. This PR uses a mostly-empty struct conforming of the `OrderSyncProductTypeProtocol`, but only setting a productID, to fulfill that need.

This removes unused code related to bundle products from the POS order syncing path, and an unused `cartItemId` property.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This requires testing of the order sync, which happens each time we tap `Check out` with a cart which doesn't match the existing order, or if it's a new order. A new order is only created when payment is taken, or after a major failure, or when the merchant leaves POS and comes back to it.

Generally speaking, the same order is reused for each edit, and when we check out with an edited cart, the a post request is sent that deletes all the existing items, then adds anything in the cart back again.

Test going back and forward, making changes to quantities, adding items, and removing entire items (i.e. all instances of a product.) You can check the orders in the Orders tab, or on the web. The totals will also give a good idea of whether the sync is correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1c63d51d-a3b5-4683-bdfe-b78fb985c0f2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.