### PR TITLE
[Shipping labels] Integrate Woo Shipping purchase action into UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedRate.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedRate.swift
@@ -13,6 +13,15 @@ struct WooShippingSelectedRate {
 }
 
 extension WooShippingSelectedRate {
+    var purchaseRate: ShippingLabelCarrierRate {
+        if let signatureRate = signatureRate {
+            return signatureRate
+        } else if let adultSignatureRate = adultSignatureRate {
+            return adultSignatureRate
+        }
+        return rate
+    }
+
     var totalRate: Double {
         if let signatureRate = signatureRate {
             return signatureRate.rate

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -224,7 +224,7 @@ private extension WooShippingCreateLabelsView {
             Text(Localization.BottomSheet.purchaseLabel(with: viewModel.totalCost))
         }
         .buttonStyle(PrimaryButtonStyle())
-        .disabled(!viewModel.canPurchaseLabel)
+        .disabled(!viewModel.isPurchaseButtonEnabled)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -223,7 +223,7 @@ private extension WooShippingCreateLabelsView {
         } label: {
             Text(Localization.BottomSheet.purchaseLabel(with: viewModel.totalCost))
         }
-        .buttonStyle(PrimaryButtonStyle())
+        .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isPurchasingLabel))
         .disabled(!viewModel.isPurchaseButtonEnabled)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -94,6 +94,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         selectedRate != nil && shippingLabel == nil
     }
 
+    /// If the label purchase is in progress.
+    @Published private(set) var isPurchasingLabel: Bool = false
+
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
@@ -146,9 +149,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Purchases a shipping label with the provided label details and settings.
     func purchaseLabel() {
-        guard isPurchaseButtonEnabled, let originSiteAddress, let destinationAddress, let selectedPackage, let selectedRate else {
+        guard isPurchaseButtonEnabled, !isPurchasingLabel, let originSiteAddress, let destinationAddress, let selectedPackage, let selectedRate else {
             return
         }
+        isPurchasingLabel = true
         // For now we support purchasing labels in a single shipment only.
         // In future milestones we can create an array of `WooShippingPackagePurchase` with unique shipment IDs for each shipment.
         let package = WooShippingPackagePurchase(shipmentID: "shipment_0",
@@ -161,6 +165,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                              destinationAddress: destinationAddress,
                                                              package: package) { [weak self] result in
             guard let self else { return }
+            isPurchasingLabel = false
             switch result {
             case .success(let shippingLabel):
                 onLabelPurchase?(markOrderComplete)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -90,7 +90,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     @Published var markOrderComplete: Bool = false
 
     /// If the purchase button should be enabled.
-    var canPurchaseLabel: Bool {
+    var isPurchaseButtonEnabled: Bool {
         selectedRate != nil && shippingLabel == nil
     }
 
@@ -146,7 +146,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Purchases a shipping label with the provided label details and settings.
     func purchaseLabel() {
-        guard canPurchaseLabel, let originSiteAddress, let destinationAddress, let selectedPackage, let selectedRate else {
+        guard isPurchaseButtonEnabled, let originSiteAddress, let destinationAddress, let selectedPackage, let selectedRate else {
             return
         }
         // For now we support purchasing labels in a single shipment only.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -7,8 +7,10 @@ import WooFoundation
 final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
     private let order: Order
+    private let itemsDataSource: WooShippingItemsDataSource
     private let originSiteAddress: ShippingLabelAddress?
     private let destinationAddress: ShippingLabelAddress?
+    private let stores: StoresManager
 
     /// The purchased shipping label.
     @Published private var shippingLabel: ShippingLabel?
@@ -98,12 +100,15 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Initialize the view model without an existing shipping label.
     init(order: Order,
          originAddress: SiteAddress? = nil,
+         selectedPackage: ShippingLabelPackageSelected? = nil,
          selectedRate: WooShippingSelectedRate? = nil,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         onLabelPurchase: ((Bool) -> Void)? = nil,
-         userDefaults: UserDefaults = .standard) {
+         userDefaults: UserDefaults = .standard,
+         stores: StoresManager = ServiceLocator.stores,
+         onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
-        self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
+        self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
+        self.items = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase
         let accountSettings = Self.getStoredAccountSettings()
@@ -116,35 +121,55 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                               userDefaults: userDefaults)
         self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
+        self.selectedPackage = selectedPackage
         self.selectedRate = selectedRate
+        self.stores = stores
     }
 
     /// Initialize the view model from an existing shipping label.
     init(order: Order,
          shippingLabel: ShippingLabel,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         stores: StoresManager = ServiceLocator.stores) {
         self.order = order
         self.shippingLabel = shippingLabel
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
-        self.items = WooShippingItemsViewModel(dataSource: DefaultWooShippingItemsDataSource(order: order))
+        self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
+        self.items = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
         self.originSiteAddress = shippingLabel.originAddress
         self.destinationAddress = shippingLabel.destinationAddress
         self.onLabelPurchase = nil
+        self.stores = stores
     }
 
     /// Purchases a shipping label with the provided label details and settings.
     func purchaseLabel() {
-        guard canPurchaseLabel else {
+        guard canPurchaseLabel, let originSiteAddress, let destinationAddress, let selectedPackage, let selectedRate else {
             return
         }
-        // TODO: 13556 - Add action to purchase label remotely
-        // TODO: 13556 - If the remote purchase is successful:
-            onLabelPurchase?(markOrderComplete)
-        if let shippingLabel {
-            postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+        // For now we support purchasing labels in a single shipment only.
+        // In future milestones we can create an array of `WooShippingPackagePurchase` with unique shipment IDs for each shipment.
+        let package = WooShippingPackagePurchase(shipmentID: "shipment_0",
+                                                 package: selectedPackage,
+                                                 rate: selectedRate.purchaseRate,
+                                                 productIDs: itemsDataSource.items.map(\.productOrVariationID))
+        let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,
+                                                             orderID: order.orderID,
+                                                             originAddress: originSiteAddress,
+                                                             destinationAddress: destinationAddress,
+                                                             package: package) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let shippingLabel):
+                onLabelPurchase?(markOrderComplete)
+                postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+            case .failure(let error):
+                DDLogError("⛔️ Error purchasing shipping label: \(error)")
+            }
         }
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -169,6 +169,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             switch result {
             case .success(let shippingLabel):
                 onLabelPurchase?(markOrderComplete)
+                self.shippingLabel = shippingLabel
                 postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
             case .failure(let error):
                 DDLogError("⛔️ Error purchasing shipping label: \(error)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import WooCommerce
 @testable import Networking
 import WooFoundation
+import Yosemite
 
 final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_inits_with_expected_values_for_shipping_label_creation() {
@@ -74,13 +75,25 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() {
         // Given
-        let order = Order.fake()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
+                completion(.success(ShippingLabel.fake()))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
 
         // When
         let markOrderComplete: Bool = waitFor { promise in
-            let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate(), onLabelPurchase: { complete in
+            let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                             originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
+                                                             selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                             selectedRate: self.sampleSelectedRate(),
+                                                             stores: stores) { complete in
                 promise(complete)
-            })
+            }
             viewModel.markOrderComplete = false
             viewModel.purchaseLabel()
         }
@@ -91,13 +104,25 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_onLabelPurchase_notifies_when_order_should_be_marked_complete() {
         // Given
-        let order = Order.fake()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
+                completion(.success(ShippingLabel.fake()))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
 
         // When
         let markOrderComplete: Bool = waitFor { promise in
-            let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate(), onLabelPurchase: { complete in
+            let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                             originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
+                                                             selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                             selectedRate: self.sampleSelectedRate(),
+                                                             stores: stores) { complete in
                 promise(complete)
-            })
+            }
             viewModel.markOrderComplete = true
             viewModel.purchaseLabel()
         }
@@ -108,8 +133,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_canPurchaseLabel_true_when_shipping_rate_is_selected() throws {
         // Given
-        let order = Order.fake()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedRate: self.sampleSelectedRate())
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                         originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
+                                                         selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                         selectedRate: sampleSelectedRate())
 
         // Then
         XCTAssertTrue(viewModel.canPurchaseLabel)
@@ -163,6 +190,33 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingRates[0].amount, "$40.06")
         XCTAssertEqual(viewModel.shippingRates[1].title, "Adult Signature Required")
         XCTAssertEqual(viewModel.shippingRates[1].amount, "$6.90")
+    }
+
+    func test_purchaseLabel_sets_postPurchase_with_purchased_shipping_label() {
+        // Given
+        let expectedShippingLabel = ShippingLabel.fake().copy(carrierID: "usps", trackingNumber: "1234567890")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
+                completion(.success(expectedShippingLabel))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                         originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
+                                                         selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                         selectedRate: sampleSelectedRate(),
+                                                         stores: stores)
+
+        // When
+        viewModel.purchaseLabel()
+
+        // Then
+        XCTAssertNotNil(viewModel.postPurchase)
+        XCTAssertEqual(viewModel.postPurchase?.pickupURL, WooShippingCarrier(rawValue: expectedShippingLabel.carrierID)?.pickupURL)
+        XCTAssertEqual(viewModel.postPurchase?.trackingURL, ShippingLabelTrackingURLGenerator.url(for: expectedShippingLabel))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -218,6 +218,36 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.postPurchase?.pickupURL, WooShippingCarrier(rawValue: expectedShippingLabel.carrierID)?.pickupURL)
         XCTAssertEqual(viewModel.postPurchase?.trackingURL, ShippingLabelTrackingURLGenerator.url(for: expectedShippingLabel))
     }
+
+    func test_purchaseLabel_sets_isPurchasingLabel_as_expected() {
+        // Given
+        var isPurchasingLabelDuringPurchase = false
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                         originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
+                                                         selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                         selectedRate: sampleSelectedRate(),
+                                                         stores: stores)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
+                isPurchasingLabelDuringPurchase = viewModel.isPurchasingLabel
+                completion(.success(ShippingLabel.fake()))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        // Check isPurchaseLabel is false before purchase
+        XCTAssertFalse(viewModel.isPurchasingLabel)
+
+        // When
+        viewModel.purchaseLabel()
+
+        // Then
+        XCTAssertTrue(isPurchasingLabelDuringPurchase)
+        // Check isPurchaseLabel is false after purchase
+        XCTAssertFalse(viewModel.isPurchasingLabel)
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -14,7 +14,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.markOrderComplete)
-        XCTAssertFalse(viewModel.canPurchaseLabel)
+        XCTAssertFalse(viewModel.isPurchaseButtonEnabled)
         XCTAssertNil(viewModel.totalCost)
         XCTAssertFalse(viewModel.canViewLabel)
     }
@@ -29,7 +29,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(viewModel.postPurchase)
-        XCTAssertFalse(viewModel.canPurchaseLabel)
+        XCTAssertFalse(viewModel.isPurchaseButtonEnabled)
         XCTAssertNotNil(viewModel.totalCost)
         XCTAssertTrue(viewModel.canViewLabel)
         XCTAssertEqual(viewModel.shippingRates.count, 1)
@@ -139,7 +139,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
                                                          selectedRate: sampleSelectedRate())
 
         // Then
-        XCTAssertTrue(viewModel.canPurchaseLabel)
+        XCTAssertTrue(viewModel.isPurchaseButtonEnabled)
     }
 
     func test_totalCost_has_expected_value_when_shipping_rate_is_set() throws {

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -182,6 +182,7 @@ public typealias WooShippingCustomPackage = Networking.WooShippingCustomPackage
 public typealias WooShippingPredefinedPackage = Networking.WooShippingPredefinedPackage
 public typealias WooShippingCreatePackageResponse = Networking.WooShippingCreatePackageResponse
 public typealias WooShippingPackagesResponse = Networking.WooShippingPackagesResponse
+public typealias WooShippingPackagePurchase = Networking.WooShippingPackagePurchase
 public typealias WPComPlan = Networking.WPComPlan
 public typealias WPComSitePlan = Networking.WPComSitePlan
 public typealias LoadSiteCurrentPlanError = Networking.LoadSiteCurrentPlanError


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13556
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This integrates the new shipping label purchase action into the UI for the revamped Woo Shipping label flow.

When the purchase button is tapped, it calls the action to purchase the label remotely:

* It doesn't allow the purchase action to be dispatched if there is already a purchased label or a label purchase is in progress.
* If the required details are available (origin and destination address, selected package, selected rate) it dispatches the purchase action.
* While the purchase is being processed remotely, the purchase button shows a loading indicator.
* After the purchase is completed, the labels view updates to display the purchased label.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The flow for selecting a package is still being implemented, so I manually tested this with a hard-coded package. We can test the entire end-to-end flow, including purchase, once the milestone is complete. Here is a sample set of testing steps:

1. Ensure the feature flag is enabled.
2. Open an order that is eligible for shipping label creation.
3. Tap "Create shipping label."
4. Select a package. (In my testing, the package was preselected/hard-coded.)
5. Select a rate in the Shipping service section.
6. Tap the purchase button and confirm it shows a loading indicator while the purchase is in progress.
7. When the purchase is complete, confirm the purchase button is removed and the purchased label details are displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4b510b3f-a3cd-4a3b-a200-ff010fd1edd9



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.