### PR TITLE
[Shipping labels] Use order currency for order details (items and shipping lines)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRowViewModel.swift
@@ -41,6 +41,7 @@ struct WooShippingItemRowViewModel: Identifiable {
     }
 
     init(item: ShippingLabelPackageItem,
+         currency: String,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.imageUrl = item.imageURL
@@ -53,7 +54,7 @@ struct WooShippingItemRowViewModel: Identifiable {
         let weightUnit = shippingSettingsService.weightUnit ?? ""
         self.weightLabel = item.formatWeight(with: weightUnit)
 
-        self.priceLabel = item.formatPrice(with: currencySettings)
+        self.priceLabel = item.formatPrice(with: currencySettings, and: currency)
     }
 }
 
@@ -84,10 +85,10 @@ private extension ShippingLabelPackageItem {
 
     /// Formats the total item price (per-unit value x quantity) with the provided currency settings.
     ///
-    func formatPrice(with settings: CurrencySettings) -> String {
+    func formatPrice(with settings: CurrencySettings, and currency: String) -> String {
         let totalPrice = Decimal(value) * quantity
         let currencyFormatter = CurrencyFormatter(currencySettings: settings)
-        return currencyFormatter.formatAmount(totalPrice) ?? totalPrice.description
+        return currencyFormatter.formatAmount(totalPrice, with: currency) ?? totalPrice.description
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsDataSource.swift
@@ -1,10 +1,12 @@
 import UIKit
 import Yosemite
 import protocol Storage.StorageManagerType
+import WooFoundation
 
 /// Provides data about items to ship for an order with the Woo Shipping extension.
 ///
 protocol WooShippingItemsDataSource {
+    var currency: String { get }
     var items: [ShippingLabelPackageItem] { get }
 }
 
@@ -12,6 +14,7 @@ final class DefaultWooShippingItemsDataSource: WooShippingItemsDataSource {
     private let order: Order
     private let storageManager: StorageManagerType
     private let stores: StoresManager
+    let currency: String
 
     /// Items to ship from an order.
     ///
@@ -65,6 +68,7 @@ final class DefaultWooShippingItemsDataSource: WooShippingItemsDataSource {
         self.order = order
         self.storageManager = storageManager
         self.stores = stores
+        self.currency = order.currency
 
         configureProductResultsController()
         configureProductVariationResultsController()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemsViewModel.swift
@@ -56,7 +56,7 @@ private extension WooShippingItemsViewModel {
     ///
     func configureItemRows() {
         itemRows = dataSource.items.map { item in
-            WooShippingItemRowViewModel(item: item)
+            WooShippingItemRowViewModel(item: item, currency: dataSource.currency)
         }
     }
 
@@ -77,7 +77,7 @@ private extension WooShippingItemsViewModel {
     func formatPrice(for items: [ShippingLabelPackageItem]) -> String {
         let totalPrice = items.map { Decimal($0.value) * $0.quantity }.reduce(0, +)
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        return currencyFormatter.formatAmount(totalPrice) ?? totalPrice.description
+        return currencyFormatter.formatAmount(totalPrice, with: dataSource.currency) ?? totalPrice.description
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -69,6 +69,7 @@ struct WooShippingCreateLabelsView: View {
                         CollapsibleHStack(spacing: Layout.bottomSheetSpacing) {
                             Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
                                 .font(.subheadline)
+                                .tint(Color(.primary))
                             purchaseButton
                         }
                         .padding(.horizontal, Layout.bottomSheetPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -123,7 +123,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                               account: defaultAccount,
                                                               userDefaults: userDefaults)
         self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
-        self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
+        self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.selectedPackage = selectedPackage
         self.selectedRate = selectedRate
         self.stores = stores
@@ -140,7 +140,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
         self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.items = WooShippingItemsViewModel(dataSource: itemsDataSource)
-        self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0) })
+        self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.originSiteAddress = shippingLabel.originAddress
         self.destinationAddress = shippingLabel.destinationAddress
         self.onLabelPurchase = nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModel.swift
@@ -13,9 +13,10 @@ struct WooShipping_ShippingLineViewModel: Identifiable {
     let formattedTotal: String
 
     init(shippingLine: ShippingLine,
+         currency: String,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         id = shippingLine.shippingID
         title = shippingLine.methodTitle
-        formattedTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
+        formattedTotal = currencyFormatter.formatAmount(shippingLine.total, with: currency) ?? shippingLine.total
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -62,7 +62,8 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_order_shipping_lines_converted_to_shippingLineViewModels() {
         // Given
-        let order = Order.fake().copy(shippingLines: [ShippingLine.fake().copy(shippingID: 1),
+        let order = Order.fake().copy(currency: "GBP",
+                                      shippingLines: [ShippingLine.fake().copy(shippingID: 1, total: "10"),
                                                       ShippingLine.fake().copy(shippingID: 2),
                                                       ShippingLine.fake().copy(shippingID: 3)])
 
@@ -71,6 +72,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(order.shippingLines.map({ $0.shippingID }), viewModel.shippingLines.map({ $0.id }))
+        XCTAssertEqual("£10.00", viewModel.shippingLines.first?.formattedTotal)
     }
 
     func test_onLabelPurchase_notifies_when_order_should_not_be_marked_complete() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemRowViewModelTests.swift
@@ -42,7 +42,7 @@ final class WooShippingItemRowViewModelTests: XCTestCase {
                                             attributes: [VariationAttributeViewModel(name: "Roast", value: "Espresso"),
                                                          VariationAttributeViewModel(name: "Size", value: "10 oz")],
                                             imageURL: URL(string: "https://woocommerce.com/woo.jpg"))
-        let row = WooShippingItemRowViewModel(item: item, shippingSettingsService: shippingSettingsService, currencySettings: currencySettings)
+        let row = WooShippingItemRowViewModel(item: item, currency: "GBP", shippingSettingsService: shippingSettingsService, currencySettings: currencySettings)
 
         // Then
         assertEqual(URL(string: "https://woocommerce.com/woo.jpg"), row.imageUrl)
@@ -50,7 +50,7 @@ final class WooShippingItemRowViewModelTests: XCTestCase {
         assertEqual("Little Nap Brazil", row.name)
         assertEqual("15 x 10 x 8 in • Espresso, 10 oz", row.detailsLabel)
         assertEqual("30 oz", row.weightLabel)
-        assertEqual("$60.00", row.priceLabel)
+        assertEqual("£60.00", row.priceLabel)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsDataSourceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import WooCommerce
 import Yosemite
+import WooFoundation
 
 final class WooShippingItemsDataSourceTests: XCTestCase {
 
@@ -60,4 +61,16 @@ final class WooShippingItemsDataSourceTests: XCTestCase {
         assertEqual(2, dataSource.items.count)
     }
 
+    func test_it_inits_with_order_currency() {
+        // Given
+        ServiceLocator.setCurrencySettings(CurrencySettings()) // Default is USD
+        let orderCurrency = "GBP"
+        let order = Order.fake().copy(currency: orderCurrency)
+
+        // When
+        let dataSource = DefaultWooShippingItemsDataSource(order: order)
+
+        // Then
+        assertEqual(orderCurrency, dataSource.currency)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingItemsViewModelTests.swift
@@ -17,7 +17,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         // Given
         let items = [sampleItem(id: 1, weight: 4, value: 10, quantity: 1),
                      sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
-        let dataSource = MockDataSource(items: items)
+        let dataSource = MockDataSource(items: items, currency: "GBP")
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
@@ -26,8 +26,8 @@ final class WooShippingItemsViewModelTests: XCTestCase {
 
         // Then
         assertEqual("2 items", viewModel.itemsCountLabel)
-        assertEqual("$12.50", viewModel.itemsPriceLabel)
-        assertEqual("7 oz • $12.50", viewModel.itemsDetailLabel)
+        assertEqual("£12.50", viewModel.itemsPriceLabel)
+        assertEqual("7 oz • £12.50", viewModel.itemsDetailLabel)
         assertEqual(2, viewModel.itemRows.count)
     }
 
@@ -60,7 +60,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
         // Given
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
                      sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
-        let dataSource = MockDataSource(items: items)
+        let dataSource = MockDataSource(items: items, currency: "GBP")
 
         // When
         let viewModel = WooShippingItemsViewModel(dataSource: dataSource,
@@ -68,7 +68,7 @@ final class WooShippingItemsViewModelTests: XCTestCase {
                                                   shippingSettingsService: shippingSettingsService)
 
         // Then
-        assertEqual("13 oz • $22.50", viewModel.itemsDetailLabel)
+        assertEqual("13 oz • £22.50", viewModel.itemsDetailLabel)
     }
 
 }
@@ -88,8 +88,11 @@ private extension WooShippingItemsViewModelTests {
 
 private final class MockDataSource: WooShippingItemsDataSource {
     var items: [ShippingLabelPackageItem]
+    var currency: String
 
-    init(items: [ShippingLabelPackageItem]) {
+    init(items: [ShippingLabelPackageItem],
+         currency: String = "GBP") {
         self.items = items
+        self.currency = currency
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping_ShippingLineViewModelTests.swift
@@ -12,11 +12,11 @@ final class WooShipping_ShippingLineViewModelTests: XCTestCase {
         let shippingLine = ShippingLine.fake().copy(shippingID: 123, methodTitle: "Flat Rate Shipping", total: "2.50")
 
         // When
-        let viewModel = WooShipping_ShippingLineViewModel(shippingLine: shippingLine, currencyFormatter: currencyFormatter)
+        let viewModel = WooShipping_ShippingLineViewModel(shippingLine: shippingLine, currency: "GBP", currencyFormatter: currencyFormatter)
 
         // Then
         assertEqual(shippingLine.shippingID, viewModel.id)
         assertEqual(shippingLine.methodTitle, viewModel.title)
-        assertEqual("$2.50", viewModel.formattedTotal)
+        assertEqual("£2.50", viewModel.formattedTotal)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14525
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the currency used in the Woo Shipping label creation flow. The order currency is now used for order details shown during label creation: items in the order and totals for items and shipping lines.

This also includes a small fix to the "Mark as completed" toggle in the bottom sheet, to use the Woo purple color instead of the default green.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Create an order on your store in a different currency from the store's default currency.
2. Ensure the `revampedShippingLabelCreation` feature flag is enabled.
3. Open the order in the app.
4. Select "Create shipping label."
5. Expand the items section and confirm the item prices are all displayed in the order currency.
6. Open the bottom sheet and confirm the order details (item and shipping totals) are displayed in the order currency.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Order|Items|Bottom sheet
-|-|-
![Simulator Screenshot - iPhone 16 Pro - 2024-11-26 at 17 31 59](https://github.com/user-attachments/assets/0c138b27-567e-45e6-9963-947ce8be9f8b)|![Simulator Screenshot - iPhone 16 Pro - 2024-11-26 at 17 51 28](https://github.com/user-attachments/assets/fc2e1c48-9ea6-4890-9b3f-2c75493f1787)|![Simulator Screenshot - iPhone 16 Pro - 2024-11-26 at 17 58 43](https://github.com/user-attachments/assets/aa0046b3-24c4-47f4-934a-67bf44acb1ed)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.