### PR TITLE
[Shipping labels] Custom packages model update

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -15,18 +15,15 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     // Holds value for toggle that determines if we are showing button for saving the template
     @Published var showSaveTemplate: Bool = false
     @Published var packageTemplateName: String = ""
-    @Published var packagesRepository: WooShippingPackagesRepositoryProtocol
 
     // MARK: Initialization
 
     init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0,
          storeOptions: ShippingLabelStoreOptions,
-         stores: StoresManager = ServiceLocator.stores,
-         packagesRepository: WooShippingPackagesRepositoryProtocol) {
+         stores: StoresManager = ServiceLocator.stores) {
         self.storeOptions = storeOptions
         self.stores = stores
         self.siteID = siteID
-        self.packagesRepository = packagesRepository
     }
 
     // Field values are invalid if one of them is empty
@@ -92,11 +89,39 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
             return .failure(WooShippingAddCustomPackageViewModel.Error.packageDataNotValid)
         }
 
-        let result =  await packagesRepository.saveCustomPackage(packageData,
-                                                                 dimensionsUnit: storeOptions.dimensionUnit,
-                                                                 weightUnit: storeOptions.weightUnit,
-                                                                 siteID: siteID,
-                                                                 stores: stores)
+        let customPackage = WooShippingCustomPackage(id: "",
+                                                     name: packageData.name,
+                                                     rawType: packageData.packageType,
+                                                     dimensions: "\(packageData.length) x \(packageData.width) x \(packageData.height)",
+                                                     boxWeight: Double(packageData.weight) ?? 0)
+        let result: Result<WooShippingPackageDataRepresentable, Error> = await withCheckedContinuation { continuation in
+            let action = WooShippingAction.createPackage(siteID: siteID,
+                                                         customPackage: customPackage,
+                                                         predefinedOption: nil) { [weak self] result in
+                switch result {
+                case let .success(packages):
+                    guard let self, let savedPackage = packages.customPackages.first(where: { $0.name == customPackage.name }) else {
+                        return continuation.resume(returning: .failure(WooShippingAddCustomPackageViewModel.Error.failedSavingTemplate))
+                    }
+                    let packageData = WooShippingPackageData(id: savedPackage.id,
+                                                             name: savedPackage.name,
+                                                             length: savedPackage.getLength().description,
+                                                             width: savedPackage.getWidth().description,
+                                                             height: savedPackage.getHeight().description,
+                                                             dimensionsUnit: storeOptions.dimensionUnit,
+                                                             weight: savedPackage.boxWeight.description,
+                                                             weightUnit: storeOptions.weightUnit,
+                                                             source: .custom,
+                                                             packageType: savedPackage.rawType)
+                    continuation.resume(returning: .success(packageData))
+                case let .failure(error):
+                    DDLogError("⛔️ Error saving custom package with WCShip: \(error)")
+                    continuation.resume(returning: .failure(WooShippingAddCustomPackageViewModel.Error.failedSavingTemplate))
+                }
+            }
+            stores.dispatch(action)
+        }
+
         switch result {
         case .success(let success):
             return .success(success)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -29,8 +29,7 @@ struct WooShippingAddPackageView: View {
          packagesRepository: WooShippingPackagesRepository = WooShippingPackagesRepository.shared,
          addPackageAction: @escaping (WooShippingPackageDataRepresentable) -> Void) {
         self._packagesRepository = StateObject(wrappedValue: packagesRepository)
-        self._customPackageViewModel = StateObject(wrappedValue: WooShippingAddCustomPackageViewModel(storeOptions: storeOptions,
-                                                                                                      packagesRepository: packagesRepository))
+        self._customPackageViewModel = StateObject(wrappedValue: WooShippingAddCustomPackageViewModel(storeOptions: storeOptions))
         self.addPackageAction = addPackageAction
     }
     // MARK: - UI

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -6,7 +6,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_it_inits_with_empty_field_values() {
         // Given/When
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -14,8 +13,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // Then
         XCTAssertNotNil(viewModel)
@@ -29,7 +27,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let expectedDimensionUnit = "in"
         let expectedWeightUnit = "kg"
         let expectedOriginCountry = "US"
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -37,8 +34,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: expectedDimensionUnit,
                                                                                                      weightUnit: expectedWeightUnit,
                                                                                                      originCountry: expectedOriginCountry),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // Then
         XCTAssertNotNil(viewModel)
@@ -52,7 +48,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_it_with_not_all_field_values_set() {
         // Given
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -60,8 +55,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // When
         viewModel.fieldValues[.height] = "1"
@@ -74,7 +68,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_it_with_all_field_values_set() {
         // Given
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -82,8 +75,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // When
         viewModel.fillWithDummyFieldValues()
@@ -96,7 +88,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_it_with_all_dimension_field_values_set_not_saving_template() {
         // Given
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -104,8 +95,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // When
         viewModel.fillWithDummyDimensionFieldValues()
@@ -119,7 +109,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_it_with_all_dimension_field_values_set_saving_template() {
         // Given
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -127,8 +116,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // When
         viewModel.fillWithDummyDimensionFieldValues()
@@ -142,7 +130,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_it_with_all_dimension_weight_field_values_set() {
         // Given
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -150,8 +137,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // When
         viewModel.fillWithDummyDimensionFieldValues()
@@ -165,7 +151,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_validate_custom_package_input_fields_when_init() {
         // Given/When
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -173,8 +158,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // Then
         XCTAssertEqual(viewModel.validateCustomPackageInputFields(), false)
@@ -183,7 +167,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_validate_custom_package_input_fields_when_fields_are_valid() {
         // Given
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -191,8 +174,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // When
         viewModel.fillWithDummyFieldValues()
@@ -204,7 +186,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_validate_custom_package_input_fields_when_fields_are_valid_and_save_template_shown() {
         // Given
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -212,8 +193,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "oz",
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
 
         // When
         viewModel.fillWithDummyFieldValues()
@@ -234,7 +214,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         // Given
         let dimensionUnit = "cm"
         let weightUnit = "kg"
-        let packagesRepository = MockWooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -242,8 +221,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: dimensionUnit,
                                                                                                      weightUnit: weightUnit,
                                                                                                      originCountry: "US"),
-                                                             stores: mockStores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: mockStores)
         let length = "1"
         let width = "2"
         let height = "3"
@@ -273,7 +251,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
     @MainActor
     func test_save_package_as_template_action() async {
         // Given
-        let packagesRepository = WooShippingPackagesRepository()
         let siteID: Int64 = 1234
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
@@ -281,8 +258,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
                                                                                                      dimensionUnit: "in",
                                                                                                      weightUnit: "lb",
                                                                                                      originCountry: "US"),
-                                                             stores: stores,
-                                                             packagesRepository: packagesRepository)
+                                                             stores: stores)
         let packageName = "a"
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Updated `WooShippingAddCustomPackageViewModel` by removing the usage of package repository and move `savePackageAsTemplateAction` function logic directly to the view model

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Install and set up the Woo Shipping extension on your store.
- Build and run the app with the revampedShippingLabelCreation feature flag enabled.
- Create an order with the processing status and at least one physical product.
- In the order details, select "Create Shipping Label."
- Tap "Select a Package" button
- Input values for custom package
- Toggle switch to save template
- Save package as template
- Check on web that the new template with data you added is saved

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
