### PR TITLE
[Shipping labels] Add Woo Shipping action to print a shipping label

### DIFF
--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -38,4 +38,11 @@ public enum WooShippingAction: Action {
                                pollingDelay: TimeInterval = 1.0,
                                pollingMaximumRetries: Int64 = 3,
                                completion: (Result<ShippingLabel, Error>) -> Void)
+
+    /// Generates a shipping label document for printing.
+    ///
+    case printLabel(siteID: Int64,
+                    labelIDs: [Int64],
+                    paperSize: ShippingLabelPaperSize,
+                    completion: (Result<ShippingLabelPrintData, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -61,6 +61,8 @@ public final class WooShippingStore: Store {
                                   pollingDelay: pollingDelay,
                                   pollingMaximumRetries: pollingMaximumRetries,
                                   completion: completion)
+        case let .printLabel(siteID, labelIDs, paperSize, completion):
+            printLabel(siteID: siteID, labelIDs: labelIDs, paperSize: paperSize, completion: completion)
         }
     }
 }
@@ -145,6 +147,13 @@ private extension WooShippingStore {
                 completion(.failure(error))
             }
         }
+    }
+
+    func printLabel(siteID: Int64,
+                    labelIDs: [Int64],
+                    paperSize: ShippingLabelPaperSize,
+                    completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
+        remote.printLabel(siteID: siteID, labelIDs: labelIDs, paperSize: paperSize, completion: completion)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -346,6 +346,56 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertTrue(remote.purchaseShippingLabelCalled)
         XCTAssertGreaterThan(remote.checkLabelStatusCallsCount, 1)
     }
+
+    func test_printLabel_returns_print_data_on_success() throws {
+        // Given
+        let expectedPrintData = ShippingLabelPrintData.fake()
+        let remote = MockWooShippingRemote()
+        remote.whenPrintLabel(siteID: sampleSiteID, thenReturn: .success(expectedPrintData))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let printData: ShippingLabelPrintData = waitFor { promise in
+            let action = WooShippingAction.printLabel(siteID: self.sampleSiteID,
+                                                     labelIDs: [123],
+                                                     paperSize: .letter) { result in
+                guard let printData = try? result.get() else {
+                    XCTFail("Error printing shipping label: \(String(describing: result.failure))")
+                    return
+                }
+                promise(printData)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(printData, expectedPrintData)
+    }
+
+    func test_printLabel_returns_error_on_failure() throws {
+        // Given
+        let expectedError = NetworkError.timeout()
+        let remote = MockWooShippingRemote()
+        remote.whenPrintLabel(siteID: sampleSiteID, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let error: Error = waitFor { promise in
+            let action = WooShippingAction.printLabel(siteID: self.sampleSiteID,
+                                                      labelIDs: [123],
+                                                      paperSize: .letter) { result in
+                guard let printData = result.failure else {
+                    XCTFail("Unexpected result when printing shipping label: \(result)")
+                    return
+                }
+                promise(printData)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(error as? NetworkError, expectedError)
+    }
 }
 
 private extension WooShippingStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14536
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds support in the Yosemite layer for printing a shipping label in the Woo Shipping label flow.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This action isn't yet used in the app, so confirm tests pass. The remote request has already been tested and in this case we only need the action to initiate the remote request and pass the data (or error) back to the UI layer.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.