### PR TITLE
Fix email receipt form being shown in split view on iPad in iOS 17

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptEmail/ReceiptEmailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptEmail/ReceiptEmailView.swift
@@ -5,7 +5,7 @@ struct ReceiptEmailView: View {
     @ObservedObject var viewModel: ReceiptEmailViewModel
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 VStack(spacing: 0) {
                     Divider()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14544 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In iOS 17, `NavigationView` is resulting in split view as the default presentation style on iPad. As `NavigationView` has been deprecated and replaced by the iOS 16+ [`NavigationStack`](https://developer.apple.com/documentation/swiftui/navigationstack) and [`NavigationSplitView`](https://developer.apple.com/documentation/swiftui/navigationsplitview) in the [official migration guide](https://developer.apple.com/documentation/swiftui/migrating-to-new-navigation-types), this PR updated the email receipt form SwiftUI view to use `NavigationStack` to fix this issue.

## How

Use `NavigationStack` instead of `NavigationView` to fix the view being shown in split view in iOS 17.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:

- In code, enable the feature flag `sendReceiptAfterPayment` locally in `DefaultFeatureFlagService`
- Have a site that meets the requirements pdfdoF-5Vk-p2#requirements, or try Povilas' site in pdfdoF-5Vk-p2#configured-site-credentials

---

Test the following steps using:

1) iOS 17 iPad
2) iOS 18 iPad

Simulators are fine.

- Go to the orders tab
- Create an order with one of the [Stripe-provided failure amounts](https://href.li/?https://docs.stripe.com/terminal/references/testing#physical-test-cards) and No Customer Email --> the ‘Email receipt’ button should be shown and open the ‘Email Receipt to Customer’ view
- Proceed with a valid email to verify the flow works as expected

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [x] @jaclync tests on iOS 17 iPhone
- [x] @jaclync tests on iOS 18 iPhone

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screenshot - iPad (10th generation) - 2024-11-28 at 11 57 14](https://github.com/user-attachments/assets/9200d685-d24c-4330-bda0-6319a6425c43) | ![Simulator Screenshot - iPad (10th generation) - 2024-11-28 at 12 05 54](https://github.com/user-attachments/assets/1dc681cd-3116-46d7-8c72-3144160ae01b)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.