### PR TITLE
[Shipping labels] Init shipping service separately from loading the label rates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -15,7 +15,7 @@ final class WooShippingServiceViewModel: ObservableObject {
     @Published private(set) var selectedRate: WooShippingSelectedRate?
 
     /// State of loading shipping rates.
-    private(set) var loadingState: LabelRatesState = .loading
+    private(set) var loadingState: LabelRatesState = .empty
 
     /// Available standard shipping rates.
     private var standardRates: [ShippingLabelCarrierRate] = []
@@ -33,7 +33,6 @@ final class WooShippingServiceViewModel: ObservableObject {
     init(order: Order,
          originAddress: ShippingLabelAddress?,
          destinationAddress: ShippingLabelAddress?,
-         selectedPackage: ShippingLabelPackageSelected,
          stores: StoresManager = ServiceLocator.stores,
          onSelectRate: ((_ selectedRate: WooShippingSelectedRate) -> Void)? = nil) {
         self.siteID = order.siteID
@@ -42,7 +41,6 @@ final class WooShippingServiceViewModel: ObservableObject {
         self.destinationAddress = destinationAddress
         self.stores = stores
         self.onSelectRate = onSelectRate
-        loadLabelRates(for: selectedPackage)
     }
 
     /// Sorts the shipping services by the provided sort order.
@@ -115,6 +113,7 @@ extension WooShippingServiceViewModel {
 
     /// States for label rates.
     enum LabelRatesState {
+        case empty
         case loading
         case loaded
         case error
@@ -171,7 +170,7 @@ private extension WooShippingServiceViewModel {
             generateServiceTabs()
         case .loaded:
             generateServiceTabs()
-        case .error:
+        case .empty, .error:
             serviceTabs = []
         }
         loadingState = state

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -48,7 +48,8 @@ struct WooShippingCreateLabelsView: View {
 
                     if viewModel.canViewLabel {
                         EmptyView()
-                    } else if let shippingService = viewModel.shippingService {
+                    } else if viewModel.selectedPackage != nil,
+                              let shippingService = viewModel.shippingService {
                         // TODO: Display package section
                         // Package heading and edit button
                         // Selected package details

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -33,7 +33,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private(set) var shippingService: WooShippingServiceViewModel?
 
     /// Selected shipping rate when creating a shipping label.
-    private var selectedRate: WooShippingSelectedRate?
+    @Published private var selectedRate: WooShippingSelectedRate?
 
     /// Address to ship from (store address), formatted for display.
     private(set) lazy var originAddress: String = {
@@ -175,6 +175,13 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
 // MARK: Utils
 private extension WooShippingCreateLabelsViewModel {
+    /// Handles changes to the selected package.
+    /// Selecting a package also refreshes the available rates for the shipping service.
+    func handleNewSelectedPackage(_ selectedPackage: ShippingLabelPackageSelected) {
+        self.selectedPackage = selectedPackage
+        shippingService?.loadLabelRates(for: selectedPackage)
+    }
+
     /// Provides the formatted label and amount for a shipping rate, based on the provided base rate.
     func formatShippingRate(name: String, rate: Double, basedOn baseRate: Double? = nil) -> (title: String, amount: String) {
         let amount = {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -27,18 +27,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     @Published private(set) var items: WooShippingItemsViewModel
 
     /// Selected package for the shipping label.
-    @Published private(set) var selectedPackage: ShippingLabelPackageSelected? {
-        didSet {
-            if let selectedPackage {
-                shippingService = WooShippingServiceViewModel(order: order,
-                                                              originAddress: originSiteAddress,
-                                                              destinationAddress: destinationAddress,
-                                                              selectedPackage: selectedPackage) { [weak self] selectedRate in
-                    self?.selectedRate = selectedRate
-                }
-            }
-        }
-    }
+    @Published private(set) var selectedPackage: ShippingLabelPackageSelected?
 
     /// View model for the label shipping service.
     private(set) var shippingService: WooShippingServiceViewModel?
@@ -127,6 +116,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.selectedPackage = selectedPackage
         self.selectedRate = selectedRate
         self.stores = stores
+        shippingService = WooShippingServiceViewModel(order: order,
+                                                      originAddress: originSiteAddress,
+                                                      destinationAddress: destinationAddress) { [weak self] selectedRate in
+            self?.selectedRate = selectedRate
+        }
     }
 
     /// Initialize the view model from an existing shipping label.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -26,12 +26,11 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
-                                                    destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake())
+                                                    destinationAddress: ShippingLabelAddress.fake())
 
         // Then
         XCTAssertNil(viewModel.selectedRate)
-        XCTAssertEqual(viewModel.loadingState, .loading)
+        XCTAssertEqual(viewModel.loadingState, .empty)
     }
 
     func test_loadLabelRates_generates_service_tabs_with_expected_data() throws {
@@ -39,7 +38,6 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake(),
                                                     stores: stores)
 
         // When
@@ -109,7 +107,6 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake(),
                                                     stores: stores)
 
         // When
@@ -126,12 +123,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
                                                     stores: stores)
-        XCTAssertNil(viewModel.selectedRate)
-        XCTAssertFalse(viewModel.serviceTabs[0].cards[1].selected)
 
         // When
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake().copy(id: samplePackageID))
         viewModel.selectRate(standardRate, signatureRate: nil, adultSignatureRate: nil)
 
         // Then
@@ -147,12 +142,9 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
                                                     stores: stores)
-        XCTAssertNil(viewModel.selectedRate)
-        XCTAssertFalse(viewModel.serviceTabs[0].cards[1].selected)
-
         // When
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake().copy(id: samplePackageID))
         viewModel.selectRate(sampleStandardRates()[1], signatureRate: sampleSignatureRates().first, adultSignatureRate: nil)
 
         // Then
@@ -167,12 +159,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
                                                     stores: stores)
-        XCTAssertNil(viewModel.selectedRate)
-        XCTAssertFalse(viewModel.serviceTabs[0].cards[1].selected)
 
         // When
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake().copy(id: samplePackageID))
         viewModel.selectRate(sampleStandardRates()[1], signatureRate: nil, adultSignatureRate: sampleAdultSignatureRates().first)
 
         // Then
@@ -188,12 +178,12 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
                                                     stores: stores) { rate in
             selectedRate = rate
         }
 
         // When
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake().copy(id: samplePackageID))
         viewModel.selectRate(sampleStandardRates()[1], signatureRate: nil, adultSignatureRate: nil)
 
         // Then
@@ -205,10 +195,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
                                                     stores: stores)
 
         // When
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake().copy(id: samplePackageID))
         viewModel.sortShipping(by: .price)
 
         // Then
@@ -222,10 +212,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: ShippingLabelAddress.fake(),
                                                     destinationAddress: ShippingLabelAddress.fake(),
-                                                    selectedPackage: ShippingLabelPackageSelected.fake().copy(id: samplePackageID),
                                                     stores: stores)
 
         // When
+        viewModel.loadLabelRates(for: ShippingLabelPackageSelected.fake().copy(id: samplePackageID))
         viewModel.sortShipping(by: .deliveryTime)
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to display the selected package from the "Add Package" section on the main screen in the Woo Shipping label creation flow. Once the package is selected, we will be able to change the package or update its weight. Any change to the selected package will update the available rates in the shipping service.

This PR is the first step for doing that: It separates the shipping service VM init method from the action to load label rates. That way we can init the VM once and load the label rates each time there are updates to the selected package.

### How

* Changes to the shipping service VM (`WooShippingServiceViewModel`):
   * This removes the selected package from the view model's init method, since it's only used to load the label rates from remote. Any time the selected package changes, we can call the `loadLabelRates(for:)` method.
   * We add an `empty` case to the `LabelRatesState` enum and set that as the default state. We can use this if we ever need to show an empty state for the shipping services.
* Changes to the main screen VM (`WooShippingCreateLabelsViewModel`):
   * We no longer set the shipping service VM every time `selectedPackage` is set. Instead, we set it once when the view model is initialized.
   * We have a new method `handleNewSelectedPackage(_:)` to handle the selected package. It sets the `selectedPackage` property and also calls `loadLabelRates(for:)` to get the rates for the package.

Note: We don't yet use the `handleNewSelectedPackage(_:)` method. The next PR will integrate this into the "Add Package" flow so we can set the selected package.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This is a preliminary step in preparation for setting the selected package in the "Add Package" flow. For now, confirm that tests pass (the shipping service works as expected when label rates are loaded).

This can also be tested by manually triggering the `handleNewSelectedPackage(_:)` method with mock package data.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.