### PR TITLE
[Shipping labels] Set selected package from "Add Package" flow

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -43,7 +43,7 @@ extension ShippingLabelPackageSelected: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(id, forKey: .id)
-        try container.encode(boxID, forKey: .boxID)
+        try container.encode(boxID.isEmpty ? "0" : boxID, forKey: .boxID)
         try container.encode(length, forKey: .length)
         try container.encode(width, forKey: .width)
         try container.encode(height, forKey: .height)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -53,7 +53,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     }
 
     private var packageDataFromCurrentData: WooShippingPackageDataRepresentable {
-        return WooShippingPackageData(id: UUID().uuidString,
+        return WooShippingPackageData(id: packageTemplateName,
                                       name: packageTemplateName,
                                       length: fieldValues[.length] ?? "",
                                       width: fieldValues[.width] ?? "",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageAndRatePlaceholder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageAndRatePlaceholder.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct WooShippingPackageAndRatePlaceholder: View {
+    /// Action to perform when a package is selected.
+    let onSelectPackage: (WooShippingPackageDataRepresentable) -> Void
+
     @State private var showAddPackage: Bool = false
+
     var body: some View {
         VStack(spacing: .zero) {
             Button {
@@ -25,7 +29,7 @@ struct WooShippingPackageAndRatePlaceholder: View {
         .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.border), lineWidth: Layout.borderLineWidth, dashed: true)
         .sheet(isPresented: $showAddPackage) {
             WooShippingAddPackageView { packageData in
-                // TODO: use packageData
+                onSelectPackage(packageData)
                 showAddPackage = false
             }
         }
@@ -58,6 +62,6 @@ private extension WooShippingPackageAndRatePlaceholder {
 }
 
 #Preview {
-    WooShippingPackageAndRatePlaceholder()
+    WooShippingPackageAndRatePlaceholder(onSelectPackage: { _ in })
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -57,7 +57,7 @@ struct WooShippingCreateLabelsView: View {
                         WooShippingServiceView(viewModel: shippingService)
                             .padding(.horizontal, -16)
                     } else {
-                        WooShippingPackageAndRatePlaceholder()
+                        WooShippingPackageAndRatePlaceholder(onSelectPackage: viewModel.selectPackage)
                     }
                 }
                 .padding(16)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -151,7 +151,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                    length: Double(packageData.length) ?? 0,
                                                    width: Double(packageData.width) ?? 0,
                                                    height: Double(packageData.height) ?? 0,
-                                                   weight: Double(packageData.weight) ?? 0,
+                                                   weight: itemsDataSource.items.map(\.weight).reduce(0, +) + (Double(packageData.weight) ?? 0),
                                                    isLetter: WooShippingPackageType(rawValue: packageData.packageType) == .envelope,
                                                    hazmatCategory: nil, // Hazmat support will be added in a future milestone
                                                    customsForm: nil) // Customs form support will be added in a future milestone

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -141,6 +141,24 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.stores = stores
     }
 
+    /// Handles package selection for the shipping label.
+    /// Selecting a package also refreshes the available rates for the shipping service.
+    func selectPackage(_ packageData: WooShippingPackageDataRepresentable) {
+        // For now we support purchasing labels in a single package for a single shipment.
+        // In future milestones we can handle an array of packages with unique IDs for each shipment.
+        let package = ShippingLabelPackageSelected(id: "shipment_0",
+                                                   boxID: packageData.id,
+                                                   length: Double(packageData.length) ?? 0,
+                                                   width: Double(packageData.width) ?? 0,
+                                                   height: Double(packageData.height) ?? 0,
+                                                   weight: Double(packageData.weight) ?? 0,
+                                                   isLetter: WooShippingPackageType(rawValue: packageData.packageType) == .envelope,
+                                                   hazmatCategory: nil, // Hazmat support will be added in a future milestone
+                                                   customsForm: nil) // Customs form support will be added in a future milestone
+        selectedPackage = package
+        shippingService?.loadLabelRates(for: package)
+    }
+
     /// Purchases a shipping label with the provided label details and settings.
     func purchaseLabel() {
         guard isPurchaseButtonEnabled, !isPurchasingLabel, let originSiteAddress, let destinationAddress, let selectedPackage, let selectedRate else {
@@ -175,13 +193,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
 // MARK: Utils
 private extension WooShippingCreateLabelsViewModel {
-    /// Handles changes to the selected package.
-    /// Selecting a package also refreshes the available rates for the shipping service.
-    func handleNewSelectedPackage(_ selectedPackage: ShippingLabelPackageSelected) {
-        self.selectedPackage = selectedPackage
-        shippingService?.loadLabelRates(for: selectedPackage)
-    }
-
     /// Provides the formatted label and amount for a shipping rate, based on the provided base rate.
     func formatShippingRate(name: String, rate: Double, basedOn baseRate: Double? = nil) -> (title: String, amount: String) {
         let amount = {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -250,6 +250,34 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Check isPurchaseLabel is false after purchase
         XCTAssertFalse(viewModel.isPurchasingLabel)
     }
+
+    func test_selectPackage_sets_selectedPackage_with_package_data() {
+        // Given
+        let packageData = WooShippingPackageData(id: "small_flat_box",
+                                                 name: "Small Flat Rate Box",
+                                                 length: "21.91",
+                                                 width: "13.65",
+                                                 height: "4.13",
+                                                 dimensionsUnit: "cm",
+                                                 weight: "0",
+                                                 weightUnit: "kg",
+                                                 source: .predefined("usps"),
+                                                 packageType: "box")
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake())
+
+        // When
+        viewModel.selectPackage(packageData)
+
+        // Then
+        XCTAssertNotNil(viewModel.selectedPackage)
+        XCTAssertEqual(viewModel.selectedPackage?.id, "shipment_0")
+        XCTAssertEqual(viewModel.selectedPackage?.boxID, "small_flat_box")
+        XCTAssertEqual(viewModel.selectedPackage?.length, 21.91)
+        XCTAssertEqual(viewModel.selectedPackage?.width, 13.65)
+        XCTAssertEqual(viewModel.selectedPackage?.height, 4.13)
+        XCTAssertEqual(viewModel.selectedPackage?.weight, 0)
+        XCTAssertEqual(viewModel.selectedPackage?.isLetter, false)
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to display the selected package from the "Select a Package" section on the main shipping label screen in the Woo Shipping label creation flow.

This PR connects the "Select a Package" flow with the main screen's view model, so the selected package can be used on the main screen.

For now, this loads the label rates in the Shipping Services section. A future PR will also add the UI to display the selected package details and allow the shipment weight to be updated.

### How

* In `WooShippingPackageAndRatePlaceholder`, the `WooShippingAddPackageView` passes back the package data for the selected package. Now, that placeholder view has an `onSelectPackage` closure to handle that data.
* In `WooShippingCreateLabelsViewModel`, we now have a `selectPackage(_:)` method that accepts package data.
   * The new method is passed to the `WooShippingPackageAndRatePlaceholder` view.
   * When this method is called, it transforms the package data into `ShippingLabelPackageSelected`, which is used to make calls to the backend that require the selected package. This method also loads the shipping rates for the selected package.
* Changes to support custom packages in calls to the backend:
   * In `WooShippingAddCustomPackageViewModel` we now set the ID for a custom package as the package name. The backend expects the custom package ID to be its name.
   * If the custom package doesn't have a name set (i.e. if it hasn't been saved as a template) we use the default ID of `0` when encoding it for remote requests. This is to match the endpoint behavior discussed with the extension team (see p1731538721371119-slack-C05VBLKHHV1).

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: The Woo Shipping extension is active on your store and you have at least one order eligible for a shipping label (with `processing` status and at least one physical product).

1. Enable the `revampedShippingLabelCreation` feature flag.
2. Build and run the app.
3. Go to the Orders tab.
4. Select an order eligible for a shipping label.
5. Tap "Create Shipping Label."
6. Tap "Select a package."
7. Enter custom package details or select a carrier package, and then tap "Add a package."
8. Confirm you are taken back to the main shipping label screen and the Shipping Service section appears and loads rates for your selected package.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/91913ac2-5a3c-48ef-bc17-76289e240a37



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.