### PR TITLE
Some additional fixes for Screenshots

### DIFF
--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -26,9 +26,8 @@ class WooCommerceScreenshots: XCTestCase {
         app.launchArguments.append("mocked-network-layer")
         app.launchArguments.append("-simulate-stripe-card-reader")
         app.launchArguments.append("disable-animations")
-        app.launchArguments.append("-mocks-port")
         app.launchArguments.append("-mocks-push-notification")
-        app.launchArguments.append("\(server.listenAddress.port)")
+        app.launchArguments.append(contentsOf: ["-mocks-port", "\(server.listenAddress.port)"])
 
         app.launch()
 

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
@@ -14,6 +14,10 @@ struct MockSystemStatusActionHandler: MockActionHandler {
             synchronizeSystemPlugins(siteID: siteID) { result in
                 onCompletion(result.map { SystemInformation(systemPlugins: $0) })
             }
+        case .fetchSystemPluginListWithNameList(let siteID, let systemPluginNameList, let onCompletion):
+            let systemPlugins = objectGraph.systemPlugins(for: siteID)
+            let filteredSystemPlugins = systemPlugins.first { systemPluginNameList.contains($0.name) }
+            onCompletion(filteredSystemPlugins)
         default:
             break
         }

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -379,8 +379,7 @@ extension ScreenshotObjectGraph {
         static let roseGoldShades = createProduct(
             name: "Rose Gold Shades",
             price: 199.0,
-            quantity: 0,
-            image: ProductImage.fromUrl("https://automatticwidgets.com/wp-content/uploads/2020/01/annie-theby-FlP6C5pkMKs-unsplash.png")
+            quantity: 0
         )
 
         static let blackCoralShades = createProduct(


### PR DESCRIPTION
## Description
Always as part of working on fixing the Screenshots tests, this PR adds two additional fixes that I missed in the previous PR:

1. Adds a fix to the initialization of the local webserver that we use for serving product images, more details in the comments.
2. Fixes the loading of the order details, previously the loading doesn't finish, and the loading top bar stays visible in the screenshots (check screenshots)

## Steps to reproduce
- Run the `WooCommerceScreenshots` test from XCode, and notice the app's behavior, and confirm the above two issues are fixed.

## Testing information
I tested using both XCode and using Fastlane's screenshot lanes.

## Screenshots
The following shows the screenshots that we take before and after:
| Before | After |
| --- | --- |
| ![iPhone 11 Pro Max-4-light-product-add](https://github.com/user-attachments/assets/3cf72c17-3f3e-4a87-96bc-47d798bf14e2) | ![iPhone 11 Pro Max-4-light-product-add](https://github.com/user-attachments/assets/d067d20f-7b28-41c6-961d-5fdc802c4580) |
| <img width="1024" alt="iPad Pro (12 9-inch) (3rd generation)-3-light-order-payment" src="https://github.com/user-attachments/assets/9982f9af-6bf3-4a96-82d1-321fb4696cd0"> |<img width="1024" alt="iPad Pro (12 9-inch) (3rd generation)-3-light-order-payment" src="https://github.com/user-attachments/assets/d3d6f2ee-7526-43ec-88c8-192b8a2841dd"> |

(For the first set of screenshots, the "After" one was taken before adding the last commit  71b81c5, that's why the last product image is broken)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.