### PR TITLE
Skips `test_purchase_product_completes_purchase` flaky IAP test

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -31,6 +31,7 @@
     {
       "skippedTests" : [
         "CardReaderConnectionControllerTests",
+        "InAppPurchaseStoreTests\/test_purchase_product_completes_purchase()",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_false_when_not_entitled()",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_true_when_entitled()",
         "StorePerformanceViewModelTests\/test_dates_for_custom_range_are_correct_for_non_custom_time_range()",

--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -117,6 +117,7 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssert(result.isFailure)
     }
 
+    // TODO: re-enable the test case when it can pass consistently.
     func test_purchase_product_completes_purchase() throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "iap/orders", filename: "iap-order-create")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

This PR disables `test_purchase_product_completes_purchase` as part of multiple _fed-up-driven-development_ instances. The test fails continuously in CI for no clear reason, and despite multiple attempts to circumvent the problem (eg: https://github.com/woocommerce/woocommerce-ios/pull/8256#pullrequestreview-1199236279) we've never figured out how to fix it due to lack of IAP API support for mocking responses. 

IAP is no longer a feature that we support, and hasn't been for a while. But since removing the feature might involve changes in ASC as well I opted to just disable the test for the moment until we tackle the rest.

## Description
No changes to the app. CI should pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
