### PR TITLE
Skip all InAppPurchases-related tests

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -31,7 +31,14 @@
     {
       "skippedTests" : [
         "CardReaderConnectionControllerTests",
+        "InAppPurchaseStoreTests",
+        "InAppPurchaseStoreTests\/test_iap_supported_in_canada()",
+        "InAppPurchaseStoreTests\/test_iap_supported_in_us()",
+        "InAppPurchaseStoreTests\/test_load_products_fails_if_iap_unsupported()",
+        "InAppPurchaseStoreTests\/test_load_products_loads_products_response()",
         "InAppPurchaseStoreTests\/test_purchase_product_completes_purchase()",
+        "InAppPurchaseStoreTests\/test_purchase_product_ensure_xcode_environment()",
+        "InAppPurchaseStoreTests\/test_purchase_product_handles_api_errors()",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_false_when_not_entitled()",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_true_when_entitled()",
         "StorePerformanceViewModelTests\/test_dates_for_custom_range_are_correct_for_non_custom_time_range()",
@@ -46,6 +53,18 @@
     },
     {
       "skippedTests" : [
+        "InAppPurchasesOrderResultMapperTests",
+        "InAppPurchasesOrderResultMapperTests\/test_iap_order_creation_is_decoded_from_json_response()",
+        "InAppPurchasesProductsMapperTests",
+        "InAppPurchasesRemoteTests",
+        "InAppPurchasesRemoteTests\/test_load_products_returns_list_of_products()",
+        "InAppPurchasesRemoteTests\/test_purchase_product_returns_created_order()",
+        "InAppPurchasesRemoteTests\/test_retrieveHandledTransactionSiteID_when_fails_to_retrieve_response_then_returns_network_error()",
+        "InAppPurchasesRemoteTests\/test_retrieveHandledTransactionSiteID_when_success_to_retrieve_response_and_transaction_is_handled_then_returns_siteID()",
+        "InAppPurchasesRemoteTests\/test_retrieveHandledTransactionSiteID_when_success_to_retrieve_response_and_transaction_is_not_handled_then_returns_errorResponse()",
+        "InAppPurchasesTransactionMapperTests",
+        "InAppPurchasesTransactionMapperTests\/test_iap_handled_transaction_is_decoded_from_json_response()",
+        "InAppPurchasesTransactionMapperTests\/test_iap_unhandled_transaction_is_decoded_from_json_response()",
         "WCPayRemoteTests\/test_loadAccount_properly_handles_implicitly_not_eligible_for_card_present_payments()",
         "WCPayRemoteTests\/test_loadAccount_properly_handles_not_eligible_for_card_present_payments()"
       ],


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Continuation of https://github.com/woocommerce/woocommerce-ios/pull/14585
Context: p1733213318054509-slack-C6H8C3G23

## Description
This PR disabled all IAP-related unit tests due to flakiness and the feature being sunset. Removing IAP code and updating ASC will come in a future iteration.

## Testing information
No changes to the app. CI should pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
