### PR TITLE
Product: Migrate product ID update for media endpoint 

### DIFF
--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -18,11 +18,7 @@ public protocol MediaRemoteProtocol {
     func updateProductID(siteID: Int64,
                          productID: Int64,
                          mediaID: Int64,
-                         completion: @escaping (Result<Media, Error>) -> Void)
-    func updateProductIDToWordPressSite(siteID: Int64,
-                                        productID: Int64,
-                                        mediaID: Int64,
-                                        completion: @escaping (Result<WordPressMedia, Error>) -> Void)
+                         completion: @escaping (Result<WordPressMedia, Error>) -> Void)
 }
 
 /// Media: Remote Endpoints
@@ -138,31 +134,6 @@ public class MediaRemote: Remote, MediaRemoteProtocol {
         }
     }
 
-    /// Sets the provided `productID` as `parent_id` of the `media`.
-    ///
-    /// API reference: https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/%24media_ID/
-    ///
-    /// - Parameters:
-    ///     - siteID: Site in which the media was uploaded to.
-    ///     - productID: Product ID to use as `parent_id` of the media.
-    ///     - mediaID: ID of media for which `parent_id` needs to be updated.
-    ///     - completion: Closure to be executed upon completion.
-    ///
-    public func updateProductID(siteID: Int64,
-                                productID: Int64,
-                                mediaID: Int64,
-                                completion: @escaping (Result<Media, Error>) -> Void) {
-        let formParameters: [String: String] = [
-            ParameterKey.wordPressMediaParentID: "\(productID)",
-            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
-        ]
-        let path = "sites/\(siteID)/media/\(mediaID)"
-        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: formParameters)
-        let mapper = MediaMapper()
-
-        enqueue(request, mapper: mapper, completion: completion)
-    }
-
     /// Sets the provided `productID` as post ID of the Media in WordPress site using WordPress site API
     ///
     /// API reference: to the WordPress site.via WordPress site API
@@ -174,10 +145,10 @@ public class MediaRemote: Remote, MediaRemoteProtocol {
     ///     - mediaID: ID of media for which post ID needs to be updated.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func updateProductIDToWordPressSite(siteID: Int64,
-                                               productID: Int64,
-                                               mediaID: Int64,
-                                               completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+    public func updateProductID(siteID: Int64,
+                                productID: Int64,
+                                mediaID: Int64,
+                                completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
         let parameters: [String: String] = [
             ParameterKey.wordPressMediaPostID: "\(productID)",
             ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -212,13 +212,13 @@ final class MediaRemoteTests: XCTestCase {
 
     // MARK: - updateProductID
 
-    /// Verifies that `updateProductID` properly parses the `media-update-product-id` sample response.
+    /// Verifies that `updateProductID` properly parses the `media-update-product-id-in-wordpress-site` sample response.
     ///
     func test_updateProductID_properly_returns_parsed_media() throws {
         // Given
         let remote = MediaRemote(network: network)
         let path = "sites/\(sampleSiteID)/media/\(sampleMediaID)"
-        network.simulateResponse(requestUrlSuffix: path, filename: "media-update-product-id")
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-update-product-id-in-wordpress-site")
 
         // When
         let result = waitFor { promise in
@@ -243,49 +243,6 @@ final class MediaRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.updateProductID(siteID: self.sampleSiteID,
-                                   productID: self.sampleProductID,
-                                   mediaID: self.sampleMediaID) { result in
-                promise(result)
-            }
-        }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-    }
-
-    // MARK: - updateProductIDToWordPressSite
-
-    /// Verifies that `updateProductIDToWordPressSite` properly parses the `media-update-product-id-in-wordpress-site` sample response.
-    ///
-    func test_updateProductIDToWordPressSite_properly_returns_parsed_media() throws {
-        // Given
-        let remote = MediaRemote(network: network)
-        let path = "sites/\(sampleSiteID)/media/\(sampleMediaID)"
-        network.simulateResponse(requestUrlSuffix: path, filename: "media-update-product-id-in-wordpress-site")
-
-        // When
-        let result = waitFor { promise in
-            remote.updateProductIDToWordPressSite(siteID: self.sampleSiteID,
-                                   productID: self.sampleProductID,
-                                   mediaID: self.sampleMediaID) { result in
-                promise(result)
-            }
-        }
-
-        // Then
-        let media = try XCTUnwrap(result.get())
-        XCTAssertEqual(media.mediaID, sampleMediaID)
-    }
-
-    /// Verifies that `updateProductIDToWordPressSite` properly relays Networking Layer errors.
-    ///
-    func test_updateProductIDToWordPressSite_properly_relays_networking_errors() {
-        // Given
-        let remote = MediaRemote(network: network)
-
-        // When
-        let result = waitFor { promise in
-            remote.updateProductIDToWordPressSite(siteID: self.sampleSiteID,
                                    productID: self.sampleProductID,
                                    mediaID: self.sampleMediaID) { result in
                 promise(result)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Payments onboarding: the custom background color of the "Choose your Payment Provider" UI when both WooPayments and Stripe Extension are available was removed to enable use cases with different container background colors. [https://github.com/woocommerce/woocommerce-ios/pull/14546]
 - [**] Products: Media upload will work for sites without XML-RPC. [https://github.com/woocommerce/woocommerce-ios/pull/14537]
 - [**] Products: Media library can now be loaded for sites without XML-RPC [https://github.com/woocommerce/woocommerce-ios/pull/14595]
+- [**] Products: Saving product images now works for sites without XML-RPC [https://github.com/woocommerce/woocommerce-ios/pull/14595]
 - [Internal] Updated CoreDataManager to be thread-safe [https://github.com/woocommerce/woocommerce-ios/pull/14534]
 - [Internal] Core Data: Migrate storage usage in SiteStore [https://github.com/woocommerce/woocommerce-ios/pull/14548]
 - [Internal] Updated storage usage in CouponStore [https://github.com/woocommerce/woocommerce-ios/pull/14530]

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -186,12 +186,8 @@ private extension MediaStore {
                          productID: Int64,
                          mediaID: Int64,
                          onCompletion: @escaping (Result<Media, Error>) -> Void) {
-        if isLoggedInWithoutWPCOMCredentials(siteID) || isSiteJetpackJCPConnected(siteID) {
-            remote.updateProductIDToWordPressSite(siteID: siteID, productID: productID, mediaID: mediaID) { result in
-                onCompletion(result.map { $0.toMedia() })
-            }
-        } else {
-            remote.updateProductID(siteID: siteID, productID: productID, mediaID: mediaID, completion: onCompletion)
+        remote.updateProductID(siteID: siteID, productID: productID, mediaID: mediaID) { result in
+            onCompletion(result.map { $0.toMedia() })
         }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
@@ -19,10 +19,7 @@ final class MockMediaRemote {
     private var uploadMediaResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
 
     /// The results to return based on the given site ID in `updateProductID`
-    private var updateProductIDResultsBySiteID = [Int64: Result<Media, Error>]()
-
-    /// The results to return based on the given site ID in `updateProductIDToWordPressSite`
-    private var updateProductIDToWordPressSiteResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
+    private var updateProductIDResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
 
     /// Returns the value as a publisher when `loadMedia` is called.
     func whenLoadingMedia(siteID: Int64, thenReturn result: Result<WordPressMedia, Error>) {
@@ -40,13 +37,8 @@ final class MockMediaRemote {
     }
 
     /// Returns the value as a publisher when `updateProductID` is called.
-    func whenUpdatingProductID(siteID: Int64, thenReturn result: Result<Media, Error>) {
+    func whenUpdatingProductID(siteID: Int64, thenReturn result: Result<WordPressMedia, Error>) {
         updateProductIDResultsBySiteID[siteID] = result
-    }
-
-    /// Returns the value as a publisher when `updateProductIDToWordPressSite` is called.
-    func whenUpdatingProductIDToWordPressSite(siteID: Int64, thenReturn result: Result<WordPressMedia, Error>) {
-        updateProductIDToWordPressSiteResultsBySiteID[siteID] = result
     }
 }
 
@@ -101,21 +93,9 @@ extension MockMediaRemote: MediaRemoteProtocol {
     func updateProductID(siteID: Int64,
                          productID: Int64,
                          mediaID: Int64,
-                         completion: @escaping (Result<Media, Error>) -> Void) {
+                         completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
         invocations.append(.updateProductID(siteID: siteID))
         guard let result = updateProductIDResultsBySiteID[siteID] else {
-            XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
-            return
-        }
-        completion(result)
-    }
-
-    func updateProductIDToWordPressSite(siteID: Int64,
-                                        productID: Int64,
-                                        mediaID: Int64,
-                                        completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
-        invocations.append(.updateProductIDToWordPressSite(siteID: siteID))
-        guard let result = updateProductIDToWordPressSiteResultsBySiteID[siteID] else {
             XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
             return
         }

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -640,8 +640,8 @@ final class MediaStoreTests: XCTestCase {
     func test_updateProductID_returns_media() throws {
         // Given
         let remote = MockMediaRemote()
-        let media = Media.fake()
-        remote.whenUpdatingProductID(siteID: sampleSiteID, thenReturn: .success(media))
+        let wordPressMedia = WordPressMedia.fake()
+        remote.whenUpdatingProductID(siteID: sampleSiteID, thenReturn: .success(wordPressMedia))
         let mediaStore = MediaStore(dispatcher: dispatcher,
                                     storageManager: storageManager,
                                     network: network,
@@ -658,7 +658,7 @@ final class MediaStoreTests: XCTestCase {
 
         // Then
         let mediaFromResult = try XCTUnwrap(result.get())
-        XCTAssertEqual(mediaFromResult, media)
+        XCTAssertEqual(mediaFromResult, wordPressMedia.toMedia())
     }
 
     /// Verifies that `MediaAction.updateProductID` returns an error whenever there is an error response from the backend.
@@ -671,88 +671,6 @@ final class MediaStoreTests: XCTestCase {
                                     storageManager: storageManager,
                                     network: network,
                                     remote: remote)
-
-        // When
-        let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.updateProductID(siteID: self.sampleSiteID,
-                                                     productID: self.sampleProductID,
-                                                     mediaID: self.sampleMediaID) { result in
-                promise(result)
-            }
-            mediaStore.onAction(action)
-        }
-
-        // Then
-        let error = try XCTUnwrap(result.failure as? DotcomError)
-        XCTAssertEqual(error, .unauthorized)
-    }
-
-    /// Verifies that `MediaAction.updateProductID` returns the expected response while connecting to site with placeholder site ID.
-    ///
-    func test_updateProductID_returns_media_when_connecting_to_site_with_placeholder_site_id() throws {
-        // Given
-        let siteID = WooConstants.placeholderSiteID
-        let remote = MockMediaRemote()
-        let media = WordPressMedia.fake()
-        remote.whenUpdatingProductIDToWordPressSite(siteID: siteID, thenReturn: .success(media))
-        let mediaStore = MediaStore(dispatcher: dispatcher,
-                                    storageManager: storageManager,
-                                    network: network,
-                                    remote: remote)
-        // When
-        let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.updateProductID(siteID: siteID,
-                                                     productID: self.sampleProductID,
-                                                     mediaID: self.sampleMediaID) { result in
-                promise(result)
-            }
-            mediaStore.onAction(action)
-        }
-
-        // Then
-        let mediaFromResult = try XCTUnwrap(result.get())
-        XCTAssertEqual(mediaFromResult, media.toMedia())
-    }
-
-    /// Verifies that `MediaAction.updateProductID` returns the expected response while connecting to JCP sites.
-    ///
-    func test_updateProductIDToWordPressSite_returns_media() throws {
-        // Given
-        let remote = MockMediaRemote()
-        let media = WordPressMedia.fake()
-        remote.whenUpdatingProductIDToWordPressSite(siteID: sampleSiteID, thenReturn: .success(media))
-        let mediaStore = MediaStore(dispatcher: dispatcher,
-                                    storageManager: storageManager,
-                                    network: network,
-                                    remote: remote)
-        insertJCPSiteToStorage(siteID: sampleSiteID)
-
-        // When
-        let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.updateProductID(siteID: self.sampleSiteID,
-                                                     productID: self.sampleProductID,
-                                                     mediaID: self.sampleMediaID) { result in
-                promise(result)
-            }
-            mediaStore.onAction(action)
-        }
-
-        // Then
-        let mediaFromResult = try XCTUnwrap(result.get())
-        XCTAssertEqual(mediaFromResult, media.toMedia())
-    }
-
-    /// Verifies that `MediaAction.updateProductID` while connecting to JCP sites returns an error whenever there is an error response from the backend.
-    ///
-    func test_updateProductIDToWordPressSite_returns_error_upon_response_error() throws {
-        // Given
-        let remote = MockMediaRemote()
-        remote.whenUpdatingProductIDToWordPressSite(siteID: sampleSiteID, thenReturn: .failure(DotcomError.unauthorized))
-        let mediaStore = MediaStore(dispatcher: dispatcher,
-                                    storageManager: storageManager,
-                                    network: network,
-                                    remote: remote)
-        insertJCPSiteToStorage(siteID: sampleSiteID)
 
         // When
         let result: Result<Media, Error> = waitFor { promise in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14550 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR unifies the logic to update the parent ID for uploaded media to use the /wp/v2 endpoint to support sites without XMLRPC.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
**a. No Jetpack case (Application Password)**
1. Have a .org site with no Jetpack, 
2. Install "Disable XML-RPC-API" plugin.
3. In the app, login to site with application password,
4. Navigate to the Products tab, select an existing product, or create a new one.
5. Upload one or more images for the product
6. Save the changes and confirm in the app and web that the images are displayed for the product.

**b. Jetpack CP site case**
1. Have a .org site with no Jetpack but with a plugin with Jetpack CP (I use "Blaze Ads" and connect WPCOM account while attempting to create a Blaze campaign from the `wp-admin` page)
2. Install "Disable XML-RPC-API" plugin.
3. Setup the Jetpack CP plugin and connect it to your WordPress.com account
4. In the app, login to site with WordPress.com account,
5. Navigate to the Products tab, select an existing product, or create a new one.
6. Upload one or more images for the product
7. Save the changes and confirm in the app and web that the images are displayed for the product.


**c. WordPress.com / full Jetpack site case**
1. Have a .org site with Jetpack plugin
2. Install "Disable XML-RPC-API" plugin.
3. Setup the Jetpack plugin and connect it to your WordPress.com account,
4. In the app, login to site with WordPress.com account,
5. Navigate to the Products tab, select an existing product, or create a new one.
6. Upload one or more images for the product
7. Save the changes and confirm in the app and web that the images are displayed for the product.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.1 and confirmed that saving new images works for sites without XMLRPC disregarding the authentication method.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
