### PR TITLE
[Shipping labels] Add refresh action to carriers list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -23,6 +23,7 @@ struct WooCarrierPackagesView: View {
     @Binding var starredPackages: Set<String>
     let tapAction: (String) -> Void
     let starAction: (String) -> Void
+    let onRefresh: () -> Void
 
     var body: some View {
         List {
@@ -62,6 +63,9 @@ struct WooCarrierPackagesView: View {
             }
         }
         .listStyle(.plain)
+        .refreshable {
+            onRefresh()
+        }
     }
 }
 
@@ -84,12 +88,6 @@ struct WooCarrierPackagesSelectionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if viewModel.isLoadingPackages {
-                // TODO: think of a better progress/loading indicator
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .padding()
-            }
             if viewModel.selectedCarriersTabIndex != nil, viewModel.carrierTabs.isNotEmpty {
                 TopTabView(tabs: viewModel.carrierTabs,
                            showContent: .constant(false),
@@ -103,6 +101,11 @@ struct WooCarrierPackagesSelectionView: View {
                            tabItemContentHorizontalPadding: Constants.tabItemContentHorizontalPadding,
                            tabItemContentVerticalPadding: Constants.tabItemContentVerticalPadding)
             }
+            if viewModel.isLoadingPackages {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .padding()
+            }
             if let selectedCarrierTab = viewModel.selectedCarrierTab {
                 WooCarrierPackagesView(carrierTab: selectedCarrierTab,
                                        selectedPackageId: $viewModel.selectedCarriersPackageId,
@@ -111,6 +114,8 @@ struct WooCarrierPackagesSelectionView: View {
                     viewModel.selectedCarriersPackageId = viewModel.selectedCarriersPackageId == packageID ? nil : packageID
                 }, starAction: { packageID in
                     viewModel.starUnstarPackage(packageID, carrierID: selectedCarrierTab.carrier.rawValue)
+                }, onRefresh: {
+                    viewModel.loadPackages()
                 })
             }
             Spacer()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Similar as for Saved packages list, the refresh option (using `.refreshable` modifier) is added to carriers packages list to enable manual refreshing of the packages

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Install and set up the Woo Shipping extension on your store.
- Build and run the app with the revampedShippingLabelCreation feature flag enabled.
- Create an order with the processing status and at least one physical product.
- In the order details, select "Create Shipping Label."
- Store options will start fetching from backend in the background.
- Tap "Select a Package" button
- Switch to Carrier tab
- Pull to refresh on the list and make sure that the loading indicator shows and after refreshing you still see the list of packages

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/5aec2f87-bebb-4be0-8668-87b2dc080dc7

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
