### PR TITLE
[Order Creation] Improve custom amount type sheet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -24,6 +24,7 @@
 - [Internal] Updated storage usage in ShippingLabelStore [https://github.com/woocommerce/woocommerce-ios/pull/14566]
 - [*] Fixed: Improved the error message displayed when Bluetooth permission is denied during the card reader connection process. [https://github.com/woocommerce/woocommerce-ios/pull/14561]
 - [*] Payments: error details are now displayed for more Stripe errors, instead of a generic error message. [https://github.com/woocommerce/woocommerce-ios/pull/14583]
+- [*] Order Creation: fixed layout of custom amount type selection drawer. [https://github.com/woocommerce/woocommerce-ios/pull/14619]
 
 
 21.2

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -122,7 +122,7 @@ struct OrderCustomAmountsSection: View {
     }
 
     @ViewBuilder private var optionsBottomSheetContent: some View {
-        VStack (spacing: Layout.optionsBottomSheetContentVerticalSpacing) {
+        VStack (alignment: .leading, spacing: Layout.optionsBottomSheetContentVerticalSpacing) {
             Text(Localization.optionsDialogAddCustomAmountTitle)
                 .subheadlineStyle()
                 .fixedSize(horizontal: false, vertical: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -105,44 +105,47 @@ struct OrderCustomAmountsSection: View {
     }
 
     @ViewBuilder private var optionsBottomSheetContent: some View {
-        VStack (alignment: .leading, spacing: Layout.optionsBottomSheetContentVerticalSpacing) {
+        VStack (spacing: Layout.optionsBottomSheetContentVerticalSpacing) {
             Text(Localization.optionsDialogAddCustomAmountTitle)
                 .subheadlineStyle()
-                .padding(.top, Layout.optionsBottomSheetContentTitleTopPadding)
-                .padding(.bottom, Layout.optionsBottomSheetContentTitleBottomPadding)
+                .fixedSize(horizontal: false, vertical: true)
 
-            HStack {
-                Text(sectionViewModel.currencySymbol)
-                    .frame(minWidth: Layout.optionsBottomSheetButtonSymbolWidth)
-                    .padding(.trailing, Layout.optionsBottomSheetButtonSymbolTrailing)
-
-                Button(Localization.optionsDialogFixedAmountButtonTitle) {
+            Grid(alignment: .leading,
+                 horizontalSpacing: Layout.optionsBottomSheetSymbolLabelSpacing,
+                 verticalSpacing: Layout.optionsBottomSheetContentVerticalSpacing) {
+                optionRow(symbol: sectionViewModel.currencySymbol,
+                          title: Localization.optionsDialogFixedAmountButtonTitle) {
                     addCustomAmountOption = .fixedAmount
                     showAddCustomAmountsAfterOptionsDialog()
-
                 }
-                .bodyStyle()
                 .accessibilityIdentifier(Accessibility.fixedAmountIdentifier)
-            }
-            .padding(.bottom, Layout.optionsBottomSheetContentVerticalSpacing)
 
-            HStack {
-                Text("%")
-                    .frame(minWidth: Layout.optionsBottomSheetButtonSymbolWidth)
-                    .padding(.trailing, Layout.optionsBottomSheetButtonSymbolTrailing)
-
-                Button(Localization.optionsDialogPercentageButtonTitle) {
+                optionRow(symbol: "%",
+                          title: Localization.optionsDialogPercentageButtonTitle) {
                     addCustomAmountOption = .orderTotalPercentage
                     showAddCustomAmountsAfterOptionsDialog()
                 }
-                .bodyStyle()
                 .accessibilityIdentifier(Accessibility.percentageAmountIdentifier)
             }
-
-            Spacer()
         }
-        .padding(.leading, Layout.optionsBottomSheetVerticalPadding)
-        .padding(.trailing, Layout.optionsBottomSheetVerticalPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(Layout.optionsBottomSheetPadding)
+        .scrollVerticallyIfNeeded()
+    }
+
+    @ViewBuilder private func optionRow(symbol: String, title: String, action: @escaping () -> Void) -> some View {
+        GridRow {
+            Text(symbol)
+            Button {
+                action()
+            } label: {
+                Text(title)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .bodyStyle()
     }
 }
 
@@ -168,11 +171,9 @@ private extension OrderCustomAmountsSection {
 private extension OrderCustomAmountsSection {
     enum Layout {
         static let optionsBottomSheetContentVerticalSpacing: CGFloat = 16
-        static let optionsBottomSheetContentTitleTopPadding: CGFloat = 30
         static let optionsBottomSheetContentTitleBottomPadding: CGFloat = 8
-        static let optionsBottomSheetButtonSymbolWidth: CGFloat = 20
-        static let optionsBottomSheetButtonSymbolTrailing: CGFloat = 18
-        static let optionsBottomSheetVerticalPadding: CGFloat = 16
+        static let optionsBottomSheetSymbolLabelSpacing: CGFloat = 18
+        static let optionsBottomSheetPadding: CGFloat = 16
         static let rowHeight: CGFloat = 56
 
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -42,6 +42,8 @@ struct OrderCustomAmountsSection: View {
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize: DynamicTypeSize
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     var body: some View {
         VStack {
             HStack {
@@ -85,7 +87,10 @@ struct OrderCustomAmountsSection: View {
         .if(viewModel.customAmountRows.isEmpty, transform: { $0.padding([.leading, .trailing]) })
         .if(!viewModel.customAmountRows.isEmpty, transform: { $0.padding() })
         .background(Color(.listForeground(modal: true)))
-        .sheet(isPresented: $sectionViewModel.showCustomAmountOptionsDialog) {
+        .popover(isPresented: isCustomAmountOptionsPopoverPresented) {
+            optionsPopoverContent
+        }
+        .sheet(isPresented: isCustomAmountOptionsSheetPresented) {
             optionsWithDetentsBottomSheetContent
         }
         .sheet(isPresented: $sectionViewModel.showAddCustomAmount,
@@ -95,6 +100,57 @@ struct OrderCustomAmountsSection: View {
         }, content: {
             AddCustomAmountView(viewModel: viewModel.addCustomAmountViewModel(with: addCustomAmountOption))
         })
+    }
+
+    // Computed bindings based on horizontalSizeClass
+    private var isCustomAmountOptionsPopoverPresented: Binding<Bool> {
+        Binding(
+            get: { sectionViewModel.showCustomAmountOptionsDialog && horizontalSizeClass == .regular },
+            set: { newValue in
+                if horizontalSizeClass == .regular {
+                    sectionViewModel.showCustomAmountOptionsDialog = newValue
+                }
+            }
+        )
+    }
+
+    private var isCustomAmountOptionsSheetPresented: Binding<Bool> {
+        Binding(
+            get: { sectionViewModel.showCustomAmountOptionsDialog && horizontalSizeClass == .compact },
+            set: { newValue in
+                if horizontalSizeClass == .compact {
+                    sectionViewModel.showCustomAmountOptionsDialog = newValue
+                }
+            }
+        )
+    }
+
+    @ViewBuilder private var optionsPopoverContent: some View {
+        optionsBottomSheetContent
+            .frame(width: optionsPopoverSize.width, height: optionsPopoverSize.height)
+    }
+
+    private var optionsPopoverSize: CGSize {
+        switch dynamicTypeSize {
+        case .xSmall, .small:
+            return CGSize(width: 325, height: 175)
+        case .medium, .large:
+            return CGSize(width: 375, height: 175)
+        case .xLarge:
+            return CGSize(width: 400, height: 175)
+        case .xxLarge, .xxxLarge:
+            return CGSize(width: 400, height: 200)
+        case .accessibility1:
+            return CGSize(width: 475, height: 225)
+        case .accessibility2:
+            return CGSize(width: 550, height: 250)
+        case .accessibility3:
+            return CGSize(width: 550, height: 350)
+        case .accessibility4, .accessibility5:
+            return CGSize(width: 550, height: 400)
+        @unknown default:
+            return CGSize(width: 550, height: 350)
+        }
     }
 
     @ViewBuilder private var optionsWithDetentsBottomSheetContent: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -6,8 +6,8 @@ final class OrderCustomAmountsSectionViewModel: ObservableObject {
     /// Defines whether the new custom amount modal is presented.
     @Published var showAddCustomAmount: Bool = false
 
-    /// Defines whether the new custom amount options dialog is presented.
-    @Published var showAddCustomAmountOptionsDialog: Bool = false
+    /// Defines whether the custom amount options dialog is presented.
+    @Published var showCustomAmountOptionsDialog: Bool = false
 
     let currencySettings: CurrencySettings
     init(currencySettings: CurrencySettings) {
@@ -85,10 +85,7 @@ struct OrderCustomAmountsSection: View {
         .if(viewModel.customAmountRows.isEmpty, transform: { $0.padding([.leading, .trailing]) })
         .if(!viewModel.customAmountRows.isEmpty, transform: { $0.padding() })
         .background(Color(.listForeground(modal: true)))
-        .sheet(isPresented: $sectionViewModel.showAddCustomAmountOptionsDialog, onDismiss: onDismissOptionsDialog) {
-            optionsWithDetentsBottomSheetContent
-        }
-        .sheet(isPresented: $viewModel.showEditCustomAmount, onDismiss: onDismissOptionsDialog) {
+        .sheet(isPresented: $sectionViewModel.showCustomAmountOptionsDialog) {
             optionsWithDetentsBottomSheetContent
         }
         .sheet(isPresented: $sectionViewModel.showAddCustomAmount,
@@ -173,17 +170,9 @@ private extension OrderCustomAmountsSection {
         viewModel.onAddCustomAmountButtonTapped()
     }
 
-    func onDismissOptionsDialog() {
-        if showAddCustomAmountAfterOptionsDialog {
-            showAddCustomAmountAfterOptionsDialog = false
-            sectionViewModel.showAddCustomAmount = true
-        }
-    }
-
     func showAddCustomAmountsAfterOptionsDialog() {
-        showAddCustomAmountAfterOptionsDialog = true
-        sectionViewModel.showAddCustomAmountOptionsDialog = false
-        viewModel.showEditCustomAmount = false
+        sectionViewModel.showCustomAmountOptionsDialog = false
+        sectionViewModel.showAddCustomAmount = true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -87,13 +87,9 @@ struct OrderCustomAmountsSection: View {
     }
 
     @ViewBuilder private var optionsWithDetentsBottomSheetContent: some View {
-        if #available(iOS 16.0, *) {
-            optionsBottomSheetContent
-                .presentationDetents([.height(218)])
-                .presentationDragIndicator(.visible)
-        } else {
-            optionsBottomSheetContent
-        }
+        optionsBottomSheetContent
+            .presentationDetents([.height(218)])
+            .presentationDragIndicator(.visible)
     }
 
     @ViewBuilder private var optionsBottomSheetContent: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WooFoundation
 
 /// View model for `OrderCustomAmountsSection` that controls the visibility states of modals from various sources.
 final class OrderCustomAmountsSectionViewModel: ObservableObject {
@@ -7,6 +8,17 @@ final class OrderCustomAmountsSectionViewModel: ObservableObject {
 
     /// Defines whether the new custom amount options dialog is presented.
     @Published var showAddCustomAmountOptionsDialog: Bool = false
+
+    let currencySettings: CurrencySettings
+    init(currencySettings: CurrencySettings) {
+        self.currencySettings = currencySettings
+    }
+
+    /// The site's currency symbol. When we support creating orders in other currencies,
+    /// the appropriate code will need to be passed in from the EditableOrderViewModel.
+    var currencySymbol: String {
+        currencySettings.currencySymbol
+    }
 }
 
 struct OrderCustomAmountsSection: View {
@@ -100,7 +112,7 @@ struct OrderCustomAmountsSection: View {
                 .padding(.bottom, Layout.optionsBottomSheetContentTitleBottomPadding)
 
             HStack {
-                Text("$")
+                Text(sectionViewModel.currencySymbol)
                     .frame(minWidth: Layout.optionsBottomSheetButtonSymbolWidth)
                     .padding(.trailing, Layout.optionsBottomSheetButtonSymbolTrailing)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -40,6 +40,8 @@ struct OrderCustomAmountsSection: View {
 
     @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize: DynamicTypeSize
+
     var body: some View {
         VStack {
             HStack {
@@ -100,8 +102,23 @@ struct OrderCustomAmountsSection: View {
 
     @ViewBuilder private var optionsWithDetentsBottomSheetContent: some View {
         optionsBottomSheetContent
-            .presentationDetents([.height(218)])
+            .presentationDetents(detentsForOptionsBottomSheet)
             .presentationDragIndicator(.visible)
+    }
+
+    private var detentsForOptionsBottomSheet: Set<PresentationDetent> {
+        switch dynamicTypeSize {
+        case .xSmall, .small, .medium, .large:
+            return [.height(175), .medium]
+        case .xLarge, .xxLarge:
+            return [.height(200), .medium]
+        case .xxxLarge:
+            return [.height(230), .medium]
+        case .accessibility1, .accessibility2, .accessibility3, .accessibility4, .accessibility5:
+            return [.medium, .large]
+        @unknown default:
+            return [.large]
+        }
     }
 
     @ViewBuilder private var optionsBottomSheetContent: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSection.swift
@@ -109,42 +109,44 @@ struct OrderCustomAmountsSection: View {
             Text(Localization.optionsDialogAddCustomAmountTitle)
                 .subheadlineStyle()
                 .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, Layout.optionsBottomSheetContentVerticalSpacing)
+                .padding([.leading, .trailing], Layout.optionsBottomSheetPadding)
 
-            Grid(alignment: .leading,
-                 horizontalSpacing: Layout.optionsBottomSheetSymbolLabelSpacing,
-                 verticalSpacing: Layout.optionsBottomSheetContentVerticalSpacing) {
-                optionRow(symbol: sectionViewModel.currencySymbol,
-                          title: Localization.optionsDialogFixedAmountButtonTitle) {
+            List {
+                Button {
                     addCustomAmountOption = .fixedAmount
                     showAddCustomAmountsAfterOptionsDialog()
+                } label: {
+                    optionLabel(symbol: sectionViewModel.currencySymbol,
+                                title: Localization.optionsDialogFixedAmountButtonTitle)
                 }
+                .listRowSeparator(.hidden)
                 .accessibilityIdentifier(Accessibility.fixedAmountIdentifier)
 
-                optionRow(symbol: "%",
-                          title: Localization.optionsDialogPercentageButtonTitle) {
+                Button {
                     addCustomAmountOption = .orderTotalPercentage
                     showAddCustomAmountsAfterOptionsDialog()
+                } label: {
+                    optionLabel(symbol: "%",
+                                title: Localization.optionsDialogPercentageButtonTitle)
                 }
+                .listRowSeparator(.hidden)
                 .accessibilityIdentifier(Accessibility.percentageAmountIdentifier)
             }
+            .listStyle(.plain)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .padding(Layout.optionsBottomSheetPadding)
-        .scrollVerticallyIfNeeded()
+        .padding([.top, .bottom], Layout.optionsBottomSheetPadding)
     }
 
-    @ViewBuilder private func optionRow(symbol: String, title: String, action: @escaping () -> Void) -> some View {
-        GridRow {
+    @ViewBuilder private func optionLabel(symbol: String, title: String) -> some View {
+        Label {
+            Text(title)
+        } icon: {
             Text(symbol)
-            Button {
-                action()
-            } label: {
-                Text(title)
-                    .multilineTextAlignment(.leading)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
         }
+        .multilineTextAlignment(.leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .bodyStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -149,7 +149,7 @@ final class EditableOrderViewModel: ObservableObject {
     /// When the value is non-nil, the bundle product configuration screen is shown.
     @Published var productToConfigureViewModel: ConfigurableBundleProductViewModel?
 
-    @Published private(set) var customAmountsSectionViewModel: OrderCustomAmountsSectionViewModel = .init()
+    @Published private(set) var customAmountsSectionViewModel: OrderCustomAmountsSectionViewModel
 
     // MARK: Status properties
 
@@ -491,6 +491,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.initialCustomer = initialCustomer
         self.barcodeScannerItemFinder = BarcodeScannerItemFinder(stores: stores)
         self.quantityDebounceDuration = quantityDebounceDuration
+        self.customAmountsSectionViewModel = OrderCustomAmountsSectionViewModel(currencySettings: currencySettings)
 
         // Set a temporary initial view model, as a workaround to avoid making it optional.
         // Needs to be reset before the view model is used.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -192,10 +192,6 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     @Published private var storedTaxRate: TaxRate? = nil
 
-    /// Display the custom amount screen to edit it
-    ///
-    @Published var showEditCustomAmount: Bool = false
-
     /// Defines if the toggle to store the tax rate in the selector should be enabled by default
     ///
     var shouldStoreTaxRateInSelectorByDefault: Bool {
@@ -1028,7 +1024,7 @@ final class EditableOrderViewModel: ObservableObject {
     func addCustomAmount() {
         editingFee = nil
         if orderIsNotEmpty {
-            customAmountsSectionViewModel.showAddCustomAmountOptionsDialog = true
+            customAmountsSectionViewModel.showCustomAmountOptionsDialog = true
         } else {
             customAmountsSectionViewModel.showAddCustomAmount = true
         }
@@ -1615,7 +1611,7 @@ private extension EditableOrderViewModel {
                                                     onEditCustomAmount: {
                         self.analytics.track(.orderCreationEditCustomAmountTapped)
                         self.editingFee = fee
-                        self.showEditCustomAmount = true
+                        self.customAmountsSectionViewModel.showCustomAmountOptionsDialog = true
                     })
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -111,7 +111,7 @@ final class EditableOrderViewModel: ObservableObject {
         !featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder)
     }
 
-    var enableAddingCustomAmountViaOrderTotalPercentage: Bool {
+    var orderIsNotEmpty: Bool {
         orderSynchronizer.order.items.isNotEmpty || orderSynchronizer.order.fees.isNotEmpty
     }
 
@@ -1026,8 +1026,11 @@ final class EditableOrderViewModel: ObservableObject {
     /// Starts the flow to add a custom amount.
     func addCustomAmount() {
         editingFee = nil
-        enableAddingCustomAmountViaOrderTotalPercentage ?
-        customAmountsSectionViewModel.showAddCustomAmountOptionsDialog.toggle() : customAmountsSectionViewModel.showAddCustomAmount.toggle()
+        if orderIsNotEmpty {
+            customAmountsSectionViewModel.showAddCustomAmountOptionsDialog = true
+        } else {
+            customAmountsSectionViewModel.showAddCustomAmount = true
+        }
     }
 
     func onCreateOrderTapped() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -791,6 +791,7 @@
 		203163BB2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163BA2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */; };
 		203163BD2C1C9602001C96DA /* PointOfSaleCardPresentPaymentAlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163BC2C1C9602001C96DA /* PointOfSaleCardPresentPaymentAlertType.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsPayoutsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsPayoutsOverviewView.swift */; };
+		203AB2A82D01B988001D989C /* OrderCustomAmountsSectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203AB2A72D01B97D001D989C /* OrderCustomAmountsSectionViewModelTests.swift */; };
 		2044158D2CE4DB480070BF54 /* PointOfSaleOrderStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2044158C2CE4DB480070BF54 /* PointOfSaleOrderStage.swift */; };
 		2044158F2CE6181E0070BF54 /* PointOfSaleOrderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2044158E2CE6181E0070BF54 /* PointOfSaleOrderState.swift */; };
 		204415912CE622BA0070BF54 /* PointOfSaleOrderTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204415902CE622BA0070BF54 /* PointOfSaleOrderTotals.swift */; };
@@ -3920,6 +3921,7 @@
 		203163BA2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift; sourceTree = "<group>"; };
 		203163BC2C1C9602001C96DA /* PointOfSaleCardPresentPaymentAlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentAlertType.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsPayoutsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewView.swift; sourceTree = "<group>"; };
+		203AB2A72D01B97D001D989C /* OrderCustomAmountsSectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSectionViewModelTests.swift; sourceTree = "<group>"; };
 		2044158C2CE4DB480070BF54 /* PointOfSaleOrderStage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderStage.swift; sourceTree = "<group>"; };
 		2044158E2CE6181E0070BF54 /* PointOfSaleOrderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderState.swift; sourceTree = "<group>"; };
 		204415902CE622BA0070BF54 /* PointOfSaleOrderTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderTotals.swift; sourceTree = "<group>"; };
@@ -10998,6 +11000,7 @@
 		B9F1489B2AD59F31008FC795 /* CustomAmounts */ = {
 			isa = PBXGroup;
 			children = (
+				203AB2A72D01B97D001D989C /* OrderCustomAmountsSectionViewModelTests.swift */,
 				B9F1489C2AD59F42008FC795 /* FormattableAmountTextFieldViewModelTests.swift */,
 				B92932E02AD5A616005B3153 /* AddCustomAmountViewModelTests.swift */,
 			);
@@ -17090,6 +17093,7 @@
 				025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */,
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
 				02CD3BFE2C35D04C00E575C4 /* MockCardPresentPaymentService.swift in Sources */,
+				203AB2A82D01B988001D989C /* OrderCustomAmountsSectionViewModelTests.swift in Sources */,
 				EE8A30472B74F3A8001D7C66 /* OrderAttributionInfo+OriginTests.swift in Sources */,
 				03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */,
 				DE74A44F2BCE2FCF0009C415 /* StorePerformanceViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -153,9 +153,25 @@ final class CurrencySettingsTests: XCTestCase {
 
     /// Test currency symbol lookup returns correctly encoded symbol.
     ///
-    func testCurrencySymbol() {
+    func testCurrencySymbol_passing_code() {
         moneyFormat = CurrencySettings()
         let symbol = moneyFormat?.symbol(from: CurrencyCode.AED)
         XCTAssertEqual("د.إ", symbol)
+    }
+
+    func test_currencySymbol_default() {
+        moneyFormat = CurrencySettings()
+        let symbol = moneyFormat?.currencySymbol
+        XCTAssertEqual("$", symbol)
+    }
+
+    func test_currencySymbol_euros() {
+        moneyFormat = CurrencySettings(currencyCode: .EUR,
+                                       currencyPosition: .left,
+                                       thousandSeparator: "",
+                                       decimalSeparator: "",
+                                       numberOfDecimals: 2)
+        let symbol = moneyFormat?.currencySymbol
+        XCTAssertEqual("€", symbol)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSectionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/OrderCustomAmountsSectionViewModelTests.swift
@@ -1,0 +1,24 @@
+import Testing
+
+@testable import WooCommerce
+import WooFoundation
+
+struct OrderCustomAmountsSectionViewModelTests {
+    @Test
+    func when_created_with_usd_currencySettings_currencySymbol_returns_dollar() throws {
+        // Given
+        let usdSettings = CurrencySettings(currencyCode: .USD, currencyPosition: .left, thousandSeparator: "", decimalSeparator: "", numberOfDecimals: 2)
+        let sut = OrderCustomAmountsSectionViewModel(currencySettings: usdSettings)
+        // When, Then
+        #expect(sut.currencySymbol == "$")
+    }
+
+    @Test
+    func when_created_with_gbp_currencySettings_currencySymbol_returns_pound() throws {
+        // Given
+        let gbpSettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: "", numberOfDecimals: 2)
+        let sut = OrderCustomAmountsSectionViewModel(currencySettings: gbpSettings)
+        // When, Then
+        #expect(sut.currencySymbol == "£")
+    }
+}

--- a/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
@@ -34,6 +34,9 @@ public class CurrencySettings: Codable, Equatable {
     public var groupingSeparator: String
     public var decimalSeparator: String
     public var fractionDigits: Int
+    public var currencySymbol: String {
+        symbol(from: currencyCode)
+    }
 
     // MARK: - Initializers & Methods
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14178 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR improves the layout of the custom amount type selection screen, and updates it to use the site's currency symbol.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Using a site with a currency that uses something other than $ as it symbol:

1. Launch the app, and go to the `Orders` tab
2. Tap `+` and add a product to the new order
3. Tap `+ Add custom amount`
4. Observe that the custom amount type selection sheet is shown leading-aligned.
5. Observe that the currency symbol matches the site's currency symbol

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

It's worth trying different dynamic type sizes; with the tools available it's not practical to have the sheet perfectly sized for every device/dynamic type setting, so I've done a best-effort here. 

It's also worth checking RTL languages.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d255ed2f-dace-4566-ba00-a0598e4c45ef

### Before
![image](https://github.com/user-attachments/assets/1ed0f6d3-5bbc-4d07-a8d8-a989c2547eed)

### On iPad, we use a popover


https://github.com/user-attachments/assets/d2d408f8-a4dd-4689-8371-c5c1aee934a4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.