### PR TITLE
[Woo POS] Move payment buttons rendering to success view

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -55,4 +55,5 @@ struct POSCardPresentPaymentInLineMessageAnimation {
     let iconTransitionId: String = "pos_card_present_payment_in_line_message_icon_matched_geometry_id"
     let titleTransitionId: String = "pos_card_present_payment_in_line_message_title_matched_geometry_id"
     let messageTransitionId: String = "pos_card_present_payment_in_line_message_message_matched_geometry_id"
+    let actionButtonsTransitionId = "pos_card_present_payment_in_line_message_action_buttons_matched_geometry_id"
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
@@ -23,6 +23,7 @@ struct PointOfSaleCardPresentPaymentSuccessMessageView: View {
                         .matchedGeometryEffect(id: animation.messageTransitionId, in: animation.namespace, properties: .position)
                 }
             }
+            PaymentsActionButtons()
         }
         .multilineTextAlignment(.center)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
@@ -24,6 +24,7 @@ struct PointOfSaleCardPresentPaymentSuccessMessageView: View {
                 }
             }
             PaymentsActionButtons()
+                .matchedGeometryEffect(id: animation.actionButtonsTransitionId, in: animation.namespace, properties: .position)
         }
         .multilineTextAlignment(.center)
     }

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -64,8 +64,6 @@ private extension PaymentsActionButtons {
 
 extension PaymentsActionButtons {
     enum Constants {
-        static let paymentsButtonSpacing: CGFloat = 80
-        static let paymentsButtonButtonSpacingAnimationDelay: CGFloat = 0.3
         static let buttonSpacing: CGFloat = 12
         static let buttonPadding: CGFloat = 32
         static let buttonFont: POSFontStyle = .posBodyEmphasized

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -14,6 +14,14 @@ struct PaymentsActionButtons: View {
                 .renderedIf(shouldShowSendReceiptButton)
             newOrderButton
         }
+        .posModal(isPresented: $isShowingSendReceiptModal) {
+            POSSendReceiptModalView(sendReceipt: { email in
+                Task { @MainActor in
+                    await posModel.sendReceipt(to: email)
+                }
+            }, isPresented: $isShowingSendReceiptModal)
+            .posModalSizing()
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -62,7 +62,7 @@ private extension PaymentsActionButtons {
     }
 }
 
-extension PaymentsActionButtons {
+private extension PaymentsActionButtons {
     enum Constants {
         static let buttonSpacing: CGFloat = 12
         static let buttonPadding: CGFloat = 32

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -25,17 +25,6 @@ struct PaymentsActionButtons: View {
     }
 }
 
-#if DEBUG
-#Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController())
-    PaymentsActionButtons()
-        .environmentObject(posModel)
-}
-#endif
-
 private extension PaymentsActionButtons {
     var sendReceiptButton: some View {
         Button(action: {
@@ -94,3 +83,14 @@ extension PaymentsActionButtons {
             comment: "Button title for the receipt button")
     }
 }
+
+#if DEBUG
+#Preview {
+    let posModel = PointOfSaleAggregateModel(
+        itemsController: PointOfSalePreviewItemsController(),
+        cardPresentPaymentService: CardPresentPaymentPreviewService(),
+        orderController: PointOfSalePreviewOrderController())
+    PaymentsActionButtons()
+        .environmentObject(posModel)
+}
+#endif

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+struct PaymentsActionButtons: View {
+    @EnvironmentObject private var posModel: PointOfSaleAggregateModel
+    @State private var isShowingSendReceiptModal: Bool = false
+
+    private var shouldShowSendReceiptButton: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sendReceiptsForPointOfSale)
+    }
+
+    var body: some View {
+        VStack {
+            sendReceiptButton
+                .renderedIf(shouldShowSendReceiptButton)
+            newOrderButton
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    let posModel = PointOfSaleAggregateModel(
+        itemsController: PointOfSalePreviewItemsController(),
+        cardPresentPaymentService: CardPresentPaymentPreviewService(),
+        orderController: PointOfSalePreviewOrderController())
+    PaymentsActionButtons()
+        .environmentObject(posModel)
+}
+#endif
+
+private extension PaymentsActionButtons {
+    var sendReceiptButton: some View {
+        Button(action: {
+            isShowingSendReceiptModal = true
+        }, label: {
+            HStack(spacing: Constants.buttonSpacing) {
+                Text(Localization.sendReceipt)
+                    .font(Constants.buttonFont)
+            }
+            .frame(minWidth: UIScreen.main.bounds.width / 2)
+        })
+        .padding(Constants.buttonPadding)
+        .foregroundColor(Color.posPrimaryText)
+        .background(Color.clear)
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.buttonCornerRadius)
+                        .stroke(Color.posPrimaryText, lineWidth: 1.0)
+        }
+    }
+
+    var newOrderButton: some View {
+        Button(action: {
+            posModel.startNewCart()
+        }, label: {
+            HStack(spacing: Constants.buttonSpacing) {
+                Text(Localization.newOrder)
+                    .font(Constants.buttonFont)
+            }
+            .frame(minWidth: UIScreen.main.bounds.width / 2)
+        })
+        .padding(Constants.buttonPadding)
+        .foregroundColor(Color.posPrimaryTextInverted)
+        .background(Color.posOverlayFillInverted)
+        .cornerRadius(Constants.buttonCornerRadius)
+    }
+}
+
+extension PaymentsActionButtons {
+    enum Constants {
+        static let paymentsButtonSpacing: CGFloat = 80
+        static let paymentsButtonButtonSpacingAnimationDelay: CGFloat = 0.3
+        static let buttonSpacing: CGFloat = 12
+        static let buttonPadding: CGFloat = 32
+        static let buttonFont: POSFontStyle = .posBodyEmphasized
+        static let buttonCornerRadius: CGFloat = 8
+    }
+
+    enum Localization {
+        static let newOrder = NSLocalizedString(
+            "pos.totalsView.newOrder",
+            value: "New order",
+            comment: "Button title for new order button")
+        static let sendReceipt = NSLocalizedString(
+            "pos.totalsView.sendReceipt",
+            value: "Receipt",
+            comment: "Button title for the receipt button")
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -16,15 +16,9 @@ struct TotalsView: View {
     private var shouldShowTotalsFields: Bool {
         viewHelper.shouldShowTotalsFields(for: posModel.paymentState)
     }
-    @State private var isShowingPaymentsButtonSpacing: Bool = false
-    @State private var isShowingSendReceiptModal: Bool = false
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.colorScheme) var colorScheme
-
-    private var shouldShowSendReceiptButton: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sendReceiptsForPointOfSale)
-    }
 
     var body: some View {
         HStack {
@@ -48,7 +42,6 @@ struct TotalsView: View {
                                 .transition(.opacity)
                                 .background(cardReaderViewLayout.backgroundColor)
                                 .accessibilityShowsLargeContentViewer()
-                                .minimumScaleFactor(0.1)
                                 .layoutPriority(1)
                         }
 
@@ -61,7 +54,6 @@ struct TotalsView: View {
                         }
                     }
                     .animation(.default, value: posModel.cardPresentPaymentInlineMessage)
-                    paymentsActionButtons
                     Spacer()
                 }
                 .animation(.default, value: isShowingCardReaderStatus)
@@ -78,14 +70,6 @@ struct TotalsView: View {
         }
         .onChange(of: shouldShowTotalsFields, perform: hideTotalsFieldsWithDelay)
         .geometryGroupIfSupported()
-        .posModal(isPresented: $isShowingSendReceiptModal) {
-            POSSendReceiptModalView(sendReceipt: { email in
-                Task { @MainActor in
-                    await posModel.sendReceipt(to: email)
-                }
-            }, isPresented: $isShowingSendReceiptModal)
-            .posModalSizing()
-        }
     }
 
     private var backgroundColor: Color {
@@ -212,62 +196,6 @@ private extension TotalsView {
 }
 
 private extension TotalsView {
-    private var newOrderButton: some View {
-        Button(action: {
-            posModel.startNewCart()
-        }, label: {
-            HStack(spacing: Constants.buttonSpacing) {
-                Text(Localization.newOrder)
-                    .font(Constants.buttonFont)
-            }
-            .frame(minWidth: UIScreen.main.bounds.width / 2)
-        })
-        .padding(Constants.buttonPadding)
-        .foregroundColor(Color.posPrimaryTextInverted)
-        .background(Color.posOverlayFillInverted)
-        .cornerRadius(Constants.buttonCornerRadius)
-    }
-
-    private var sendReceiptButton: some View {
-        Button(action: {
-            isShowingSendReceiptModal = true
-        }, label: {
-            HStack(spacing: Constants.buttonSpacing) {
-                Text(Localization.sendReceipt)
-                    .font(Constants.buttonFont)
-            }
-            .frame(minWidth: UIScreen.main.bounds.width / 2)
-        })
-        .padding(Constants.buttonPadding)
-        .foregroundColor(Color.posPrimaryText)
-        .background(Color.clear)
-        .overlay {
-            RoundedRectangle(cornerRadius: Constants.buttonCornerRadius)
-                        .stroke(Color.posPrimaryText, lineWidth: 1.0)
-        }
-    }
-
-    @ViewBuilder
-    private var paymentsActionButtons: some View {
-        if posModel.paymentState == .cardPaymentSuccessful {
-            if isShowingPaymentsButtonSpacing {
-                Spacer().frame(height: Constants.paymentsButtonSpacing)
-            }
-            sendReceiptButton
-                .renderedIf(shouldShowSendReceiptButton)
-            newOrderButton
-                .onAppear {
-                    isShowingPaymentsButtonSpacing = false
-                    withAnimation(.default.delay(Constants.paymentsButtonButtonSpacingAnimationDelay)) {
-                        isShowingPaymentsButtonSpacing = true
-                    }
-                }
-            Spacer().frame(height: Constants.paymentsButtonSpacing)
-        }
-        else {
-            EmptyView()
-        }
-    }
 
     @ViewBuilder private var cardReaderView: some View {
         switch posModel.cardReaderConnectionStatus {
@@ -362,8 +290,6 @@ private extension TotalsView {
 private extension TotalsView {
     enum Constants {
         static let pricesIdealWidth: CGFloat = 382
-        static let buttonCornerRadius: CGFloat = 8
-
         static let verticalSpacing: CGFloat = 56
 
         static let totalsLineViewPadding: EdgeInsets = .init(top: 20, leading: 24, bottom: 20, trailing: 24)
@@ -380,12 +306,6 @@ private extension TotalsView {
         static let shimmeringWidth: CGFloat = 334
         static let subtotalsShimmeringHeight: CGFloat = 36
         static let totalShimmeringHeight: CGFloat = 40
-
-        static let paymentsButtonSpacing: CGFloat = 80
-        static let paymentsButtonButtonSpacingAnimationDelay: CGFloat = 0.3
-        static let buttonSpacing: CGFloat = 12
-        static let buttonPadding: CGFloat = 32
-        static let buttonFont: POSFontStyle = .posBodyEmphasized
 
         /// Used for synchronizing animations of shimmeringLine and textField
         static let matchedGeometrySubtotalId: String = "pos_totals_view_subtotal_matched_geometry_id"
@@ -408,14 +328,6 @@ private extension TotalsView {
             "pos.totalsView.taxes",
             value: "Taxes",
             comment: "Title for taxes amount field")
-        static let newOrder = NSLocalizedString(
-            "pos.totalsView.newOrder",
-            value: "New order",
-            comment: "Button title for new order button")
-        static let sendReceipt = NSLocalizedString(
-            "pos.totalsView.sendReceipt",
-            value: "Receipt",
-            comment: "Button title for the receipt button")
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1555,6 +1555,7 @@
 		6885E2CC2C32B14B004C8D70 /* TotalsViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */; };
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
 		6888A2CA2A66C42C0026F5C0 /* FullFeatureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */; };
+		68A345642D029E12002EE324 /* PaymentButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A345632D029E09002EE324 /* PaymentButtons.swift */; };
 		68A38DF52B293B030090C263 /* MockProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A38DF42B293B030090C263 /* MockProductListViewModel.swift */; };
 		68A5221B2BA1804900A6A584 /* PluginDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */; };
 		68A905012ACCFC13004C71D3 /* CollapsibleProductCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */; };
@@ -4620,6 +4621,7 @@
 		6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewHelper.swift; sourceTree = "<group>"; };
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
 		6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListViewModel.swift; sourceTree = "<group>"; };
+		68A345632D029E09002EE324 /* PaymentButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtons.swift; sourceTree = "<group>"; };
 		68A38DF42B293B030090C263 /* MockProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductListViewModel.swift; sourceTree = "<group>"; };
 		68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		68A905002ACCFC13004C71D3 /* CollapsibleProductCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCard.swift; sourceTree = "<group>"; };
@@ -6915,6 +6917,7 @@
 				014BD4B62C64E26B0011A66E /* Order Messages */,
 				02B1914A2CCF278100CF38C9 /* Payments Onboarding */,
 				026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */,
+				68A345632D029E09002EE324 /* PaymentButtons.swift */,
 				026826A52BF59DF60036F959 /* PointOfSaleDashboardView.swift */,
 				DA013F502C65125100D9A391 /* PointOfSaleExitPosAlertView.swift */,
 				DA0DBE2E2C4FC61D00DF14C0 /* POSFloatingControlView.swift */,
@@ -15582,6 +15585,7 @@
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,
 				E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */,
 				CE29A63029F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift in Sources */,
+				68A345642D029E12002EE324 /* PaymentButtons.swift in Sources */,
 				DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */,
 				203163AF2C1C5C6B001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift in Sources */,
 				EE45E2BF2A409E250085F227 /* UIColor+Tooltip.swift in Sources */,


### PR DESCRIPTION
## Description

This PR is preparation work for displaying receipts full-screen. Ref: p1733375209052419-slack-C070SJRA8DP , for this we extract the payment buttons from the TotalsView to its own file/struct, and render them in the `PointOfSaleCardPresentPaymentSuccessMessageView` instead, as these will only appear when `PaymentState == .cardPaymentSuccessful`


https://github.com/user-attachments/assets/615d28ad-6b4c-4f1e-9908-c0449280ec95

## Changes
- Moved buttons to `PaymentsActionButtons` view
- Removed usage of isShowingPaymentsButtonSpacing for animations, used `.matchedGeometryEffect` instead.
- Removed checks for `posModel.paymentState == .cardPaymentSuccessful` and this can only render when we're already on that state.

## Testing information
- With `.sendReceiptsForPointOfSale` set to false, go through a POS transaction
- Observe the success screen looks and behaves the same:

![simulator_screenshot_701E17DC-4F7C-4B8E-8798-750B39D068D9](https://github.com/user-attachments/assets/a489aeec-4213-46d3-bac2-39a81b93dd6c)

- Turn `.sendReceiptsForPointOfSale` to `true`
- Log into Povilas testing site https://lovely-aware-sturgeon.jurassic.ninja/ details: PdfdoF-5Qj-p2
- Proceed with a POS transaction
- Observe the `Receipt` button appears now along the `New order` button
- Tapping the receipt button will present a modal, enter your email address and confirm the receipt email is received. 

Please note the modal will not provide any feedback about the receipt being sent and it will not dismiss automatically (tap the x or outside the modal to dismiss). Changes to the receipt view will come in a future PR.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
