### PR TITLE
[Shipping labels] Sort carriers from response to keep the previous order in UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -98,8 +98,23 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         let predefinedSavedPackages = packagesResult.savedPredefinedPackages.map {
             return $0.toPackageData(storeOptions: packagesResult.storeOptions)
         }
-        let carrierPackages: [WooShippingCarrierPackages] = packagesResult.allPredefinedOptions.compactMap {
+        var carrierPackages: [WooShippingCarrierPackages] = packagesResult.allPredefinedOptions.compactMap {
             return $0.toCarrierPackages(storeOptions: packagesResult.storeOptions)
+        }
+        if self.carrierPackages.isNotEmpty {
+            // sort new packages so they stay in similar order
+            // sort only if we already had carrier packages before
+            let sortedCarrierPackages = self.carrierPackages.sorted { (carrierA, carrierB) in
+                let carrierAIndex = self.carrierPackages.firstIndex(where: { $0.id == carrierA.id })
+                let carrierBIndex = self.carrierPackages.firstIndex(where: { $0.id == carrierB.id })
+                if let firstI = carrierAIndex, let secondI = carrierBIndex {
+                    return firstI < secondI
+                }
+                else {
+                    return carrierAIndex != nil
+                }
+            }
+            carrierPackages = sortedCarrierPackages
         }
         let carrierTabs: [TopTabItem<EmptyView>] = carrierPackages.map { carrierTab in
             return TopTabItem(name: carrierTab.carrier.name, icon: carrierTab.carrier.logo, content: {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- If we refresh the carriers list with pull to refresh backend might return us carriers in a different order than we already have. This way (if there were carriers before) we sort them to be in the same order as they already were in the UI. That way we avoid problems where UI would change (order of the carriers)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Install and set up the Woo Shipping extension on your store.
- Build and run the app with the revampedShippingLabelCreation feature flag enabled.
- Create an order with the processing status and at least one physical product.
- In the order details, select "Create Shipping Label."
- Store options will start fetching from backend in the background.
- Tap "Select a Package" button
- Switch to Carrier tab
- Pull to refresh couple of times and check that the carriers are still in the same order

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

With changes in this PR:

https://github.com/user-attachments/assets/da2dc026-76c9-4dd0-95dc-d9690236ff90

Without changes in this PR:

https://github.com/user-attachments/assets/18741dae-f913-4409-8953-c25244b5cf5c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
