### PR TITLE
Remove reveal animation from orders list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -140,10 +140,6 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     ///
     private var selectedOrderID: Int64?
 
-    /// Tracks if the swipe actions have been glanced to the user.
-    ///
-    private var swipeActionsGlanced = false
-
     /// Banner variation that will be shown as In-Person Payments feedback banner. If any.
     ///
     private var inPersonPaymentsSurveyVariation: SurveyViewController.Source?
@@ -414,16 +410,6 @@ extension OrderListViewController {
         /// Fires fulfillment action, observes its result and enqueue the appropriate notices.
         let presenter = OrderFulfillmentNoticePresenter(noticeConfiguration: noticeConfiguration)
         presenter.present(process: fulfillmentProcess)
-    }
-
-    /// Slightly reveal swipe actions of the first visible cell that contains at least one swipe action.
-    /// This action is performed only once, using `swipeActionsGlanced` as a control variable.
-    ///
-    private func glanceTrailingActionsIfNeeded() {
-        if !swipeActionsGlanced {
-            swipeActionsGlanced = true
-            tableView.glanceTrailingSwipeActions()
-        }
     }
 }
 
@@ -928,7 +914,7 @@ private extension OrderListViewController {
         case .syncing:
             ensureFooterSpinnerIsStarted()
         case .results:
-            glanceTrailingActionsIfNeeded()
+            break
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14025
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Removed reveal animation from orders list

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Open the app and navigate to the orders tab
- Pull to refresh
- See the first order row no more has the glitch due to the reveal animation (since it is now removed)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| With reveal      | Without reveal |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-12-09 at 12 41 55](https://github.com/user-attachments/assets/eadaab1b-49bf-4943-9739-25bed0567898)      | ![Simulator Screenshot - iPhone 16 Pro - 2024-12-09 at 12 42 15](https://github.com/user-attachments/assets/d12955d6-6e74-411d-9d8e-c05ea4508044)       |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
