### PR TITLE
Use revenueCompact to show revenue compact amount in widgets

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -30,6 +30,7 @@
 - [*] Fixed: Improved the error message displayed when Bluetooth permission is denied during the card reader connection process. [https://github.com/woocommerce/woocommerce-ios/pull/14561]
 - [*] Payments: error details are now displayed for more Stripe errors, instead of a generic error message. [https://github.com/woocommerce/woocommerce-ios/pull/14583]
 - [*] Order Creation: fixed layout of custom amount type selection drawer. [https://github.com/woocommerce/woocommerce-ios/pull/14619]
+- [*] Widgets: Show revenue compact amount in widgets, instead of $123,456,789 (and being truncated) we show $123,5m. [https://github.com/woocommerce/woocommerce-ios/pull/14634]
 
 21.2
 -----

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -79,7 +79,7 @@ private struct StatsCard: View {
                     Text(StoreInfoView.Localization.revenue)
                         .statTitleStyle()
 
-                    Text(entryData.revenue)
+                    Text(entryData.revenueCompact)
                         .statValueStyle()
 
                 }
@@ -132,7 +132,7 @@ private struct AccessibilityStatsCard: View {
                 Text(StoreInfoView.Localization.revenue)
                     .statTitleStyle()
 
-                Text(entryData.revenue)
+                Text(entryData.revenueCompact)
                     .statValueStyle()
             }
 
@@ -278,12 +278,14 @@ private extension UnableToFetchView {
 }
 
 // MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
 
 struct StoreWidgets_Previews: PreviewProvider {
     static var exampleData = StoreInfoData(range: "Today",
                                            name: "Ernest Shop",
-                                           revenue: "$132.234",
-                                           revenueCompact: "$132",
+                                           revenue: StoreInfoFormatter.formattedAmountString(for: Decimal(123456789), with: CurrencySettings()),
+                                           revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: Decimal(123456789), with: CurrencySettings()),
                                            visitors: "67",
                                            orders: "23",
                                            conversion: "34%",
@@ -307,3 +309,4 @@ struct StoreWidgets_Previews: PreviewProvider {
             .previewDisplayName("Unable to fetch data")
     }
 }
+#endif

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoCircularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoCircularWidget.swift
@@ -30,6 +30,7 @@ private struct StoreInfoCircularView: View {
                 .fill(Color.black)
             Text(entryData.revenueCompact)
         }
+        .widgetBackground(backgroundView: Color(.brand))
     }
 }
 
@@ -45,13 +46,15 @@ private struct UnableToFetchView: View {
 }
 
 // MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
 
 @available(iOSApplicationExtension 16.0, *)
 struct StoreInfoCircularWidget_Previews: PreviewProvider {
     static var exampleData = StoreInfoData(range: "Today",
                                            name: "Ernest Shop",
-                                           revenue: "$132.234",
-                                           revenueCompact: "$132",
+                                           revenue: StoreInfoFormatter.formattedAmountString(for: Decimal(123456789), with: CurrencySettings()),
+                                           revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: Decimal(123456789), with: CurrencySettings()),
                                            visitors: "67",
                                            orders: "23",
                                            conversion: "34%",
@@ -66,3 +69,4 @@ struct StoreInfoCircularWidget_Previews: PreviewProvider {
             .previewDisplayName("Unable to fetch")
     }
 }
+#endif

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoInlineWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoInlineWidget.swift
@@ -25,7 +25,7 @@ private struct StoreInfoInlineView: View {
     let entryData: StoreInfoData
 
     var body: some View {
-        Text(Localization.titleWithRevenue(entryData.revenue))
+        Text(Localization.titleWithRevenue(entryData.revenueCompact))
             .statValueStyle()
     }
 }
@@ -60,13 +60,15 @@ private extension UnableToFetchView {
 }
 
 // MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
 
 @available(iOSApplicationExtension 16.0, *)
 struct StoreInfoInlineWidget_Previews: PreviewProvider {
     static var exampleData = StoreInfoData(range: "Today",
                                            name: "Ernest Shop",
-                                           revenue: "$132.234",
-                                           revenueCompact: "$132",
+                                           revenue: StoreInfoFormatter.formattedAmountString(for: Decimal(123456789), with: CurrencySettings()),
+                                           revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: Decimal(123456789), with: CurrencySettings()),
                                            visitors: "67",
                                            orders: "23",
                                            conversion: "34%",
@@ -81,3 +83,4 @@ struct StoreInfoInlineWidget_Previews: PreviewProvider {
             .previewDisplayName("Unable to fetch")
     }
 }
+#endif

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
@@ -29,10 +29,11 @@ private struct StoreInfoRectangularView: View {
             VStack(alignment: .leading) {
                 Text(Localization.revenue)
                     .font(.headline)
-                Text(entryData.revenue)
+                Text(entryData.revenueCompact)
             }
             Spacer()
         }
+        .widgetBackground(backgroundView: Color(.brand))
     }
 }
 
@@ -72,13 +73,15 @@ private extension UnableToFetchView {
 }
 
 // MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
 
 @available(iOSApplicationExtension 16.0, *)
 struct StoreInfoRectangularWidget_Previews: PreviewProvider {
     static var exampleData = StoreInfoData(range: "Today",
                                            name: "Ernest Shop",
-                                           revenue: "$132.234",
-                                           revenueCompact: "$132",
+                                           revenue: StoreInfoFormatter.formattedAmountString(for: Decimal(123456789), with: CurrencySettings()),
+                                           revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: Decimal(123456789), with: CurrencySettings()),
                                            visitors: "67",
                                            orders: "23",
                                            conversion: "34%",
@@ -93,3 +96,4 @@ struct StoreInfoRectangularWidget_Previews: PreviewProvider {
             .previewDisplayName("Unable to fetch")
     }
 }
+#endif


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7887
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Using revenueCompact to show revenue compact amount in widgets, instead of $123,456,789 (and being truncated) we show $123,5m

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Add all Woo widgets and test how the revenue amount looks
- For easier testing you can use SwiftUI previews in Xcode for every widget type

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before/after examples with large revenue

| Before      | After |
| ----------- | ----------- |
| <img width="482" alt="Screenshot 2024-12-09 at 13 52 52" src="https://github.com/user-attachments/assets/60c491b5-49b6-4eaa-a650-e6a215178299">      | <img width="471" alt="Screenshot 2024-12-09 at 13 52 41" src="https://github.com/user-attachments/assets/ffa6f94d-9396-4b13-a52f-af1e45408ecc">       |
| <img width="566" alt="Screenshot 2024-12-09 at 13 57 19" src="https://github.com/user-attachments/assets/4eb31f64-8806-4289-8bcb-ee03e3c36b5d">      | <img width="485" alt="Screenshot 2024-12-09 at 13 57 29" src="https://github.com/user-attachments/assets/cd67d76d-31e7-414d-b54f-43c733fa4934">       |
| <img width="482" alt="Screenshot 2024-12-09 at 14 00 45" src="https://github.com/user-attachments/assets/08ef368b-20a6-4297-bc31-2bffbe14fc33">      | <img width="488" alt="Screenshot 2024-12-09 at 14 00 35" src="https://github.com/user-attachments/assets/9d418f1c-f8af-44f7-a5b9-68f2150edc21">       |
| <img width="477" alt="Screenshot 2024-12-09 at 14 01 14" src="https://github.com/user-attachments/assets/02266222-6cc4-4820-b1b6-ac3660875421">      | <img width="482" alt="Screenshot 2024-12-09 at 14 01 03" src="https://github.com/user-attachments/assets/39d32391-8d41-442f-81ef-1632b993da95">       |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
