### PR TITLE
[Shipping Labels] Add selected package and shipment weight to main Woo Shipping screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -30,7 +30,7 @@ struct WooCarrierPackagesView: View {
             ForEach(carrierTab.packageGroups, id: \.id) { packageGroup in
                 Section {
                     ForEach(packageGroup.packages, id: \.id) { package in
-                        PackageOptionView(
+                        WooShippingPackageOptionView(
                             isSelected: selectedPackageId == package.id,
                             package: package,
                             showTopDivider: false,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -149,7 +149,7 @@ struct WooSavedPackagesSelectionView: View {
 
     private func packagesRows(for packages: [any WooShippingPackageDataRepresentable]) -> some View {
         ForEach(packages, id: \.id) { package in
-            PackageOptionView(
+            WooShippingPackageOptionView(
                 isSelected: viewModel.selectedSavedPackageId == package.id,
                 package: package,
                 showTopDivider: false,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct PackageOptionView: View {
+struct WooShippingPackageOptionView: View {
     enum Constants {
         static let verticalSpacing: CGFloat = 4.0
         static let textContentLeadingPadding: CGFloat = 4.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct SelectedPackageView: View {
+struct WooShippingSelectedPackageView: View {
     let package: WooShippingPackageDataRepresentable
     let weightUnit: String
     @Binding var totalWeight: String
@@ -16,10 +16,10 @@ struct SelectedPackageView: View {
                 }
                 .buttonStyle(TextButtonStyle())
             }
-            PackageOptionView(package: package,
-                              showTopDivider: false,
-                              showSource: true,
-                              tapAction: {})
+            WooShippingPackageOptionView(package: package,
+                                         showTopDivider: false,
+                                         showSource: true,
+                                         tapAction: {})
             .roundedBorder(cornerRadius: Constants.cornerRadius, lineColor: Constants.lineColor, lineWidth: Constants.lineWidth)
             .padding(.bottom)
             shipmentWeight
@@ -44,7 +44,7 @@ struct SelectedPackageView: View {
     }
 }
 
-private extension SelectedPackageView {
+private extension WooShippingSelectedPackageView {
     enum Constants {
         static let cornerRadius: CGFloat = 8
         static let lineColor = Color(.separator)
@@ -62,7 +62,7 @@ private extension SelectedPackageView {
 }
 
 #Preview {
-    SelectedPackageView(package: WooShippingPackageData(name: "Small Flat Rate Box",
+    WooShippingSelectedPackageView(package: WooShippingPackageData(name: "Small Flat Rate Box",
                                                         length: "12",
                                                         width: "6",
                                                         height: "6",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -48,12 +48,11 @@ struct WooShippingCreateLabelsView: View {
 
                     if viewModel.canViewLabel {
                         EmptyView()
-                    } else if viewModel.selectedPackage != nil,
+                    } else if let package = viewModel.selectedPackage,
                               let shippingService = viewModel.shippingService {
-                        // TODO: Display package section
-                        // Package heading and edit button
-                        // Selected package details
-                        // Total shipment weight field
+                        WooShippingSelectedPackageView(package: package,
+                                                       weightUnit: viewModel.weightUnit,
+                                                       totalWeight: $viewModel.shipmentWeight)
                         WooShippingServiceView(viewModel: shippingService)
                             .padding(.horizontal, -16)
                     } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -34,14 +34,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Selected package data for the shipping label.
     @Published private(set) var selectedPackage: WooShippingPackageDataRepresentable?
 
-    /// Total weight for the shipment.
-    var shipmentWeight: Double {
-        let itemsWeight = itemsDataSource.items.map { $0.weight * Double(truncating: $0.quantity as NSDecimalNumber) }.reduce(0, +)
-        guard let selectedPackage else {
-            return itemsWeight
-        }
-        return itemsWeight + (Double(selectedPackage.weight) ?? 0)
-    }
+    /// String representing the total weight for the shipment.
+    @Published var shipmentWeight: String = ""
 
     /// View model for the label shipping service.
     private(set) var shippingService: WooShippingServiceViewModel?
@@ -102,37 +96,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     @Published var storeOptions: ShippingLabelStoreOptions?
     @Published var isLoadingStoreOptions: Bool = false
-
-    func loadStoreOptions(completion: ((ShippingLabelStoreOptions) -> Void)? = nil) {
-        guard isLoadingStoreOptions == false,
-              let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else { return }
-
-        isLoadingStoreOptions = true
-
-        let action = WooShippingAction.loadAccountSettings(siteID: siteID) { result in
-            switch result {
-            case .success(let settings):
-                self.storeOptions = settings.storeOptions
-                completion?(settings.storeOptions)
-            case .failure(let error):
-                DDLogError("⛔️ Error loading account settings: \(error)")
-                // fallback to store settings
-                let shippingSettingsService = ServiceLocator.shippingSettingsService
-                let currencySettings = ServiceLocator.currencySettings
-                let currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
-                let originCountry = SiteAddress().countryCode.rawValue
-                if let dimensionUnit = shippingSettingsService.dimensionUnit,
-                   let weightUnit = shippingSettingsService.weightUnit {
-                    let fallbackStoreOptions = ShippingLabelStoreOptions(currencySymbol: currencySymbol,
-                                                            dimensionUnit: dimensionUnit,
-                                                            weightUnit: weightUnit,
-                                                            originCountry: originCountry)
-                    self.storeOptions = fallbackStoreOptions
-                }
-            }
-            self.isLoadingStoreOptions = false
-        }
-        ServiceLocator.stores.dispatch(action)
+    var weightUnit: String {
+        storeOptions?.weightUnit ?? ServiceLocator.shippingSettingsService.weightUnit ?? ""
     }
 
     /// Closure to execute after the label is successfully purchased.
@@ -172,6 +137,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                       destinationAddress: destinationAddress) { [weak self] selectedRate in
             self?.selectedRate = selectedRate
         }
+
+        observeSelectedPackage()
     }
 
     /// Initialize the view model from an existing shipping label.
@@ -196,7 +163,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Selecting a package also refreshes the available rates for the shipping service.
     func selectPackage(_ packageData: WooShippingPackageDataRepresentable) {
         selectedPackage = packageData
-        shippingService?.loadLabelRates(for: fromPackageDataToPackageSelected(packageData, weight: shipmentWeight, shipmentID: shipmentID))
+        shippingService?.loadLabelRates(for: fromPackageDataToPackageSelected(packageData, weight: Double(shipmentWeight) ?? 0, shipmentID: shipmentID))
     }
 
     /// Purchases a shipping label with the provided label details and settings.
@@ -207,7 +174,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         isPurchasingLabel = true
         let packagePurchase = WooShippingPackagePurchase(shipmentID: shipmentID,
                                                          package: fromPackageDataToPackageSelected(selectedPackage,
-                                                                                                   weight: shipmentWeight,
+                                                                                                   weight: Double(shipmentWeight) ?? 0,
                                                                                                    shipmentID: shipmentID),
                                                          rate: selectedRate.purchaseRate,
                                                          productIDs: itemsDataSource.items.map(\.productOrVariationID))
@@ -229,10 +196,55 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         }
         stores.dispatch(action)
     }
+
+    func loadStoreOptions(completion: ((ShippingLabelStoreOptions) -> Void)? = nil) {
+        guard isLoadingStoreOptions == false,
+              let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else { return }
+
+        isLoadingStoreOptions = true
+
+        let action = WooShippingAction.loadAccountSettings(siteID: siteID) { result in
+            switch result {
+            case .success(let settings):
+                self.storeOptions = settings.storeOptions
+                completion?(settings.storeOptions)
+            case .failure(let error):
+                DDLogError("⛔️ Error loading account settings: \(error)")
+                // fallback to store settings
+                let shippingSettingsService = ServiceLocator.shippingSettingsService
+                let currencySettings = ServiceLocator.currencySettings
+                let currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
+                let originCountry = SiteAddress().countryCode.rawValue
+                if let dimensionUnit = shippingSettingsService.dimensionUnit,
+                   let weightUnit = shippingSettingsService.weightUnit {
+                    let fallbackStoreOptions = ShippingLabelStoreOptions(currencySymbol: currencySymbol,
+                                                            dimensionUnit: dimensionUnit,
+                                                            weightUnit: weightUnit,
+                                                            originCountry: originCountry)
+                    self.storeOptions = fallbackStoreOptions
+                }
+            }
+            self.isLoadingStoreOptions = false
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
 }
 
 // MARK: Utils
 private extension WooShippingCreateLabelsViewModel {
+    /// Observes the selected package and updates the shipment weight.
+    func observeSelectedPackage() {
+        let itemsWeight = itemsDataSource.items.map { $0.weight * Double(truncating: $0.quantity as NSDecimalNumber) }.reduce(0, +)
+        $selectedPackage
+            .map { selectedPackage in
+                guard let selectedPackage else {
+                    return itemsWeight.description
+                }
+                return (itemsWeight + (Double(selectedPackage.weight) ?? 0)).description
+            }
+            .assign(to: &$shipmentWeight)
+    }
+
     /// Provides the formatted label and amount for a shipping rate, based on the provided base rate.
     func formatShippingRate(name: String, rate: Double, basedOn baseRate: Double? = nil) -> (title: String, amount: String) {
         let amount = {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -26,8 +26,22 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// View model for the items to ship.
     @Published private(set) var items: WooShippingItemsViewModel
 
-    /// Selected package for the shipping label.
-    @Published private(set) var selectedPackage: ShippingLabelPackageSelected?
+    /// ID for the shipment.
+    ///
+    /// For now we support purchasing labels in a single shipment only, so we only need a single shipment ID.
+    let shipmentID = "shipment_0"
+
+    /// Selected package data for the shipping label.
+    @Published private(set) var selectedPackage: WooShippingPackageDataRepresentable?
+
+    /// Total weight for the shipment.
+    var shipmentWeight: Double {
+        let itemsWeight = itemsDataSource.items.map { $0.weight * Double(truncating: $0.quantity as NSDecimalNumber) }.reduce(0, +)
+        guard let selectedPackage else {
+            return itemsWeight
+        }
+        return itemsWeight + (Double(selectedPackage.weight) ?? 0)
+    }
 
     /// View model for the label shipping service.
     private(set) var shippingService: WooShippingServiceViewModel?
@@ -127,14 +141,16 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Initialize the view model without an existing shipping label.
     init(order: Order,
          originAddress: SiteAddress? = nil,
-         selectedPackage: ShippingLabelPackageSelected? = nil,
+         selectedPackage: WooShippingPackageDataRepresentable? = nil,
          selectedRate: WooShippingSelectedRate? = nil,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          userDefaults: UserDefaults = .standard,
          stores: StoresManager = ServiceLocator.stores,
+         itemsDataSource: WooShippingItemsDataSource? = nil,
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
-        self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
+        let itemsDataSource = itemsDataSource ?? DefaultWooShippingItemsDataSource(order: order)
+        self.itemsDataSource = itemsDataSource
         self.items = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase
@@ -179,19 +195,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Handles package selection for the shipping label.
     /// Selecting a package also refreshes the available rates for the shipping service.
     func selectPackage(_ packageData: WooShippingPackageDataRepresentable) {
-        // For now we support purchasing labels in a single package for a single shipment.
-        // In future milestones we can handle an array of packages with unique IDs for each shipment.
-        let package = ShippingLabelPackageSelected(id: "shipment_0",
-                                                   boxID: packageData.id,
-                                                   length: Double(packageData.length) ?? 0,
-                                                   width: Double(packageData.width) ?? 0,
-                                                   height: Double(packageData.height) ?? 0,
-                                                   weight: itemsDataSource.items.map(\.weight).reduce(0, +) + (Double(packageData.weight) ?? 0),
-                                                   isLetter: WooShippingPackageType(rawValue: packageData.packageType) == .envelope,
-                                                   hazmatCategory: nil, // Hazmat support will be added in a future milestone
-                                                   customsForm: nil) // Customs form support will be added in a future milestone
-        selectedPackage = package
-        shippingService?.loadLabelRates(for: package)
+        selectedPackage = packageData
+        shippingService?.loadLabelRates(for: fromPackageDataToPackageSelected(packageData, weight: shipmentWeight, shipmentID: shipmentID))
     }
 
     /// Purchases a shipping label with the provided label details and settings.
@@ -200,17 +205,17 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             return
         }
         isPurchasingLabel = true
-        // For now we support purchasing labels in a single shipment only.
-        // In future milestones we can create an array of `WooShippingPackagePurchase` with unique shipment IDs for each shipment.
-        let package = WooShippingPackagePurchase(shipmentID: "shipment_0",
-                                                 package: selectedPackage,
-                                                 rate: selectedRate.purchaseRate,
-                                                 productIDs: itemsDataSource.items.map(\.productOrVariationID))
+        let packagePurchase = WooShippingPackagePurchase(shipmentID: shipmentID,
+                                                         package: fromPackageDataToPackageSelected(selectedPackage,
+                                                                                                   weight: shipmentWeight,
+                                                                                                   shipmentID: shipmentID),
+                                                         rate: selectedRate.purchaseRate,
+                                                         productIDs: itemsDataSource.items.map(\.productOrVariationID))
         let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,
                                                              orderID: order.orderID,
                                                              originAddress: originSiteAddress,
                                                              destinationAddress: destinationAddress,
-                                                             package: package) { [weak self] result in
+                                                             package: packagePurchase) { [weak self] result in
             guard let self else { return }
             isPurchasingLabel = false
             switch result {
@@ -298,6 +303,19 @@ private extension WooShippingCreateLabelsViewModel {
         let resultsController = ResultsController<StorageAccountSettings>(storageManager: storageManager, sortedBy: [])
         try? resultsController.performFetch()
         return resultsController.fetchedObjects.first
+    }
+
+    /// Converts the package data to a `ShippingLabelPackageSelected` object.
+    func fromPackageDataToPackageSelected(_ packageData: WooShippingPackageDataRepresentable, weight: Double, shipmentID: String) -> ShippingLabelPackageSelected {
+        ShippingLabelPackageSelected(id: shipmentID,
+                                     boxID: packageData.id,
+                                     length: Double(packageData.length) ?? 0,
+                                     width: Double(packageData.width) ?? 0,
+                                     height: Double(packageData.height) ?? 0,
+                                     weight: weight,
+                                     isLetter: WooShippingPackageType(rawValue: packageData.packageType) == .envelope,
+                                     hazmatCategory: nil, // Hazmat support will be added in a future milestone
+                                     customsForm: nil) // Customs form support will be added in a future milestone
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import WooFoundation
+import Combine
 
 /// Provides view data for `WooShippingCreateLabelsView`.
 ///
@@ -11,6 +12,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let originSiteAddress: ShippingLabelAddress?
     private let destinationAddress: ShippingLabelAddress?
     private let stores: StoresManager
+    private var subscriptions: Set<AnyCancellable> = []
+    private var debounceDuration: Double = 1
 
     /// The purchased shipping label.
     @Published private var shippingLabel: ShippingLabel?
@@ -112,6 +115,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          userDefaults: UserDefaults = .standard,
          stores: StoresManager = ServiceLocator.stores,
          itemsDataSource: WooShippingItemsDataSource? = nil,
+         debounceDuration: Double = 1,
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
         let itemsDataSource = itemsDataSource ?? DefaultWooShippingItemsDataSource(order: order)
@@ -132,13 +136,16 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.selectedPackage = selectedPackage
         self.selectedRate = selectedRate
         self.stores = stores
+        self.debounceDuration = debounceDuration
         shippingService = WooShippingServiceViewModel(order: order,
                                                       originAddress: originSiteAddress,
-                                                      destinationAddress: destinationAddress) { [weak self] selectedRate in
+                                                      destinationAddress: destinationAddress,
+                                                      stores: stores) { [weak self] selectedRate in
             self?.selectedRate = selectedRate
         }
 
         observeSelectedPackage()
+        observeForLabelRates()
     }
 
     /// Initialize the view model from an existing shipping label.
@@ -163,7 +170,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Selecting a package also refreshes the available rates for the shipping service.
     func selectPackage(_ packageData: WooShippingPackageDataRepresentable) {
         selectedPackage = packageData
-        shippingService?.loadLabelRates(for: fromPackageDataToPackageSelected(packageData, weight: Double(shipmentWeight) ?? 0, shipmentID: shipmentID))
     }
 
     /// Purchases a shipping label with the provided label details and settings.
@@ -243,6 +249,19 @@ private extension WooShippingCreateLabelsViewModel {
                 return (itemsWeight + (Double(selectedPackage.weight) ?? 0)).description
             }
             .assign(to: &$shipmentWeight)
+    }
+
+    /// Observes the selected package and shipment weight and requests the available shipping rates.
+    func observeForLabelRates() {
+        $shipmentWeight
+            .debounce(for: .seconds(debounceDuration), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .combineLatest($selectedPackage)
+            .sink { [weak self] weight, selectedPackage in
+                guard let self, let selectedPackage, let shippingService else { return }
+                shippingService.loadLabelRates(for: fromPackageDataToPackageSelected(selectedPackage, weight: Double(weight) ?? 0, shipmentID: shipmentID))
+            }
+            .store(in: &subscriptions)
     }
 
     /// Provides the formatted label and amount for a shipping rate, based on the provided base rate.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2342,8 +2342,8 @@
 		CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEE006042077D1280079161F /* SummaryTableViewCell.xib */; };
 		CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006072077D14C0079161F /* OrderDetailsViewController.swift */; };
 		CEE02AF82C1859B400B0B6AB /* MessageComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */; };
-		CEE1138F2CFA2D8900F53E30 /* PackageOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE1138E2CFA2D8900F53E30 /* PackageOptionView.swift */; };
-		CEE113952CFA2F7700F53E30 /* SelectedPackageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE113942CFA2F7700F53E30 /* SelectedPackageView.swift */; };
+		CEE1138F2CFA2D8900F53E30 /* WooShippingPackageOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE1138E2CFA2D8900F53E30 /* WooShippingPackageOptionView.swift */; };
+		CEE113952CFA2F7700F53E30 /* WooShippingSelectedPackageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE113942CFA2F7700F53E30 /* WooShippingSelectedPackageView.swift */; };
 		CEE125512CC66C8700D3183D /* WooShippingServiceCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE125502CC66C8100D3183D /* WooShippingServiceCardViewModel.swift */; };
 		CEE482D52B83A9A300FAC8C5 /* AnalyticsCard+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */; };
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
@@ -5446,8 +5446,8 @@
 		CEE006042077D1280079161F /* SummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SummaryTableViewCell.xib; sourceTree = "<group>"; };
 		CEE006072077D14C0079161F /* OrderDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewController.swift; sourceTree = "<group>"; };
 		CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposeView.swift; sourceTree = "<group>"; };
-		CEE1138E2CFA2D8900F53E30 /* PackageOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageOptionView.swift; sourceTree = "<group>"; };
-		CEE113942CFA2F7700F53E30 /* SelectedPackageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPackageView.swift; sourceTree = "<group>"; };
+		CEE1138E2CFA2D8900F53E30 /* WooShippingPackageOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPackageOptionView.swift; sourceTree = "<group>"; };
+		CEE113942CFA2F7700F53E30 /* WooShippingSelectedPackageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingSelectedPackageView.swift; sourceTree = "<group>"; };
 		CEE125502CC66C8100D3183D /* WooShippingServiceCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingServiceCardViewModel.swift; sourceTree = "<group>"; };
 		CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsCard+UI.swift"; sourceTree = "<group>"; };
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
@@ -12122,11 +12122,11 @@
 				CEE125502CC66C8100D3183D /* WooShippingServiceCardViewModel.swift */,
 				DA4080712CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift */,
 				DAF689E02CD23941008B8398 /* WooAddCustomPackageView.swift */,
-				CEE1138E2CFA2D8900F53E30 /* PackageOptionView.swift */,
+				CEE1138E2CFA2D8900F53E30 /* WooShippingPackageOptionView.swift */,
 				DA4080732CC2A7BC002A4577 /* WooCarrierPackagesSelectionView.swift */,
 				DA4080742CC2A7BC002A4577 /* WooSavedPackagesSelectionView.swift */,
 				DAAF53B72CF75701006D8880 /* WooShippingAddPackageViewModel.swift */,
-				CEE113942CFA2F7700F53E30 /* SelectedPackageView.swift */,
+				CEE113942CFA2F7700F53E30 /* WooShippingSelectedPackageView.swift */,
 			);
 			path = "WooShipping Package and Rate Selection";
 			sourceTree = "<group>";
@@ -15356,7 +15356,7 @@
 				028296EC237D28B600E84012 /* TextViewViewController.swift in Sources */,
 				02B8650F24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift in Sources */,
 				203163B92C1C5F42001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift in Sources */,
-				CEE113952CFA2F7700F53E30 /* SelectedPackageView.swift in Sources */,
+				CEE113952CFA2F7700F53E30 /* WooShippingSelectedPackageView.swift in Sources */,
 				454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */,
 				AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */,
 				03A6C18628B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift in Sources */,
@@ -16056,7 +16056,7 @@
 				029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */,
 				DE19BB0C26C2688B00AB70D9 /* SingleSelectionList.swift in Sources */,
 				261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */,
-				CEE1138F2CFA2D8900F53E30 /* PackageOptionView.swift in Sources */,
+				CEE1138F2CFA2D8900F53E30 /* WooShippingPackageOptionView.swift in Sources */,
 				2004E2C42C076D3800D62521 /* CardPresentPaymentEvent.swift in Sources */,
 				68ED2BD62ADD2C8C00ECA88D /* LineDetailView.swift in Sources */,
 				45DB705A26124C710064A6CF /* TitleAndTextFieldRow.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -91,7 +91,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let markOrderComplete: Bool = waitFor { promise in
             let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
                                                              originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
-                                                             selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                             selectedPackage: self.samplePackageData(),
                                                              selectedRate: self.sampleSelectedRate(),
                                                              stores: stores) { complete in
                 promise(complete)
@@ -120,7 +120,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let markOrderComplete: Bool = waitFor { promise in
             let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
                                                              originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
-                                                             selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                             selectedPackage: self.samplePackageData(),
                                                              selectedRate: self.sampleSelectedRate(),
                                                              stores: stores) { complete in
                 promise(complete)
@@ -137,7 +137,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
                                                          originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
-                                                         selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                         selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate())
 
         // Then
@@ -208,7 +208,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
                                                          originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
-                                                         selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                         selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate(),
                                                          stores: stores)
 
@@ -227,7 +227,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
                                                          originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
-                                                         selectedPackage: ShippingLabelPackageSelected.fake(),
+                                                         selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate(),
                                                          stores: stores)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -253,30 +253,25 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_selectPackage_sets_selectedPackage_with_package_data() {
         // Given
-        let packageData = WooShippingPackageData(id: "small_flat_box",
-                                                 name: "Small Flat Rate Box",
-                                                 length: "21.91",
-                                                 width: "13.65",
-                                                 height: "4.13",
-                                                 dimensionsUnit: "cm",
-                                                 weight: "0",
-                                                 weightUnit: "kg",
-                                                 source: .predefined(sourceTitle: "usps", sourceID: "usps"),
-                                                 packageType: "box")
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake())
 
         // When
-        viewModel.selectPackage(packageData)
+        viewModel.selectPackage(samplePackageData())
 
         // Then
         XCTAssertNotNil(viewModel.selectedPackage)
-        XCTAssertEqual(viewModel.selectedPackage?.id, "shipment_0")
-        XCTAssertEqual(viewModel.selectedPackage?.boxID, "small_flat_box")
-        XCTAssertEqual(viewModel.selectedPackage?.length, 21.91)
-        XCTAssertEqual(viewModel.selectedPackage?.width, 13.65)
-        XCTAssertEqual(viewModel.selectedPackage?.height, 4.13)
-        XCTAssertEqual(viewModel.selectedPackage?.weight, 0)
-        XCTAssertEqual(viewModel.selectedPackage?.isLetter, false)
+        XCTAssertEqual(viewModel.selectedPackage?.id, samplePackageData().id)
+    }
+
+    func test_selectedPackage_sets_shipmentWeight_with_items_and_package_weight() {
+        // Given
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), itemsDataSource: MockItemsDataSource())
+
+        // When
+        viewModel.selectPackage(samplePackageData())
+
+        // Then
+        XCTAssertEqual(viewModel.shipmentWeight, 1.25)
     }
 }
 
@@ -340,4 +335,24 @@ private extension WooShippingCreateLabelsViewModelTests {
                                                              deliveryDays: 2,
                                                              deliveryDateGuaranteed: false) : nil)
     }
+
+    func samplePackageData() -> WooShippingPackageDataRepresentable {
+        WooShippingPackageData(id: "small_flat_box",
+                               name: "Small Flat Rate Box",
+                               length: "21.91",
+                               width: "13.65",
+                               height: "4.13",
+                               dimensionsUnit: "cm",
+                               weight: ".25",
+                               weightUnit: "kg",
+                               source: .predefined(sourceTitle: "usps", sourceID: "usps"),
+                               packageType: "box")
+    }
+}
+
+private final class MockItemsDataSource: WooShippingItemsDataSource {
+    var items: [ShippingLabelPackageItem] = [
+        ShippingLabelPackageItem(productOrVariationID: 1, name: "Shirt", weight: 0.5, quantity: 2, value: 9.99, dimensions: ProductDimensions.fake(), attributes: [], imageURL: nil),
+    ]
+    var currency: String = "GBP"
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -271,7 +271,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         viewModel.selectPackage(samplePackageData())
 
         // Then
-        XCTAssertEqual(viewModel.shipmentWeight, 1.25)
+        XCTAssertEqual(viewModel.shipmentWeight, "1.25")
     }
 }
 
@@ -351,8 +351,13 @@ private extension WooShippingCreateLabelsViewModelTests {
 }
 
 private final class MockItemsDataSource: WooShippingItemsDataSource {
-    var items: [ShippingLabelPackageItem] = [
-        ShippingLabelPackageItem(productOrVariationID: 1, name: "Shirt", weight: 0.5, quantity: 2, value: 9.99, dimensions: ProductDimensions.fake(), attributes: [], imageURL: nil),
-    ]
-    var currency: String = "GBP"
+    var items = [ShippingLabelPackageItem(productOrVariationID: 1,
+                                          name: "Shirt",
+                                          weight: 0.5,
+                                          quantity: 2,
+                                          value: 9.99,
+                                          dimensions: ProductDimensions.fake(),
+                                          attributes: [],
+                                          imageURL: nil)]
+    var currency = "GBP"
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -263,7 +263,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedPackage?.id, samplePackageData().id)
     }
 
-    func test_selectedPackage_sets_shipmentWeight_with_items_and_package_weight() {
+    func test_selectPackage_sets_shipmentWeight_with_items_and_package_weight() {
         // Given
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), itemsDataSource: MockItemsDataSource())
 
@@ -272,6 +272,36 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.shipmentWeight, "1.25")
+    }
+
+    func test_changing_shipmentWeight_loads_new_label_rates_with_updated_weight() {
+        // Given
+        let expectedWeight = 2.5
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                         originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
+                                                         selectedPackage: samplePackageData(),
+                                                         stores: stores,
+                                                         itemsDataSource: MockItemsDataSource(),
+                                                         debounceDuration: 0)
+
+
+        // When
+        let packageWeightForLabelRates: Double? = waitFor { promise in
+            stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+                switch action {
+                case let .loadLabelRates(_, _, _, _, packages, _):
+                    promise(packages.first?.weight)
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+
+            viewModel.shipmentWeight = expectedWeight.description
+        }
+
+        // Then
+        XCTAssertEqual(packageWeightForLabelRates, expectedWeight)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -235,6 +235,8 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
                 isPurchasingLabelDuringPurchase = viewModel.isPurchasingLabel
                 completion(.success(ShippingLabel.fake()))
+            case let .loadLabelRates(_, _, _, _, _, completion):
+                completion(.success([]))
             default:
                 XCTFail("Unexpected action: \(action)")
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the main Woo Shipping label creation screen to include the selected package and shipment weight:

* After selecting a package, the selected package and shipment weight field appear.
* By default, the shipment weight is the total item weight + the empty package weight.
* Entering a new shipment weight reloads the available rates in the Shipping Service section after 1 second.

Notes:
* The edit (pencil) icon on the selected package does nothing for now; that will be added in a future PR.
* If you add a custom package without saving it as a template, the selected package title is empty. This needs design input to confirm what should be shown in that case.

### How

* Updates the view model `selectedPackage` property to be an instance of `WooShippingPackageDataRepresentable`.
   * This makes it easier to pass around the selected package data up to the point where it needs to be sent to remote. 
   * To support this, we now have `fromPackageDataToPackageSelected(_: weight: shipmentID:)` to combine the data needed to send the selected package to remote (to load the label rates or purchase the label).
* Adds a new `shipmentWeight` property to hold the entered shipment weight.
* `observeSelectedPackage()` sets the shipment weight whenever the selected package changes, to account for the package weight.
* `observeForLabelRates()` reloads the label rates whenever the selected package or shipment weight changes, with a debounce of 1 second.
* Cleanup: Adds `WooShipping` prefix to two views.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In the order details, select "Create Shipping Label."
5. Tap "Select a Package."
6. Enter custom package details or select a carrier package and tap "Add Package."
7. Confirm the package details are displayed on the main screen.
8. Confirm the shipment weight field shows the total weight of the items and the package.
9. Enter a new weight and confirm the label rates are reloaded after 1 second.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f40a00f6-fb48-4d13-b29d-a998adca4dde


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.