### PR TITLE
[Tooling] Publish GitHub Releases for beta immediately

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -667,7 +667,8 @@ platform :ios do
       version: version,
       release_notes_file_path: RELEASE_NOTES_PATH,
       release_assets: archive_zip_path.to_s,
-      prerelease: options[:beta_release]
+      prerelease: options[:beta_release], # Beta = Prerelease, Final = normal Release
+      is_draft: !options[:beta_release] # Beta = publish immediately, Final = Draft (only publish manually after Apple approval)
     )
     sh("rm #{archive_zip_path}")
 


### PR DESCRIPTION
## Description

When the MC Release tool and automation builds a new beta or final build, it also creates a corresponding GitHub Release once the CI build is finished.

Currently those GitHub Releases are all created as draft.

 - This makes sense for the GitHub Release corresponding to the final build submitted to Apple, because we only want to publish that GitHub Release (which has the side effect of creating the corresponding `git tag`) once we're sure that Apple has approved the build (otherwise if we need to add last-minute commits to address the rejection from Apple, we'd need to move the git tag after it had been created, which is generally a bad idea)
 - But for beta builds, we don't have this restriction, and it makes more sense to create the GitHub Pre-Releases for beta as published immediately rather than as Draft

The GitHub Prereleases being currently created as draft for betas has been an issue in the past because the Release Manager often forgets to publish them later. Automating that step should avoid that issue and stop us having old GitHub Prereleases left as Draft because we forgot to publish them.
