### PR TITLE
Core Data: Optimize storage for MetaDataStore

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -28,6 +28,7 @@
 - [Internal] Updated storage usage in SystemStatusStore [https://github.com/woocommerce/woocommerce-ios/pull/14559]
 - [Internal] Updated storage usage in SitePluginStore [https://github.com/woocommerce/woocommerce-ios/pull/14560]
 - [Internal] Updated storage usage in ShippingLabelStore [https://github.com/woocommerce/woocommerce-ios/pull/14566]
+- [Internal] Updated storage usage in MetaDataStore [https://github.com/woocommerce/woocommerce-ios/pull/14642]
 - [*] Fixed: Improved the error message displayed when Bluetooth permission is denied during the card reader connection process. [https://github.com/woocommerce/woocommerce-ios/pull/14561]
 - [*] Payments: error details are now displayed for more Stripe errors, instead of a generic error message. [https://github.com/woocommerce/woocommerce-ios/pull/14583]
 - [Internal] Updated transformable attribute types from Swift Array to NSArray [https://github.com/woocommerce/woocommerce-ios/pull/14611]

--- a/Yosemite/Yosemite/Stores/MetaDataStore.swift
+++ b/Yosemite/Yosemite/Stores/MetaDataStore.swift
@@ -116,25 +116,20 @@ private extension MetaDataStore {
                                                orderID: Int64,
                                                siteID: Int64,
                                                onCompletion: @escaping () -> Void) {
-        let derivedStorage = sharedDerivedStorage
-
-        derivedStorage.perform {
-            let storedMetaData = derivedStorage.loadOrderMetaData(siteID: siteID, orderID: orderID)
+        storageManager.performAndSave({ [weak self] storage in
+            guard let self else { return }
+            let storedMetaData = storage.loadOrderMetaData(siteID: siteID, orderID: orderID)
 
             for readOnlyOrderMetaData in readOnlyOrderMetaDatas {
-                self.saveMetaData(derivedStorage, readOnlyOrderMetaData, storedMetaData, orderID: orderID, siteID: siteID)
+                saveMetaData(storage, readOnlyOrderMetaData, storedMetaData, orderID: orderID, siteID: siteID)
             }
 
             storedMetaData.forEach { storedMetaData in
                 if !readOnlyOrderMetaDatas.contains(where: { $0.metadataID == storedMetaData.metadataID }) {
-                    derivedStorage.deleteObject(storedMetaData)
+                    storage.deleteObject(storedMetaData)
                 }
             }
-        }
-
-        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
-            DispatchQueue.main.async(execute: onCompletion)
-        }
+        }, completion: onCompletion, on: .main)
     }
 
     /// Using the provided StorageType, update or insert a Storage.MetaData using the provided ReadOnly

--- a/Yosemite/Yosemite/Stores/MetaDataStore.swift
+++ b/Yosemite/Yosemite/Stores/MetaDataStore.swift
@@ -190,24 +190,25 @@ private extension MetaDataStore {
                                                  productID: Int64,
                                                  siteID: Int64,
                                                  onCompletion: @escaping () -> Void) {
-        let derivedStorage = sharedDerivedStorage
-        derivedStorage.perform {
-            let storedMetaData = derivedStorage.loadProductMetaData(siteID: siteID, productID: productID)
+        storageManager.performAndSave({ [weak self] storage in
+            guard let self else { return }
 
+            let storedMetaData = storage.loadProductMetaData(siteID: siteID, productID: productID)
+
+            guard let storageProduct = storage.loadProduct(siteID: siteID, productID: productID) else {
+                DDLogWarn("⚠️ Could not persist the Product MetaData — unable to retrieve stored product with ID \(productID).")
+                return
+            }
             for readOnlyProductMetaData in readOnlyProductMetaDatas {
-                self.saveMetaData(derivedStorage, readOnlyProductMetaData, storedMetaData, productID: productID, siteID: siteID)
+                saveMetaData(storage, readOnlyProductMetaData, storedMetaData, storageProduct: storageProduct)
             }
 
             storedMetaData.forEach { storedMetaData in
                 if !readOnlyProductMetaDatas.contains(where: { $0.metadataID == storedMetaData.metadataID }) {
-                    derivedStorage.deleteObject(storedMetaData)
+                    storage.deleteObject(storedMetaData)
                 }
             }
-        }
-
-        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
-            DispatchQueue.main.async(execute: onCompletion)
-        }
+        }, completion: onCompletion, on: .main)
     }
 
     /// Using the provided StorageType, update or insert a Storage.MetaData using the provided ReadOnly
@@ -218,20 +219,15 @@ private extension MetaDataStore {
     ///   - productID: ID of the product.
     ///   - siteID: Site id of the product.
     ///
-    func saveMetaData(_ storage: StorageType, _ readOnlyMetaData: MetaData, _ storedMetaData: [Storage.MetaData], productID: Int64, siteID: Int64) {
+    func saveMetaData(_ storage: StorageType, _ readOnlyMetaData: MetaData, _ storedMetaData: [Storage.MetaData], storageProduct: Storage.Product) {
         if let existingStorageMetaData = storedMetaData.first(where: { $0.metadataID == readOnlyMetaData.metadataID }) {
             existingStorageMetaData.update(with: readOnlyMetaData)
             return
         }
 
-        guard let storageOrder = storage.loadProduct(siteID: siteID, productID: productID) else {
-            DDLogWarn("⚠️ Could not persist the Product MetaData with ID \(readOnlyMetaData.metadataID) — unable to retrieve stored product with ID \(productID).")
-            return
-        }
-
         let newStorageMetaData = storage.insertNewObject(ofType: Storage.MetaData.self)
         newStorageMetaData.update(with: readOnlyMetaData)
-        newStorageMetaData.product = storageOrder
-        storageOrder.addToCustomFields(newStorageMetaData)
+        newStorageMetaData.product = storageProduct
+        storageProduct.addToCustomFields(newStorageMetaData)
     }
 }

--- a/Yosemite/Yosemite/Stores/MetaDataStore.swift
+++ b/Yosemite/Yosemite/Stores/MetaDataStore.swift
@@ -120,8 +120,12 @@ private extension MetaDataStore {
             guard let self else { return }
             let storedMetaData = storage.loadOrderMetaData(siteID: siteID, orderID: orderID)
 
+            guard let storageOrder = storage.loadOrder(siteID: siteID, orderID: orderID) else {
+                DDLogWarn("⚠️ Could not persist the Order MetaData — unable to retrieve stored order with ID \(orderID).")
+                return
+            }
             for readOnlyOrderMetaData in readOnlyOrderMetaDatas {
-                saveMetaData(storage, readOnlyOrderMetaData, storedMetaData, orderID: orderID, siteID: siteID)
+                saveMetaData(storage, readOnlyOrderMetaData, storedMetaData, storageOrder: storageOrder)
             }
 
             storedMetaData.forEach { storedMetaData in
@@ -140,14 +144,9 @@ private extension MetaDataStore {
     ///   - orderID: ID of the order.
     ///   - siteID: Site id of the order.
     ///
-    func saveMetaData(_ storage: StorageType, _ readOnlyMetaData: MetaData, _ storedMetaData: [Storage.MetaData], orderID: Int64, siteID: Int64) {
+    func saveMetaData(_ storage: StorageType, _ readOnlyMetaData: MetaData, _ storedMetaData: [Storage.MetaData], storageOrder: Storage.Order) {
         if let existingStorageMetaData = storedMetaData.first(where: { $0.metadataID == readOnlyMetaData.metadataID }) {
             existingStorageMetaData.update(with: readOnlyMetaData)
-            return
-        }
-
-        guard let storageOrder = storage.loadOrder(siteID: siteID, orderID: orderID) else {
-            DDLogWarn("⚠️ Could not persist the Order MetaData with ID \(readOnlyMetaData.metadataID) — unable to retrieve stored order with ID \(orderID).")
             return
         }
 

--- a/Yosemite/Yosemite/Stores/MetaDataStore.swift
+++ b/Yosemite/Yosemite/Stores/MetaDataStore.swift
@@ -8,10 +8,6 @@ import Storage
 public final class MetaDataStore: Store {
     private let remote: MetaDataRemoteProtocol
 
-    private lazy var sharedDerivedStorage: StorageType = {
-        return storageManager.writerDerivedStorage
-    }()
-
     init(dispatcher: Dispatcher,
          storageManager: StorageManagerType,
          network: Network,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14122 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the storage usage in MetaDataStore: 
- Replaced the deprecated usage of `writerDerivedStorage` with the new method `performAndSave` to ensure write operations being handled in the same operation queue.
- Optimized fetch requests by sharing the stored order/product when saving metadata for the same order/product.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Test some core flows from the testing plan pe5sF9-357-p2 to ensure that updating custom fields in orders and products still work correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested using simulator iPhone 16 Pro iOS 18.1 and confirmed that custom fields updating still work correctly after these changes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.