### PR TITLE
Core Data: Enforce all write operations in the background

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -32,6 +32,7 @@
 - [*] Fixed: Improved the error message displayed when Bluetooth permission is denied during the card reader connection process. [https://github.com/woocommerce/woocommerce-ios/pull/14561]
 - [*] Payments: error details are now displayed for more Stripe errors, instead of a generic error message. [https://github.com/woocommerce/woocommerce-ios/pull/14583]
 - [Internal] Updated transformable attribute types from Swift Array to NSArray [https://github.com/woocommerce/woocommerce-ios/pull/14611]
+- [Internal] Updated the storage layer to enforce write operations in the background. [https://github.com/woocommerce/woocommerce-ios/pull/14644]
 - [*] Order Creation: fixed layout of custom amount type selection drawer. [https://github.com/woocommerce/woocommerce-ios/pull/14619]
 
 21.2

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -154,7 +154,6 @@ public final class CoreDataManager: StorageManagerType {
         viewContext.performAndWait {
             viewContext.reset()
             self.deleteAllStoredObjects(in: viewContext)
-            viewContext.saveIfNeeded()
         }
 
         /// Delete all objects in the background context to avoid discrepancy with the view context

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -112,7 +112,7 @@ public final class CoreDataManager: StorageManagerType {
             derivedStorage.perform {
                 operation(derivedStorage)
 
-                derivedStorage.saveIfNeeded()
+                (derivedStorage as! NSManagedObjectContext).saveIfNeeded()
                 queue.async { completion?() }
                 done()
             }
@@ -138,7 +138,7 @@ public final class CoreDataManager: StorageManagerType {
             derivedStorage.perform {
                 let result = Result(catching: { try operation(derivedStorage) })
                 if case .success = result {
-                    derivedStorage.saveIfNeeded()
+                    (derivedStorage as! NSManagedObjectContext).saveIfNeeded()
                 }
                 queue.async { completion(result) }
                 done()

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -146,28 +146,21 @@ public final class CoreDataManager: StorageManagerType {
         })
     }
 
-    /// This method effectively destroys all of the stored data, and generates a blank Persistent Store from scratch.
+    /// This method effectively **deletes** all of the stored data from the persistent container,
+    /// and generates a blank Persistent Store from scratch.
+    /// We don't use `NSManagedObjectContext.reset` here as it does not affect the persistent container,
+    /// only reverts the changes made on a particular context.
     ///
-    public func reset() {
-        /// Reset the view context first
-        let viewContext = persistentContainer.viewContext
-        viewContext.performAndWait {
-            viewContext.reset()
-            self.deleteAllStoredObjects(in: viewContext)
-        }
-
+    public func reset(onCompletion: (() -> Void)?) {
         /// Delete all objects in the background context to avoid discrepancy with the view context
+        /// The view context will get updated automatically once the changes are saved to the persistent container.
         performAndSave({ storage in
-            guard let backgroundContext = storage as? NSManagedObjectContext else {
-                DDLogError("⛔️ CoreDataManager failed to reset due to unexpected storage type!")
-                return
-            }
+            let backgroundContext = storage as! NSManagedObjectContext
             /// persist self to complete deleting objects
             self.deleteAllStoredObjects(in: backgroundContext)
-            backgroundContext.reset()
         }, completion: {
             DDLogVerbose("💣 [CoreDataManager] Stack Destroyed!")
-            NotificationCenter.default.post(name: .StorageManagerDidResetStorage, object: self)
+            onCompletion?()
         }, on: .main)
     }
 

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -95,15 +95,6 @@ public final class CoreDataManager: StorageManagerType {
     ///
     public let persistentContainer: NSPersistentContainer
 
-    /// Saves the derived storage. Note: the closure may be called on a different thread
-    ///
-    public func saveDerivedType(derivedStorage: StorageType, _ closure: @escaping () -> Void) {
-        derivedStorage.perform {
-            derivedStorage.saveIfNeeded()
-            closure()
-        }
-    }
-
     /// Execute the given operation with a background context and save the changes.
     ///
     /// This function _does not block_ its running thread. The operation is executed in background and its return value

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -65,7 +65,7 @@ public final class CoreDataManager: StorageManagerType {
             return context
         }()
 
-        self.writerDerivedStorage = {
+        self.writerStorage = {
             let backgroundContext = persistentContainer.newBackgroundContext()
             backgroundContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
             return backgroundContext
@@ -87,9 +87,9 @@ public final class CoreDataManager: StorageManagerType {
     ///
     public let viewStorage: StorageType
 
-    /// Returns a shared derived storage instance dedicated for write operations.
+    /// Returns a storage instance dedicated for write operations.
     ///
-    public let writerDerivedStorage: StorageType
+    private let writerStorage: StorageType
 
     /// Persistent Container: Holds the full CoreData Stack
     ///
@@ -116,7 +116,7 @@ public final class CoreDataManager: StorageManagerType {
     public func performAndSave(_ operation: @escaping (StorageType) -> Void,
                                completion: (() -> Void)?,
                                on queue: DispatchQueue) {
-        let derivedStorage = writerDerivedStorage
+        let derivedStorage = writerStorage
         writerQueue.addOperation(AsyncBlockOperation { done in
             derivedStorage.perform {
                 operation(derivedStorage)
@@ -142,7 +142,7 @@ public final class CoreDataManager: StorageManagerType {
                                   completion: @escaping (Result<T, Error>) -> Void,
                                   on queue: DispatchQueue) {
         assert((T.self is NSManagedObject.Type) == false, "Managed objects should not be sent between different contexts to avoid threading issues.")
-        let derivedStorage = writerDerivedStorage
+        let derivedStorage = writerStorage
         writerQueue.addOperation(AsyncBlockOperation { done in
             derivedStorage.perform {
                 let result = Result(catching: { try operation(derivedStorage) })

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -87,7 +87,7 @@ public final class CoreDataManager: StorageManagerType {
     ///
     public let viewStorage: StorageType
 
-    /// Returns a storage instance dedicated for write operations.
+    /// Storage instance dedicated for write operations.
     ///
     private let writerStorage: StorageType
 
@@ -148,8 +148,6 @@ public final class CoreDataManager: StorageManagerType {
 
     /// This method effectively **deletes** all of the stored data from the persistent container,
     /// and generates a blank Persistent Store from scratch.
-    /// We don't use `NSManagedObjectContext.reset` here as it does not affect the persistent container,
-    /// only reverts the changes made on a particular context.
     ///
     public func reset(onCompletion: (() -> Void)?) {
         /// Delete all objects in the background context to avoid discrepancy with the view context

--- a/Storage/Storage/Protocols/StorageManagerType.swift
+++ b/Storage/Storage/Protocols/StorageManagerType.swift
@@ -46,5 +46,14 @@ public protocol StorageManagerType: AnyObject {
     /// This method is expected to destroy all persisted data. A notification of type `StorageManagerDidResetStorage` should get
     /// posted.
     ///
-    func reset()
+    /// - Parameter onCompletion: A callback closure triggered when the resetting is done.
+    ///
+    func reset(onCompletion: (() -> Void)?)
+}
+
+public extension StorageManagerType {
+    /// Simplified method to reset the storage.
+    func reset() {
+        reset(onCompletion: nil)
+    }
 }

--- a/Storage/Storage/Protocols/StorageManagerType.swift
+++ b/Storage/Storage/Protocols/StorageManagerType.swift
@@ -16,24 +16,6 @@ public protocol StorageManagerType: AnyObject {
     ///
     var viewStorage: StorageType { get }
 
-    /// Returns a shared derived storage instance dedicated for write operations.
-    ///
-    @available(*, deprecated, message: "Use `performAndSave` to handle write operations instead.")
-    var writerDerivedStorage: StorageType { get }
-
-    /// Performs a task in Background: a special `Storage` instance will be provided (which is expected to be used within the closure!).
-    /// Note that you must NEVER use the viewStorage within the backgroundClosure.
-    ///
-
-    /// Save a derived context created with `writerDerivedStorage` via this convenience method
-    ///
-    /// - Parameters:
-    ///   - derivedStorageType: a derived StorageType constructed with `newDerivedStorage`
-    ///   - closure: Callback to be executed on completion
-    ///
-    @available(*, deprecated, message: "Use `performAndSave` to handle write operations instead.")
-    func saveDerivedType(derivedStorage: StorageType, _ closure: @escaping () -> Void)
-
     /// Execute the given operation with a background context and save the changes.
     ///
     /// This function _does not block_ its running thread. The operation is executed in background and its return value

--- a/Storage/Storage/Protocols/StorageType.swift
+++ b/Storage/Storage/Protocols/StorageType.swift
@@ -56,10 +56,6 @@ public protocol StorageType: AnyObject {
     /// This will ensure that `NSFetchedResultsController` will not ever receive temporary IDs.
     func obtainPermanentIDs(for objects: [NSManagedObject]) throws
 
-    /// Persists unsaved changes, if needed.
-    ///
-    func saveIfNeeded()
-
     /// Asynchronously performs a given block on the StorageType's queue.
     ///
     func perform(_ closure: @escaping () -> Void)

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -140,8 +140,13 @@ final class CoreDataManagerTests: XCTestCase {
         let modelsInventory = try makeModelsInventory()
         var manager = try makeManager(using: modelsInventory, deletingExistingStoreFiles: true)
 
-        insertAccount(to: manager.viewStorage)
-        manager.viewStorage.saveIfNeeded()
+        waitFor { promise in
+            manager.performAndSave({ storage in
+                self.insertAccount(to: storage)
+            }, completion: {
+                promise(())
+            }, on: .main)
+        }
 
         XCTAssertEqual(manager.viewStorage.countObjects(ofType: Account.self), 1)
         XCTAssertNotNil(NSEntityDescription.entity(forEntityName: Note.entityName,
@@ -193,8 +198,13 @@ final class CoreDataManagerTests: XCTestCase {
 
         var manager = try makeManager(using: olderModelsInventory, deletingExistingStoreFiles: true)
 
-        insertAccount(to: manager.viewStorage)
-        manager.viewStorage.saveIfNeeded()
+        waitFor { promise in
+            manager.performAndSave({ storage in
+                self.insertAccount(to: storage)
+            }, completion: {
+                promise(())
+            }, on: .main)
+        }
 
         XCTAssertEqual(manager.viewStorage.countObjects(ofType: Account.self), 1)
         // The ShippineLineTax entity does not exist in Model 33.
@@ -229,8 +239,13 @@ final class CoreDataManagerTests: XCTestCase {
 
         var manager = try makeManager(using: modelsInventory, deletingExistingStoreFiles: true)
 
-        insertAccount(to: manager.viewStorage)
-        manager.viewStorage.saveIfNeeded()
+        waitFor { promise in
+            manager.performAndSave({ storage in
+                self.insertAccount(to: storage)
+            }, completion: {
+                promise(())
+            }, on: .main)
+        }
 
         XCTAssertEqual(manager.viewStorage.countObjects(ofType: Account.self), 1)
         try assertThat(manager, isCompatibleWith: modelsInventory.currentModel)

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -41,19 +41,6 @@ final class CoreDataManagerTests: XCTestCase {
         XCTAssertEqual(manager.viewStorage as? NSManagedObjectContext, manager.persistentContainer.viewContext)
     }
 
-    /// Verifies that derived context is instantiated correctly.
-    ///
-    func test_derived_storage_is_instantiated_correctly() {
-        let manager = CoreDataManager(name: storageIdentifier, crashLogger: MockCrashLogger())
-        let viewContext = (manager.viewStorage as? NSManagedObjectContext)
-        let derivedContext = (manager.writerDerivedStorage as? NSManagedObjectContext)
-
-        XCTAssertNotNil(viewContext)
-        XCTAssertNotNil(derivedContext)
-        XCTAssertNotEqual(derivedContext, viewContext)
-        XCTAssertNil(derivedContext?.parent)
-    }
-
     func test_resetting_CoreData_deletes_preexisting_objects() throws {
         // Arrange
         let modelsInventory = try makeModelsInventory()

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -53,8 +53,9 @@ final class CoreDataManagerTests: XCTestCase {
                 _ = storage.insertNewObject(ofType: ShippingLine.self)
             }, completion: {
                 XCTAssertEqual(viewContext.countObjects(ofType: ShippingLine.self), 1)
-                manager.reset()
-                expectation.fulfill()
+                manager.reset {
+                    expectation.fulfill()
+                }
             }, on: .main)
         }
 

--- a/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
@@ -159,13 +159,7 @@ private extension DefaultBlazeLocalNotificationScheduler {
             self?.scheduleNoCampaignReminderIfNeeded()
         }
         blazeCampaignResultsController.onDidResetContent = { [weak self] in
-            /// Upon logging out, `CoreDataManager` resets the storage and triggers the reset notification
-            /// causing refetching data. Checking the authentication state helps avoiding reloading data
-            /// in the unauthenticated state.
-            guard let self, stores.isAuthenticated else {
-                return
-            }
-            scheduleNoCampaignReminderIfNeeded()
+            self?.scheduleNoCampaignReminderIfNeeded()
         }
 
         do {
@@ -177,6 +171,12 @@ private extension DefaultBlazeLocalNotificationScheduler {
     }
 
     func scheduleNoCampaignReminderIfNeeded() {
+        /// Upon logging out, `CoreDataManager` clears the storage triggering data change.
+        /// Checking the authentication state helps avoiding reloading data
+        /// in the unauthenticated state.
+        guard stores.isAuthenticated else {
+            return
+        }
         guard !userDefaults.blazeNoCampaignReminderOpened() else {
             DDLogDebug("Blaze: User interacted with a previously scheduled no campaign local notification. Don't schedule again.")
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -532,6 +532,13 @@ private extension DashboardViewModel {
 
     func configureOrdersResultController() {
         func refreshHasOrders() {
+            /// Upon logging out, `CoreDataManager` clears the storage triggering data change.
+            /// Checking the authentication state helps avoiding reloading data
+            /// in the unauthenticated state.
+            guard stores.isAuthenticated else {
+                return
+            }
+
             guard ordersResultsController.fetchedObjects.isEmpty else {
                 hasOrders = true
                 return
@@ -545,13 +552,7 @@ private extension DashboardViewModel {
         ordersResultsController.onDidChangeContent = {
             refreshHasOrders()
         }
-        ordersResultsController.onDidResetContent = { [weak self] in
-            /// Upon logging out, `CoreDataManager` resets the storage and triggers the reset notification
-            /// causing refetching data. Checking the authentication state helps avoiding reloading data
-            /// in the unauthenticated state.
-            guard let self, stores.isAuthenticated else {
-                return
-            }
+        ordersResultsController.onDidResetContent = {
             refreshHasOrders()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -98,8 +98,9 @@ class StoreOnboardingViewModel: ObservableObject {
         $noTasksAvailableForDisplay
             .combineLatest(defaults.publisher(for: \.completedAllStoreOnboardingTasks))
             .filter { [weak self] _ in
-                /// Upon logging out, `UserDefaults` is reset causing `completedAllStoreOnboardingTasks` to change value.
-                /// Checking the authentication state helps avoiding reloading data in the unauthenticated state.
+                /// Upon logging out, `CoreDataManager` clears the storage triggering data change.
+                /// Checking the authentication state helps avoiding reloading data
+                /// in the unauthenticated state.
                 guard let self, self.stores.isAuthenticated else {
                     return false
                 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -250,8 +250,8 @@ class DefaultStoresManager: StoresManager {
             dispatch(resetAction)
         }
 
-        state = DeauthenticatedState()
         sessionManager.reset()
+        state = DeauthenticatedState()
 
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -125,7 +125,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-enforce-core-data-write-in-background"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-com.apple.CoreData.ConcurrencyDebug 1"

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
@@ -48,15 +48,9 @@ struct MockOrderActionHandler: MockActionHandler {
     }
 
     private func saveOrders(orders: [Order], onCompletion: @escaping () -> ()) {
-        let storage = storageManager.viewStorage
-
-        storage.perform {
+        storageManager.performAndSave({ storage in
             let updater = OrdersUpsertUseCase(storage: storage)
             updater.upsert(orders)
-        }
-
-        storageManager.saveDerivedType(derivedStorage: storage) {
-            DispatchQueue.main.async(execute: onCompletion)
-        }
+        }, completion: onCompletion, on: .main)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockProductActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockProductActionHandler.swift
@@ -59,14 +59,8 @@ struct MockProductActionHandler: MockActionHandler {
     }
 
     func upsert(products: [Product], onCompletion: @escaping () -> ()) {
-        let storage = storageManager.writerDerivedStorage
-
-        storage.perform {
-            productStore.upsertStoredProducts(readOnlyProducts: products, in: storage)
-        }
-
-        storageManager.saveDerivedType(derivedStorage: storage) {
-            DispatchQueue.main.async(execute: onCompletion)
-        }
+        storageManager.performAndSave({ storage in
+            self.productStore.upsertStoredProducts(readOnlyProducts: products, in: storage)
+        }, completion: onCompletion, on: .main)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockProductReviewAction.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockProductReviewAction.swift
@@ -23,7 +23,6 @@ struct MockProductReviewActionHandler: MockActionHandler {
         // Deletes previous product reviews before saving new ones to avoid duplicate reviews after multiple runs.
         let storage = storageManager.viewStorage
         storage.deleteAllObjects(ofType: StorageProductReview.self)
-        storage.saveIfNeeded()
 
         save(mocks: reviews, as: StorageProductReview.self) { error in
             if let error = error {

--- a/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
+++ b/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
@@ -7,10 +7,6 @@ import Storage
 public final class GoogleAdsStore: Store {
     private let remote: GoogleListingsAndAdsRemoteProtocol
 
-    private lazy var sharedDerivedStorage: StorageType = {
-        return storageManager.writerDerivedStorage
-    }()
-
     init(dispatcher: Dispatcher,
          storageManager: StorageManagerType,
          network: Network,

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -8,10 +8,6 @@ public final class ProductVariationStore: Store {
     private let remote: ProductVariationsRemoteProtocol
     private let productVariationStorageManager: ProductVariationStorageManager
 
-    private lazy var sharedDerivedStorage: StorageType = {
-        return storageManager.writerDerivedStorage
-    }()
-
     public override convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         let remote = ProductVariationsRemote(network: network)
         self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -11,10 +11,6 @@ public class ReceiptStore: Store {
     private let fileStorage: FileStorage
     private let remote: ReceiptRemote
 
-    private lazy var sharedDerivedStorage: StorageType = {
-        storageManager.writerDerivedStorage
-    }()
-
     private lazy var currencyFormatter: CurrencyFormatter = {
         CurrencyFormatter(currencySettings: CurrencySettings())
     }()

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
@@ -43,6 +43,7 @@ public class MockStorageManager: StorageManagerType {
 
     /// Persists the Derived Storage's Changes.
     ///
+    @available(*, deprecated, message: "Use `MockStorageManager`'s `performAndSave` to handle write operations instead of writing directly.")
     public func saveDerivedType(derivedStorage: StorageType, _ closure: @escaping () -> Void) {
         derivedStorage.perform {
             derivedStorage.saveIfNeeded()
@@ -158,5 +159,12 @@ extension MockStorageManager {
         }
 
         return url
+    }
+}
+
+extension StorageType {
+    @available(*, deprecated, message: "Use `MockStorageManager`'s `performAndSave` to handle write operations instead of writing directly.")
+    func saveIfNeeded() {
+        (self as! NSManagedObjectContext).saveIfNeeded()
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
@@ -56,7 +56,7 @@ public class MockStorageManager: StorageManagerType {
 
     /// This method effectively destroys all of the stored data, and generates a blank Persistent Store from scratch.
     ///
-    public func reset() {
+    public func reset(onCompletion: (() -> Void)?) {
         let storeCoordinator = persistentContainer.persistentStoreCoordinator
         let storeDescriptor = self.storeDescription
         let viewContext = persistentContainer.viewContext

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
@@ -73,6 +73,7 @@ public class MockStorageManager: StorageManagerType {
 
             storeCoordinator.addPersistentStore(with: storeDescriptor) { (_, error) in
                 guard let error = error else {
+                    onCompletion?()
                     return
                 }
 

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
@@ -17,7 +17,7 @@ public class MockStorageManager: StorageManagerType {
         return persistentContainer.viewContext
     }
 
-    /// Returns a shared derived storage instance dedicated for write operations.
+    /// Returns a shared derived storage instance dedicated for write operations in the background.
     ///
     public lazy var writerDerivedStorage: StorageType = {
         let childManagedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
@@ -43,7 +43,6 @@ public class MockStorageManager: StorageManagerType {
 
     /// Persists the Derived Storage's Changes.
     ///
-    @available(*, deprecated, message: "Use `MockStorageManager`'s `performAndSave` to handle write operations instead of writing directly.")
     public func saveDerivedType(derivedStorage: StorageType, _ closure: @escaping () -> Void) {
         derivedStorage.perform {
             derivedStorage.saveIfNeeded()

--- a/Yosemite/YosemiteTests/SnapshotsProvider/FetchResultSnapshotsProviderTests.swift
+++ b/Yosemite/YosemiteTests/SnapshotsProvider/FetchResultSnapshotsProviderTests.swift
@@ -268,9 +268,9 @@ final class FetchResultSnapshotsProviderTests: XCTestCase {
                 let zanzaInDerived = derivedStorage.loadObject(ofType: StorageAccount.self, with: zanza.objectID)!
                 zanzaInDerived.username = "Zanza Lockman"
 
-                derivedStorage.saveIfNeeded()
-
-                exp.fulfill()
+                self.storageManager.saveDerivedType(derivedStorage: derivedStorage, {
+                    exp.fulfill()
+                })
             }
         }
 

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -8,7 +8,7 @@ import Storage
 final class OrdersUpsertUseCaseTests: XCTestCase {
 
     private let defaultSiteID: Int64 = 10
-    private var storageManager: StorageManagerType!
+    private var storageManager: MockStorageManager!
     private var viewStorage: StorageType {
         storageManager.viewStorage
     }

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -356,11 +356,11 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
-        DispatchQueue.global(qos: .background).async {
+        backgroundContext.perform {
             orderUseCase.upsert([order])
             productStore.upsertStoredProducts(readOnlyProducts: [product], in: backgroundContext)
-            backgroundContext.saveIfNeeded()
         }
+        storageManager.saveDerivedType(derivedStorage: backgroundContext, {})
 
         // Then
         self.waitUntil {

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -25,6 +25,8 @@ Notes:
 - For thread safety, do not send any `NSManagedObject` instance to the completion closure of `performAndSave`. There's an assertion to ensure at debug runtime this does not happen.
 - For performance reasons, please be mindful with fetch requests. Avoid making multiple fetch requests in for loops. This can be replaced by a single fetch request for a list of objects instead.
 - For attributes of type Transformable, if the transformer is `NSSecureUnarchiveFromData`, make sure to input a `class` type in the Custom Class field in the Core Data model. Using a Swift type (e.g. [Int64] or [String]) would cause an error logged in Xcode 16.
+- We have a launch argument `-enforce-core-data-write-in-background` enabled by default in the WooCommerce scheme. This will intentionally crashes the app in the debug mode when one attempts to perform write operations in the main thread with the view context.
+- We also enable `-com.apple.CoreData.ConcurrencyDebug` launch argument by default to get notified when there's a concurrency issue with our Core Data stack. Please keep an eye out for errors from Core Data in the console log and report any problems when you see them.
 
 ## File storage
 The Storage module also exposes a protocol, called [`FileStorage`](../Storage/Storage/Protocols/FileStorage.swift) to abstract saving and reading data to and from local storage. 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -25,7 +25,7 @@ Notes:
 - For thread safety, do not send any `NSManagedObject` instance to the completion closure of `performAndSave`. There's an assertion to ensure at debug runtime this does not happen.
 - For performance reasons, please be mindful with fetch requests. Avoid making multiple fetch requests in for loops. This can be replaced by a single fetch request for a list of objects instead.
 - For attributes of type Transformable, if the transformer is `NSSecureUnarchiveFromData`, make sure to input a `class` type in the Custom Class field in the Core Data model. Using a Swift type (e.g. [Int64] or [String]) would cause an error logged in Xcode 16.
-- We have a launch argument `-enforce-core-data-write-in-background` enabled by default in the WooCommerce scheme. This will intentionally crashes the app in the debug mode when one attempts to perform write operations in the main thread with the view context.
+- We have a launch argument `-enforce-core-data-write-in-background` enabled by default in the WooCommerce scheme. This will intentionally crash the app in the debug mode when one attempts to perform write operations in the main thread with the view context.
 - We also enable `-com.apple.CoreData.ConcurrencyDebug` launch argument by default to get notified when there's a concurrency issue with our Core Data stack. Please keep an eye out for errors from Core Data in the console log and report any problems when you see them.
 
 ## File storage


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14641 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the last updates to the storage layer to enforce all write operations in the background:
- Removed `writerDerivedStorage` and `saveDerivedType` to make it official from now on that we have to use `performAndSave` for all write operations.
- Removed `saveIfNeeded` as we no longer need to use this method directly. This comes with a few changes:
  - The method is kept in the extension of `NSManagedObjectContext` to be used by `CoreDataManager`.
  - Updated unit tests for `CoreDataManager`.
  - Since many of our tests still use this method when writing data, I've added an extension method to support this in `MockStorageManager` and marked it as deprecated to avoid fixing all the tests.
  - Updated tests that require the background context for writing to use `saveDerivedType` to avoid the unnecessary warnings about `saveIfNeeded`.
- Enabled the `-enforce-core-data-write-in-background` flag by default to crash the app in debug mode if one attempts to write data in the main thread (view context).
- Updated the behavior of `CoreDataManager`'s `reset` method: 
  - Removed the changes made to the view context as this is unnecessary with our new setup. Now we only need to clear the writer context and save the changes - the view context would then get the updates immediately from the persistent container.
  - Removed the [`reset`](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/1506807-reset) call to the background context. This method essentially resets unsaved changes made to a context and would not affect the persistent container. Deleting all stored items should be sufficient for clearing the persistent container.

Additionally, to avoid undefined behavior, the `DefaultStoresManager`'s `deauthenticate` method was updated to reset the session manager first before setting the state to deauthenticated. The wrong order causes a case where the user is unauthenticated with a selected store, which [triggers](https://github.com/woocommerce/woocommerce-ios/blob/f30517c85795ad30e860e12266300ca7ed202b13/WooCommerce/Classes/ViewRelated/AppCoordinator.swift#L85) `deauthenticate` one more time.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Build and run the app.
- Do some quick smoke tests to confirm that everything works as expected.
- Log out of the app to confirm that it works correctly.
- Log back in to confirm that data is freshly fetched again.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.1 and confirmed that the app works correctly when logging in/out and loading data.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.