### PR TITLE
[Brand Updats] Update color palette

### DIFF
--- a/WooCommerce/Classes/ViewRelated/LaunchScreen.storyboard
+++ b/WooCommerce/Classes/ViewRelated/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -26,7 +26,7 @@
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" name="WooCommercePurple60"/>
+                        <color key="backgroundColor" name="WooCommercePurple40"/>
                         <constraints>
                             <constraint firstItem="Q7F-qQ-dHf" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="Ilw-Kx-7ga"/>
                             <constraint firstItem="Q7F-qQ-dHf" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Wnf-iK-LGA"/>
@@ -40,8 +40,8 @@
     </scenes>
     <resources>
         <image name="LaunchLogo" width="164" height="96"/>
-        <namedColor name="WooCommercePurple60">
-            <color red="0.40392156862745099" green="0.2627450980392157" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="WooCommercePurple40">
+            <color red="0.52941176470588236" green="0.24313725490196078" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple0.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple0.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xED",
-          "red" : "0xF2"
+          "blue" : "255",
+          "green" : "237",
+          "red" : "242"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple10.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple10.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF6",
-          "green" : "0xB9",
-          "red" : "0xCF"
+          "blue" : "255",
+          "green" : "193",
+          "red" : "209"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple100.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple100.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x1F",
-          "green" : "0x0E",
-          "red" : "0x14"
+          "blue" : "66",
+          "green" : "3",
+          "red" : "31"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple20.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple20.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF2",
-          "green" : "0xA0",
-          "red" : "0xBE"
+          "blue" : "255",
+          "green" : "153",
+          "red" : "183"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple30.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple30.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE9",
-          "green" : "0x86",
-          "red" : "0xAD"
+          "blue" : "255",
+          "green" : "126",
+          "red" : "167"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple40.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple40.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xCF",
-          "green" : "0x6C",
-          "red" : "0x96"
+          "blue" : "255",
+          "green" : "62",
+          "red" : "135"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple5.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple5.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFB",
-          "green" : "0xD1",
-          "red" : "0xDF"
+          "blue" : "255",
+          "green" : "215",
+          "red" : "225"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple50.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple50.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB3",
-          "green" : "0x54",
-          "red" : "0x7F"
+          "blue" : "236",
+          "green" : "14",
+          "red" : "114"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple60.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple60.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x99",
-          "green" : "0x43",
-          "red" : "0x67"
+          "blue" : "206",
+          "green" : "8",
+          "red" : "97"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple70.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple70.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x82",
-          "green" : "0x35",
-          "red" : "0x53"
+          "blue" : "170",
+          "green" : "7",
+          "red" : "80"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple80.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple80.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x61",
-          "green" : "0x28",
-          "red" : "0x3C"
+          "blue" : "126",
+          "green" : "8",
+          "red" : "60"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple90.colorset/Contents.json
+++ b/WooFoundation/WooFoundation/Colors/ColorPalette.xcassets/WooCommercePurple90.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x3D",
-          "green" : "0x1B",
-          "red" : "0x27"
+          "blue" : "93",
+          "green" : "4",
+          "red" : "44"
         }
       },
       "idiom" : "universal"

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -2,11 +2,10 @@ import UIKit
 
 // MARK: - Base colors.
 public extension UIColor {
-    /// Accent. Purple-50 (Light Mode) and Purple-30 (Dark Mode)
+    /// Accent. WooCommercePurple-40
     ///
     static var accent: UIColor {
-        return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
-                       dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
+        return .withColorStudio(.wooCommercePurple, shade: .shade40)
     }
 
     /// Accent Dark. Purple-70 (Light Mode) and Purple-50 (Dark Mode)
@@ -27,11 +26,10 @@ public extension UIColor {
                         dark: withColorStudio(.red, shade: .shade30))
     }
 
-    /// Primary. WooCommercePurple-60 (< iOS 13 and Light Mode) and WooCommercePurple-30 (Dark Mode)
+    /// Primary. WooCommercePurple-40
     ///
     static var primary: UIColor {
-        return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
-                       dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
+        return .withColorStudio(.wooCommercePurple, shade: .shade40)
     }
 
     /// Warning. Orange-30 (< iOS 13 and Light Mode) and Orange-50 (Dark Mode)
@@ -184,8 +182,7 @@ public extension UIColor {
     /// Primary Button Background.
     ///
     static var primaryButtonBackground: UIColor {
-        return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
-                       dark: .withColorStudio(.wooCommercePurple, shade: .shade50))
+        return .withColorStudio(.wooCommercePurple, shade: .shade40)
     }
 
     /// Primary Button Title.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: 382-gh-woocommerce/woomobile-private
<!-- Id number of the GitHub issue this PR addresses. -->

> [!NOTE]
> For the brand updates, we'll be merging all changes to the feature branch `feature/woo-2.0-brand-updates`, which we'll later merge to `trunk` when it's time to release them.

## Description
This PR updates the color palette to match the new brand, and also updates the accent and primary colors of the app to follow the new designs.

## Steps to reproduce
1. Open the app.
2. See few screens.

## Testing information
- Confirm that the splash screen uses purple40.
- Confirm that Link buttons use purple40 in both light and dark thems.
- Confirm that primary buttons have a purple40 background.

For the above, please check the below screenshots.

## Screenshots
For ignore the illustration differences in the following screenshots, focus only on the color changes of the components (buttons, tab bar...), the other differences will be handled in separate PRs.

| Mockup | App |
| --- | --- |
| <img width="320" src="https://github.com/user-attachments/assets/fa9561e7-aec7-4ada-9efd-9d8c09778af0"> |  <img width="320" src="https://github.com/user-attachments/assets/df8da3ce-04cb-4c48-ac88-75ff640dfe27"> |
| <img width="320" alt="Screenshot 2024-12-10 at 17 15 41" src="https://github.com/user-attachments/assets/677128be-502c-46d6-8095-cd24c17dd617"> |<img width="320" src="https://github.com/user-attachments/assets/2879f100-91f9-49e5-92bd-efa935813650" >
| <img width="320" alt="Screenshot 2024-12-10 at 17 13 43" src="https://github.com/user-attachments/assets/2a8dacd9-ba13-48e2-a057-501f5a9d3635"> | <img width="320" src="https://github.com/user-attachments/assets/bda4cc9a-c078-43b5-a2f3-59f07f5c53c2"> |
| <img width="320" alt="Screenshot 2024-12-10 at 17 18 10" src="https://github.com/user-attachments/assets/34e4d7fe-9da9-40d8-8089-05f1ab030bc0"> | <img width="320" src="https://github.com/user-attachments/assets/82e328e3-2465-45e9-8674-6332c525d1c8" >

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.