### PR TITLE
[Shipping labels] Set weight and dimension units as environment values

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
@@ -15,6 +15,9 @@ struct WooAddCustomPackageView: View {
     @State private var isSavingPackage: Bool = false
     @State private var isAddingPackage: Bool = false
 
+    @Environment(\.shippingDimensionsUnit) private var dimensionsUnit
+    @Environment(\.shippingWeightUnit) private var weightUnit
+
     let addPackageAction: (WooShippingPackageDataRepresentable) -> Void
 
     init(viewModel: WooShippingAddCustomPackageViewModel, addPackageAction: @escaping (WooShippingPackageDataRepresentable) -> Void) {
@@ -62,12 +65,12 @@ struct WooAddCustomPackageView: View {
                         VStack {
                             AdaptiveStack(spacing: 8) {
                                 ForEach(WooShippingPackageUnitType.dimensionUnits, id: \.self) { dimensionUnit in
-                                    unitInputView(for: dimensionUnit, unit: viewModel.dimensionsUnit)
+                                    unitInputView(for: dimensionUnit, unit: dimensionsUnit)
                                 }
                             }
                             // showing weight input only if we are saving the template
                             if viewModel.showSaveTemplate {
-                                unitInputView(for: WooShippingPackageUnitType.weight, unit: viewModel.weightUnit)
+                                unitInputView(for: WooShippingPackageUnitType.weight, unit: weightUnit)
                             }
                         }
                         .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -23,8 +23,6 @@ protocol WooShippingPackageDataRepresentable {
     var height: String { get }
     var weight: String { get }
     // local
-    var weightDescription: String { get }
-    var dimensionsDescription: String { get }
     var source: WooShippingPackageSource { get } // custom, predefined
     var packageType: String { get } // box, envelope
 }
@@ -38,8 +36,6 @@ struct WooShippingPackageData: WooShippingPackageDataRepresentable {
     let height: String
     let weight: String
     // local
-    let weightDescription: String
-    let dimensionsDescription: String
     let source: WooShippingPackageSource
     let packageType: String
 
@@ -48,9 +44,7 @@ struct WooShippingPackageData: WooShippingPackageDataRepresentable {
          length: String,
          width: String,
          height: String,
-         dimensionsUnit: String,
          weight: String,
-         weightUnit: String,
          source: WooShippingPackageSource,
          packageType: String) {
         self.id = id
@@ -62,18 +56,13 @@ struct WooShippingPackageData: WooShippingPackageDataRepresentable {
 
         self.source = source
         self.packageType = packageType
-
-        self.dimensionsDescription = WooShippingPackageData.createDimensionsDescription(length: length, width: width, height: height, unit: dimensionsUnit)
-        self.weightDescription = WooShippingPackageData.createWeightsDescription(weight: weight, unit: weightUnit)
     }
 
     init(name: String,
          length: String,
          width: String,
          height: String,
-         dimensionsUnit: String,
          weight: String,
-         weightUnit: String,
          source: WooShippingPackageSource,
          packageType: String) {
         self.init(id: name,
@@ -81,20 +70,18 @@ struct WooShippingPackageData: WooShippingPackageDataRepresentable {
                   length: length,
                   width: width,
                   height: height,
-                  dimensionsUnit: dimensionsUnit,
                   weight: weight,
-                  weightUnit: weightUnit,
                   source: source,
                   packageType: packageType)
     }
 }
 
 extension WooShippingPackageDataRepresentable {
-    static func createDimensionsDescription(length: String, width: String, height: String, unit: String) -> String {
+    func dimensionsDescription(unit: String) -> String {
         return "\(length) x \(width) x \(height) \( unit)"
     }
 
-    static func createWeightsDescription(weight: String, unit: String) -> String {
+    func weightDescription(unit: String) -> String {
         return "\(weight) \(unit)"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -14,21 +14,13 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     // Holds value for toggle that determines if we are showing button for saving the template
     @Published var showSaveTemplate: Bool = false
     @Published var packageTemplateName: String = ""
-    // The dimension unit used in the store (e.g. "in")
-    let dimensionsUnit: String
-    // The weight unit used in the store (e.g. "kg")
-    let weightUnit: String
 
     // MARK: Initialization
 
     init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0,
-         dimensionsUnit: String,
-         weightUnit: String,
          stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
         self.siteID = siteID
-        self.dimensionsUnit = dimensionsUnit
-        self.weightUnit = weightUnit
     }
 
     // Field values are invalid if one of them is empty
@@ -55,9 +47,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
                                       length: fieldValues[.length] ?? "",
                                       width: fieldValues[.width] ?? "",
                                       height: fieldValues[.height] ?? "",
-                                      dimensionsUnit: dimensionsUnit,
                                       weight: fieldValues[.weight] ?? "",
-                                      weightUnit: weightUnit,
                                       source: .custom,
                                       packageType: packageType.rawValue)
     }
@@ -113,9 +103,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
                                                              length: savedPackage.getLength().description,
                                                              width: savedPackage.getWidth().description,
                                                              height: savedPackage.getHeight().description,
-                                                             dimensionsUnit: dimensionsUnit,
                                                              weight: savedPackage.boxWeight.description,
-                                                             weightUnit: weightUnit,
                                                              source: .custom,
                                                              packageType: savedPackage.rawType)
                     continuation.resume(returning: .success(packageData))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -22,23 +22,17 @@ struct WooShippingAddPackageView: View {
     // Holds type of selected package, it can be `custom`, `carrier` or `saved`
     @State var selectedPackageType = PackageProviderType.custom
     @StateObject var packagesViewModel = WooShippingAddPackageViewModel()
-    @State var customPackageViewModel: WooShippingAddCustomPackageViewModel?
-    @ObservedObject var createLabelsViewModel: WooShippingCreateLabelsViewModel
+    @State var customPackageViewModel = WooShippingAddCustomPackageViewModel()
 
     let addPackageAction: (WooShippingPackageDataRepresentable) -> Void
 
     @State private var cancellable: AnyCancellable?
 
-    init(createLabelsViewModel: WooShippingCreateLabelsViewModel,
-         addPackageAction: @escaping (WooShippingPackageDataRepresentable) -> Void) {
-        self.createLabelsViewModel = createLabelsViewModel
-        self.addPackageAction = addPackageAction
-    }
+    @Environment(\.shippingWeightUnit) private var weightUnit
+    @Environment(\.shippingDimensionsUnit) private var dimensionsUnit
 
-    private func loadCustomPackageViewModelWithStoreOptions(_ storeOptions: ShippingLabelStoreOptions?) {
-        guard let storeOptions, customPackageViewModel == nil else { return }
-        customPackageViewModel = WooShippingAddCustomPackageViewModel(dimensionsUnit: storeOptions.dimensionUnit,
-                                                                      weightUnit: storeOptions.weightUnit)
+    init(addPackageAction: @escaping (WooShippingPackageDataRepresentable) -> Void) {
+        self.addPackageAction = addPackageAction
     }
 
     // MARK: - UI
@@ -71,18 +65,6 @@ struct WooShippingAddPackageView: View {
         .task {
             packagesViewModel.loadPackages()
         }
-        .onAppear() {
-            if let storeOptions = createLabelsViewModel.storeOptions {
-                loadCustomPackageViewModelWithStoreOptions(storeOptions)
-            }
-            else {
-                cancellable = createLabelsViewModel.$storeOptions
-                    .receive(on: DispatchQueue.main)
-                    .sink { storeOptions in
-                        loadCustomPackageViewModelWithStoreOptions(storeOptions)
-                    }
-            }
-        }
     }
 
     // MARK: UI components
@@ -91,58 +73,14 @@ struct WooShippingAddPackageView: View {
     private var selectedPackageTypeView: some View {
         switch selectedPackageType {
         case .custom:
-            customPackageView
+            WooAddCustomPackageView(viewModel: customPackageViewModel,
+                                    addPackageAction: addPackageAction)
         case .carrier:
-            carrierPackageView
+            WooCarrierPackagesSelectionView(viewModel: packagesViewModel,
+                                            addPackageAction: addPackageAction)
         case .saved:
-            savedPackageView
-        }
-    }
-
-    @ViewBuilder
-    private var customPackageView: some View {
-        if let customPackageViewModel {
-            WooAddCustomPackageView(viewModel: customPackageViewModel) { packageData in
-                addPackageAction(packageData)
-            }
-        }
-        else {
-            storeOptionsLoadingView
-        }
-    }
-
-    private var storeOptionsLoadingView: some View {
-        VStack {
-            HStack {
-                Spacer()
-                if createLabelsViewModel.isLoadingStoreOptions {
-                    ActivityIndicator(isAnimating: .constant(true), style: .large)
-                }
-                else {
-                    Button {
-                        createLabelsViewModel.loadStoreOptions()
-                    } label: {
-                        Image(systemName: "arrow.trianglehead.counterclockwise")
-                    }
-                }
-                Spacer()
-            }
-            Spacer()
-        }
-        .padding()
-    }
-
-    @ViewBuilder
-    private var carrierPackageView: some View {
-        WooCarrierPackagesSelectionView(viewModel: packagesViewModel) { packageData in
-            addPackageAction(packageData)
-        }
-    }
-
-    @ViewBuilder
-    private var savedPackageView: some View {
-        WooSavedPackagesSelectionView(viewModel: packagesViewModel) { packageData in
-            addPackageAction(packageData)
+            WooSavedPackagesSelectionView(viewModel: packagesViewModel,
+                                          addPackageAction: addPackageAction)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -16,7 +16,6 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     }
 
     @Published private(set) var isLoadingPackages: Bool = false
-    @Published private(set) var storeOptions: ShippingLabelStoreOptions?
 
     // MARK: - saved
 
@@ -93,13 +92,13 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     // transform packages
     private func transformLoadedPackages(_ packagesResult: WooShippingPackagesResponse) {
         let customSavedPackages = packagesResult.customPackages.map {
-            return $0.toPackageData(storeOptions: packagesResult.storeOptions)
+            return $0.toPackageData()
         }
         let predefinedSavedPackages = packagesResult.savedPredefinedPackages.map {
-            return $0.toPackageData(storeOptions: packagesResult.storeOptions)
+            return $0.toPackageData()
         }
         var carrierPackages: [WooShippingCarrierPackages] = packagesResult.allPredefinedOptions.compactMap {
-            return $0.toCarrierPackages(storeOptions: packagesResult.storeOptions)
+            return $0.toCarrierPackages()
         }
         if self.carrierPackages.isNotEmpty {
             // sort new packages so they stay in similar order
@@ -126,7 +125,6 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         self.predefinedSavedPackages = predefinedSavedPackages
         self.carrierPackages = carrierPackages
         self.carrierTabs = carrierTabs
-        self.storeOptions = packagesResult.storeOptions
 
         self.allPredefinedOptions = packagesResult.allPredefinedOptions
 
@@ -138,10 +136,6 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     }
 
     private func transformSavedPackages(_ response: WooShippingCreatePackageResponse) {
-        guard let storeOptions = self.storeOptions else {
-            return
-        }
-
         // helper function for creating jointIDs for easier checking if package should be used or not
         func jointID(carrierID: String, packageID: String) -> String {
             return "\(carrierID)-\(packageID)"
@@ -163,8 +157,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
             for option in carrier.predefinedOptions {
                 for package in option.predefinedPackages {
                     if jointIDs.contains(jointID(carrierID: carrierID, packageID: package.id)) {
-                        allPredefinedSaved.append(package.toPackageData(storeOptions: storeOptions,
-                                                                        groupTitle: option.title,
+                        allPredefinedSaved.append(package.toPackageData(groupTitle: option.title,
                                                                         sourceID: option.providerID))
                     }
                 }
@@ -174,7 +167,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         self.predefinedSavedPackages = allPredefinedSaved
 
         self.customSavedPackages = response.customPackages.map {
-            return $0.toPackageData(storeOptions: storeOptions)
+            return $0.toPackageData()
         }
     }
 
@@ -224,57 +217,51 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 }
 
 extension WooShippingCustomPackage {
-    func toPackageData(storeOptions: ShippingLabelStoreOptions) -> WooShippingPackageData {
+    func toPackageData() -> WooShippingPackageData {
         return WooShippingPackageData(id: id,
                                       name: name,
                                       length: String(getLength()),
                                       width: String(getWidth()),
                                       height: String(getHeight()),
-                                      dimensionsUnit: storeOptions.dimensionUnit,
                                       weight: String(boxWeight),
-                                      weightUnit: storeOptions.weightUnit,
                                       source: .custom,
                                       packageType: rawType)
     }
 }
 
 extension WooShippingPredefinedPackage {
-    func toPackageData(storeOptions: ShippingLabelStoreOptions, groupTitle: String, sourceID: String) -> WooShippingPackageData {
+    func toPackageData(groupTitle: String, sourceID: String) -> WooShippingPackageData {
         return WooShippingPackageData(id: id,
                                       name: name,
                                       length: String(getLength()),
                                       width: String(getWidth()),
                                       height: String(getHeight()),
-                                      dimensionsUnit: storeOptions.dimensionUnit,
                                       weight: String(boxWeight),
-                                      weightUnit: storeOptions.weightUnit,
                                       source: .predefined(sourceTitle: groupTitle, sourceID: sourceID),
                                       packageType: isLetter ? "envelope" : "box")
     }
 }
 
 extension WooShippingSavedPredefinedPackage {
-    func toPackageData(storeOptions: ShippingLabelStoreOptions) -> WooShippingPackageData {
+    func toPackageData() -> WooShippingPackageData {
         return WooShippingPackageData(id: id,
                                       name: self.package.name,
                                       length: String(self.package.getLength()),
                                       width: String(self.package.getWidth()),
                                       height: String(self.package.getHeight()),
-                                      dimensionsUnit: storeOptions.dimensionUnit,
                                       weight: self.package.boxWeight,
-                                      weightUnit: storeOptions.weightUnit,
                                       source: .predefined(sourceTitle: groupTitle, sourceID: providerID),
                                       packageType: self.package.isLetter ? "envelope" : "box")
     }
 }
 
 extension WooShippingCarrierPredefinedOptions {
-    func toCarrierPackages(storeOptions: ShippingLabelStoreOptions) -> WooShippingCarrierPackages? {
+    func toCarrierPackages() -> WooShippingCarrierPackages? {
         guard let shippingCarrier = WooShippingCarrier(rawValue: carrierID) else { return nil }
 
         let packageGroups = predefinedOptions.compactMap { predefinedOption in
             let packages = predefinedOption.predefinedPackages.map { package in
-                return package.toPackageData(storeOptions: storeOptions, groupTitle: predefinedOption.title, sourceID: predefinedOption.providerID)
+                return package.toPackageData(groupTitle: predefinedOption.title, sourceID: predefinedOption.providerID)
             }
             let group = WooPackageGroup(name: predefinedOption.title, packages: packages)
             return group

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageAndRatePlaceholder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageAndRatePlaceholder.swift
@@ -29,7 +29,7 @@ struct WooShippingPackageAndRatePlaceholder: View {
         .padding(Layout.padding)
         .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.border), lineWidth: Layout.borderLineWidth, dashed: true)
         .sheet(isPresented: $showAddPackage) {
-            WooShippingAddPackageView(createLabelsViewModel: viewModel) { packageData in
+            WooShippingAddPackageView() { packageData in
                 onSelectPackage(packageData)
                 showAddPackage = false
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
@@ -15,6 +15,9 @@ struct WooShippingPackageOptionView: View {
     var starAction: (() -> Void)?
     var starred: Bool?
 
+    @Environment(\.shippingDimensionsUnit) private var dimensionsUnit
+    @Environment(\.shippingWeightUnit) private var weightUnit
+
     var body: some View {
         HStack(spacing: 0) {
             HStack {
@@ -32,9 +35,9 @@ struct WooShippingPackageOptionView: View {
                     Text(package.name)
                         .bodyStyle()
                     HStack {
-                        Text(package.dimensionsDescription)
+                        Text(package.dimensionsDescription(unit: dimensionsUnit))
                         Text("•")
-                        Text(package.weightDescription)
+                        Text(package.weightDescription(unit: weightUnit))
                     }
                     .font(.subheadline)
                     .foregroundStyle(Color(.text))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
@@ -2,8 +2,9 @@ import SwiftUI
 
 struct WooShippingSelectedPackageView: View {
     let package: WooShippingPackageDataRepresentable
-    let weightUnit: String
     @Binding var totalWeight: String
+
+    @Environment(\.shippingWeightUnit) private var weightUnit
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -63,14 +64,11 @@ private extension WooShippingSelectedPackageView {
 
 #Preview {
     WooShippingSelectedPackageView(package: WooShippingPackageData(name: "Small Flat Rate Box",
-                                                        length: "12",
-                                                        width: "6",
-                                                        height: "6",
-                                                        dimensionsUnit: "in",
-                                                        weight: "4",
-                                                        weightUnit: "oz",
-                                                        source: .predefined(sourceTitle: "USPS Priority Mail Flat Rate Boxes", sourceID: "usps"),
-                                                        packageType: "box"),
-                        weightUnit: "oz",
-                        totalWeight: .constant("6"))
+                                                                   length: "12",
+                                                                   width: "6",
+                                                                   height: "6",
+                                                                   weight: "4",
+                                                                   source: .predefined(sourceTitle: "USPS Priority Mail Flat Rate Boxes", sourceID: "usps"),
+                                                                   packageType: "box"),
+                                   totalWeight: .constant("6"))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -51,7 +51,6 @@ struct WooShippingCreateLabelsView: View {
                     } else if let package = viewModel.selectedPackage,
                               let shippingService = viewModel.shippingService {
                         WooShippingSelectedPackageView(package: package,
-                                                       weightUnit: viewModel.weightUnit,
                                                        totalWeight: $viewModel.shipmentWeight)
                         WooShippingServiceView(viewModel: shippingService)
                             .padding(.horizontal, -16)
@@ -141,6 +140,8 @@ struct WooShippingCreateLabelsView: View {
                 }
                 .ignoresSafeArea(edges: .horizontal)
             }
+            .shippingWeightUnit(viewModel.weightUnit)
+            .shippingDimensionsUnit(viewModel.dimensionsUnit)
             .navigationTitle(viewModel.canViewLabel ? Localization.viewLabelTitle : Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -150,10 +151,6 @@ struct WooShippingCreateLabelsView: View {
                     }
                 }
             }
-        }
-        .onAppear() {
-            guard viewModel.storeOptions == nil else { return }
-            viewModel.loadStoreOptions()
         }
     }
 }
@@ -230,6 +227,22 @@ private extension WooShippingCreateLabelsView {
         }
         .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isPurchasingLabel))
         .disabled(!viewModel.isPurchaseButtonEnabled)
+    }
+}
+
+// MARK: Store Options
+extension EnvironmentValues {
+    @Entry var shippingWeightUnit: String = ServiceLocator.shippingSettingsService.weightUnit ?? ""
+    @Entry var shippingDimensionsUnit: String = ServiceLocator.shippingSettingsService.dimensionUnit ?? ""
+}
+
+extension View {
+    func shippingWeightUnit(_ weightUnit: String) -> some View {
+        environment(\.shippingWeightUnit, weightUnit)
+    }
+
+    func shippingDimensionsUnit(_ dimensionsUnit: String) -> some View {
+        environment(\.shippingDimensionsUnit, dimensionsUnit)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -97,11 +97,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// If the label purchase is in progress.
     @Published private(set) var isPurchasingLabel: Bool = false
 
-    @Published var storeOptions: ShippingLabelStoreOptions?
-    @Published var isLoadingStoreOptions: Bool = false
-    var weightUnit: String {
-        storeOptions?.weightUnit ?? ServiceLocator.shippingSettingsService.weightUnit ?? ""
-    }
+    /// Unit to use for weight measurements.
+    @Published var weightUnit: String = ServiceLocator.shippingSettingsService.weightUnit ?? ""
+
+    /// Unit to use for dimensions measurements.
+    @Published var dimensionsUnit: String = ServiceLocator.shippingSettingsService.dimensionUnit ?? ""
 
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
@@ -146,6 +146,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
         observeSelectedPackage()
         observeForLabelRates()
+        loadStoreOptions()
     }
 
     /// Initialize the view model from an existing shipping label.
@@ -203,36 +204,21 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         stores.dispatch(action)
     }
 
-    func loadStoreOptions(completion: ((ShippingLabelStoreOptions) -> Void)? = nil) {
-        guard isLoadingStoreOptions == false,
-              let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else { return }
+    /// Updates store options (weight and dimensions units) with remote settings.
+    func loadStoreOptions() {
+        guard let siteID = stores.sessionManager.defaultStoreID else { return }
 
-        isLoadingStoreOptions = true
-
-        let action = WooShippingAction.loadAccountSettings(siteID: siteID) { result in
+        let action = WooShippingAction.loadAccountSettings(siteID: siteID) { [weak self] result in
             switch result {
             case .success(let settings):
-                self.storeOptions = settings.storeOptions
-                completion?(settings.storeOptions)
+                guard let self else { return }
+                weightUnit = settings.storeOptions.weightUnit
+                dimensionsUnit = settings.storeOptions.dimensionUnit
             case .failure(let error):
                 DDLogError("⛔️ Error loading account settings: \(error)")
-                // fallback to store settings
-                let shippingSettingsService = ServiceLocator.shippingSettingsService
-                let currencySettings = ServiceLocator.currencySettings
-                let currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
-                let originCountry = SiteAddress().countryCode.rawValue
-                if let dimensionUnit = shippingSettingsService.dimensionUnit,
-                   let weightUnit = shippingSettingsService.weightUnit {
-                    let fallbackStoreOptions = ShippingLabelStoreOptions(currencySymbol: currencySymbol,
-                                                            dimensionUnit: dimensionUnit,
-                                                            weightUnit: weightUnit,
-                                                            originCountry: originCountry)
-                    self.storeOptions = fallbackStoreOptions
-                }
             }
-            self.isLoadingStoreOptions = false
         }
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -9,32 +9,11 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // Then
         XCTAssertNotNil(viewModel)
         viewModel.checkDefaultInitProperties()
-    }
-
-    @MainActor
-    func test_it_inits_with_store_options() {
-        // Given/When
-        let expectedDimensionUnit = "in"
-        let expectedWeightUnit = "kg"
-        let siteID: Int64 = 1234
-        let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: expectedDimensionUnit,
-                                                             weightUnit: expectedWeightUnit,
-                                                             stores: mockStores)
-
-        // Then
-        XCTAssertNotNil(viewModel)
-        viewModel.checkDefaultInitProperties()
-        XCTAssertEqual(viewModel.dimensionsUnit, expectedDimensionUnit)
-        XCTAssertEqual(viewModel.weightUnit, expectedWeightUnit)
     }
 
     @MainActor
@@ -43,8 +22,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // When
@@ -61,8 +38,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // When
@@ -79,8 +54,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // When
@@ -98,8 +71,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // When
@@ -117,8 +88,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // When
@@ -136,8 +105,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // Then
@@ -150,8 +117,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // When
@@ -167,8 +132,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: mockStores)
 
         // When
@@ -193,8 +156,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: dimensionUnit,
-                                                             weightUnit: weightUnit,
                                                              stores: mockStores)
         let length = "1"
         let width = "2"
@@ -215,8 +176,8 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         switch packageDataResult {
         case .success(let packageData):
             XCTAssertNotNil(packageData)
-            XCTAssertEqual(packageData.dimensionsDescription, expectedDimensions)
-            XCTAssertEqual(packageData.weightDescription, expectedWeight)
+            XCTAssertEqual(packageData.dimensionsDescription(unit: dimensionUnit), expectedDimensions)
+            XCTAssertEqual(packageData.weightDescription(unit: weightUnit), expectedWeight)
         case .failure(let failure):
             XCTFail(failure.localizedDescription)
         }
@@ -228,8 +189,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         let siteID: Int64 = 1234
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
-                                                             dimensionsUnit: "in",
-                                                             weightUnit: "oz",
                                                              stores: stores)
         let packageName = "a"
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -374,9 +374,7 @@ private extension WooShippingCreateLabelsViewModelTests {
                                length: "21.91",
                                width: "13.65",
                                height: "4.13",
-                               dimensionsUnit: "cm",
                                weight: ".25",
-                               weightUnit: "kg",
                                source: .predefined(sourceTitle: "usps", sourceID: "usps"),
                                packageType: "box")
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the Woo Shipping label flow, we want to support editing the selected package. In preparation for modifying the package selection UI (to pass in the data about the selected package), this PR simplifies the setup for those package selection views and view models.

In particular, it removes the need to pass around the store options by setting the weight and dimension units as environment values on the parent view. This way they can be updated in place when the store options are fetched from remote.

### How

* In `WooShippingCreateLabelsViewModel`:
   * We now have the weight and dimension units as published properties. These default to the values from `ServiceLocator.shippingSettingsService`, which is synced when the app opens.
   * When the view model inits, we load the store options from remote and update the weight and dimension units.
* Weight and dimensions units as environment values/variables:
   * In `WooShippingCreateLabelsView`, we now define two new environment values for the weight and dimension units and set them with the view model properties. This way we can access the latest values as needed in other views.
   * In views that use the weight and/or dimensions unit, we now set those as environment variables.
* Simplifying view models and structs:
   * Removes unit properties from child view models and sets them as environment variables in the corresponding child views instead.
   * Instead of using the units to initialize a `WooShippingPackageDataRepresentable` with a weight and dimensions description, there are now have instance methods to generate a description with a provided unit.
   * `WooShippingAddPackageView` has a simpler setup: It now longer needs `WooShippingCreateLabelsViewModel` and can create its `WooShippingAddCustomPackageViewModel` immediately.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Immediately tap "Select a Package."
8. Notice that the units in the custom packages view are updated in place to the new values.
9. Enter custom package details or select a carrier package and tap "Add Package."
10. Confirm the package details are displayed on the main screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

With weight/dimensions units changed from kg/cm to lbs/in:

https://github.com/user-attachments/assets/447c66f9-c816-4ed5-82bf-1a7c2162efcd




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.