### PR TITLE
[Woo POS] Integrate "include_types" backend API changes for POS Products API call

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -97,6 +97,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .tapToPayEducation:
             return false
+        case .variableProductsInPointOfSale:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -207,4 +207,8 @@ public enum FeatureFlag: Int {
     /// Enables new Tap to Pay onboarding and education features
     ///
     case tapToPayEducation
+
+    /// Supports variable products in POS.
+    ///
+    case variableProductsInPointOfSale
 }

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -204,7 +204,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - productTypes: A list of product types to be included in the results.
     /// - pageNumber: Number of page that should be retrieved.
     ///
-    public func loadProductsForPointOfSale(for siteID: Int64, productTypes: [ProductType], pageNumber: Int = 1) async throws -> [Product] {
+    public func loadProductsForPointOfSale(for siteID: Int64, productTypes: [ProductType] = [.simple], pageNumber: Int = 1) async throws -> [Product] {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: POSConstants.productsPerPage,

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -639,7 +639,6 @@ private extension ProductsRemote {
     enum POSConstants {
         static let productsPerPage = "100"
         static let productType = "simple"
-        static let productTypes = "simple,variable"
         static let productStatus = "publish"
     }
 }

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -197,17 +197,20 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Retrieves simple products for the Point of Sale
+    /// Retrieves products for the Point of Sale. Simple and variable products are loaded for WC version 9.6+, otherwise only simple products are loaded.
     ///
     /// - Parameters:
     /// - siteID: Site for which we'll fetch remote products.
+    /// - productTypes: A list of product types to be included in the results.
     /// - pageNumber: Number of page that should be retrieved.
     ///
-    public func loadSimpleProductsForPointOfSale(for siteID: Int64, pageNumber: Int = 1) async throws -> [Product] {
+    public func loadProductsForPointOfSale(for siteID: Int64, productTypes: [ProductType], pageNumber: Int = 1) async throws -> [Product] {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: POSConstants.productsPerPage,
+            // When both productType and productTypes are provided, the productType is ignored in WC versions 9.6+.
             ParameterKey.productType: POSConstants.productType,
+            ParameterKey.productTypes: productTypes.map { $0.rawValue }.joined(separator: ","),
             ParameterKey.orderBy: OrderKey.name.value,
             ParameterKey.order: Order.ascending.value,
             ParameterKey.productStatus: POSConstants.productStatus,
@@ -611,6 +614,7 @@ public extension ProductsRemote {
         static let globalUniqueID: String = "global_unique_id"
         static let productStatus: String = "status"
         static let productType: String = "type"
+        static let productTypes: String = "include_types"
         static let stockStatus: String = "stock_status"
         static let category: String   = "category"
         static let fields: String     = "_fields"
@@ -635,6 +639,7 @@ private extension ProductsRemote {
     enum POSConstants {
         static let productsPerPage = "100"
         static let productType = "simple"
+        static let productTypes = "simple,variable"
         static let productStatus = "publish"
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -932,7 +932,7 @@ final class ProductsRemoteTests: XCTestCase {
         })
     }
 
-    func test_loadSimpleProductsForPointOfSale_loads_simple_products() async throws {
+    func test_loadProductsForPointOfSale_loads_simple_products() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let expectedProductsFromResponse = 6
@@ -940,7 +940,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
 
-        let products = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID)
+        let products = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
 
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)
@@ -949,19 +949,19 @@ final class ProductsRemoteTests: XCTestCase {
         }
     }
 
-    func test_loadSimpleProductsForPointOfSale_relays_networking_error() async throws {
+    func test_loadProductsForPointOfSale_relays_networking_error() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
         // When/Then
         await assertThrowsError({
-            let _ = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID)
+            let _ = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
         }, errorAssert: {
             $0 as? NetworkError == .notFound()
         })
     }
 
-    func test_loadSimpleProductsForPointOfSale_when_page_has_products_then_loads_expected_products() async throws {
+    func test_loadProductsForPointOfSale_when_page_has_products_then_loads_expected_products() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let initialPageNumber = 1
@@ -970,7 +970,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
 
-        let products = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID, pageNumber: initialPageNumber)
+        let products = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: initialPageNumber)
 
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)
@@ -979,7 +979,7 @@ final class ProductsRemoteTests: XCTestCase {
         }
     }
 
-    func test_loadSimpleProductsForPointOfSale_when_page_has_no_products_then_loads_expected_products() async throws {
+    func test_loadProductsForPointOfSale_when_page_has_no_products_then_loads_expected_products() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let pageNumber = 2
@@ -988,7 +988,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
 
-        let products = try await remote.loadSimpleProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
+        let products = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
 
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -96,8 +96,9 @@ final class HubMenuViewModel: ObservableObject {
         let currencySettings = ServiceLocator.currencySettings
 
         return PointOfSaleProductService(siteID: siteID,
-                                  currencySettings: currencySettings,
-                                  credentials: credentials)
+                                         currencySettings: currencySettings,
+                                         credentials: credentials,
+                                         featureFlagService: featureFlagService)
     }()
 
     private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -98,7 +98,7 @@ final class HubMenuViewModel: ObservableObject {
         return PointOfSaleProductService(siteID: siteID,
                                          currencySettings: currencySettings,
                                          credentials: credentials,
-                                         featureFlagService: featureFlagService)
+                                         isVariableProductsFeatureEnabled: featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale))
     }()
 
     private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import protocol Experiments.FeatureFlagService
 import protocol Networking.Network
 import class Networking.ProductsRemote
 import class Networking.AlamofireNetwork
@@ -18,23 +17,23 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     private var siteID: Int64
     private var currencySettings: CurrencySettings
     private let productsRemote: ProductsRemote
-    private let featureFlagService: FeatureFlagService
+    private let isVariableProductsFeatureEnabled: Bool
 
-    public init(siteID: Int64, currencySettings: CurrencySettings, network: Network, featureFlagService: FeatureFlagService) {
+    public init(siteID: Int64, currencySettings: CurrencySettings, network: Network, isVariableProductsFeatureEnabled: Bool) {
         self.siteID = siteID
         self.currencySettings = currencySettings
         self.productsRemote = ProductsRemote(network: network)
-        self.featureFlagService = featureFlagService
+        self.isVariableProductsFeatureEnabled = isVariableProductsFeatureEnabled
     }
 
     public convenience init(siteID: Int64,
                             currencySettings: CurrencySettings,
                             credentials: Credentials?,
-                            featureFlagService: FeatureFlagService) {
+                            isVariableProductsFeatureEnabled: Bool) {
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
                   network: AlamofireNetwork(credentials: credentials),
-                  featureFlagService: featureFlagService)
+                  isVariableProductsFeatureEnabled: isVariableProductsFeatureEnabled)
     }
 
     /// Provides a list of products for the Point of Sale, by fetching simple products from the remote, applying any eligibility criteria,
@@ -43,7 +42,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     /// - pageNumber: Number of the page that should be retrieved. If none given, defaults to 1
     ///
     public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSDisplayableItem] {
-        let productTypes: [ProductType] = featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale) ?
+        let productTypes: [ProductType] = isVariableProductsFeatureEnabled ?
         [.simple, .variable] : [.simple]
         let products = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import protocol Experiments.FeatureFlagService
 import protocol Networking.Network
 import class Networking.ProductsRemote
 import class Networking.AlamofireNetwork
@@ -17,19 +18,23 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     private var siteID: Int64
     private var currencySettings: CurrencySettings
     private let productsRemote: ProductsRemote
+    private let featureFlagService: FeatureFlagService
 
-    public init(siteID: Int64, currencySettings: CurrencySettings, network: Network) {
+    public init(siteID: Int64, currencySettings: CurrencySettings, network: Network, featureFlagService: FeatureFlagService) {
         self.siteID = siteID
         self.currencySettings = currencySettings
         self.productsRemote = ProductsRemote(network: network)
+        self.featureFlagService = featureFlagService
     }
 
     public convenience init(siteID: Int64,
                             currencySettings: CurrencySettings,
-                            credentials: Credentials?) {
+                            credentials: Credentials?,
+                            featureFlagService: FeatureFlagService) {
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
-                  network: AlamofireNetwork(credentials: credentials))
+                  network: AlamofireNetwork(credentials: credentials),
+                  featureFlagService: featureFlagService)
     }
 
     /// Provides a list of products for the Point of Sale, by fetching simple products from the remote, applying any eligibility criteria,
@@ -38,7 +43,9 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     /// - pageNumber: Number of the page that should be retrieved. If none given, defaults to 1
     ///
     public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSDisplayableItem] {
-        let products = try await productsRemote.loadSimpleProductsForPointOfSale(for: siteID, pageNumber: pageNumber)
+        let productTypes: [ProductType] = featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale) ?
+        [.simple, .variable] : [.simple]
+        let products = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
 
         if pageNumber != 1 && products.count == 0 {
             throw PointOfSaleProductServiceError.pageOutOfRange

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -14,8 +14,9 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         network = MockNetwork()
         currencySettings = CurrencySettings()
         itemProvider = PointOfSaleProductService(siteID: siteID,
-                                          currencySettings: currencySettings,
-                                          network: network)
+                                                 currencySettings: currencySettings,
+                                                 network: network,
+                                                 isVariableProductsFeatureEnabled: false)
     }
 
     override func tearDown() {
@@ -107,5 +108,35 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         }
         XCTAssertEqual(firstEligibleItem.name, expectedItemNames.first)
         XCTAssertEqual(secondEligibleItem.name, expectedItemNames.last)
+    }
+
+    // MARK: - Query Parameters
+
+    func test_providePointOfSaleItems_sets_types_parameters_to_simple_only() async throws {
+        // Given
+        let itemProvider = PointOfSaleProductService(siteID: siteID,
+                                                     currencySettings: currencySettings,
+                                                     network: network,
+                                                     isVariableProductsFeatureEnabled: false)
+
+        // When
+        _ = try? await itemProvider.providePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(network.queryParametersDictionary?["include_types"] as? String, "simple")
+    }
+
+    func test_providePointOfSaleItems_sets_types_parameters_correctly_when_variable_products_feature_is_enabled() async throws {
+        // Given
+        let itemProvider = PointOfSaleProductService(siteID: siteID,
+                                                     currencySettings: currencySettings,
+                                                     network: network,
+                                                     isVariableProductsFeatureEnabled: true)
+
+        // When
+        _ = try? await itemProvider.providePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(network.queryParametersDictionary?["include_types"] as? String, "simple,variable")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14649
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request includes adding a new feature flag for variable products support, and updating POS product retrieval API request to include variable products for WC versions 9.6+. For older WC versions, only simple products are returned.

### New Feature Flag:
* Added a new case `variableProductsInPointOfSale` to the `FeatureFlag` enum to support variable products in POS. (`Experiments/Experiments/FeatureFlag.swift` [Experiments/Experiments/FeatureFlag.swiftR210-R213](diffhunk://#diff-d42bbc633193f198cb514f56f2b0fe8ac65787a3e40a56c44b24069217788929R210-R213))
* Updated the `DefaultFeatureFlagService` to enable the `variableProductsInPointOfSale` feature flag for local developer and alpha build configurations. (`Experiments/Experiments/DefaultFeatureFlagService.swift` [Experiments/Experiments/DefaultFeatureFlagService.swiftR100-R101](diffhunk://#diff-26c9afc49bb1f1a168517d43d5e36a64ff45adb046469369ef3e4d6800ccc19bR100-R101))

### Product Retrieval Updates:
* Modified the `ProductsRemote` class to include variable products when the feature flag is enabled, and updated the method signature to accept product types. (`Networking/Networking/Remote/ProductsRemote.swift` [Networking/Networking/Remote/ProductsRemote.swiftL200-R213](diffhunk://#diff-dde78446a8994905cf951ddc694e4b3620a81a6dfd9e719f48afec2cd4c3e7b6L200-R213))
* Added a new constant `productTypes` in `ProductsRemote` to handle multiple product types. (`Networking/Networking/Remote/ProductsRemote.swift` [Networking/Networking/Remote/ProductsRemote.swiftR617](diffhunk://#diff-dde78446a8994905cf951ddc694e4b3620a81a6dfd9e719f48afec2cd4c3e7b6R617))

### POS Product Service Updates:
* Updated the `PointOfSaleProductService` to check the feature flag and request the appropriate product types. (`Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift` [[1]](diffhunk://#diff-03cc427764fb8714a46696aed239423dfc04e8b8094e074b8e4c3662dc913531R20-R36) [[2]](diffhunk://#diff-03cc427764fb8714a46696aed239423dfc04e8b8094e074b8e4c3662dc913531L41-R47)
* Modified the `HubMenuViewModel` to pass the feature flag status to the `PointOfSaleProductService`. (`WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift` [WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swiftL100-R101](diffhunk://#diff-a7353a3c9b54e18ce66e192000f034059a624c6824a359575150dc1788697d04L100-R101))

### Test Updates:
* Updated the `ProductsRemoteTests` to reflect changes in the product retrieval method and to ensure the correct product types are loaded based on the feature flag. (`Networking/NetworkingTests/Remote/ProductsRemoteTests.swift` [[1]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL935-R943) [[2]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL952-R964) [[3]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL973-R973) [[4]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL982-R982) [[5]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL991-R991)
* Added new tests in `PointOfSaleProductServiceTests` to verify that the correct query parameters are set based on the feature flag status. (`Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift` [[1]](diffhunk://#diff-1ba1528eb413467eaecc7aa17e37f46dfc3988342bd6c1460f0ba82ac3feceeaL18-R19) [[2]](diffhunk://#diff-1ba1528eb413467eaecc7aa17e37f46dfc3988342bd6c1460f0ba82ac3feceeaR112-R141)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### WC version 9.6+

Prerequisite: have a store with WC version 9.6+, I find JN site with Beta Tester option + `trunk` in core the easiest way. The store should have at least one purchasable simple & variable product.

🗒️ If trying to access the site with WPCOM login using Jetpack connection, JN sites with dev WC version seem to have `woocommerce_is_active: false` in the `me/sites` API response and thus these sites don't show up in the store picker. I hard-coded [this line](https://github.com/woocommerce/woocommerce-ios/blob/f30517c85795ad30e860e12266300ca7ed202b13/Networking/Networking/Model/Site.swift#L108) to be `true` for all sites and also the [POS eligibility](https://github.com/woocommerce/woocommerce-ios/blob/f30517c85795ad30e860e12266300ca7ed202b13/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift#L19) to return `Just(true).eraseToAnyPublisher()` as a workaround locally.

- Switch to the store in the prerequisite
- Go to Menu > Point of Sale mode --> the variable product(s) should appear in the product selector, along with simple product(s). Support for adding variable products to cart & payment is not available yet

### WC version < 9.6

Prerequisite: have a store with WC version < 9.6. The store should have at least one purchasable simple & variable product.

- Switch to the store in the prerequisite
- Go to Menu > Point of Sale mode --> the variable product(s) should **not** appear in the product selector. Only simple products should be listed

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [ ] @jaclync tests when the feature flag is disabled, only simple products are loaded for WC version 9.6+
- [ ] @jaclync tests when the feature flag is disabled, only simple products are loaded for WC version < 9.6

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

WC version 9.6+, feature flag disabled | WC version 9.6+, feature flag enabled
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-12-11 at 12 21 05](https://github.com/user-attachments/assets/299a1a09-fc6f-43a8-8374-63cf6e892586) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-12-11 at 12 19 38](https://github.com/user-attachments/assets/9e99ea90-a352-47cb-bfe5-019dc8ef05cb)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.