### PR TITLE
[Woo POS] [Cash & Receipts] Handle errors when sending receipts

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -12,7 +12,7 @@ protocol PointOfSaleOrderControllerProtocol {
     var order: Order? { get }
 
     func syncOrder(for cartProducts: [CartItem], retryHandler: @escaping () async -> Void) async
-    func sendReceipt(recipientEmail: String) async
+    func sendReceipt(recipientEmail: String) async throws
     func clearOrder()
 }
 
@@ -70,16 +70,11 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
         }))
     }
 
-    func sendReceipt(recipientEmail: String) async {
+    func sendReceipt(recipientEmail: String) async throws {
         guard let order = order else {
             return
         }
-        do {
-            try await orderService.sendReceipt(order: order, recipientEmail: recipientEmail)
-        } catch {
-            // TODO:
-            // https://github.com/woocommerce/woocommerce-ios/issues/14464
-        }
+        try await orderService.sendReceipt(order: order, recipientEmail: recipientEmail)
     }
 
     func clearOrder() {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -204,8 +204,8 @@ extension PointOfSaleAggregateModel {
     }
 
     @MainActor
-    func sendReceipt(to emailAddress: String) async {
-        await orderController.sendReceipt(recipientEmail: emailAddress)
+    func sendReceipt(to emailAddress: String) async throws {
+        try await orderController.sendReceipt(recipientEmail: emailAddress)
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -72,6 +72,7 @@ struct POSSendReceiptView: View {
             Spacer()
         }
         .padding()
+        .animation(.easeInOut, value: errorMessage)
         .onChange(of: textFieldInput) { _ in
             errorMessage = nil
         }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -82,6 +82,11 @@ struct POSSendReceiptView: View {
             Spacer()
         }
         .padding()
+        .onChange(of: textFieldInput) { _ in
+            if errorMessage != nil {
+                errorMessage = nil
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -67,6 +67,7 @@ struct POSSendReceiptView: View {
             .background(Color.posOverlayFillInverted)
             .cornerRadius(Constants.buttonCornerRadius)
             .contentShape(Rectangle())
+            .disabled(isLoading)
 
             Spacer()
         }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -83,9 +83,7 @@ struct POSSendReceiptView: View {
         }
         .padding()
         .onChange(of: textFieldInput) { _ in
-            if errorMessage != nil {
-                errorMessage = nil
-            }
+            errorMessage = nil
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -5,11 +5,12 @@ struct POSSendReceiptView: View {
 
     @State private var textFieldInput: String = ""
     @State private var isLoading: Bool = false
+    @State private var isError: Bool = false
 
     @Binding private(set) var isShowingSendReceiptView: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .center, spacing: 20) {
             HStack {
                 Button(action: {
                     isShowingSendReceiptView = false
@@ -30,13 +31,22 @@ struct POSSendReceiptView: View {
                 .font(POSFontStyle.posTitleRegular)
                 .focused()
                 .padding()
+            if isError {
+                Text(Localization.errorText)
+                    .font(POSFontStyle.posBodyRegular)
+                    .foregroundColor(.red)
+            }
 
             Button(action: {
                 Task { @MainActor in
                     isLoading = true
-                    await posModel.sendReceipt(to: textFieldInput)
+                    do {
+                        try await posModel.sendReceipt(to: textFieldInput)
+                        isShowingSendReceiptView = false
+                    } catch {
+                        isError = true
+                    }
                     isLoading = false
-                    isShowingSendReceiptView = false
                 }
             }, label: {
                 HStack(spacing: Constants.buttonSpacing) {
@@ -83,6 +93,10 @@ private extension POSSendReceiptView {
             "pointOfSale.sendreceipt.modal.textfield.placeholder",
             value: "Type email",
             comment: "Placeholder for the view where an email address should be entered when sending receipts")
+        static let errorText = NSLocalizedString(
+            "pointOfSale.sendreceipt.modal.errortext",
+            value: "Error trying to send this email. Try again.",
+            comment: "Generic error message that is displayed when there's an error emailing a receipt.")
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -86,9 +86,9 @@ struct POSSendReceiptView: View {
             }
             isLoading = true
             do {
+                errorMessage = nil
                 try await posModel.sendReceipt(to: textFieldInput)
                 isShowingSendReceiptView = false
-                errorMessage = nil
             } catch {
                 errorMessage = Localization.sendReceiptErrorText
             }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -36,6 +36,10 @@ struct POSSendReceiptView: View {
                 .font(POSFontStyle.posTitleRegular)
                 .focused()
                 .padding()
+                .onSubmit {
+                    sendReceipt()
+                }
+
             if let errorMessage = errorMessage {
                 Text(errorMessage)
                     .font(POSFontStyle.posBodyRegular)
@@ -43,21 +47,7 @@ struct POSSendReceiptView: View {
             }
 
             Button(action: {
-                Task { @MainActor in
-                    guard isEmailValid else {
-                        errorMessage = Localization.emailValidationErrorText
-                        return
-                    }
-                    isLoading = true
-                    do {
-                        try await posModel.sendReceipt(to: textFieldInput)
-                        isShowingSendReceiptView = false
-                        errorMessage = nil
-                    } catch {
-                        errorMessage = Localization.sendReceiptErrorText
-                    }
-                    isLoading = false
-                }
+                sendReceipt()
             }, label: {
                 HStack(spacing: Constants.buttonSpacing) {
                     if isLoading {
@@ -84,6 +74,24 @@ struct POSSendReceiptView: View {
         .padding()
         .onChange(of: textFieldInput) { _ in
             errorMessage = nil
+        }
+    }
+
+    private func sendReceipt() {
+        Task { @MainActor in
+            guard isEmailValid else {
+                errorMessage = Localization.emailValidationErrorText
+                return
+            }
+            isLoading = true
+            do {
+                try await posModel.sendReceipt(to: textFieldInput)
+                isShowingSendReceiptView = false
+                errorMessage = nil
+            } catch {
+                errorMessage = Localization.sendReceiptErrorText
+            }
+            isLoading = false
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -1,13 +1,18 @@
 import SwiftUI
+import class WordPressShared.EmailFormatValidator
 
 struct POSSendReceiptView: View {
     @EnvironmentObject private var posModel: PointOfSaleAggregateModel
 
     @State private var textFieldInput: String = ""
     @State private var isLoading: Bool = false
-    @State private var isError: Bool = false
+    @State private var errorMessage: String?
 
     @Binding private(set) var isShowingSendReceiptView: Bool
+
+    private var isEmailValid: Bool {
+        EmailFormatValidator.validate(string: textFieldInput)
+    }
 
     var body: some View {
         VStack(alignment: .center, spacing: 20) {
@@ -31,20 +36,25 @@ struct POSSendReceiptView: View {
                 .font(POSFontStyle.posTitleRegular)
                 .focused()
                 .padding()
-            if isError {
-                Text(Localization.errorText)
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
                     .font(POSFontStyle.posBodyRegular)
                     .foregroundColor(.red)
             }
 
             Button(action: {
                 Task { @MainActor in
+                    guard isEmailValid else {
+                        errorMessage = Localization.emailValidationErrorText
+                        return
+                    }
                     isLoading = true
                     do {
                         try await posModel.sendReceipt(to: textFieldInput)
                         isShowingSendReceiptView = false
+                        errorMessage = nil
                     } catch {
-                        isError = true
+                        errorMessage = Localization.sendReceiptErrorText
                     }
                     isLoading = false
                 }
@@ -94,10 +104,14 @@ private extension POSSendReceiptView {
             "pointOfSale.sendreceipt.modal.textfield.placeholder",
             value: "Type email",
             comment: "Placeholder for the view where an email address should be entered when sending receipts")
-        static let errorText = NSLocalizedString(
-            "pointOfSale.sendreceipt.modal.errortext",
+        static let sendReceiptErrorText = NSLocalizedString(
+            "pointOfSale.sendreceipt.modal.sendReceiptErrorText",
             value: "Error trying to send this email. Try again.",
             comment: "Generic error message that is displayed when there's an error emailing a receipt.")
+        static let emailValidationErrorText = NSLocalizedString(
+            "pointOfSale.sendreceipt.modal.emailValidationErrorText",
+            value: "Please enter a valid email.",
+            comment: "Error message that is displayed when an invalid email is used when emailing a receipt.")
     }
 }
 

--- a/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
+++ b/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
@@ -18,7 +18,7 @@ class PointOfSalePreviewOrderController: PointOfSaleOrderControllerProtocol {
     func syncOrder(for cartProducts: [CartItem],
                    retryHandler: @escaping () async -> Void) async { }
 
-    func sendReceipt(recipientEmail: String) async { }
+    func sendReceipt(recipientEmail: String) async throws { }
 
     func clearOrder() { }
 }

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -135,8 +135,16 @@ public final class POSOrderService: POSOrderServiceProtocol {
         let updatedBillingAddress = order.billingAddress?.copy(email: recipientEmail)
         let updatedOrder = order.copy(billingAddress: updatedBillingAddress)
 
-        let _ = try await ordersRemote.updatePOSOrder(siteID: siteID, order: updatedOrder, fields: [.billingAddress])
-        try await receiptsRemote.sendReceipt(siteID: siteID, orderID: order.orderID)
+        do {
+            let _ = try await ordersRemote.updatePOSOrder(siteID: siteID, order: updatedOrder, fields: [.billingAddress])
+        } catch {
+            throw POSOrderServiceError.updateOrderFailed
+        }
+        do {
+            try await receiptsRemote.sendReceipt(siteID: siteID, orderID: order.orderID)
+        } catch {
+            throw POSOrderServiceError.sendReceiptFailed
+        }
     }
 }
 
@@ -193,5 +201,7 @@ private extension POSOrderService {
 private extension POSOrderService {
     enum POSOrderServiceError: Error {
         case emailAlreadySet
+        case updateOrderFailed
+        case sendReceiptFailed
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes: https://github.com/woocommerce/woocommerce-ios/issues/14464

## Description
This PR adds error handling for the receipt view, that is:

- Shows error message when sending receipts fails
- Shows error message when updating the order fails
- Shows error when an invalid email is used
- Disables the "send" button while loading, to avoid multiple calls.

## Testing
- Set feature flag `.sendReceiptsForPointOfSale` to true
- You can use your site by bypassing `posModel.eligibleWooCommerceVersionForPOSReceipts` by setting the breakpoint to `expression posModel.eligibleWooCommerceVersionForPOSReceipts = true` on `PaymentsActionButtons` line 26, otherwise use the testing site: https://lovely-aware-sturgeon.jurassic.ninja/ details: PdfdoF-5Qj-p2
- Proceed with a POS transaction
- Tap the "receipt" button and enter an invalid email address, observe the error message is shown:

![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-12-11 at 16 13 56](https://github.com/user-attachments/assets/2f115dfb-2fa5-46d0-b323-b2d880d1be23)

- Add a valid email address, but throw an error from `POSOrderService.sendReceipt`, observe the error message is shown:

![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2024-12-11 at 16 15 37](https://github.com/user-attachments/assets/ed7da687-288f-4f18-9d8f-b205a70f836d)

- Attempt to tap multiple times while the "Send" button is loading and showing the loading indicator, observe that is not responsive.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
