### PR TITLE
[Shipping labels] Update boxWeight coding to use box_weight for custom packages

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
@@ -92,6 +92,6 @@ extension WooShippingCustomPackage: Codable {
         case name
         case type
         case dimensions
-        case boxWeight
+        case boxWeight = "box_weight"
     }
 }

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -39,6 +39,11 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         let packagesResponse = try XCTUnwrap(result.get())
         XCTAssertEqual(packagesResponse.customPackages.count, 5)
+        XCTAssertEqual(packagesResponse.customPackages.first?.id, "69d7052f934a7c218329de9c1abe3858")
+        XCTAssertEqual(packagesResponse.customPackages.first?.name, "WCS&T Box")
+        XCTAssertEqual(packagesResponse.customPackages.first?.dimensions, "15 x 15 x 15")
+        XCTAssertEqual(packagesResponse.customPackages.first?.type, .box)
+        XCTAssertEqual(packagesResponse.customPackages.first?.boxWeight, 0.25)
         XCTAssertEqual(packagesResponse.predefinedOptions.count, 1)
     }
 

--- a/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
@@ -11,8 +11,8 @@
                 "id": "69d7052f934a7c218329de9c1abe3858",
                 "name": "WCS&T Box",
                 "dimensions": "15 x 15 x 15",
-                "boxWeight": 0.25,
-                "maxWeight": 0,
+                "box_weight": 0.25,
+                "max_weight": 0,
                 "type": "box",
                 "is_user_defined": true
             },
@@ -20,8 +20,8 @@
                 "id": "517116d2f2d929115f6e081ba780b84e",
                 "name": "WCS&T Envelope",
                 "dimensions": "30 x 10 x 1",
-                "boxWeight": 0.1,
-                "maxWeight": 0,
+                "box_weight": 0.1,
+                "max_weight": 0,
                 "type": "envelope",
                 "is_user_defined": true
             },
@@ -29,8 +29,8 @@
                 "id": "a344e7fa99e8bb88b15feb13141bf62c",
                 "name": "WCShip Envelope",
                 "dimensions": "100 x 10 x 1",
-                "boxWeight": 0.25,
-                "maxWeight": 0,
+                "box_weight": 0.25,
+                "max_weight": 0,
                 "type": "envelope",
                 "is_user_defined": true
             },
@@ -38,8 +38,8 @@
                 "id": "22025742fbfaf4d7e73da11caaff9a2a",
                 "name": "WCShip Box",
                 "dimensions": "10 x 10 x 10",
-                "boxWeight": 1,
-                "maxWeight": 0,
+                "box_weight": 1,
+                "max_weight": 0,
                 "type": "box",
                 "is_user_defined": true
             },
@@ -47,8 +47,8 @@
                 "id": "dd58dcd5dc044b6c56540c557c231c4f",
                 "name": "WCShip Envelope 2",
                 "dimensions": "10 x 10 x 1",
-                "boxWeight": 1,
-                "maxWeight": 0,
+                "box_weight": 1,
+                "max_weight": 0,
                 "type": "envelope",
                 "is_user_defined": true
             }

--- a/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
@@ -11,10 +11,10 @@
             "custom": [
               {
                 "name": "Custom name",
-                "boxWeight": "0.01",
+                "box_weight": "0.01",
                 "id": "849225dc153",
                 "type": "box",
-                "isLetter": false,
+                "is_letter": false,
                 "dimensions": "12 x 12 x 12",
                 "is_user_defined": true
               }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Update `boxWeight` coding to use `box_weight` for custom packages (looks like it was updated from backend, before it was `boxWeight`)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Tap "Select a Package."
8. Switch to "Saved" tab
9. Notice that proper weights are showing now

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-12-11 at 12 17 33](https://github.com/user-attachments/assets/6a5cfad1-0088-471d-b52d-6d11ba449fcd)      | ![Simulator Screenshot - iPhone 16 Pro - 2024-12-11 at 12 16 44](https://github.com/user-attachments/assets/1ac315c8-4a14-43c5-b1ca-2ac2ced9865f)       |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
