### PR TITLE
[Shipping labels] Ensure consistent ordering of carrier packages

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -60,15 +60,14 @@ extension WooShippingPackagesResponse: Decodable {
                     providerOptions.append(option)
                     allSavedPredefinedPackages.append(contentsOf: WooShippingPackagesResponse.savedPackages(savedOptions: savedPredefinedOptions, option: option))
                 })
+                providerOptions.sort { $0.title < $1.title }
                 allPredefinedOptions.append(WooShippingCarrierPredefinedOptions(carrierID: key, predefinedOptions: providerOptions))
             }
         }
 
         // sort to make sure they are always in same order
         // since we get the carriers data as a dictionary (key is carrier id)
-        allPredefinedOptions.sort {
-            return $0.carrierID < $1.carrierID
-        }
+        allPredefinedOptions.sort { $0.carrierID < $1.carrierID }
 
         self.init(storeOptions: storeOptions,
                   customPackages: customPackages,

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -64,6 +64,12 @@ extension WooShippingPackagesResponse: Decodable {
             }
         }
 
+        // sort to make sure they are always in same order
+        // since we get the carriers data as a dictionary (key is carrier id)
+        allPredefinedOptions.sort {
+            return $0.carrierID < $1.carrierID
+        }
+
         self.init(storeOptions: storeOptions,
                   customPackages: customPackages,
                   savedPredefinedPackages: allSavedPredefinedPackages,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14656
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Sort carriers from backend response to ensure consistent ordering. Backend response contains carrier packages in a dictionary structure where keys are carrier IDs, so we need to sort them to make sure they are not shown in UI in random order.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Install and set up the Woo Shipping extension on your store.
- Build and run the app with the revampedShippingLabelCreation feature flag enabled.
- Create an order with the processing status and at least one physical product.
- In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
 On the Orders tab in the app, open the order you created.
- In the order details, select "Create Shipping Label."
- Tap "Select a Package."
- Switch to "Carriers" tab
- Pull to refresh couple of times and make sure the carriers tabs (DHL, USPS) are always in same order

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPhone 16 Pro - 2024-12-11 at 15 58 43](https://github.com/user-attachments/assets/d17e33d7-ee49-47c8-9acb-84426eb6efde)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
