### PR TITLE
[Tooling] Only run UI Tests on trunk

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -94,7 +94,8 @@ steps:
   - label: ":microscope: UI Tests (iPhone)"
     command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 16'
     depends_on: build
-    if: build.branch == 'trunk'
+    # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
+    if: build.branch == 'trunk' || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*
@@ -105,7 +106,8 @@ steps:
   - label: ":microscope: UI Tests (iPad)"
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad (10th generation)"
     depends_on: build
-    if: build.branch == 'trunk'
+    # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
+    if: build.branch == 'trunk' || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -94,6 +94,7 @@ steps:
   - label: ":microscope: UI Tests (iPhone)"
     command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 16'
     depends_on: build
+    if: build.branch == 'trunk'
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*
@@ -104,6 +105,7 @@ steps:
   - label: ":microscope: UI Tests (iPad)"
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad (10th generation)"
     depends_on: build
+    if: build.branch == 'trunk'
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*


### PR DESCRIPTION
## Description

As discussed in p91TBi-cBM-p2#comment-13736 

With the UI Tests currently being quite unstable and hindering the merging of PRs, the team has decided to only run them on `trunk` after PRs are merged, instead of having their flakiness block the PRs, until the flakiness is resolved.

## Testing information

 - [x] Ensure the CI doesn't run the 2 UI Tests jobs on this PR
 - [x] Ensure the "UI Tests" CI checks are not marked as required by the GitHub branch protection and thus that this PR can still be merged without those having run
 - [ ] Once this PR is merged, ensure that the 2 UI Tests jobs are still run on the resulting merge commit on `trunk`

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.