### PR TITLE
Location pre-alert view for card reader payments

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -35,6 +35,7 @@
 - [*] Order Creation: fixed layout of custom amount type selection drawer. [https://github.com/woocommerce/woocommerce-ios/pull/14619]
 - [*] Payments: Improved the Tap to Pay connection process by introducing a location permission pre-alert and earlier location request, ensuring greater clarity for users. [https://github.com/woocommerce/woocommerce-ios/pull/14660]
 - [*] Widgets: Show revenue compact amount in widgets, instead of $123,456,789 (and being truncated) we show $123,5m. [https://github.com/woocommerce/woocommerce-ios/pull/14634]
+- [*] Payments: Improved the card reader connection process by introducing a location permission pre-alert and earlier location request, ensuring greater clarity for users. [https://github.com/woocommerce/woocommerce-ios/pull/14672]
 
 21.2
 -----

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -242,7 +242,15 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
                 viewModel: PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel()))
 
             /// Not-yet supported types
-        case .selectSearchType, .locationRequestPreAlert, .locationRequired:
+        case .selectSearchType:
+            return nil
+            /// Immediately request location permission until POS view is created
+        case .locationRequestPreAlert(let requestPermission):
+            requestPermission()
+            return nil
+            /// Skip location required step and rely on error during the payment process until POS view is created
+        case .locationRequired(_, let skip):
+            skip()
             return nil
         }
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -88,7 +88,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     private let storageManager: StorageManagerType
     private let stores: StoresManager
 
-    private let locationService: LocationService
+    private let locationService: LocationServiceProtocol
 
     private var state: ControllerState {
         didSet {
@@ -143,7 +143,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
         configuration: CardPresentPaymentsConfiguration,
         analyticsTracker: CardReaderConnectionAnalyticsTracker,
         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-        locationService: LocationService = LocationService(),
+        locationService: LocationServiceProtocol = LocationService(),
         allowTermsOfServiceAcceptance: Bool = true
     ) {
         siteID = forSiteID

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -39,6 +39,10 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
         ///
         case foundSeveralReaders
 
+        /// Requests location permission during the connection process
+        ///
+        case requestLocationPermission
+
         /// Attempting to connect to a card reader. The completion passed to `searchAndConnect`
         /// will be called with a `success` `Bool` `True` result if successful, after which the view controller
         /// passed to `searchAndConnect` will be dereferenced and the state set to `idle`
@@ -84,6 +88,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     private let knownCardReaderProvider: CardReaderSettingsKnownReaderProvider
     private let alertsPresenter: AlertPresenter
     private let configuration: CardPresentPaymentsConfiguration
+    private let locationService: LocationServiceProtocol
 
     private let alertsProvider: AlertProvider
 
@@ -140,7 +145,8 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
         alertsPresenter: AlertPresenter,
         alertsProvider: AlertProvider,
         configuration: CardPresentPaymentsConfiguration,
-        analyticsTracker: CardReaderConnectionAnalyticsTracker
+        analyticsTracker: CardReaderConnectionAnalyticsTracker,
+        locationService: LocationServiceProtocol = LocationService()
     ) {
         siteID = forSiteID
         self.storageManager = storageManager
@@ -154,6 +160,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
         skippedReaderIDs = []
         self.configuration = configuration
         self.analyticsTracker = analyticsTracker
+        self.locationService = locationService
 
         configureResultsControllers()
     }
@@ -200,6 +207,8 @@ private extension CardReaderConnectionController {
             onRetry()
         case .cancel(let cancellationSource):
             onCancel(from: cancellationSource)
+        case .requestLocationPermission:
+            onRequestLocationPermission()
         case .connectToReader:
             onConnectToReader()
         case .connectingFailed(let error):
@@ -356,7 +365,7 @@ private extension CardReaderConnectionController {
                     if !didAutoAdvance {
                         didAutoAdvance = true
                         self.candidateReader = foundKnownReader
-                        self.state = .connectToReader
+                        self.state = .requestLocationPermission
                         return
                     }
                 }
@@ -396,7 +405,7 @@ private extension CardReaderConnectionController {
         /// (unknown) reader, auto-connect to that known reader
         if let foundKnownReader = self.getFoundKnownReader() {
             self.candidateReader = foundKnownReader
-            self.state = .connectToReader
+            self.state = .requestLocationPermission
             return
         }
 
@@ -437,7 +446,7 @@ private extension CardReaderConnectionController {
             viewModel: alertsProvider.foundReader(
                 name: candidateReader.id,
                 connect: {
-                    self.state = .connectToReader
+                    self.state = .requestLocationPermission
                 },
                 continueSearch: {
                     self.skippedReaderIDs.append(candidateReader.id)
@@ -461,7 +470,7 @@ private extension CardReaderConnectionController {
                     return
                 }
                 self.candidateReader = self.getFoundReaderByID(readerID: readerID)
-                self.state = .connectToReader
+                self.state = .requestLocationPermission
             },
             cancelSearch: { [weak self] in
                 self?.state = .cancel(.foundSeveralReaders)
@@ -510,6 +519,44 @@ private extension CardReaderConnectionController {
             self?.returnSuccess(result: .canceled(cancellationSource))
         }
         stores.dispatch(action)
+    }
+
+    /// Handle location permission status and request
+    ///
+    func onRequestLocationPermission() {
+        let status = locationService.authorizationStatus
+        switch status {
+        case .authorized:
+            state = .connectToReader
+        case .denied:
+            // Refresh the view if the location permission state changes
+            locationService.observePermissionChanges { [weak self] _ in
+                guard let self else { return }
+                locationService.stopObservingPermissionChanges()
+                if case .requestLocationPermission = state {
+                    onRequestLocationPermission()
+                }
+            }
+
+            alertsPresenter.present(viewModel: alertsProvider.locationRequired(
+                dismiss: { [weak self] in
+                    guard let self else { return }
+                    locationService.stopObservingPermissionChanges()
+                    state = .cancel(.locationPermissionDenied)
+                },
+                skip: { [weak self] in
+                    guard let self else { return }
+                    locationService.stopObservingPermissionChanges()
+                    state = .connectToReader
+                }
+            ))
+        case .notDetermined:
+            alertsPresenter.present(viewModel: alertsProvider.locationRequestPreAlert { [weak self] in
+                self?.locationService.requestPermission { [weak self] _ in
+                    self?.onRequestLocationPermission()
+                }
+            })
+        }
     }
 
     /// Connect to the candidate card reader

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		01BD774A2C58D29700147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD77492C58D29700147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageView.swift */; };
 		01BD774C2C58D2BE00147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD774B2C58D2BE00147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift */; };
 		01D082402C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */; };
+		01F067ED2D0C5D59001C5805 /* MockLocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F067EC2D0C5D56001C5805 /* MockLocationService.swift */; };
 		01F42C162CE34AB8003D0A5A /* CardPresentModalBuiltInSuccessEmailSent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F42C152CE34AB3003D0A5A /* CardPresentModalBuiltInSuccessEmailSent.swift */; };
 		01F42C182CE34AD2003D0A5A /* CardPresentModalSuccessEmailSent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F42C172CE34AD1003D0A5A /* CardPresentModalSuccessEmailSent.swift */; };
 		01F579952C7DE709008BCA28 /* PointOfSaleCardPresentPaymentCaptureErrorMessageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F579942C7DE709008BCA28 /* PointOfSaleCardPresentPaymentCaptureErrorMessageViewModelTests.swift */; };
@@ -3201,6 +3202,7 @@
 		01BD77492C58D29700147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisconnectedMessageView.swift; sourceTree = "<group>"; };
 		01BD774B2C58D2BE00147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift; sourceTree = "<group>"; };
 		01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSBackgroundAppearanceKey.swift; sourceTree = "<group>"; };
+		01F067EC2D0C5D56001C5805 /* MockLocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocationService.swift; sourceTree = "<group>"; };
 		01F42C152CE34AB3003D0A5A /* CardPresentModalBuiltInSuccessEmailSent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInSuccessEmailSent.swift; sourceTree = "<group>"; };
 		01F42C172CE34AD1003D0A5A /* CardPresentModalSuccessEmailSent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessEmailSent.swift; sourceTree = "<group>"; };
 		01F579942C7DE709008BCA28 /* PointOfSaleCardPresentPaymentCaptureErrorMessageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCaptureErrorMessageViewModelTests.swift; sourceTree = "<group>"; };
@@ -9611,6 +9613,7 @@
 		746791642108D853007CF1DC /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				01F067EC2D0C5D56001C5805 /* MockLocationService.swift */,
 				0182C8BD2CE3B10E00474355 /* MockReceiptEligibilityUseCase.swift */,
 				EEA3C2202CA5440A000E82EC /* MockFavoriteProductsUseCase.swift */,
 				D85136CC231E15B700DD0539 /* MockReviews.swift */,
@@ -17105,6 +17108,7 @@
 				DEDA8DC02B19CDC50076BF0F /* ThemeSettingViewModelTests.swift in Sources */,
 				CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */,
 				03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */,
+				01F067ED2D0C5D59001C5805 /* MockLocationService.swift in Sources */,
 				86B3E2572C6B249C0002420B /* HelpAndSupportViewModelTests.swift in Sources */,
 				DE2FE5832924DA2F0018040A /* JetpackSetupRequiredViewModelTests.swift in Sources */,
 				AEB4DB99290AE8F300AE4340 /* MockCookieJar.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -17,6 +17,9 @@ final class MockCardReaderSettingsAlerts {
     private var mode: MockCardReaderSettingsAlertsMode
     private var didPresentFoundReader: Bool
 
+    var onLocationRequestPreAlert: ((_ onLocationRequestPreAlert: @escaping () -> Void) -> Void)?
+    var onLocationRequired: ((_ dismiss: @escaping () -> Void, _ skip: @escaping () -> Void) -> Void)?
+
     init(mode: MockCardReaderSettingsAlertsMode) {
         self.mode = mode
         self.didPresentFoundReader = false
@@ -166,10 +169,16 @@ extension MockCardReaderSettingsAlerts: BluetoothReaderConnnectionAlertsProvidin
     }
 
     func locationRequestPreAlert(requestPermission: @escaping () -> Void) -> any AlertDetails {
+        if let onLocationRequestPreAlert {
+            onLocationRequestPreAlert(requestPermission)
+        }
         return MockCardPresentPaymentsModalViewModel()
     }
 
     func locationRequired(dismiss: @escaping () -> Void, skip: @escaping () -> Void) -> any AlertDetails {
+        if let onLocationRequired {
+            onLocationRequired(dismiss, skip)
+        }
         return MockCardPresentPaymentsModalViewModel()
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockLocationService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockLocationService.swift
@@ -1,0 +1,43 @@
+import Foundation
+@testable import WooCommerce
+
+final class MockLocationService: LocationServiceProtocol {
+    private var observers: [(LocationAuthorizationStatus) -> Void] = []
+    private var currentStatus: LocationAuthorizationStatus
+    var requestPermissionStatus: LocationAuthorizationStatus = .notDetermined
+
+    init(status: LocationAuthorizationStatus = .authorized) {
+        self.currentStatus = status
+    }
+
+    var authorizationStatus: LocationAuthorizationStatus {
+        currentStatus
+    }
+
+    func requestPermission(_ completion: @escaping (LocationAuthorizationStatus) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.currentStatus = self.requestPermissionStatus
+            completion(self.currentStatus)
+            self.notifyObservers()
+        }
+    }
+
+    func observePermissionChanges(_ onChange: @escaping (LocationAuthorizationStatus) -> Void) {
+        observers.append(onChange)
+    }
+
+    func stopObservingPermissionChanges() {
+        observers.removeAll()
+    }
+
+    func simulatePermissionChange(to newStatus: LocationAuthorizationStatus) {
+        currentStatus = newStatus
+        notifyObservers()
+    }
+
+    private func notifyObservers() {
+        for observer in observers {
+            observer(currentStatus)
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -15,10 +15,12 @@ final class CardReaderConnectionControllerTests: XCTestCase {
     private var storageManager: MockStorageManager!
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
+    private var locationService: MockLocationService!
 
     override func setUp() {
         super.setUp()
         storageManager = MockStorageManager()
+        locationService = MockLocationService(status: .authorized)
 
         let paymentGateway = storageManager.viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
         paymentGateway.update(with: .fake().copy(siteID: sampleSiteID, gatewayID: "woocommerce-payments", isCardPresentEligible: true))
@@ -61,7 +63,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -104,7 +107,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -150,7 +154,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -195,7 +200,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -233,7 +239,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -279,7 +286,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -326,7 +334,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -370,7 +379,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -416,7 +426,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -462,7 +473,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -504,7 +516,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
                                     siteID: sampleSiteID,
                                     connectionType: .userInitiated,
                                     stores: mockStoresManager,
-                                    analytics: analytics)
+                                    analytics: analytics),
+            locationService: locationService
         )
 
         // When
@@ -521,6 +534,156 @@ final class CardReaderConnectionControllerTests: XCTestCase {
             return XCTFail("Expected connection to be canceled")
         }
         assertEqual(.foundReader, source)
+    }
+
+    func test_seachAndConnect_when_locationDenied_and_skipped_to_connect() {
+        // Given
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [],
+            discoveredReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            storageManager: storageManager
+        )
+
+        let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
+        let mockAlerts = MockCardReaderSettingsAlerts(mode: .connectFoundReader)
+        let mockLocationService = MockLocationService(status: .denied)
+        mockAlerts.onLocationRequired = { _, skip in
+            skip()
+        }
+
+        let controller = CardReaderConnectionController(
+            forSiteID: sampleSiteID,
+            storageManager: storageManager,
+            stores: mockStoresManager,
+            knownReaderProvider: mockKnownReaderProvider,
+            alertsPresenter: MockCardPresentPaymentAlertsPresenter(),
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics),
+            locationService: mockLocationService
+        )
+
+        // When
+        let connectionResult: CardReaderConnectionResult = waitFor { promise in
+            controller.searchAndConnect() { result in
+                if case .success(let connectionResult) = result {
+                    promise(connectionResult)
+                }
+            }
+        }
+
+        // Then
+        guard case .connected(let reader) = connectionResult else {
+            return XCTFail("Expected reader to be connected")
+        }
+        assertEqual(MockCardReader.bbposChipper2XBT(), reader)
+    }
+
+    func test_seachAndConnect_when_locationNotDetermined_and_later_authorized() {
+        // Given
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [],
+            discoveredReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            storageManager: storageManager
+        )
+
+        let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
+        let mockAlerts = MockCardReaderSettingsAlerts(mode: .connectFoundReader)
+        let mockLocationService = MockLocationService(status: .notDetermined)
+        mockAlerts.onLocationRequestPreAlert = { requestPermission in
+            mockLocationService.requestPermissionStatus = .authorized
+            requestPermission()
+        }
+
+        let controller = CardReaderConnectionController(
+            forSiteID: sampleSiteID,
+            storageManager: storageManager,
+            stores: mockStoresManager,
+            knownReaderProvider: mockKnownReaderProvider,
+            alertsPresenter: MockCardPresentPaymentAlertsPresenter(),
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics),
+            locationService: mockLocationService
+        )
+
+        // When
+        let connectionResult: CardReaderConnectionResult = waitFor { promise in
+            controller.searchAndConnect() { result in
+                if case .success(let connectionResult) = result {
+                    promise(connectionResult)
+                }
+            }
+        }
+
+        // Then
+        guard case .connected(let reader) = connectionResult else {
+            return XCTFail("Expected reader to be connected")
+        }
+        assertEqual(MockCardReader.bbposChipper2XBT(), reader)
+    }
+
+    func test_seachAndConnect_when_locationNotDetermined_and_later_denied() {
+        // Given
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [],
+            discoveredReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            storageManager: storageManager
+        )
+
+        let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
+        let mockAlerts = MockCardReaderSettingsAlerts(mode: .connectFoundReader)
+        let mockLocationService = MockLocationService(status: .notDetermined)
+        mockAlerts.onLocationRequestPreAlert = { requestPermission in
+            mockLocationService.requestPermissionStatus = .denied
+            requestPermission()
+        }
+
+        mockAlerts.onLocationRequired = { dismiss, _ in
+            dismiss()
+        }
+
+        let controller = CardReaderConnectionController(
+            forSiteID: sampleSiteID,
+            storageManager: storageManager,
+            stores: mockStoresManager,
+            knownReaderProvider: mockKnownReaderProvider,
+            alertsPresenter: MockCardPresentPaymentAlertsPresenter(),
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    siteID: sampleSiteID,
+                                    connectionType: .userInitiated,
+                                    stores: mockStoresManager,
+                                    analytics: analytics),
+            locationService: mockLocationService
+        )
+
+        // When
+        let connectionResult: CardReaderConnectionResult = waitFor(timeout: 6.0) { promise in
+            controller.searchAndConnect() { result in
+                if case .success(let connectionResult) = result {
+                    promise(connectionResult)
+                }
+            }
+        }
+
+        // Then
+        guard case .canceled(let source) = connectionResult else {
+            return XCTFail("Expected connection to be canceled")
+        }
+        assertEqual(.locationPermissionDenied, source)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14168
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add location permission pre-alert modal before requesting location permission and handle the location denied state during the card reader connection process.

This PR builds on top of the functionality already developed for TTP:
- https://github.com/woocommerce/woocommerce-ios/pull/14660

POS doesn't show any new permission modals. If the location is not determined it immediately shows a native alert and continues with the payment flow regardless of the response. I created a task to implement the functionality:
- https://github.com/woocommerce/woocommerce-ios/issues/14671

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Prerequisites
- Install a fresh app or go to Settings -> Privacy & Security -> Location Services -> Woo and set to "Ask Next Time Or When I Share"
- Store eligible for IPP
- Card Reader

1. Make an order with product or custom amount
2. Select Card Reader
3. Confirm Location pre-alert appears
4. Tap Continue
5. Confirm native iOS alert appears
6. Not Allow the permission
7. Confirm Location required alert appears
8. Dismiss
9. Confirm the modal closes
10. Select Card Reader again
11. Confirm Location required alert appears
12. Select Open Settings
13. Change Location access to 'While Using the App'
14. Return to the app
15. Confirm the payment flow proceeds

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iOS 18 simulators, and iOS 17 devices. Tested POS for regressions. Tested alternative flows during the reader discovery process - selecting a list of multiple readers, or canceling the search.

## Videos
<!-- Include before and after images or gifs when appropriate. -->

### Card Reader Connection

https://github.com/user-attachments/assets/49c0bbeb-bfb4-4e5e-a48f-9160b525a2f9

### POS regression testing - location allowed

https://github.com/user-attachments/assets/dd51a929-1500-418c-bfa0-a16b3bf7deca

### POS regression testing - location denied

https://github.com/user-attachments/assets/5b0d1ba5-ed75-42cb-ae4b-37681ab81252

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.