### PR TITLE
[Tooling] Update GitHub Actions

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
     - name: "Check out Project"
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: "Set up Ruby"
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
     - name: Restore CocoaPods Dependency Cache
       id: restore-cocoapods-dependency-cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: Pods
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -37,13 +37,13 @@ jobs:
       run: bundle exec fastlane build_screenshots
 
     - name: Archive App
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: screenshot-app
         path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerce.app
 
     - name: Archive Runner
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: screenshot-runner
         path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerceScreenshots-Runner.app
@@ -58,7 +58,7 @@ jobs:
         language: [ar, de-DE, en-US, es-ES, fr-FR, he, id, it, ja, ko, nl-NL, pt-BR, ru, sv, tr, zh-Hans, zh-Hant]
         mode: [dark, light]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: "Set up Ruby"
       uses: ruby/setup-ruby@v1
       with:
@@ -68,13 +68,13 @@ jobs:
       run: bundle exec fastlane run configure_apply
     
     - name: Download Screenshot App
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: screenshot-app
         path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerce.app
 
     - name: Download Screenshot Runner
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: screenshot-runner
         path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerceScreenshots-Runner.app
@@ -85,7 +85,7 @@ jobs:
 
     - name: Store Logs
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: "screenshot-log-${{ matrix.language }}-${{ matrix.mode }}"
         path: fastlane/logs
@@ -101,7 +101,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Install Native Dependencies
         run: |
@@ -130,7 +130,7 @@ jobs:
           aws s3 cp fastlane/screenshots/screenshots.html s3://$S3_BUCKET/$GITHUB_RUN_ID/screenshots/screenshots.html
 
       - name: Archive Raw Screenshots
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: raw-screenshots
           path: fastlane/screenshots
@@ -159,7 +159,7 @@ jobs:
           bundle exec fastlane create_promo_screenshots force:true
 
       - name: Archive Promo Screenshots
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: promo-screenshots
           path: fastlane/promo_screenshots


### PR DESCRIPTION
Reference: p7H4VZ-59z-p2

We were notified by GitHub about a few GitHub Actions about to have its older versions deprecated as `actions/upload-artifact`, `actions/download-artifact` or `actions/cache` (see also: https://github.com/actions/cache/discussions/1510 and https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/), so this PR updates them to their latest version.