### PR TITLE
Reviews: Add workaround to reload last selected row

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Product Tags: Improved the tag list screen by displaying the cached items on first load and fixed issue clearing all tags [https://github.com/woocommerce/woocommerce-ios/pull/14511]
 - [**] Media Library: On sites logged in with application password, when picking image from WordPress Media Library, all images will now load correctly. [https://github.com/woocommerce/woocommerce-ios/pull/14444]
 - [*] Payments onboarding: the custom background color of the "Choose your Payment Provider" UI when both WooPayments and Stripe Extension are available was removed to enable use cases with different container background colors. [https://github.com/woocommerce/woocommerce-ios/pull/14546]
+- [*] Reviews: Fix issue removing highlight from read reviews [https://github.com/woocommerce/woocommerce-ios/pull/14675]
 - [**] Products: Media upload will work for sites without XML-RPC. [https://github.com/woocommerce/woocommerce-ios/pull/14537]
 - [**] Products: Media library can now be loaded for sites without XML-RPC [https://github.com/woocommerce/woocommerce-ios/pull/14595]
 - [**] Products: Saving product images now works for sites without XML-RPC [https://github.com/woocommerce/woocommerce-ios/pull/14595]

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -100,6 +100,8 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
     ///
     private var topBannerView: TopBannerView?
 
+    private var lastSelectedItemIndexPath: IndexPath?
+
     // MARK: - Initializers
     //
     convenience init(siteID: Int64) {
@@ -158,6 +160,12 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
             // show make sure it's displayed again
             self.removeGhostContent()
             self.displayGhostContent()
+        }
+
+        // Reload last selected row to update highlight state
+        if let lastSelectedItemIndexPath {
+            tableView.reloadRows(at: [lastSelectedItemIndexPath], with: .none)
+            self.lastSelectedItemIndexPath = nil
         }
     }
 
@@ -298,6 +306,7 @@ extension ReviewsViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        lastSelectedItemIndexPath = indexPath
         viewModel.delegate.didSelectItem(at: indexPath, in: self)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14640 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a quick fix for the highlighted state of the read reviews in the review list. The fix is to reload the last selected row to update its state, which should be more efficient than reloading the whole table.

No unit test was added as the fix was made on the view controller.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Leave a new review on your test store.
- Build and run the app.
- Log in to your test store.
- Navigate to Menu > Reviews, notice that the new review is loaded and highlighted.
- Select the new review and then navigate back to the list.
- Confirm that the new review is no longer highlighted.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.1 and confirmed that new reviews are no longer highlighted after being opened.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/af670fe5-913e-4a51-ac51-0c4fa7458fab



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
