### PR TITLE
Double loading indicator on saved package list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -23,7 +23,7 @@ struct WooCarrierPackagesView: View {
     @Binding var starredPackages: Set<String>
     let tapAction: (String) -> Void
     let starAction: (String) -> Void
-    let onRefresh: () -> Void
+    let onRefresh: () async -> Void
 
     var body: some View {
         List {
@@ -64,7 +64,7 @@ struct WooCarrierPackagesView: View {
         }
         .listStyle(.plain)
         .refreshable {
-            onRefresh()
+            await onRefresh()
         }
     }
 }
@@ -101,10 +101,19 @@ struct WooCarrierPackagesSelectionView: View {
                            tabItemContentHorizontalPadding: Constants.tabItemContentHorizontalPadding,
                            tabItemContentVerticalPadding: Constants.tabItemContentVerticalPadding)
             }
-            if viewModel.isLoadingPackages {
+            // Show extra loading indicator in case there are no packages
+            else if viewModel.isLoadingPackages {
                 ProgressView()
                     .progressViewStyle(.circular)
                     .padding()
+            }
+            else {
+                Button {
+                    viewModel.loadPackages()
+                } label: {
+                    Image(systemName: "arrow.trianglehead.counterclockwise")
+                }
+                .padding()
             }
             if let selectedCarrierTab = viewModel.selectedCarrierTab {
                 WooCarrierPackagesView(carrierTab: selectedCarrierTab,
@@ -115,7 +124,11 @@ struct WooCarrierPackagesSelectionView: View {
                 }, starAction: { packageID in
                     viewModel.starUnstarPackage(packageID, carrierID: selectedCarrierTab.carrier.rawValue)
                 }, onRefresh: {
-                    viewModel.loadPackages()
+                    await withCheckedContinuation { continuation in
+                        viewModel.loadPackages {
+                            continuation.resume()
+                        }
+                    }
                 })
             }
             Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -97,21 +97,39 @@ struct WooSavedPackagesSelectionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Divider()
-            if viewModel.isLoadingPackages {
-                ProgressView()
-                    .progressViewStyle(.circular)
+            if !viewModel.hasSavedPackages {
+                // Show extra loading indicator in case there are no packages
+                if viewModel.isLoadingPackages {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .padding()
+                }
+                else {
+                    Button {
+                        viewModel.loadPackages()
+                    } label: {
+                        Image(systemName: "arrow.trianglehead.counterclockwise")
+                    }
                     .padding()
+                }
             }
-            List {
-                packagesSection(for: viewModel.customSavedPackages)
-                packagesSection(for: viewModel.predefinedSavedPackages)
+            else {
+                Divider()
+                List {
+                    packagesSection(for: viewModel.customSavedPackages)
+                    packagesSection(for: viewModel.predefinedSavedPackages)
+                }
+                .listStyle(.plain)
+                .refreshable {
+                    await withCheckedContinuation { continuation in
+                        viewModel.loadPackages {
+                            continuation.resume()
+                        }
+                    }
+                }
+                Divider()
             }
-            .listStyle(.plain)
-            .refreshable {
-                viewModel.loadPackages()
-            }
-            Divider()
+            Spacer()
             Button(WooShippingAddPackageView.Localization.addPackage) {
                 addPackageButtonTapped()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -71,7 +71,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 
     // MARK: - loading
 
-    func loadPackages() {
+    func loadPackages(completion: (() -> (Void))? = nil) {
         guard !isLoadingPackages else { return }
 
         isLoadingPackages = true
@@ -84,6 +84,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
                 break
             }
             self.isLoadingPackages = false
+            completion?()
         }
 
         ServiceLocator.stores.dispatch(loadPackagesAction)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14668
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Make refreshable loading async
- Show separate loading indicator in case we are loading data and there is no data already shown

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Install and set up the Woo Shipping extension on your store.
- Build and run the app with the revampedShippingLabelCreation feature flag enabled.
- Create an order with the processing status and at least one physical product.
- In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
 On the Orders tab in the app, open the order you created.
- In the order details, select "Create Shipping Label."
- Tap "Select a Package."
- Switch to Carriers and Saved tab and on both tabs do the pull to refresh action
- Check that only the loading indicator of the pull to refresh control is shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Saved packages      | Carrier packages |
| ----------- | ----------- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2024-12-12 at 15 19 50](https://github.com/user-attachments/assets/f0f2c8f2-de75-4bcc-ab90-995e67b592e2) | ![Simulator Screen Recording - iPhone 16 Pro - 2024-12-12 at 15 20 01](https://github.com/user-attachments/assets/467194c2-43e4-4b81-807d-b9fe87d552ec) |

| Saved packages (no data)      | Carrier packages (no data) |
| ----------- | ----------- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2024-12-13 at 10 43 21](https://github.com/user-attachments/assets/4a9493cc-6085-43c8-9775-f9e4f9ff6a59)      | ![Simulator Screen Recording - iPhone 16 Pro - 2024-12-13 at 10 43 11](https://github.com/user-attachments/assets/22f29f7e-f751-467c-9674-bfa918113216)       |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
