### PR TITLE
[TTPReq] Allow trying another payment method after PIN required error

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -40,6 +40,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     init(errorDescription: String?,
          transactionType: CardPresentTransactionType,
          image: UIImage = .paymentErrorImage,
+         requiresFallbackPaymentMethod: Bool = false,
          tryAgainAction: @escaping () -> Void,
          emailReceiptAction: @escaping () -> Void,
          dismissCompletion: @escaping () -> Void) {
@@ -47,7 +48,8 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
         self.bottomTitle = errorDescription
         self.image = image
         self.primaryButtonTitle = Localization.tryAgain(transactionType: transactionType)
-        self.auxiliaryButtonTitle = Localization.noThanks(transactionType: transactionType)
+        self.auxiliaryButtonTitle = Localization.dismiss(transactionType: transactionType,
+                                                         requiresFallbackPaymentMethod: requiresFallbackPaymentMethod)
         self.tryAgainAction = tryAgainAction
         self.emailReceiptAction = emailReceiptAction
         self.dismissCompletion = dismissCompletion
@@ -100,20 +102,42 @@ extension CardPresentModalError {
             }
         }
 
-        static func noThanks(transactionType: CardPresentTransactionType) -> String {
+        static func dismiss(transactionType: CardPresentTransactionType, requiresFallbackPaymentMethod: Bool) -> String {
             switch transactionType {
             case .collectPayment:
-                return NSLocalizedString(
-                    "Back to Order",
-                    comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails"
-                )
+                if requiresFallbackPaymentMethod {
+                    return Localization.tryAnotherPaymentMethod
+                } else {
+                   return Localization.backToOrder
+                }
             case .refund:
-                return NSLocalizedString(
-                    "Close",
-                    comment: "Button to dismiss modal overlay. Presented to users after refunding a payment fails"
-                )
+                return Localization.close
             }
         }
+
+        static let tryAnotherPaymentMethod = NSLocalizedString(
+            "cardPresentPaymentsModal.error.tryAnotherPaymentMethod",
+            value: "Try Another Payment Method",
+            comment: "Button to dismiss modal overlay and try another payment method. Presented to users after collecting a payment fails"
+        )
+
+        static let backToOrder = NSLocalizedString(
+            "cardPresentPaymentsModal.error.backToOrder",
+            value: "Back to Order",
+            comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails"
+        )
+
+        static let dismiss = NSLocalizedString(
+            "cardPresentPaymentsModal.error.dismiss",
+            value: "Dismiss",
+            comment: "Button to dismiss. Presented to users after collecting a payment fails"
+        )
+
+        static let close = NSLocalizedString(
+            "cardPresentPaymentsModal.error.close",
+            value: "Close",
+            comment: "Button to dismiss modal overlay. Presented to users after refunding a payment fails"
+        )
 
         static let receiptMessage = NSLocalizedString(
             "cardPresentPaymentsModal.error.receiptMessage",

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorEmailSent.swift
@@ -40,13 +40,15 @@ final class CardPresentModalErrorEmailSent: CardPresentPaymentsModalViewModel {
          transactionType: CardPresentTransactionType,
          image: UIImage = .paymentErrorImage,
          email: String,
+         requiresFallbackPaymentMethod: Bool = false,
          tryAgainAction: @escaping () -> Void,
          dismissCompletion: @escaping () -> Void) {
         self.topTitle = CardPresentModalError.Localization.paymentFailed(transactionType: transactionType)
         self.bottomTitle = errorDescription
         self.image = image
         self.primaryButtonTitle = CardPresentModalError.Localization.tryAgain(transactionType: transactionType)
-        self.secondaryButtonTitle = CardPresentModalError.Localization.noThanks(transactionType: transactionType)
+        self.secondaryButtonTitle = CardPresentModalError.Localization.dismiss(transactionType: transactionType,
+                                                                               requiresFallbackPaymentMethod: requiresFallbackPaymentMethod)
         self.tryAgainAction = tryAgainAction
         self.dismissCompletion = dismissCompletion
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
@@ -37,13 +37,15 @@ final class CardPresentModalErrorWithoutEmail: CardPresentPaymentsModalViewModel
     init(errorDescription: String?,
          transactionType: CardPresentTransactionType,
          image: UIImage = .paymentErrorImage,
+         requiresFallbackPaymentMethod: Bool = false,
          tryAgainAction: @escaping () -> Void,
          dismissCompletion: @escaping () -> Void) {
         self.topTitle = CardPresentModalError.Localization.paymentFailed(transactionType: transactionType)
         self.bottomTitle = errorDescription
         self.image = image
         self.primaryButtonTitle = CardPresentModalError.Localization.tryAgain(transactionType: transactionType)
-        self.secondaryButtonTitle = CardPresentModalError.Localization.noThanks(transactionType: transactionType)
+        self.secondaryButtonTitle = CardPresentModalError.Localization.dismiss(transactionType: transactionType,
+                                                                               requiresFallbackPaymentMethod: requiresFallbackPaymentMethod)
         self.tryAgainAction = tryAgainAction
         self.dismissCompletion = dismissCompletion
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -23,7 +23,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
 
     let image: UIImage
 
-    let primaryButtonTitle: String? = Localization.dismiss
+    let primaryButtonTitle: String?
 
     let secondaryButtonTitle: String? = CardPresentModalError.Localization.emailReceipt
 
@@ -44,11 +44,13 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     init(amount: String,
          errorDescription: String?,
          image: UIImage = .paymentErrorImage,
+        requiresFallbackPaymentMethod: Bool = false,
          onDismiss: @escaping () -> Void,
          emailReceiptAction: @escaping () -> Void) {
         self.amount = amount
         self.bottomTitle = errorDescription
         self.image = image
+        self.primaryButtonTitle = Localization.dismiss(requiresFallbackPaymentMethod: requiresFallbackPaymentMethod)
         self.onDismiss = onDismiss
         self.emailReceiptAction = emailReceiptAction
     }
@@ -86,9 +88,12 @@ extension CardPresentModalNonRetryableError {
             comment: "Error message. Presented to users after collecting a payment fails"
         )
 
-        static let dismiss = NSLocalizedString(
-            "Dismiss",
-            comment: "Button to dismiss. Presented to users after collecting a payment fails"
-        )
+        static func dismiss(requiresFallbackPaymentMethod: Bool) -> String {
+            if requiresFallbackPaymentMethod {
+                return CardPresentModalError.Localization.tryAnotherPaymentMethod
+            } else {
+                return CardPresentModalError.Localization.dismiss
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorEmailSent.swift
@@ -20,7 +20,7 @@ final class CardPresentModalNonRetryableErrorEmailSent: CardPresentPaymentsModal
 
     let image: UIImage
 
-    let primaryButtonTitle: String? = CardPresentModalNonRetryableError.Localization.dismiss
+    let primaryButtonTitle: String?
 
     let secondaryButtonTitle: String? = nil
 
@@ -45,10 +45,12 @@ final class CardPresentModalNonRetryableErrorEmailSent: CardPresentPaymentsModal
          errorDescription: String?,
          image: UIImage = .paymentErrorImage,
          email: String,
+         requiresFallbackPaymentMethod: Bool = false,
          onDismiss: @escaping () -> Void) {
         self.amount = amount
         self.bottomTitle = errorDescription
         self.image = image
+        self.primaryButtonTitle = CardPresentModalNonRetryableError.Localization.dismiss(requiresFallbackPaymentMethod: requiresFallbackPaymentMethod)
         self.onDismiss = onDismiss
 
         let formattedMessage = String(format: CardPresentModalError.Localization.receiptMessage, email)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
@@ -20,8 +20,7 @@ final class CardPresentModalNonRetryableErrorWithoutEmail: CardPresentPaymentsMo
 
     let image: UIImage
 
-    let primaryButtonTitle: String? = CardPresentModalNonRetryableError.Localization.dismiss
-
+    let primaryButtonTitle: String?
     let secondaryButtonTitle: String? = nil
 
     let auxiliaryButtonTitle: String? = nil
@@ -41,10 +40,12 @@ final class CardPresentModalNonRetryableErrorWithoutEmail: CardPresentPaymentsMo
     init(amount: String,
          errorDescription: String?,
          image: UIImage = .paymentErrorImage,
+         requiresFallbackPaymentMethod: Bool = false,
          onDismiss: @escaping () -> Void) {
         self.amount = amount
         self.bottomTitle = errorDescription
         self.image = image
+        self.primaryButtonTitle = CardPresentModalNonRetryableError.Localization.dismiss(requiresFallbackPaymentMethod: requiresFallbackPaymentMethod)
         self.onDismiss = onDismiss
     }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -188,12 +188,14 @@ private extension CardPresentPaymentsModalViewController {
         primaryButton.applyPrimaryButtonStyle()
         primaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
         primaryButton.titleLabel?.minimumScaleFactor = 0.5
+        primaryButton.titleLabel?.lineBreakMode = .byClipping
     }
 
     func styleSecondaryButton() {
         secondaryButton.applyPaymentsModalCancelButtonStyle()
         secondaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
         secondaryButton.titleLabel?.minimumScaleFactor = 0.5
+        secondaryButton.titleLabel?.lineBreakMode = .byClipping
     }
 
     func styleAuxiliaryButton() {
@@ -202,6 +204,7 @@ private extension CardPresentPaymentsModalViewController {
         }
         auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
         auxiliaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        auxiliaryButton.titleLabel?.lineBreakMode = .byClipping
     }
 
     func initializeContent() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -60,20 +60,20 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                receiptState: CardReaderTransactionFailureAlertReceiptState,
                tryAgain: @escaping () -> Void,
                dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-
-
         switch receiptState {
         case let .paymentSuccessEmailSent(email):
             return CardPresentModalErrorEmailSent(errorDescription: builtInReaderDescription(for: error),
                                                   transactionType: .collectPayment,
                                                   image: .builtInReaderError,
                                                   email: email,
+                                                  requiresFallbackPaymentMethod: errorRequiresFallbackPaymentMethod(error),
                                                   tryAgainAction: tryAgain,
                                                   dismissCompletion: dismissCompletion)
         case let .promptToSendEmailReceipt(emailReceiptAction):
             return CardPresentModalError(errorDescription: builtInReaderDescription(for: error),
                                          transactionType: .collectPayment,
                                          image: .builtInReaderError,
+                                         requiresFallbackPaymentMethod: errorRequiresFallbackPaymentMethod(error),
                                          tryAgainAction: tryAgain,
                                          emailReceiptAction: emailReceiptAction,
                                          dismissCompletion: dismissCompletion)
@@ -81,6 +81,7 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
             return CardPresentModalErrorWithoutEmail(errorDescription: builtInReaderDescription(for: error),
                                                      transactionType: .collectPayment,
                                                      image: .builtInReaderError,
+                                                     requiresFallbackPaymentMethod: errorRequiresFallbackPaymentMethod(error),
                                                      tryAgainAction: tryAgain,
                                                      dismissCompletion: dismissCompletion)
         }
@@ -95,17 +96,20 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                                                        errorDescription: builtInReaderDescription(for: error),
                                                        image: .builtInReaderError,
                                                        email: email,
+                                                       requiresFallbackPaymentMethod: errorRequiresFallbackPaymentMethod(error),
                                                        onDismiss: dismissCompletion)
         case let .promptToSendEmailReceipt(emailReceiptAction):
             CardPresentModalNonRetryableError(amount: amount,
                                               errorDescription: builtInReaderDescription(for: error),
                                               image: .builtInReaderError,
+                                              requiresFallbackPaymentMethod: errorRequiresFallbackPaymentMethod(error),
                                               onDismiss: dismissCompletion,
                                               emailReceiptAction: emailReceiptAction)
         case .noEmailReceipt:
             CardPresentModalNonRetryableErrorWithoutEmail(amount: amount,
                                                           errorDescription: builtInReaderDescription(for: error),
                                                           image: .builtInReaderError,
+                                                          requiresFallbackPaymentMethod: errorRequiresFallbackPaymentMethod(error),
                                                           onDismiss: dismissCompletion)
         }
     }
@@ -133,6 +137,14 @@ private extension BuiltInCardReaderPaymentAlertsProvider {
             }
         } else {
             return error.localizedDescription
+        }
+    }
+
+    func errorRequiresFallbackPaymentMethod(_ error: Error) -> Bool {
+        if let error = error as? CardPaymentErrorProtocol {
+            return error.requiresFallbackPaymentMethod
+        } else {
+            return false
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -977,6 +977,7 @@ enum CardPaymentRetryApproach {
 
 protocol CardPaymentErrorProtocol: Error {
     var retryApproach: CardPaymentRetryApproach { get }
+    var requiresFallbackPaymentMethod: Bool { get }
 }
 
 extension CardReaderServiceError: CardPaymentErrorProtocol {
@@ -996,6 +997,16 @@ extension CardReaderServiceError: CardPaymentErrorProtocol {
             return .dontRetry
         default:
             return .restart
+        }
+    }
+
+    var requiresFallbackPaymentMethod: Bool {
+        switch self {
+        case .paymentCaptureWithPaymentMethod(.paymentDeclinedByPaymentProcessorAPI(declineReason: .pinRequired), _),
+                .paymentCapture(.paymentDeclinedByPaymentProcessorAPI(declineReason: .pinRequired)):
+            return true
+        default:
+            return false
         }
     }
 
@@ -1020,6 +1031,15 @@ extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
             return .restart
         case .couldNotRefreshOrder:
             return .reuseIntent
+        }
+    }
+
+    var requiresFallbackPaymentMethod: Bool {
+        switch self {
+        case .alreadyRetried(let error as CardReaderServiceError):
+            return error.requiresFallbackPaymentMethod
+        default:
+            return false
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -268,7 +268,13 @@ final class PaymentMethodsViewModel: ObservableObject {
                 // Update order in case its status and/or other details are updated after a failed in-person payment
                 self?.updateOrderAsynchronously()
 
-                onFailure()
+                switch error {
+                case let error as CardPaymentErrorProtocol where error.requiresFallbackPaymentMethod:
+                    // The flow remains on screen to choose other payment methods.
+                    break
+                default:
+                    onFailure()
+                }
             },
             onCancel: {
                 // No tracking required because the flow remains on screen to choose other payment methods.

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -264,17 +264,17 @@ final class PaymentMethodsViewModel: ObservableObject {
             using: discoveryMethod,
             channel: channel,
             onFailure: { [weak self] error in
-                self?.trackFlowFailed()
-                // Update order in case its status and/or other details are updated after a failed in-person payment
-                self?.updateOrderAsynchronously()
+                guard let self else { return }
 
-                switch (discoveryMethod, error) {
-                case (.localMobile, let error as CardPaymentErrorProtocol) where error.requiresFallbackPaymentMethod:
-                    // The flow remains on screen to choose other payment methods.
-                    break
-                default:
+                trackFlowFailed()
+                // Update order in case its status and/or other details are updated after a failed in-person payment
+                updateOrderAsynchronously()
+
+                if shouldReturnToOrderDetails(for: discoveryMethod, error: error) {
                     onFailure()
+                    return
                 }
+
             },
             onCancel: {
                 // No tracking required because the flow remains on screen to choose other payment methods.
@@ -535,6 +535,20 @@ private extension PaymentMethodsViewModel {
         if order.currency != currencySettings.currencyCode.rawValue {
             // swiftlint:disable:next line_length
             DDLogWarn("⚠️ Order currency \(order.currency) differs from store's currency \(currencySettings.currencyCode.rawValue) which can lead to payment methods being unavailable")
+        }
+    }
+}
+
+private extension PaymentMethodsViewModel {
+    /// Determines if the flow should return to the order details screen after a failed payment attempt.
+    /// For some specific errors that require the user to select a different payment method, we should not return to the order details screen.
+    ///
+    func shouldReturnToOrderDetails(for discoveryMethod: CardReaderDiscoveryMethod, error: Error) -> Bool {
+        switch (discoveryMethod, error) {
+        case (.localMobile, let error as CardPaymentErrorProtocol) where error.requiresFallbackPaymentMethod:
+            return false
+        default:
+            return true
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -268,8 +268,8 @@ final class PaymentMethodsViewModel: ObservableObject {
                 // Update order in case its status and/or other details are updated after a failed in-person payment
                 self?.updateOrderAsynchronously()
 
-                switch error {
-                case let error as CardPaymentErrorProtocol where error.requiresFallbackPaymentMethod:
+                switch (discoveryMethod, error) {
+                case (.localMobile, let error as CardPaymentErrorProtocol) where error.requiresFallbackPaymentMethod:
                     // The flow remains on screen to choose other payment methods.
                     break
                 default:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -1016,7 +1016,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(orderID, order.orderID)
     }
 
-    func test_collectPayment_when_payment_error_then_onFailure_called() {
+    func test_collectPayment_when_ttp_payment_error_then_onFailure_called() {
         // Given
         storage.insertSampleOrder(readOnlyOrder: .fake())
         stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
@@ -1039,7 +1039,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
 
         // When
         var onFailureCalled: Bool = false
-        viewModel.collectPayment(using: .bluetoothScan, on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {
+        viewModel.collectPayment(using: .localMobile, on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {
             onFailureCalled = true
         })
 
@@ -1047,7 +1047,39 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertTrue(onFailureCalled)
     }
 
-    func test_collectPayment_when_payment_error_requiresFallbackPaymentMethod_then_onFailure_not_called() {
+    func test_collectPayment_when_ttp_payment_error_requiresFallbackPaymentMethod_then_onFailure_not_called() {
+        // Given
+        storage.insertSampleOrder(readOnlyOrder: .fake())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
+                onCompletion(PaymentGatewayAccount.fake())
+            }
+        }
+
+        let error: CardReaderServiceError = .paymentCapture(underlyingError: .paymentDeclinedByPaymentProcessorAPI(declineReason: .pinRequired))
+        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .failure(error))
+        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+        let dependencies = Dependencies(
+            cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+            stores: stores,
+            storage: storage)
+        let viewModel = PaymentMethodsViewModel(total: "12",
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                channel: .storeManagement,
+                                                dependencies: dependencies)
+
+        // When
+        var onFailureCalled: Bool = false
+        viewModel.collectPayment(using: .localMobile, on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {
+            onFailureCalled = true
+        })
+
+        // Then
+        XCTAssertFalse(onFailureCalled)
+    }
+
+    func test_collectPayment_when_card_reader_payment_error_requiresFallbackPaymentMethod_then_onFailure_called() {
         // Given
         storage.insertSampleOrder(readOnlyOrder: .fake())
         stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
@@ -1076,7 +1108,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         })
 
         // Then
-        XCTAssertFalse(onFailureCalled)
+        XCTAssertTrue(onFailureCalled)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -1015,6 +1015,69 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(siteID, order.siteID)
         XCTAssertEqual(orderID, order.orderID)
     }
+
+    func test_collectPayment_when_payment_error_then_onFailure_called() {
+        // Given
+        storage.insertSampleOrder(readOnlyOrder: .fake())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
+                onCompletion(PaymentGatewayAccount.fake())
+            }
+        }
+
+        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .failure(NSError(domain: "Error", code: 0, userInfo: nil)))
+        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+        let dependencies = Dependencies(
+            cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+            stores: stores,
+            storage: storage)
+        let viewModel = PaymentMethodsViewModel(total: "12",
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                channel: .storeManagement,
+                                                dependencies: dependencies)
+
+        // When
+        var onFailureCalled: Bool = false
+        viewModel.collectPayment(using: .bluetoothScan, on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {
+            onFailureCalled = true
+        })
+
+        // Then
+        XCTAssertTrue(onFailureCalled)
+    }
+
+    func test_collectPayment_when_payment_error_requiresFallbackPaymentMethod_then_onFailure_not_called() {
+        // Given
+        storage.insertSampleOrder(readOnlyOrder: .fake())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
+                onCompletion(PaymentGatewayAccount.fake())
+            }
+        }
+
+        let error: CardReaderServiceError = .paymentCapture(underlyingError: .paymentDeclinedByPaymentProcessorAPI(declineReason: .pinRequired))
+        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .failure(error))
+        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+        let dependencies = Dependencies(
+            cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+            stores: stores,
+            storage: storage)
+        let viewModel = PaymentMethodsViewModel(total: "12",
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                channel: .storeManagement,
+                                                dependencies: dependencies)
+
+        // When
+        var onFailureCalled: Bool = false
+        viewModel.collectPayment(using: .bluetoothScan, on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {
+            onFailureCalled = true
+        })
+
+        // Then
+        XCTAssertFalse(onFailureCalled)
+    }
 }
 
 private extension PaymentMethodsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14171
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Some cards are not able to complete contactless transactions using a PIN, which can result in payment failure. In regions where a significant number of cards cannot be used with contactless under specific circumstances (e.g. Offline PIN markets) the app must provide alternative payment methods and ensure a seamless transition between TTP UI and the alternative payment method.

## Solution

I made the changes to handle the PIN error and dismiss the modal with "Try Another Payment Method" option rather than returning to the order. Limiting these changes for Tap to Pay since the requirement only concerns this payment method.

Although the fix is relatively straightforward there are multiple places where this logic could be introduced. There are two main parts:
1. Handling the dismiss action: whether the app navigates back to the order or stays on the payment method selection. This logic belongs to the place that presents the payment UI in the first place. Therefore, I decided `PaymentMethodViewModel` holds the navigation part of the logic.
2. Showing "Try another payment method" rather than "Back to order" on modals. This logic belongs only to specific IPP flow, therefore only IPP models should be affected. 

### Error Handling Logic:
* Implemented a new method `errorRequiresFallbackPaymentMethod` in `BuiltInCardReaderPaymentAlertsProvider` to check if an error requires a fallback payment method.
* Added the `requiresFallbackPaymentMethod` property to the `CardPaymentErrorProtocol` and its conforming types to determine if a fallback payment method is needed based on the error type. [[1]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38R980) [[2]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38R1003-R1012) [[3]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38R1036-R1044)

### Additions to error modals:
* Added a new parameter `requiresFallbackPaymentMethod` to various modal error classes (`CardPresentModalError`, `CardPresentModalErrorEmailSent`, `CardPresentModalErrorWithoutEmail`, `CardPresentModalNonRetryableError`, `CardPresentModalNonRetryableErrorEmailSent`, and `CardPresentModalNonRetryableErrorWithoutEmail`) to determine if a fallback payment method is required. [[1]](diffhunk://#diff-99ea148b9844cf6d7a5ef130bdb81655ce7289f52251b057c90043fd4b51c246R43-R52) [[2]](diffhunk://#diff-f90ed76bc5a5061daa5350ce5646ee76efc331ae19c72afb1e5fe49b8c79ba9aR43-R51) [[3]](diffhunk://#diff-f146bf7c9708025df6078d137a423f29a10ecb6a23e42875c94df055c8eefcb1R40-R48) [[4]](diffhunk://#diff-0bba9870c6e76d205eb6c3ad8bfc4a18717c1cdbe84f16d6dc6289782a95342fR47-R53) [[5]](diffhunk://#diff-42efa4db281defc7a3ebc50b1dfa8be48064cded98dae08bd16a48bf2c58f8c4R48-R53) [[6]](diffhunk://#diff-8a7ed1e13df685ba9d754d069f0517da0a8e1c01923c68ea2e5cf3483a84e2c0R43-R48)
* Updated the `Localization` extension to provide different button labels based on the `requiresFallbackPaymentMethod` parameter. [[1]](diffhunk://#diff-99ea148b9844cf6d7a5ef130bdb81655ce7289f52251b057c90043fd4b51c246L103-L116) [[2]](diffhunk://#diff-0bba9870c6e76d205eb6c3ad8bfc4a18717c1cdbe84f16d6dc6289782a95342fL89-R97)

### Modal UI fixes:
* Modified the `primaryButton`, `secondaryButton`, and `auxiliaryButton` styles to make font size adjustment work by setting `lineBreakMode` to `.byClipping`. [[1]](diffhunk://#diff-9cab1b19c4132b588a65c18367cf12e058b47df70ec5ec302e4eeaaa6dfafe71R191-R198) [[2]](diffhunk://#diff-9cab1b19c4132b588a65c18367cf12e058b47df70ec5ec302e4eeaaa6dfafe71R207)

### Payment Methods Handling:
* Updated the `PaymentMethodsViewModel` to handle cases where a fallback payment method is required by not calling the `onFailure` callback immediately.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:
- An iPhone and store that supports TTP

### Offline PIN error

1. Make a 1.02 payment
2. Get an error
3. Confirm "Try Another Payment Method" button is shown instead of "Back to Order"
4. Tap "Try Another Payment Method"
5. Confirm the modal is dismissed

### Offline PIN error + Retry

1. Make a 1.02 payment and get an error
2. Tap "Try Collecting Again"
3. Confirm "Try Another Payment Method" button is shown
4. Tap "Try Another Payment Method"
5. Confirm the modal is dismissed

### Offline PIN error + email options

1. Return `return onCompletion(true)` in `isEligibleSendingReceiptAfterPayment` `ReceiptEligibilityUseCase`
1. Make a 1.02 payment and get an error
3. Confirm "Try Another Payment Method" button is shown along "Email Receipt Button"
4. Tap "Try Another Payment Method"
5. Confirm the modal is dismissed

### Other error

1. Make a 1.05 payment and get an error
3. Confirm "Back to Order" button is shown
5. Tap "Back to Order"
6. Confirm the modal is dismissed and the view navigated back to the order

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested cases using iPhone 14 Pro 17.7
- Tested with US and UK stores. UK shows a PIN entry for the online-PIN option (1.03 amount)
- Added Payment method view model tests

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### PIN required errors

| PIN Error | Retried PIN Error | PIN Error + Email | Retried PIN Error + Email |
|-----------|-------------------|-------------------|---------------------------|
| ![IMG_9580](https://github.com/user-attachments/assets/e8dda14e-1f0a-48d6-9f96-ee0ad65efd17) | ![IMG_9581](https://github.com/user-attachments/assets/e3d5c86c-f314-4c08-8dcd-01c7fde586be) | ![IMG_9578](https://github.com/user-attachments/assets/2e57d1fb-b71c-42e6-88df-2f6dba4976d0) | ![IMG_9579](https://github.com/user-attachments/assets/38cfe588-a55a-4e25-84ce-c43d06c63b98) |

### Other errors

| Error | Retried Error | Error + Email | Retried Error + Email |
|-------|---------------|--------------|-----------------------|
| ![IMG_9582](https://github.com/user-attachments/assets/bb8b2e36-0943-4dec-8b90-1c1913dc70c7) | ![IMG_9584](https://github.com/user-attachments/assets/41e94b37-3255-439b-9387-f40647a7d9c8) | ![IMG_9585](https://github.com/user-attachments/assets/1f63126f-9058-4d7e-890e-37f5a01fc956) | ![IMG_9586](https://github.com/user-attachments/assets/5f54f98f-36d8-4ca8-b0b3-a77b3bebf5cf) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.