### PR TITLE
[Woo POS] [Variable Products] Show POS with `fullScreenCover` with its own navigation stack

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -31,6 +31,21 @@ struct HubMenu: View {
                 .onAppear {
                     viewModel.setupMenuElements()
                 }
+                .fullScreenCover(isPresented: $viewModel.showsPOS) {
+                    if let cardPresentPaymentService = viewModel.cardPresentPaymentService,
+                       let orderService = POSOrderService(siteID: viewModel.siteID,
+                                                          credentials: viewModel.credentials) {
+                        PointOfSaleEntryPointView(
+                            itemsController: PointOfSaleItemsController(itemProvider: viewModel.posItemProvider),
+                            onPointOfSaleModeActiveStateChange: { isEnabled in
+                                viewModel.updateDefaultConfigurationForPointOfSale(isEnabled)
+                            },
+                            cardPresentPaymentService: cardPresentPaymentService,
+                            orderController: PointOfSaleOrderController(orderService: orderService))
+                    } else {
+                        EmptyView()
+                    }
+                }
         }
     }
 
@@ -46,6 +61,8 @@ struct HubMenu: View {
             ServiceLocator.analytics.track(.hubMenuSettingsTapped)
         case HubMenuViewModel.Blaze.id:
             ServiceLocator.analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .menu))
+        case HubMenuViewModel.PointOfSaleEntryPoint.id:
+            viewModel.showsPOS = true
         default:
             break
         }
@@ -154,21 +171,6 @@ private extension HubMenu {
                 SubscriptionsView(viewModel: .init())
             case .customers:
                 CustomersListView(viewModel: .init(siteID: viewModel.siteID))
-            case .pointOfSales:
-                if let cardPresentPaymentService = viewModel.cardPresentPaymentService,
-                   let orderService = POSOrderService(siteID: viewModel.siteID,
-                                                      credentials: viewModel.credentials) {
-                    PointOfSaleEntryPointView(
-                        itemsController: PointOfSaleItemsController(itemProvider: viewModel.posItemProvider),
-                        onPointOfSaleModeActiveStateChange: { isEnabled in
-                            viewModel.updateDefaultConfigurationForPointOfSale(isEnabled)
-                        },
-                        cardPresentPaymentService: cardPresentPaymentService,
-                        orderController: PointOfSaleOrderController(orderService: orderService))
-                } else {
-                    // TODO: When we have a singleton for the card payment service, this should not be required.
-                    Text("Error creating card payment service")
-                }
             case .reviewDetails(let parcel):
                 reviewDetailView(parcel: parcel)
             case .blazeCampaignDetails(let campaignID):

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -43,7 +43,8 @@ struct HubMenu: View {
                             cardPresentPaymentService: cardPresentPaymentService,
                             orderController: PointOfSaleOrderController(orderService: orderService))
                     } else {
-                        EmptyView()
+                        // TODO: When we have a singleton for the card payment service, this should not be required.
+                        Text("Error creating card payment service")
                     }
                 }
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -28,7 +28,6 @@ enum HubMenuNavigationDestination: Hashable {
     case inAppPurchase
     case subscriptions
     case customers
-    case pointOfSales
     case reviewDetails(parcel: ProductReviewFromNoteParcel)
 }
 
@@ -82,6 +81,9 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var hasGoogleAdsCampaigns = false
     @Published private var currentSite: Yosemite.Site?
+
+    /// Whether the app is in POS mode for an eligible site.
+    @Published var showsPOS: Bool = false
 
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
@@ -660,7 +662,8 @@ extension HubMenuViewModel {
         let accessibilityIdentifier: String = "menu-pointOfSale"
         let trackingOption: String = "pointOfSale"
         let iconBadge: HubMenuBadgeType? = nil
-        let navigationDestination: HubMenuNavigationDestination? = .pointOfSales
+        // POS is presented with its own navigation stack as nested navigation stack is not supported.
+        let navigationDestination: HubMenuNavigationDestination? = nil
     }
 
     struct Subscriptions: HubMenuItem {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -224,7 +224,6 @@ final class HubMenuViewModel: ObservableObject {
     }
 
     func updateDefaultConfigurationForPointOfSale(_ isPointOfSaleActive: Bool) {
-        updateTabBarVisibility(isPointOfSaleActive)
         updateInAppNotifications(isPointOfSaleActive)
     }
 
@@ -247,38 +246,6 @@ final class HubMenuViewModel: ObservableObject {
 // MARK: - Helper method for WooCommerce POS
 //
 private extension HubMenuViewModel {
-    // Hides the app's tab bars when Point of Sale is active
-    //
-    func updateTabBarVisibility(_ isPointOfSaleActive: Bool) {
-        guard let mainTabBarController = AppDelegate.shared.tabBarController else {
-            return
-        }
-        /*
-         When hidding the app's tab bar on POS initialization, we've observed a recurring issue with the UI not being updated appropiately,
-         leaving additional padding in the bottom rather than re-positioning components taking all the available space.
-         In order to address this issue we have to explicitely call for an update to the safeAreaInsets in order to trigger the layout update we need,
-         so that the view controller's view can occupy the space left by the hidden tab bar.
-         Updating the bottom UIEdgeInset to a non-zero value seems to be enough to trigger the UI layout refresh we need.
-         Ref: gh-13785
-         */
-        if isPointOfSaleActive {
-            UIView.animate(withDuration: 0.5) {
-                mainTabBarController.tabBar.alpha = 0
-            } completion: { _ in
-                mainTabBarController.tabBar.isHidden = isPointOfSaleActive
-                let bottomInset = CGFloat.leastNonzeroMagnitude
-                mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
-            }
-        } else {
-            mainTabBarController.tabBar.isHidden = isPointOfSaleActive
-            mainTabBarController.additionalSafeAreaInsets = .zero
-            mainTabBarController.tabBar.alpha = 0
-            UIView.animate(withDuration: 0.5) {
-                mainTabBarController.tabBar.alpha = 1
-            }
-        }
-    }
-
     // Disables foreground in-app notifications when Point of Sale is active
     //
     func updateInAppNotifications(_ isPointOfSaleActive: Bool) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -523,14 +523,15 @@ final class HubMenuViewModelTests: XCTestCase {
             .coupons: HubMenuViewModel.Coupons(),
             .reviews: HubMenuViewModel.Reviews(),
             .inbox: HubMenuViewModel.Inbox(),
-            .customers: HubMenuViewModel.Customers(),
-            .pointOfSales: HubMenuViewModel.PointOfSaleEntryPoint()
+            .customers: HubMenuViewModel.Customers()
         ]
 
         /// Counting the cases to ensure new cases are tested.
+        /// POS row/element does not use the push/pop navigation destination like other elements.
+        let nonNavigationDestinationElementsCount = 1
         viewModel.setupMenuElements()
         waitUntil {
-            expectedMenusAndDestinations.count == viewModel.settingsElements.count + viewModel.generalElements.count
+            expectedMenusAndDestinations.count == viewModel.settingsElements.count + viewModel.generalElements.count - nonNavigationDestinationElementsCount
         }
 
         for (expected, menuItem) in expectedMenusAndDestinations {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

First iteration of #14683 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From @joshheald's technical post pdfdoF-61P-p2:

> Using NavigationStack requires that we change how the POS is presented. Currently it is pushed onto the HubMenu‘s navigation stack, and we can’t nest them.

As a simple solution, we could present the POS view using `fullScreenCover` from the HubMenu view with the native present/dismiss animation from the bottom. Unfortunately, I haven't found a way to customize the animation for `fullScreenCover`. If we want to customize the transition to/from POS later, we could consider using a ZStack like in this exploration https://github.com/woocommerce/woocommerce-ios/commit/b29fc32043b34bf5a96696b7fb75a027d27b2636. I tested this approach with the experiment branch in https://github.com/woocommerce/woocommerce-ios/commit/f9656cbc6001b51ed3008c46149458e7855e5106 and the navigation between the products list and variations list works as expected under the POS' navigation stack.

With the changes in this PR, it does change how the POS is presented from the push navigation (horizontal transition) to the presentation navigation (vertical transition). @joshheald Please let me know if I missed any key reasons why a `UIWindow` in your WIP branch https://github.com/woocommerce/woocommerce-ios/pull/14674 is required (the window has no transition animation in the branch yet).

## How

The changes include adding a new full-screen cover for the POS entry point, removing the old POS navigation destination, and updating the view model to manage the POS state.

Key changes include:

### Improvements to POS handling:

* [`WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift`](diffhunk://#diff-3005ff4e49c7b74962724c77a4a606b4398af51e4726bda1ae390220cf67fc8cR34-R49): Added a full-screen cover to present the POS entry point when `showsPOS` is true. This includes necessary checks and error handling for creating the card payment service and order service.
* [`WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift`](diffhunk://#diff-3005ff4e49c7b74962724c77a4a606b4398af51e4726bda1ae390220cf67fc8cR65-R66): Updated the action for the POS entry point to set `showsPOS` to true, triggering the new full-screen cover.
* [`WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift`](diffhunk://#diff-3005ff4e49c7b74962724c77a4a606b4398af51e4726bda1ae390220cf67fc8cL157-L171): Removed the old case for handling the POS entry point within the existing navigation structure.

### View model updates:

* [`WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift`](diffhunk://#diff-a7353a3c9b54e18ce66e192000f034059a624c6824a359575150dc1788697d04L31): Removed the `pointOfSales` case from the `HubMenuNavigationDestination` enum as it is no longer needed.
* [`WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift`](diffhunk://#diff-a7353a3c9b54e18ce66e192000f034059a624c6824a359575150dc1788697d04R85-R87): Added a new `showsPOS` property to manage the state of the POS feature and updated the POS menu item to have no navigation destination. [[1]](diffhunk://#diff-a7353a3c9b54e18ce66e192000f034059a624c6824a359575150dc1788697d04R85-R87) [[2]](diffhunk://#diff-a7353a3c9b54e18ce66e192000f034059a624c6824a359575150dc1788697d04L663-R666)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Switch to a store eligible for POS
- Go to Menu > Point of Sale mode --> the POS view should be presented from bottom to top, this is a change from the push navigation in trunk
- Feel free to perform any actions in POS
- Tap eliipsis menu in the bottom bar > Exit POS > Exit --> the POS view should be dismissed from top to bottom, this is a change from the pop navigation in trunk


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before:



https://github.com/user-attachments/assets/c2b3dc6a-5feb-43a8-b1b4-c0c96e9c6730



After:

https://github.com/user-attachments/assets/3be110f0-5087-48f0-8e32-190a75c0f41b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.