### PR TITLE
[Woo POS] [Variable Products] Networking layer support to load variations for POS

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -12,6 +12,10 @@ public protocol ProductVariationsRemoteProtocol {
                                   pageNumber: Int,
                                   pageSize: Int,
                                   completion: @escaping ([ProductVariation]?, Error?) -> Void)
+    func loadVariationsForPointOfSale(for siteID: Int64,
+                                      parentProductID: Int64,
+                                      pageNumber: Int,
+                                      pageSize: Int) async throws -> [ProductVariation]
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func createProductVariation(for siteID: Int64,
                                 productID: Int64,
@@ -57,6 +61,43 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                          pageNumber: Int = Default.pageNumber,
                                          pageSize: Int = Default.pageSize,
                                          completion: @escaping ([ProductVariation]?, Error?) -> Void) {
+        let request = productVariationsRequest(for: siteID,
+                                               productID: productID,
+                                               variationIDs: variationIDs,
+                                               context: context,
+                                               pageNumber: pageNumber,
+                                               pageSize: pageSize)
+        let mapper = ProductVariationListMapper(siteID: siteID, productID: productID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Retrieves all of the `ProductVariation`s available in POS.
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch remote product variations.
+    ///   - parentProductID: Product for which we'll fetch remote product variations.
+    ///   - pageNumber: Number of page that should be retrieved.
+    ///   - pageSize: Number of product variations to be retrieved per page.
+    /// - Returns: Variations for the provided parent product.
+    public func loadVariationsForPointOfSale(for siteID: Int64,
+                                             parentProductID: Int64,
+                                             pageNumber: Int = Default.pageNumber,
+                                             pageSize: Int = Default.pageSize) async throws -> [ProductVariation] {
+        let request = productVariationsRequest(for: siteID,
+                                               productID: parentProductID,
+                                               variationIDs: [],
+                                               context: nil,
+                                               pageNumber: pageNumber,
+                                               pageSize: pageSize)
+        let mapper = ProductVariationListMapper(siteID: siteID, productID: parentProductID)
+        return try await enqueue(request, mapper: mapper)
+    }
+
+    private func productVariationsRequest(for siteID: Int64,
+                                          productID: Int64,
+                                          variationIDs: [Int64],
+                                          context: String?,
+                                          pageNumber: Int,
+                                          pageSize: Int) -> JetpackRequest {
         let stringOfVariationIDs = variationIDs.map { String($0) }
             .joined(separator: ",")
         let parameters = [
@@ -74,8 +115,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                      path: path,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        let mapper = ProductVariationListMapper(siteID: siteID, productID: productID)
-        enqueue(request, mapper: mapper, completion: completion)
+        return request
     }
 
     /// Retrieves a specific `ProductVariation`.

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -152,6 +152,106 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertFalse(queryParametersDictionary.contains(where: { $0.key == "include" }))
     }
 
+    // MARK: - Load all POS product variations tests
+
+    func test_loadVariationsForPointOfSale_returns_parsed_variation() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+
+        // When
+        let variations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID)
+
+        // Then
+        XCTAssertEqual(variations.count, 8)
+
+        guard let firstVariation = variations.first else {
+            XCTFail("The first product variation should exist.")
+            return
+        }
+        XCTAssertEqual(firstVariation.productVariationID, 1275)
+        XCTAssertEqual(firstVariation.description, "<p>Nutty chocolate marble, 99% and organic.</p>\n")
+        XCTAssertEqual(firstVariation.sku, "99%-nuts-marble")
+        XCTAssertEqual(firstVariation.globalUniqueID, "12345")
+        XCTAssertEqual(firstVariation.permalink, "https://chocolate.com/marble")
+
+        XCTAssertEqual(firstVariation.dateCreated, DateFormatter.dateFromString(with: "2019-11-14T12:40:55"))
+        XCTAssertEqual(firstVariation.dateModified, DateFormatter.dateFromString(with: "2019-11-14T13:06:42"))
+        XCTAssertEqual(firstVariation.dateOnSaleStart, DateFormatter.dateFromString(with: "2019-10-15T21:30:00"))
+        XCTAssertEqual(firstVariation.dateOnSaleEnd, DateFormatter.dateFromString(with: "2019-10-27T21:29:59"))
+
+        let expectedPrice = 12
+        XCTAssertEqual(firstVariation.price, "\(expectedPrice)")
+        XCTAssertEqual(firstVariation.regularPrice, "\(expectedPrice)")
+        XCTAssertEqual(firstVariation.salePrice, "8")
+
+        XCTAssertEqual(firstVariation.status, .published)
+        XCTAssertEqual(firstVariation.stockStatus, .inStock)
+
+        let expectedAttributes: [ProductVariationAttribute] = [
+            ProductVariationAttribute(id: 0, name: "Darkness", option: "99%"),
+            ProductVariationAttribute(id: 0, name: "Flavor", option: "nuts"),
+            ProductVariationAttribute(id: 0, name: "Shape", option: "marble")
+        ]
+        XCTAssertEqual(firstVariation.attributes, expectedAttributes)
+
+        XCTAssertEqual(firstVariation.image?.imageID, 1063)
+
+        XCTAssertFalse(firstVariation.onSale)
+        XCTAssertTrue(firstVariation.purchasable)
+        XCTAssertFalse(firstVariation.virtual)
+        XCTAssertTrue(firstVariation.downloadable)
+
+        XCTAssertTrue(firstVariation.manageStock)
+        XCTAssertEqual(firstVariation.stockQuantity, 16.5)
+        XCTAssertEqual(firstVariation.backordersKey, "notify")
+        XCTAssertTrue(firstVariation.backordersAllowed)
+        XCTAssertFalse(firstVariation.backordered)
+
+        XCTAssertEqual(firstVariation.downloads.count, 0)
+        XCTAssertEqual(firstVariation.downloadLimit, -1)
+        XCTAssertEqual(firstVariation.downloadExpiry, 0)
+
+        XCTAssertEqual(firstVariation.taxStatusKey, "taxable")
+        XCTAssertEqual(firstVariation.taxClass, "")
+
+        XCTAssertEqual(firstVariation.weight, "2.5")
+        XCTAssertEqual(firstVariation.dimensions, ProductDimensions(length: "10", width: "2.5", height: ""))
+
+        XCTAssertEqual(firstVariation.shippingClass, "")
+        XCTAssertEqual(firstVariation.shippingClassID, 0)
+
+        XCTAssertEqual(firstVariation.menuOrder, 8)
+    }
+
+    func test_loadVariationsForPointOfSale_properly_relays_networking_error() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        do {
+            _ = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID)
+        } catch let error as NetworkError {
+            // Then
+            XCTAssertEqual(error, .notFound(response: nil), "Expected a notFound error, but got \(error) instead.")
+        } catch {
+            XCTFail("Expected NetworkError.notFound, but got different error: \(error)")
+        }
+    }
+
+
+    func test_loadVariationsForPointOfSale_does_not_add_include_parameter() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID)
+
+        // Then
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertFalse(queryParametersDictionary.contains(where: { $0.key == "include" }))
+    }
+
     // MARK: - Load single product variation tests
 
     /// Verifies that loadProductVariation properly parses the `product-variation` sample response.

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -91,6 +91,10 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
         // no-op
     }
 
+    func loadVariationsForPointOfSale(for siteID: Int64, parentProductID: Int64, pageNumber: Int, pageSize: Int) async throws -> [Networking.ProductVariation] {
+        return []
+    }
+
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14685 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces a new asynchronous method to load variations for POS and includes corresponding unit tests. The changes primarily affect `ProductVariationsRemote`, and are not used in the app yet.

Key changes include:

### New Method for Loading POS Variations:
* [`Networking/Networking/Remote/ProductVariationsRemote.swift`](diffhunk://#diff-fa44db8cd4f05911d0bf515e02c8108729a7a649f31820a43ec91aee7306df67R15-R18): Added a new asynchronous method `loadVariationsForPointOfSale` to the `ProductVariationsRemoteProtocol` and its implementation in the `ProductVariationsRemote` class. This method fetches product variations for a specific site and parent product. [[1]](diffhunk://#diff-fa44db8cd4f05911d0bf515e02c8108729a7a649f31820a43ec91aee7306df67R15-R18) [[2]](diffhunk://#diff-fa44db8cd4f05911d0bf515e02c8108729a7a649f31820a43ec91aee7306df67R64-R100)
  * It follows the same [parameters in Android](https://github.com/woocommerce/woocommerce-android/blob/0c886d21a5d5bdb9f9b7a5ece7171146c0d8d350/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationListHandler.kt#L46) to include just the product ID, page number, and page size.

### Refactoring:
* [`Networking/Networking/Remote/ProductVariationsRemote.swift`](diffhunk://#diff-fa44db8cd4f05911d0bf515e02c8108729a7a649f31820a43ec91aee7306df67L77-R118): Refactored the `productVariationsRequest` method to return a request object, removing the mapper and enqueue call from within this method.

### Unit Tests:
* [`Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift`](diffhunk://#diff-993b04f0083a1b6d4f24d6b9972fd23f7ff46183ff6cec4864d7081ce1762365R155-R254): Added new unit tests to verify the functionality of the `loadVariationsForPointOfSale` method, including tests for successful data retrieval, error handling, and parameter validation.

### Mock Implementation:
* [`Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift`](diffhunk://#diff-debb1089f86adeac7950def2db91c65ae6a4865b1aaa9d388790aada41a7d8fdR94-R97): Updated the mock implementation to include the new `loadVariationsForPointOfSale` method for testing purposes when we implement Yosemite changes.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

A confidence test to prevent regressions:

Prerequisites: the store has at least one variable product.

- Go to the products tab
- Tap on a variable product
- Tap Variations --> the variations should be loaded correctly as before, with pull-to-refresh and infinite scroll support

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested in stores with variable products with more than one page of variations.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.