### PR TITLE
[Shipping labels] Update networking layer to prepare for caching packages response

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2812,7 +2812,6 @@ extension Networking.WooShippingPackagesResponse {
     public static func fake() -> Networking.WooShippingPackagesResponse {
         .init(
             siteID: .fake(),
-            storeOptions: .fake(),
             customPackages: .fake(),
             savedPredefinedPackages: .fake(),
             allPredefinedOptions: .fake()

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2761,6 +2761,16 @@ extension Networking.WooShippingAccountSettings {
         )
     }
 }
+extension Networking.WooShippingCarrierPredefinedOptions {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingCarrierPredefinedOptions {
+        .init(
+            carrierID: .fake(),
+            predefinedOptions: .fake()
+        )
+    }
+}
 extension Networking.WooShippingCreatePackageResponse {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -2801,6 +2811,7 @@ extension Networking.WooShippingPackagesResponse {
     ///
     public static func fake() -> Networking.WooShippingPackagesResponse {
         .init(
+            siteID: .fake(),
             storeOptions: .fake(),
             customPackages: .fake(),
             savedPredefinedPackages: .fake(),

--- a/Networking/Networking/Mapper/WooShippingPackagesMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingPackagesMapper.swift
@@ -1,10 +1,19 @@
 import Foundation
 
 struct WooShippingPackagesMapper: Mapper {
+    /// Site Identifier associated to the order that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
+    ///
+    let siteID: Int64
+
     /// (Attempts) to convert a dictionary into WooShippingPackagesResponse.
     ///
     func map(response: Data) throws -> WooShippingPackagesResponse {
         let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
         if hasDataEnvelope(in: response) {
             return try decoder.decode(WooShippingPackagesMapperEnvelope.self, from: response).data
         } else {

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -4120,20 +4120,17 @@ extension Networking.WooShippingPackagePurchase {
 extension Networking.WooShippingPackagesResponse {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
-        storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
         customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
         savedPredefinedPackages: CopiableProp<[WooShippingSavedPredefinedPackage]> = .copy,
         allPredefinedOptions: CopiableProp<[WooShippingCarrierPredefinedOptions]> = .copy
     ) -> Networking.WooShippingPackagesResponse {
         let siteID = siteID ?? self.siteID
-        let storeOptions = storeOptions ?? self.storeOptions
         let customPackages = customPackages ?? self.customPackages
         let savedPredefinedPackages = savedPredefinedPackages ?? self.savedPredefinedPackages
         let allPredefinedOptions = allPredefinedOptions ?? self.allPredefinedOptions
 
         return Networking.WooShippingPackagesResponse(
             siteID: siteID,
-            storeOptions: storeOptions,
             customPackages: customPackages,
             savedPredefinedPackages: savedPredefinedPackages,
             allPredefinedOptions: allPredefinedOptions

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -4119,17 +4119,20 @@ extension Networking.WooShippingPackagePurchase {
 
 extension Networking.WooShippingPackagesResponse {
     public func copy(
+        siteID: CopiableProp<Int64> = .copy,
         storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
         customPackages: CopiableProp<[WooShippingCustomPackage]> = .copy,
         savedPredefinedPackages: CopiableProp<[WooShippingSavedPredefinedPackage]> = .copy,
         allPredefinedOptions: CopiableProp<[WooShippingCarrierPredefinedOptions]> = .copy
     ) -> Networking.WooShippingPackagesResponse {
+        let siteID = siteID ?? self.siteID
         let storeOptions = storeOptions ?? self.storeOptions
         let customPackages = customPackages ?? self.customPackages
         let savedPredefinedPackages = savedPredefinedPackages ?? self.savedPredefinedPackages
         let allPredefinedOptions = allPredefinedOptions ?? self.allPredefinedOptions
 
         return Networking.WooShippingPackagesResponse(
+            siteID: siteID,
             storeOptions: storeOptions,
             customPackages: customPackages,
             savedPredefinedPackages: savedPredefinedPackages,

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/WooShippingPredefinedOption.swift
@@ -26,6 +26,11 @@ public struct WooShippingPredefinedOption: Equatable, GeneratedFakeable {
 public struct WooShippingCarrierPredefinedOptions: Equatable, GeneratedFakeable {
     public let carrierID: String
     public let predefinedOptions: [WooShippingPredefinedOption]
+
+    public init(carrierID: String, predefinedOptions: [WooShippingPredefinedOption]) {
+        self.carrierID = carrierID
+        self.predefinedOptions = predefinedOptions
+    }
 }
 
 // MARK: Decodable

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -5,6 +5,8 @@ import Codegen
 ///
 public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, GeneratedCopiable {
 
+    public let siteID: Int64
+
     /// Store options
     public let storeOptions: ShippingLabelStoreOptions
 
@@ -17,10 +19,12 @@ public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, Generat
     /// All predefined options
     public let allPredefinedOptions: [WooShippingCarrierPredefinedOptions]
 
-    public init(storeOptions: ShippingLabelStoreOptions,
+    public init(siteID: Int64,
+                storeOptions: ShippingLabelStoreOptions,
                 customPackages: [WooShippingCustomPackage],
                 savedPredefinedPackages: [WooShippingSavedPredefinedPackage],
                 allPredefinedOptions: [WooShippingCarrierPredefinedOptions]) {
+        self.siteID = siteID
         self.storeOptions = storeOptions
         self.customPackages = customPackages
         self.savedPredefinedPackages = savedPredefinedPackages
@@ -31,6 +35,10 @@ public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, Generat
 // MARK: Decodable
 extension WooShippingPackagesResponse: Decodable {
     public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw WooShippingPackagesDecodingError.missingSiteID
+        }
+
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let storeOptions = try container.decode(ShippingLabelStoreOptions.self, forKey: .storeOptions)
@@ -69,7 +77,8 @@ extension WooShippingPackagesResponse: Decodable {
         // since we get the carriers data as a dictionary (key is carrier id)
         allPredefinedOptions.sort { $0.carrierID < $1.carrierID }
 
-        self.init(storeOptions: storeOptions,
+        self.init(siteID: siteID,
+                  storeOptions: storeOptions,
                   customPackages: customPackages,
                   savedPredefinedPackages: allSavedPredefinedPackages,
                   allPredefinedOptions: allPredefinedOptions)
@@ -110,4 +119,11 @@ extension WooShippingPackagesResponse: Decodable {
         case predefined
         case saved
     }
+}
+
+
+// MARK: - Decoding Errors
+//
+enum WooShippingPackagesDecodingError: Error {
+    case missingSiteID
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -1,14 +1,11 @@
 import Foundation
 import Codegen
 
-/// Represents store options, a list of saved Shipping Label Packages (custom and predefined) for the WooCommerce Shipping extension.
+/// Represents a list of available Shipping Label Packages (custom and predefined) for the WooCommerce Shipping extension.
 ///
 public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     public let siteID: Int64
-
-    /// Store options
-    public let storeOptions: ShippingLabelStoreOptions
 
     /// Saved custom packages
     public let customPackages: [WooShippingCustomPackage]
@@ -20,12 +17,10 @@ public struct WooShippingPackagesResponse: Equatable, GeneratedFakeable, Generat
     public let allPredefinedOptions: [WooShippingCarrierPredefinedOptions]
 
     public init(siteID: Int64,
-                storeOptions: ShippingLabelStoreOptions,
                 customPackages: [WooShippingCustomPackage],
                 savedPredefinedPackages: [WooShippingSavedPredefinedPackage],
                 allPredefinedOptions: [WooShippingCarrierPredefinedOptions]) {
         self.siteID = siteID
-        self.storeOptions = storeOptions
         self.customPackages = customPackages
         self.savedPredefinedPackages = savedPredefinedPackages
         self.allPredefinedOptions = allPredefinedOptions
@@ -41,7 +36,6 @@ extension WooShippingPackagesResponse: Decodable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let storeOptions = try container.decode(ShippingLabelStoreOptions.self, forKey: .storeOptions)
         let packagesData = try container.nestedContainer(keyedBy: PackagesKeys.self, forKey: .packages)
 
         let savedPackagesData = try packagesData.nestedContainer(keyedBy: SavedPackagesKeys.self, forKey: .saved)
@@ -78,7 +72,6 @@ extension WooShippingPackagesResponse: Decodable {
         allPredefinedOptions.sort { $0.carrierID < $1.carrierID }
 
         self.init(siteID: siteID,
-                  storeOptions: storeOptions,
                   customPackages: customPackages,
                   savedPredefinedPackages: allSavedPredefinedPackages,
                   allPredefinedOptions: allPredefinedOptions)
@@ -107,7 +100,6 @@ extension WooShippingPackagesResponse: Decodable {
     private enum CodingKeys: String, CodingKey {
         case packages
         case predefined
-        case storeOptions
     }
 
     private enum SavedPackagesKeys: String, CodingKey {

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -129,7 +129,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                                          path: path,
                                          availableAsRESTRequest: true)
 
-            let mapper = WooShippingPackagesMapper()
+            let mapper = WooShippingPackagesMapper(siteID: siteID)
             enqueue(request, mapper: mapper, completion: completion)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are going to cache the packages response so we can fetch packages from storage during Woo Shipping label creation.

This PR updates the Networking layer in preparation for that caching:

* Adds a `siteID` property to `WooShippingPackagesResponse` to support caching and fetching the packages per site in Core Data.
* Adds an `init` method for `WooShippingCarrierPredefinedOptions`. This is required for `GeneratedFakeable` support, so the `rake generate` command can generate its `fake()` method. (Prior to this, the command was failing and couldn't finish regenerating the methods for the Networking layer.)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Confirm unit tests pass. You can also confirm the packages response continues to work as expected:

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Immediately tap "Select a Package."
8. Select each tab and confirm the expected packages appear.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.