### PR TITLE
[Shipping labels] Add packages response to Storage layer (Core Data)

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -2139,7 +2139,7 @@
 				DEC51ADE275B41BE009F3DF4 /* Model 47.xcdatamodel */,
 				DEC51ADF275B41BE009F3DF4 /* Model 19.xcdatamodel */,
 			);
-			currentVersion = B99824A12CCBA8120090DDF3 /* Model 118.xcdatamodel */;
+			currentVersion = CE0FBB072D0C4420008B7789 /* Model 119.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 		CCBEBD3F27C68E660010C96F /* FeatureIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureIcon.swift; sourceTree = "<group>"; };
 		CCD2E70625DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV45toV46.xcmappingmodel; sourceTree = "<group>"; };
 		CCF3209E2927EBEE002114B1 /* Model 78.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 78.xcdatamodel"; sourceTree = "<group>"; };
+		CE0FBB072D0C4420008B7789 /* Model 119.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 119.xcdatamodel"; sourceTree = "<group>"; };
 		CE12FBE22220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV9toV10.xcmappingmodel; sourceTree = "<group>"; };
 		CE13681229FA8E6500EBF43C /* Model 86.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 86.xcdatamodel"; sourceTree = "<group>"; };
 		CE1999302A1C22B20093F863 /* Model 88.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 88.xcdatamodel"; sourceTree = "<group>"; };
@@ -2018,6 +2019,7 @@
 		DEC51AA4275B41BE009F3DF4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				CE0FBB072D0C4420008B7789 /* Model 119.xcdatamodel */,
 				B99824A12CCBA8120090DDF3 /* Model 118.xcdatamodel */,
 				454AE50A2C8878B800D3C6FE /* Model 117.xcdatamodel */,
 				EE7448702C856E2400947FF4 /* Model 116.xcdatamodel */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -194,6 +194,18 @@
 		CC80E408294B33F100D5FF45 /* SiteSummaryStats+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC80E407294B33F100D5FF45 /* SiteSummaryStats+CoreDataProperties.swift */; };
 		CCBEBD4027C68E660010C96F /* FeatureIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBEBD3F27C68E660010C96F /* FeatureIcon.swift */; };
 		CCD2E70725DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E70625DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel */; };
+		CE0FBB122D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB092D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataProperties.swift */; };
+		CE0FBB132D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB0B2D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataProperties.swift */; };
+		CE0FBB142D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB0A2D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataClass.swift */; };
+		CE0FBB152D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB082D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataClass.swift */; };
+		CE0FBB162D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB0D2D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataProperties.swift */; };
+		CE0FBB172D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB0C2D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataClass.swift */; };
+		CE0FBB182D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB0E2D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataClass.swift */; };
+		CE0FBB192D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB0F2D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataProperties.swift */; };
+		CE0FBB1A2D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB102D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataClass.swift */; };
+		CE0FBB1B2D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB112D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataProperties.swift */; };
+		CE0FBB282D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB272D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataProperties.swift */; };
+		CE0FBB292D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB262D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataClass.swift */; };
 		CE12FBE32220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBE22220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel */; };
 		CE3B7AD22225E62C0050FE4B /* OrderStatus+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3B7AD02225E62C0050FE4B /* OrderStatus+CoreDataClass.swift */; };
 		CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3B7AD12225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift */; };
@@ -506,6 +518,18 @@
 		CCD2E70625DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV45toV46.xcmappingmodel; sourceTree = "<group>"; };
 		CCF3209E2927EBEE002114B1 /* Model 78.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 78.xcdatamodel"; sourceTree = "<group>"; };
 		CE0FBB072D0C4420008B7789 /* Model 119.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 119.xcdatamodel"; sourceTree = "<group>"; };
+		CE0FBB082D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingCarrierPredefinedOptions+CoreDataClass.swift"; sourceTree = "<group>"; };
+		CE0FBB092D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingCarrierPredefinedOptions+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		CE0FBB0A2D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingCustomPackage+CoreDataClass.swift"; sourceTree = "<group>"; };
+		CE0FBB0B2D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingCustomPackage+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		CE0FBB0C2D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPredefinedOption+CoreDataClass.swift"; sourceTree = "<group>"; };
+		CE0FBB0D2D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPredefinedOption+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		CE0FBB0E2D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPredefinedPackage+CoreDataClass.swift"; sourceTree = "<group>"; };
+		CE0FBB0F2D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPredefinedPackage+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		CE0FBB102D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingSavedPredefinedPackage+CoreDataClass.swift"; sourceTree = "<group>"; };
+		CE0FBB112D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingSavedPredefinedPackage+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		CE0FBB262D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPackagesResponse+CoreDataClass.swift"; sourceTree = "<group>"; };
+		CE0FBB272D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPackagesResponse+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		CE12FBE22220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV9toV10.xcmappingmodel; sourceTree = "<group>"; };
 		CE13681229FA8E6500EBF43C /* Model 86.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 86.xcdatamodel"; sourceTree = "<group>"; };
 		CE1999302A1C22B20093F863 /* Model 88.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 88.xcdatamodel"; sourceTree = "<group>"; };
@@ -979,6 +1003,18 @@
 				CC2C0305262DCC6900928C9C /* ShippingLabelAccountSettings+CoreDataProperties.swift */,
 				CC2C0306262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataClass.swift */,
 				CC2C0308262DCC6900928C9C /* ShippingLabelPaymentMethod+CoreDataProperties.swift */,
+				CE0FBB082D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataClass.swift */,
+				CE0FBB092D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataProperties.swift */,
+				CE0FBB0A2D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataClass.swift */,
+				CE0FBB0B2D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataProperties.swift */,
+				CE0FBB0C2D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataClass.swift */,
+				CE0FBB0D2D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataProperties.swift */,
+				CE0FBB0E2D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataClass.swift */,
+				CE0FBB0F2D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataProperties.swift */,
+				CE0FBB102D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataClass.swift */,
+				CE0FBB112D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataProperties.swift */,
+				CE0FBB262D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataClass.swift */,
+				CE0FBB272D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataProperties.swift */,
 				57A8819E24CA395000AE0943 /* AppSettings */,
 				025CA2BB238EB86200B05C81 /* ProductShippingClass+CoreDataClass.swift */,
 				025CA2BC238EB86200B05C81 /* ProductShippingClass+CoreDataProperties.swift */,
@@ -1406,6 +1442,8 @@
 				45E462072684BCEE00011BF2 /* StateOfACountry+CoreDataClass.swift in Sources */,
 				CCD2E70725DE9AAA00BD975D /* WooCommerceModelV45toV46.xcmappingmodel in Sources */,
 				26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */,
+				CE0FBB282D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataProperties.swift in Sources */,
+				CE0FBB292D0C936E008B7789 /* WooShippingPackagesResponse+CoreDataClass.swift in Sources */,
 				EE8A303F2B7352D3001D7C66 /* OrderAttributionInfo+CoreDataProperties.swift in Sources */,
 				457E6E8327D8B60F00173F69 /* Order+CoreDataProperties.swift in Sources */,
 				CE4FD4492350EB7600A16B31 /* OrderItemTax+CoreDataClass.swift in Sources */,
@@ -1458,6 +1496,16 @@
 				031C1EA427AD3AFE00298699 /* WCPayCardPresentPaymentDetails+CoreDataProperties.swift in Sources */,
 				B505F6E020BEEA8100BB1B69 /* StorageType.swift in Sources */,
 				747453A82242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift in Sources */,
+				CE0FBB122D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataProperties.swift in Sources */,
+				CE0FBB132D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataProperties.swift in Sources */,
+				CE0FBB142D0C4AAC008B7789 /* WooShippingCustomPackage+CoreDataClass.swift in Sources */,
+				CE0FBB152D0C4AAC008B7789 /* WooShippingCarrierPredefinedOptions+CoreDataClass.swift in Sources */,
+				CE0FBB162D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataProperties.swift in Sources */,
+				CE0FBB172D0C4AAC008B7789 /* WooShippingPredefinedOption+CoreDataClass.swift in Sources */,
+				CE0FBB182D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataClass.swift in Sources */,
+				CE0FBB192D0C4AAC008B7789 /* WooShippingPredefinedPackage+CoreDataProperties.swift in Sources */,
+				CE0FBB1A2D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataClass.swift in Sources */,
+				CE0FBB1B2D0C4AAC008B7789 /* WooShippingSavedPredefinedPackage+CoreDataProperties.swift in Sources */,
 				D8FBFF5A22D66A06006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
 				D88E234125AE08F10023F3B1 /* OrderFeeLine+CoreDataProperties.swift in Sources */,
 				0371C38028781E2700277E2C /* FeatureAnnouncementCampaign.swift in Sources */,

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -2,6 +2,15 @@
 
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
+## Model 119 (Release 21.3.0.0)
+- @rachelmcr 2024-12-16
+    - Added `WooShippingPackagesResponse` entity.
+    - Added `WooShippingCarrierPredefinedOptions` entity.
+    - Added `WooShippingPredefinedOption` entity.
+    - Added `WooShippingPredefinedPackage` entity.
+    - Added `WooShippingCustomPackage` entity.
+    - Added `WooShippingSavedPredefinedPackage` entity.
+
 ## Model 118 (Release 21.0.0.0)
 - @cvargascasaseca 2024-10-25
     - Added `globalUniqueID` attribute to `Product` and `ProductVariation` entities.

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 118.xcdatamodel</string>
+	<string>Model 119.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23H124" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String"/>
         <attribute name="email" optional="YES" attributeType="String"/>
@@ -1020,5 +1020,24 @@
         <attribute name="status" attributeType="String"/>
         <relationship name="cardDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPaymentDetails"/>
         <relationship name="cardPresentDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPresentPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPresentPaymentDetails"/>
+    </entity>
+    <entity name="WooShippingCarrierPredefinedOptions" representedClassName="WooShippingCarrierPredefinedOptions" syncable="YES" codeGenerationType="class">
+        <attribute name="carrierID" attributeType="String" defaultValueString=""/>
+        <relationship name="predefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingPredefinedOption" inverseName="carrier" inverseEntity="WooShippingPredefinedOption"/>
+    </entity>
+    <entity name="WooShippingPredefinedOption" representedClassName="WooShippingPredefinedOption" syncable="YES" codeGenerationType="class">
+        <attribute name="providerID" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="carrier" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingCarrierPredefinedOptions" inverseName="predefinedOptions" inverseEntity="WooShippingCarrierPredefinedOptions"/>
+        <relationship name="predefinedPackages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingPredefinedPackage" inverseName="predefinedOption" inverseEntity="WooShippingPredefinedPackage"/>
+    </entity>
+    <entity name="WooShippingPredefinedPackage" representedClassName="WooShippingPredefinedPackage" syncable="YES" codeGenerationType="class">
+        <attribute name="boxWeight" attributeType="String" defaultValueString=""/>
+        <attribute name="dimensions" attributeType="String" defaultValueString=""/>
+        <attribute name="groupID" attributeType="String" defaultValueString=""/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isLetter" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <relationship name="predefinedOption" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedOption" inverseName="predefinedPackages" inverseEntity="WooShippingPredefinedOption"/>
     </entity>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
@@ -1039,5 +1039,11 @@
         <attribute name="isLetter" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String" defaultValueString=""/>
         <relationship name="predefinedOption" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedOption" inverseName="predefinedPackages" inverseEntity="WooShippingPredefinedOption"/>
+        <relationship name="savedPredefinedPackage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingSavedPredefinedPackage" inverseName="package" inverseEntity="WooShippingSavedPredefinedPackage"/>
+    </entity>
+    <entity name="WooShippingSavedPredefinedPackage" representedClassName="WooShippingSavedPredefinedPackage" syncable="YES" codeGenerationType="class">
+        <attribute name="groupTitle" attributeType="String" defaultValueString=""/>
+        <attribute name="providerID" attributeType="String" defaultValueString=""/>
+        <relationship name="package" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedPackage" inverseName="savedPredefinedPackage" inverseEntity="WooShippingPredefinedPackage"/>
     </entity>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
@@ -1023,6 +1023,7 @@
     </entity>
     <entity name="WooShippingCarrierPredefinedOptions" representedClassName="WooShippingCarrierPredefinedOptions" syncable="YES" codeGenerationType="class">
         <attribute name="carrierID" attributeType="String" defaultValueString=""/>
+        <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="allPredefinedOptions" inverseEntity="WooShippingPackagesResponse"/>
         <relationship name="predefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingPredefinedOption" inverseName="carrier" inverseEntity="WooShippingPredefinedOption"/>
     </entity>
     <entity name="WooShippingCustomPackage" representedClassName="WooShippingCustomPackage" syncable="YES" codeGenerationType="class">
@@ -1031,6 +1032,13 @@
         <attribute name="id" attributeType="String" defaultValueString=""/>
         <attribute name="name" attributeType="String" defaultValueString=""/>
         <attribute name="rawType" attributeType="String" defaultValueString=""/>
+        <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="customPackages" inverseEntity="WooShippingPackagesResponse"/>
+    </entity>
+    <entity name="WooShippingPackagesResponse" representedClassName="WooShippingPackagesResponse" syncable="YES" codeGenerationType="class">
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="allPredefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingCarrierPredefinedOptions" inverseName="packagesResponse" inverseEntity="WooShippingCarrierPredefinedOptions"/>
+        <relationship name="customPackages" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingCustomPackage" inverseName="packagesResponse" inverseEntity="WooShippingCustomPackage"/>
+        <relationship name="savedPredefinedPackages" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingSavedPredefinedPackage" inverseName="packagesResponse" inverseEntity="WooShippingSavedPredefinedPackage"/>
     </entity>
     <entity name="WooShippingPredefinedOption" representedClassName="WooShippingPredefinedOption" syncable="YES" codeGenerationType="class">
         <attribute name="providerID" attributeType="String" defaultValueString=""/>
@@ -1052,5 +1060,6 @@
         <attribute name="groupTitle" attributeType="String" defaultValueString=""/>
         <attribute name="providerID" attributeType="String" defaultValueString=""/>
         <relationship name="package" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedPackage" inverseName="savedPredefinedPackage" inverseEntity="WooShippingPredefinedPackage"/>
+        <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="savedPredefinedPackages" inverseEntity="WooShippingPackagesResponse"/>
     </entity>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
@@ -1021,12 +1021,12 @@
         <relationship name="cardDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPaymentDetails"/>
         <relationship name="cardPresentDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPresentPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPresentPaymentDetails"/>
     </entity>
-    <entity name="WooShippingCarrierPredefinedOptions" representedClassName="WooShippingCarrierPredefinedOptions" syncable="YES" codeGenerationType="class">
+    <entity name="WooShippingCarrierPredefinedOptions" representedClassName="WooShippingCarrierPredefinedOptions" syncable="YES">
         <attribute name="carrierID" attributeType="String" defaultValueString=""/>
         <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="allPredefinedOptions" inverseEntity="WooShippingPackagesResponse"/>
         <relationship name="predefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingPredefinedOption" inverseName="carrier" inverseEntity="WooShippingPredefinedOption"/>
     </entity>
-    <entity name="WooShippingCustomPackage" representedClassName="WooShippingCustomPackage" syncable="YES" codeGenerationType="class">
+    <entity name="WooShippingCustomPackage" representedClassName="WooShippingCustomPackage" syncable="YES">
         <attribute name="boxWeight" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="dimensions" attributeType="String" defaultValueString=""/>
         <attribute name="id" attributeType="String" defaultValueString=""/>
@@ -1034,19 +1034,19 @@
         <attribute name="rawType" attributeType="String" defaultValueString=""/>
         <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="customPackages" inverseEntity="WooShippingPackagesResponse"/>
     </entity>
-    <entity name="WooShippingPackagesResponse" representedClassName="WooShippingPackagesResponse" syncable="YES" codeGenerationType="class">
+    <entity name="WooShippingPackagesResponse" representedClassName="WooShippingPackagesResponse" syncable="YES">
         <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="allPredefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingCarrierPredefinedOptions" inverseName="packagesResponse" inverseEntity="WooShippingCarrierPredefinedOptions"/>
         <relationship name="customPackages" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingCustomPackage" inverseName="packagesResponse" inverseEntity="WooShippingCustomPackage"/>
         <relationship name="savedPredefinedPackages" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingSavedPredefinedPackage" inverseName="packagesResponse" inverseEntity="WooShippingSavedPredefinedPackage"/>
     </entity>
-    <entity name="WooShippingPredefinedOption" representedClassName="WooShippingPredefinedOption" syncable="YES" codeGenerationType="class">
+    <entity name="WooShippingPredefinedOption" representedClassName="WooShippingPredefinedOption" syncable="YES">
         <attribute name="providerID" attributeType="String" defaultValueString=""/>
         <attribute name="title" attributeType="String" defaultValueString=""/>
         <relationship name="carrier" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingCarrierPredefinedOptions" inverseName="predefinedOptions" inverseEntity="WooShippingCarrierPredefinedOptions"/>
         <relationship name="predefinedPackages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingPredefinedPackage" inverseName="predefinedOption" inverseEntity="WooShippingPredefinedPackage"/>
     </entity>
-    <entity name="WooShippingPredefinedPackage" representedClassName="WooShippingPredefinedPackage" syncable="YES" codeGenerationType="class">
+    <entity name="WooShippingPredefinedPackage" representedClassName="WooShippingPredefinedPackage" syncable="YES">
         <attribute name="boxWeight" attributeType="String" defaultValueString=""/>
         <attribute name="dimensions" attributeType="String" defaultValueString=""/>
         <attribute name="groupID" attributeType="String" defaultValueString=""/>
@@ -1056,7 +1056,7 @@
         <relationship name="predefinedOption" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedOption" inverseName="predefinedPackages" inverseEntity="WooShippingPredefinedOption"/>
         <relationship name="savedPredefinedPackage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingSavedPredefinedPackage" inverseName="package" inverseEntity="WooShippingSavedPredefinedPackage"/>
     </entity>
-    <entity name="WooShippingSavedPredefinedPackage" representedClassName="WooShippingSavedPredefinedPackage" syncable="YES" codeGenerationType="class">
+    <entity name="WooShippingSavedPredefinedPackage" representedClassName="WooShippingSavedPredefinedPackage" syncable="YES">
         <attribute name="groupTitle" attributeType="String" defaultValueString=""/>
         <attribute name="providerID" attributeType="String" defaultValueString=""/>
         <relationship name="package" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedPackage" inverseName="savedPredefinedPackage" inverseEntity="WooShippingPredefinedPackage"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
@@ -1,0 +1,1024 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="username" attributeType="String"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
+        <attribute name="firstName" optional="YES" attributeType="String"/>
+        <attribute name="lastName" optional="YES" attributeType="String"/>
+        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="AddOnGroup" representedClassName="AddOnGroup" syncable="YES">
+        <attribute name="groupID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="priority" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="addOns" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOn" inverseName="group" inverseEntity="ProductAddOn"/>
+    </entity>
+    <entity name="BlazeCampaignListItem" representedClassName="BlazeCampaignListItem" syncable="YES">
+        <attribute name="budgetAmount" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="budgetCurrency" attributeType="String" defaultValueString="USD"/>
+        <attribute name="budgetMode" attributeType="String" defaultValueString="total"/>
+        <attribute name="campaignID" attributeType="String" defaultValueString=""/>
+        <attribute name="clicks" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="durationDays" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="imageURL" optional="YES" attributeType="String"/>
+        <attribute name="impressions" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isEvergreen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rawStatus" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="spentBudget" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="targetUrl" optional="YES" attributeType="String"/>
+        <attribute name="textSnippet" attributeType="String" defaultValueString=""/>
+        <attribute name="totalBudget" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="BlazeCampaignObjective" representedClassName="BlazeCampaignObjective" syncable="YES">
+        <attribute name="generalDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="suitableForDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="BlazeTargetDevice" representedClassName="BlazeTargetDevice" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="BlazeTargetLanguage" representedClassName="BlazeTargetLanguage" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="BlazeTargetTopic" representedClassName="BlazeTargetTopic" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="Country" representedClassName="Country" syncable="YES">
+        <attribute name="code" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <relationship name="states" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="StateOfACountry" inverseName="relationship" inverseEntity="StateOfACountry"/>
+    </entity>
+    <entity name="Coupon" representedClassName="Coupon" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="code" optional="YES" attributeType="String"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateExpires" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="discountType" optional="YES" attributeType="String"/>
+        <attribute name="emailRestrictions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="excludedProductCategories" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="excludedProducts" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="excludeSaleItems" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="freeShipping" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="individualUse" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="limitUsageToXItems" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="maximumAmount" optional="YES" attributeType="String"/>
+        <attribute name="minimumAmount" optional="YES" attributeType="String"/>
+        <attribute name="productCategories" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="products" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usageCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usageLimit" optional="YES" attributeType="Integer 64" usesScalarValueType="NO"/>
+        <attribute name="usageLimitPerUser" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="usedBy" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CouponSearchResult" inverseName="coupons" inverseEntity="CouponSearchResult"/>
+    </entity>
+    <entity name="CouponSearchResult" representedClassName="CouponSearchResult" syncable="YES">
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="searchResults" inverseEntity="Coupon"/>
+    </entity>
+    <entity name="Customer" representedClassName="Customer" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="billingCity" optional="YES" attributeType="String"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="billingState" optional="YES" attributeType="String"/>
+        <attribute name="customerID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="firstName" optional="YES" attributeType="String"/>
+        <attribute name="lastName" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="shippingState" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="username" optional="YES" attributeType="String"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CustomerSearchResult" inverseName="customers" inverseEntity="CustomerSearchResult"/>
+    </entity>
+    <entity name="CustomerSearchResult" representedClassName="CustomerSearchResult" syncable="YES">
+        <attribute name="keyword" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="customers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Customer" inverseName="searchResults" inverseEntity="Customer"/>
+    </entity>
+    <entity name="GenericAttribute" representedClassName="GenericAttribute" syncable="YES">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="key" attributeType="String"/>
+        <attribute name="value" attributeType="String"/>
+        <relationship name="productBundleItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductBundleItem" inverseName="defaultVariationAttributes" inverseEntity="ProductBundleItem"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="InboxAction" representedClassName="InboxAction" syncable="YES">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="inboxNote" maxCount="1" deletionRule="Nullify" destinationEntity="InboxNote" inverseName="actions" inverseEntity="InboxNote"/>
+    </entity>
+    <entity name="InboxNote" representedClassName="InboxNote" syncable="YES">
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isRead" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isRemoved" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <relationship name="actions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="InboxAction" inverseName="inboxNote" inverseEntity="InboxAction"/>
+    </entity>
+    <entity name="MetaData" representedClassName="MetaData" elementID="OrderMetaData" versionHashModifier="1" syncable="YES">
+        <attribute name="key" optional="YES" attributeType="String"/>
+        <attribute name="metadataID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="customFields" inverseEntity="Order"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="customFields" inverseEntity="Product"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Binary"/>
+        <attribute name="deleteInProgress" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="header" optional="YES" attributeType="Binary"/>
+        <attribute name="icon" optional="YES" attributeType="String"/>
+        <attribute name="meta" optional="YES" attributeType="Binary"/>
+        <attribute name="noteHash" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String"/>
+        <attribute name="read" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Binary"/>
+        <attribute name="subtype" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="billingCity" optional="YES" attributeType="String"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="billingState" optional="YES" attributeType="String"/>
+        <attribute name="chargeID" optional="YES" attributeType="String"/>
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="discountTax" optional="YES" attributeType="String"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String"/>
+        <attribute name="exclusiveForSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isEditable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="needsPayment" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="needsProcessing" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="number" optional="YES" attributeType="String"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="orderKey" attributeType="String" defaultValueString=""/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paymentMethodID" optional="YES" attributeType="String"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String"/>
+        <attribute name="paymentURL" optional="YES" attributeType="URI"/>
+        <attribute name="renewalSubscriptionID" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="shippingState" optional="YES" attributeType="String"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="appliedGiftCards" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderGiftCard" inverseName="order" inverseEntity="OrderGiftCard"/>
+        <relationship name="attributionInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderAttributionInfo" inverseName="order" inverseEntity="OrderAttributionInfo"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon"/>
+        <relationship name="customFields" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MetaData" inverseName="order" inverseEntity="MetaData"/>
+        <relationship name="fees" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderFeeLine" inverseName="order" inverseEntity="OrderFeeLine"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote"/>
+        <relationship name="refunds" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderRefundCondensed" inverseName="order" inverseEntity="OrderRefundCondensed"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults"/>
+        <relationship name="shippingLabels" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLabel" inverseName="order" inverseEntity="ShippingLabel"/>
+        <relationship name="shippingLabelSettings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelSettings" inverseName="order" inverseEntity="ShippingLabelSettings"/>
+        <relationship name="shippingLines" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLine" inverseName="order" inverseEntity="ShippingLine"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderTaxLine" inverseName="order" inverseEntity="OrderTaxLine"/>
+    </entity>
+    <entity name="OrderAttributionInfo" representedClassName="OrderAttributionInfo" syncable="YES">
+        <attribute name="campaign" optional="YES" attributeType="String"/>
+        <attribute name="deviceType" optional="YES" attributeType="String"/>
+        <attribute name="medium" optional="YES" attributeType="String"/>
+        <attribute name="sessionPageViews" optional="YES" attributeType="String"/>
+        <attribute name="source" optional="YES" attributeType="String"/>
+        <attribute name="sourceType" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="attributionInfo" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String"/>
+        <attribute name="discountTax" optional="YES" attributeType="String"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderFeeLine" representedClassName="OrderFeeLine" syncable="YES">
+        <attribute name="feeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemAttribute" inverseName="orderFeeLine" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="fees" inverseEntity="Order"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItemTax" inverseName="feeLine" inverseEntity="OrderItemTax"/>
+    </entity>
+    <entity name="OrderGiftCard" representedClassName="OrderGiftCard" syncable="YES">
+        <attribute name="amount" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="code" attributeType="String" defaultValueString=""/>
+        <attribute name="giftCardID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="appliedGiftCards" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="parent" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="addOns" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderItemProductAddOn" inverseName="orderItem" inverseEntity="OrderItemProductAddOn"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderItemAttribute" inverseName="orderItem" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemTax" inverseName="item" inverseEntity="OrderItemTax"/>
+    </entity>
+    <entity name="OrderItemAttribute" representedClassName="OrderItemAttribute" syncable="YES">
+        <attribute name="metaID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="value" attributeType="String"/>
+        <relationship name="orderFeeLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderFeeLine" inverseName="attributes" inverseEntity="OrderFeeLine"/>
+        <relationship name="orderItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="attributes" inverseEntity="OrderItem"/>
+        <relationship name="orderTaxLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderTaxLine" inverseName="attributes" inverseEntity="OrderTaxLine"/>
+    </entity>
+    <entity name="OrderItemProductAddOn" representedClassName="OrderItemProductAddOn" syncable="YES">
+        <attribute name="addOnID" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="key" attributeType="String" defaultValueString=""/>
+        <attribute name="value" attributeType="String" defaultValueString=""/>
+        <relationship name="orderItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="addOns" inverseEntity="OrderItem"/>
+    </entity>
+    <entity name="OrderItemRefund" representedClassName="OrderItemRefund" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="refundedItemID" optional="YES" attributeType="String"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Refund" inverseName="items" inverseEntity="Refund"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemTaxRefund" inverseName="item" inverseEntity="OrderItemTaxRefund"/>
+    </entity>
+    <entity name="OrderItemTax" representedClassName="OrderItemTax" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="feeLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderFeeLine" inverseName="taxes" inverseEntity="OrderFeeLine"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="taxes" inverseEntity="OrderItem"/>
+    </entity>
+    <entity name="OrderItemTaxRefund" representedClassName="OrderItemTaxRefund" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItemRefund" inverseName="taxes" inverseEntity="OrderItemRefund"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderRefundCondensed" representedClassName="OrderRefundCondensed" syncable="YES">
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="refundID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="refunds" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderSearchResults" representedClassName="OrderSearchResults" syncable="YES">
+        <attribute name="keyword" attributeType="String"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="searchResults" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderStatsV4" representedClassName="OrderStatsV4" syncable="YES">
+        <attribute name="granularity" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeRange" optional="YES" attributeType="String"/>
+        <relationship name="intervals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="OrderStatsV4Interval" inverseName="stats" inverseEntity="OrderStatsV4Interval"/>
+        <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals"/>
+    </entity>
+    <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES">
+        <attribute name="dateEnd" optional="YES" attributeType="String"/>
+        <attribute name="dateStart" optional="YES" attributeType="String"/>
+        <attribute name="interval" optional="YES" attributeType="String"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="intervals" inverseEntity="OrderStatsV4"/>
+        <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals"/>
+    </entity>
+    <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES">
+        <attribute name="averageOrderValue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="grossRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="netRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="totalItemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="interval" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4Interval" inverseName="subtotals" inverseEntity="OrderStatsV4Interval"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="totals" inverseEntity="OrderStatsV4"/>
+    </entity>
+    <entity name="OrderStatus" representedClassName="OrderStatus" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="OrderTaxLine" representedClassName="OrderTaxLine" syncable="YES">
+        <attribute name="isCompoundTaxRate" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="rateCode" optional="YES" attributeType="String"/>
+        <attribute name="rateID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ratePercent" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="taxID" attributeType="Integer 64" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="totalShippingTax" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemAttribute" inverseName="orderTaxLine" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="taxes" inverseEntity="Order"/>
+    </entity>
+    <entity name="PaymentGateway" representedClassName="PaymentGateway" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="features" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="gatewayDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="gatewayID" attributeType="String" defaultValueString=""/>
+        <attribute name="instructions" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="PaymentGatewayAccount" representedClassName="PaymentGatewayAccount" syncable="YES">
+        <attribute name="country" optional="YES" attributeType="String"/>
+        <attribute name="currentDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="defaultCurrency" optional="YES" attributeType="String"/>
+        <attribute name="gatewayID" optional="YES" attributeType="String"/>
+        <attribute name="hasOverdueRequirements" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasPendingRequirements" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isCardPresentEligible" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isInTestMode" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isLive" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statementDescriptor" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="supportedCurrencies" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="averageRating" attributeType="String"/>
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="briefDescription" optional="YES" attributeType="String"/>
+        <attribute name="bundleMaxSize" optional="YES" attributeType="Decimal"/>
+        <attribute name="bundleMinSize" optional="YES" attributeType="Decimal"/>
+        <attribute name="bundleStockQuantity" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="bundleStockStatus" optional="YES" attributeType="String"/>
+        <attribute name="buttonText" attributeType="String" defaultValueString=""/>
+        <attribute name="catalogVisibilityKey" attributeType="String"/>
+        <attribute name="combineVariationQuantities" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="externalURL" optional="YES" attributeType="String"/>
+        <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="globalUniqueID" optional="YES" attributeType="String"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="groupOfQuantity" optional="YES" attributeType="String"/>
+        <attribute name="isSampleItem" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="maxAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="minAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="parentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="password" optional="YES" attributeType="String"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productTypeKey" attributeType="String"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="purchaseNote" optional="YES" attributeType="String"/>
+        <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="shippingRequired" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="shippingTaxable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="soldIndividually" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="addOns" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOn" inverseName="product" inverseEntity="ProductAddOn"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
+        <relationship name="bundledItems" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductBundleItem" inverseName="product" inverseEntity="ProductBundleItem"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="products" inverseEntity="ProductCategory"/>
+        <relationship name="compositeComponents" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductCompositeComponent" inverseName="product" inverseEntity="ProductCompositeComponent"/>
+        <relationship name="customFields" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MetaData" inverseName="product" inverseEntity="MetaData"/>
+        <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage"/>
+        <relationship name="productShippingClass" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductShippingClass" inverseName="products" inverseEntity="ProductShippingClass"/>
+        <relationship name="productVariations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariation" inverseName="product" inverseEntity="ProductVariation"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductSearchResults" inverseName="products" inverseEntity="ProductSearchResults"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductSubscription" inverseName="product" inverseEntity="ProductSubscription"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ProductTag" inverseName="products" inverseEntity="ProductTag"/>
+    </entity>
+    <entity name="ProductAddOn" representedClassName="ProductAddOn" syncable="YES">
+        <attribute name="adjustPrice" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptionEnabled" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptions" attributeType="String" defaultValueString=""/>
+        <attribute name="display" attributeType="String" defaultValueString=""/>
+        <attribute name="max" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="min" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="price" attributeType="String" defaultValueString=""/>
+        <attribute name="priceType" attributeType="String" defaultValueString=""/>
+        <attribute name="required" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="restrictions" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="restrictionsType" attributeType="String" defaultValueString=""/>
+        <attribute name="titleFormat" attributeType="String" defaultValueString=""/>
+        <attribute name="type" attributeType="String" defaultValueString=""/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AddOnGroup" inverseName="addOns" inverseEntity="AddOnGroup"/>
+        <relationship name="options" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOnOption" inverseName="addOn" inverseEntity="ProductAddOnOption"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="addOns" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductAddOnOption" representedClassName="ProductAddOnOption" syncable="YES">
+        <attribute name="imageID" optional="YES" attributeType="String"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="String"/>
+        <attribute name="priceType" optional="YES" attributeType="String"/>
+        <relationship name="addOn" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductAddOn" inverseName="options" inverseEntity="ProductAddOn"/>
+    </entity>
+    <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="attributes" inverseEntity="Product"/>
+        <relationship name="terms" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductAttributeTerm" inverseName="attribute" inverseEntity="ProductAttributeTerm"/>
+    </entity>
+    <entity name="ProductAttributeTerm" representedClassName="ProductAttributeTerm" syncable="YES">
+        <attribute name="count" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="termID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="attribute" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductAttribute" inverseName="terms" inverseEntity="ProductAttribute"/>
+    </entity>
+    <entity name="ProductBundleItem" representedClassName="ProductBundleItem" syncable="YES">
+        <attribute name="allowedVariations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="bundledItemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="defaultQuantity" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="isOptional" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="maxQuantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="minQuantity" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="overridesDefaultVariationAttributes" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="overridesVariations" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="pricedIndividually" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="stockStatus" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="defaultVariationAttributes" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GenericAttribute" inverseName="productBundleItem" inverseEntity="GenericAttribute"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="bundledItems" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductCategory" representedClassName="ProductCategory" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" destinationEntity="Product" inverseName="categories" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductCompositeComponent" representedClassName="ProductCompositeComponent" syncable="YES">
+        <attribute name="componentDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="componentID" attributeType="String" defaultValueString=""/>
+        <attribute name="defaultOptionID" attributeType="String" defaultValueString=""/>
+        <attribute name="imageURL" attributeType="String" defaultValueString=""/>
+        <attribute name="optionIDs" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="optionType" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="compositeComponents" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="option" optional="YES" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="defaultAttributes" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductDimensions" representedClassName="ProductDimensions" syncable="YES">
+        <attribute name="height" attributeType="String"/>
+        <attribute name="length" attributeType="String"/>
+        <attribute name="width" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductDownload" representedClassName="ProductDownload" syncable="YES">
+        <attribute name="downloadID" attributeType="String"/>
+        <attribute name="fileURL" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="downloads" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="downloads" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="src" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="image" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductReview" representedClassName="ProductReview" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rating" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="review" optional="YES" attributeType="String"/>
+        <attribute name="reviewer" optional="YES" attributeType="String"/>
+        <attribute name="reviewerAvatarURL" optional="YES" attributeType="String"/>
+        <attribute name="reviewerEmail" optional="YES" attributeType="String"/>
+        <attribute name="reviewID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusKey" optional="YES" attributeType="String"/>
+        <attribute name="verified" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="ProductSearchResults" representedClassName="ProductSearchResults" syncable="YES">
+        <attribute name="filterKey" optional="YES" attributeType="String"/>
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="searchResults" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductShippingClass" representedClassName="ProductShippingClass" syncable="YES">
+        <attribute name="count" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptionHTML" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="productShippingClass" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductSubscription" representedClassName="ProductSubscription" syncable="YES">
+        <attribute name="length" attributeType="String" defaultValueString=""/>
+        <attribute name="oneTimeShipping" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="paymentSyncDate" attributeType="String" defaultValueString=""/>
+        <attribute name="paymentSyncMonth" attributeType="String" defaultValueString=""/>
+        <attribute name="period" attributeType="String" defaultValueString=""/>
+        <attribute name="periodInterval" attributeType="String" defaultValueString=""/>
+        <attribute name="price" attributeType="String" defaultValueString=""/>
+        <attribute name="signUpFee" attributeType="String" defaultValueString=""/>
+        <attribute name="trialLength" attributeType="String" defaultValueString=""/>
+        <attribute name="trialPeriod" attributeType="String" defaultValueString=""/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="subscription" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="subscription" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" ordered="YES" destinationEntity="Product" inverseName="tags" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES">
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="globalUniqueID" optional="YES" attributeType="String"/>
+        <attribute name="groupOfQuantity" optional="YES" attributeType="String"/>
+        <attribute name="manageStock" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="maxAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="minAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="onSale" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="overrideProductQuantities" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productVariationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="virtual" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="attributes" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GenericAttribute" inverseName="productVariation" inverseEntity="GenericAttribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="productVariation" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDownload" inverseName="productVariation" inverseEntity="ProductDownload"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductImage" inverseName="productVariation" inverseEntity="ProductImage"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="productVariations" inverseEntity="Product"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductSubscription" inverseName="productVariation" inverseEntity="ProductSubscription"/>
+    </entity>
+    <entity name="Refund" representedClassName="Refund" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="byUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createAutomated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isAutomated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="refundID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="supportShippingRefunds" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemRefund" inverseName="refund" inverseEntity="OrderItemRefund"/>
+        <relationship name="shippingLines" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLine" inverseName="refund" inverseEntity="ShippingLine"/>
+    </entity>
+    <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
+        <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="trackingID" attributeType="String"/>
+        <attribute name="trackingNumber" optional="YES" attributeType="String"/>
+        <attribute name="trackingProvider" optional="YES" attributeType="String"/>
+        <attribute name="trackingURL" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="ShipmentTrackingProvider" representedClassName="ShipmentTrackingProvider" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShipmentTrackingProviderGroup" inverseName="providers" inverseEntity="ShipmentTrackingProviderGroup"/>
+    </entity>
+    <entity name="ShipmentTrackingProviderGroup" representedClassName="ShipmentTrackingProviderGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="providers" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShipmentTrackingProvider" inverseName="group" inverseEntity="ShipmentTrackingProvider"/>
+    </entity>
+    <entity name="ShippingLabel" representedClassName="ShippingLabel" syncable="YES">
+        <attribute name="carrierID" attributeType="String" defaultValueString=""/>
+        <attribute name="commercialInvoiceURL" optional="YES" attributeType="String"/>
+        <attribute name="currency" attributeType="String" defaultValueString=""/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="packageName" attributeType="String" defaultValueString=""/>
+        <attribute name="productIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="productNames" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="rate" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="refundableAmount" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="serviceName" attributeType="String" defaultValueString=""/>
+        <attribute name="shippingLabelID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" attributeType="String" defaultValueString=""/>
+        <attribute name="trackingNumber" attributeType="String" defaultValueString=""/>
+        <relationship name="destinationAddress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelAddress" inverseName="destinationShippingLabel" inverseEntity="ShippingLabelAddress"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLabels" inverseEntity="Order"/>
+        <relationship name="originAddress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelAddress" inverseName="originShippingLabel" inverseEntity="ShippingLabelAddress"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelRefund" inverseName="shippingLabel" inverseEntity="ShippingLabelRefund"/>
+    </entity>
+    <entity name="ShippingLabelAccountSettings" representedClassName="ShippingLabelAccountSettings" syncable="YES">
+        <attribute name="canEditSettings" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="canManagePayments" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isEmailReceiptsEnabled" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastSelectedPackageID" attributeType="String" defaultValueString=""/>
+        <attribute name="paperSize" attributeType="String"/>
+        <attribute name="selectedPaymentMethodID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="storeOwnerDisplayName" attributeType="String"/>
+        <attribute name="storeOwnerUsername" attributeType="String"/>
+        <attribute name="storeOwnerWpcomEmail" attributeType="String"/>
+        <attribute name="storeOwnerWpcomUsername" attributeType="String"/>
+        <relationship name="paymentMethods" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLabelPaymentMethod" inverseName="accountSettings" inverseEntity="ShippingLabelPaymentMethod"/>
+    </entity>
+    <entity name="ShippingLabelAddress" representedClassName="ShippingLabelAddress" syncable="YES">
+        <attribute name="address1" attributeType="String" defaultValueString=""/>
+        <attribute name="address2" attributeType="String" defaultValueString=""/>
+        <attribute name="city" attributeType="String" defaultValueString=""/>
+        <attribute name="company" attributeType="String" defaultValueString=""/>
+        <attribute name="country" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="phone" attributeType="String" defaultValueString=""/>
+        <attribute name="postcode" attributeType="String" defaultValueString=""/>
+        <attribute name="state" attributeType="String" defaultValueString=""/>
+        <relationship name="destinationShippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="destinationAddress" inverseEntity="ShippingLabel"/>
+        <relationship name="originShippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="originAddress" inverseEntity="ShippingLabel"/>
+    </entity>
+    <entity name="ShippingLabelPaymentMethod" representedClassName="ShippingLabelPaymentMethod" syncable="YES">
+        <attribute name="cardDigits" attributeType="String"/>
+        <attribute name="cardType" attributeType="String"/>
+        <attribute name="expiry" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="paymentMethodID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="accountSettings" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabelAccountSettings" inverseName="paymentMethods" inverseEntity="ShippingLabelAccountSettings"/>
+    </entity>
+    <entity name="ShippingLabelRefund" representedClassName="ShippingLabelRefund" syncable="YES">
+        <attribute name="dateRequested" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" attributeType="String" defaultValueString=""/>
+        <relationship name="shippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="refund" inverseEntity="ShippingLabel"/>
+    </entity>
+    <entity name="ShippingLabelSettings" representedClassName="ShippingLabelSettings" syncable="YES">
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paperSize" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLabelSettings" inverseEntity="Order"/>
+    </entity>
+    <entity name="ShippingLine" representedClassName="ShippingLine" syncable="YES">
+        <attribute name="methodID" optional="YES" attributeType="String"/>
+        <attribute name="methodTitle" optional="YES" attributeType="String"/>
+        <attribute name="shippingID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLines" inverseEntity="Order"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Refund" inverseName="shippingLines" inverseEntity="Refund"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLineTax" inverseName="shipping" inverseEntity="ShippingLineTax"/>
+    </entity>
+    <entity name="ShippingLineTax" representedClassName="ShippingLineTax" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="shipping" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLine" inverseName="taxes" inverseEntity="ShippingLine"/>
+    </entity>
+    <entity name="ShippingMethod" representedClassName="ShippingMethod" syncable="YES">
+        <attribute name="methodID" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="adminURL" optional="YES" attributeType="String"/>
+        <attribute name="canBlaze" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="frameNonce" optional="YES" attributeType="String"/>
+        <attribute name="gmtOffset" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="isAdmin" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isAIAssitantFeatureActive" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isJetpackConnected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isJetpackThePluginInstalled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSiteOwner" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="jetpackConnectionActivePlugins" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="loginURL" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="plan" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String"/>
+        <attribute name="timezone" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visibility" attributeType="Integer 64" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="wasEcommerceTrial" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SitePlugin" representedClassName="SitePlugin" syncable="YES">
+        <attribute name="author" attributeType="String" defaultValueString=""/>
+        <attribute name="authorUri" attributeType="String" defaultValueString=""/>
+        <attribute name="descriptionRaw" attributeType="String" defaultValueString=""/>
+        <attribute name="descriptionRendered" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="networkOnly" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="plugin" attributeType="String" defaultValueString=""/>
+        <attribute name="pluginUri" attributeType="String" defaultValueString=""/>
+        <attribute name="requiresPHPVersion" attributeType="String" defaultValueString=""/>
+        <attribute name="requiresWPVersion" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" attributeType="String" defaultValueString="unknown"/>
+        <attribute name="textDomain" attributeType="String" defaultValueString=""/>
+        <attribute name="version" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="settingDescription" optional="YES" attributeType="String"/>
+        <attribute name="settingGroupKey" optional="YES" attributeType="String"/>
+        <attribute name="settingID" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="SiteSummaryStats" representedClassName="SiteSummaryStats" syncable="YES">
+        <attribute name="date" attributeType="String" defaultValueString=""/>
+        <attribute name="period" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="views" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitors" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SiteVisitStats" representedClassName="SiteVisitStats" syncable="YES">
+        <attribute name="date" attributeType="String"/>
+        <attribute name="granularity" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeRange" attributeType="String" defaultValueString=""/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SiteVisitStatsItem" inverseName="stats" inverseEntity="SiteVisitStatsItem"/>
+    </entity>
+    <entity name="SiteVisitStatsItem" representedClassName="SiteVisitStatsItem" syncable="YES">
+        <attribute name="period" optional="YES" attributeType="String"/>
+        <attribute name="views" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats"/>
+    </entity>
+    <entity name="StateOfACountry" representedClassName="StateOfACountry" syncable="YES">
+        <attribute name="code" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Country" inverseName="states" inverseEntity="Country"/>
+    </entity>
+    <entity name="SystemPlugin" representedClassName="SystemPlugin" syncable="YES">
+        <attribute name="active" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="authorName" attributeType="String"/>
+        <attribute name="authorUrl" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="networkActivated" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="plugin" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" attributeType="String"/>
+        <attribute name="version" attributeType="String"/>
+        <attribute name="versionLatest" attributeType="String"/>
+    </entity>
+    <entity name="TaxClass" representedClassName="TaxClass" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+    </entity>
+    <entity name="TaxRate" representedClassName="TaxRate" versionHashModifier="2" syncable="YES">
+        <attribute name="cities" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray" versionHashModifier="2"/>
+        <attribute name="city" optional="YES" attributeType="String"/>
+        <attribute name="compound" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="country" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="postcode" optional="YES" attributeType="String"/>
+        <attribute name="postcodes" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray" versionHashModifier="2"/>
+        <attribute name="priority" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rate" optional="YES" attributeType="String"/>
+        <attribute name="shipping" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="state" optional="YES" attributeType="String"/>
+        <attribute name="taxRateClass" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String"/>
+        <attribute name="granularity" attributeType="String"/>
+        <attribute name="limit" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats"/>
+    </entity>
+    <entity name="WCAnalyticsCustomer" representedClassName="WCAnalyticsCustomer" syncable="YES">
+        <attribute name="averageOrderValue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="city" optional="YES" attributeType="String"/>
+        <attribute name="country" optional="YES" attributeType="String"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dateLastActive" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateRegistered" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="ordersCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="postcode" optional="YES" attributeType="String"/>
+        <attribute name="region" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalSpend" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="username" optional="YES" attributeType="String"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WCAnalyticsCustomerSearchResult" inverseName="customers" inverseEntity="WCAnalyticsCustomerSearchResult"/>
+    </entity>
+    <entity name="WCAnalyticsCustomerSearchResult" representedClassName="WCAnalyticsCustomerSearchResult" syncable="YES">
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="customers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WCAnalyticsCustomer" inverseName="searchResults" inverseEntity="WCAnalyticsCustomer"/>
+    </entity>
+    <entity name="WCPayCardPaymentDetails" representedClassName="WCPayCardPaymentDetails" syncable="YES">
+        <attribute name="brand" attributeType="String"/>
+        <attribute name="funding" attributeType="String"/>
+        <attribute name="last4" attributeType="String"/>
+        <relationship name="charge" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WCPayCharge" inverseName="cardDetails" inverseEntity="WCPayCharge"/>
+    </entity>
+    <entity name="WCPayCardPresentPaymentDetails" representedClassName="WCPayCardPresentPaymentDetails" syncable="YES">
+        <attribute name="brand" attributeType="String"/>
+        <attribute name="funding" attributeType="String"/>
+        <attribute name="last4" attributeType="String"/>
+        <relationship name="charge" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WCPayCharge" inverseName="cardPresentDetails" inverseEntity="WCPayCharge"/>
+        <relationship name="receipt" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPresentReceiptDetails" inverseName="cardPresentPayment" inverseEntity="WCPayCardPresentReceiptDetails"/>
+    </entity>
+    <entity name="WCPayCardPresentReceiptDetails" representedClassName="WCPayCardPresentReceiptDetails" syncable="YES">
+        <attribute name="accountType" attributeType="String"/>
+        <attribute name="applicationPreferredName" optional="YES" attributeType="String"/>
+        <attribute name="dedicatedFileName" optional="YES" attributeType="String"/>
+        <relationship name="cardPresentPayment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WCPayCardPresentPaymentDetails" inverseName="receipt" inverseEntity="WCPayCardPresentPaymentDetails"/>
+    </entity>
+    <entity name="WCPayCharge" representedClassName="WCPayCharge" syncable="YES">
+        <attribute name="amount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="amountCaptured" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="amountRefunded" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="authorizationCode" optional="YES" attributeType="String"/>
+        <attribute name="captured" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="chargeID" attributeType="String"/>
+        <attribute name="created" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="currency" attributeType="String"/>
+        <attribute name="paid" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="paymentIntentID" optional="YES" attributeType="String"/>
+        <attribute name="paymentMethodID" attributeType="String"/>
+        <attribute name="paymentMethodType" attributeType="String"/>
+        <attribute name="refunded" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" attributeType="String"/>
+        <relationship name="cardDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPaymentDetails"/>
+        <relationship name="cardPresentDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPresentPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPresentPaymentDetails"/>
+    </entity>
+</model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
@@ -1025,6 +1025,13 @@
         <attribute name="carrierID" attributeType="String" defaultValueString=""/>
         <relationship name="predefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingPredefinedOption" inverseName="carrier" inverseEntity="WooShippingPredefinedOption"/>
     </entity>
+    <entity name="WooShippingCustomPackage" representedClassName="WooShippingCustomPackage" syncable="YES" codeGenerationType="class">
+        <attribute name="boxWeight" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="dimensions" attributeType="String" defaultValueString=""/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="rawType" attributeType="String" defaultValueString=""/>
+    </entity>
     <entity name="WooShippingPredefinedOption" representedClassName="WooShippingPredefinedOption" syncable="YES" codeGenerationType="class">
         <attribute name="providerID" attributeType="String" defaultValueString=""/>
         <attribute name="title" attributeType="String" defaultValueString=""/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 119.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23H124" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="23H124" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String"/>
         <attribute name="email" optional="YES" attributeType="String"/>
@@ -1059,7 +1059,7 @@
     <entity name="WooShippingSavedPredefinedPackage" representedClassName="WooShippingSavedPredefinedPackage" syncable="YES">
         <attribute name="groupTitle" attributeType="String" defaultValueString=""/>
         <attribute name="providerID" attributeType="String" defaultValueString=""/>
-        <relationship name="package" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedPackage" inverseName="savedPredefinedPackage" inverseEntity="WooShippingPredefinedPackage"/>
+        <relationship name="package" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WooShippingPredefinedPackage" inverseName="savedPredefinedPackage" inverseEntity="WooShippingPredefinedPackage"/>
         <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="savedPredefinedPackages" inverseEntity="WooShippingPackagesResponse"/>
     </entity>
 </model>

--- a/Storage/Storage/Model/WooShippingCarrierPredefinedOptions+CoreDataClass.swift
+++ b/Storage/Storage/Model/WooShippingCarrierPredefinedOptions+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(WooShippingCarrierPredefinedOptions)
+public class WooShippingCarrierPredefinedOptions: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/WooShippingCarrierPredefinedOptions+CoreDataProperties.swift
+++ b/Storage/Storage/Model/WooShippingCarrierPredefinedOptions+CoreDataProperties.swift
@@ -1,0 +1,54 @@
+import Foundation
+import CoreData
+
+
+extension WooShippingCarrierPredefinedOptions {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WooShippingCarrierPredefinedOptions> {
+        return NSFetchRequest<WooShippingCarrierPredefinedOptions>(entityName: "WooShippingCarrierPredefinedOptions")
+    }
+
+    @NSManaged public var carrierID: String?
+    @NSManaged public var packagesResponse: WooShippingPackagesResponse?
+    @NSManaged public var predefinedOptions: NSOrderedSet?
+
+}
+
+// MARK: Generated accessors for predefinedOptions
+extension WooShippingCarrierPredefinedOptions {
+
+    @objc(insertObject:inPredefinedOptionsAtIndex:)
+    @NSManaged public func insertIntoPredefinedOptions(_ value: WooShippingPredefinedOption, at idx: Int)
+
+    @objc(removeObjectFromPredefinedOptionsAtIndex:)
+    @NSManaged public func removeFromPredefinedOptions(at idx: Int)
+
+    @objc(insertPredefinedOptions:atIndexes:)
+    @NSManaged public func insertIntoPredefinedOptions(_ values: [WooShippingPredefinedOption], at indexes: NSIndexSet)
+
+    @objc(removePredefinedOptionsAtIndexes:)
+    @NSManaged public func removeFromPredefinedOptions(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInPredefinedOptionsAtIndex:withObject:)
+    @NSManaged public func replacePredefinedOptions(at idx: Int, with value: WooShippingPredefinedOption)
+
+    @objc(replacePredefinedOptionsAtIndexes:withPredefinedOptions:)
+    @NSManaged public func replacePredefinedOptions(at indexes: NSIndexSet, with values: [WooShippingPredefinedOption])
+
+    @objc(addPredefinedOptionsObject:)
+    @NSManaged public func addToPredefinedOptions(_ value: WooShippingPredefinedOption)
+
+    @objc(removePredefinedOptionsObject:)
+    @NSManaged public func removeFromPredefinedOptions(_ value: WooShippingPredefinedOption)
+
+    @objc(addPredefinedOptions:)
+    @NSManaged public func addToPredefinedOptions(_ values: NSOrderedSet)
+
+    @objc(removePredefinedOptions:)
+    @NSManaged public func removeFromPredefinedOptions(_ values: NSOrderedSet)
+
+}
+
+extension WooShippingCarrierPredefinedOptions: Identifiable {
+
+}

--- a/Storage/Storage/Model/WooShippingCustomPackage+CoreDataClass.swift
+++ b/Storage/Storage/Model/WooShippingCustomPackage+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(WooShippingCustomPackage)
+public class WooShippingCustomPackage: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/WooShippingCustomPackage+CoreDataProperties.swift
+++ b/Storage/Storage/Model/WooShippingCustomPackage+CoreDataProperties.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CoreData
+
+
+extension WooShippingCustomPackage {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WooShippingCustomPackage> {
+        return NSFetchRequest<WooShippingCustomPackage>(entityName: "WooShippingCustomPackage")
+    }
+
+    @NSManaged public var boxWeight: Double
+    @NSManaged public var dimensions: String?
+    @NSManaged public var id: String?
+    @NSManaged public var name: String?
+    @NSManaged public var rawType: String?
+    @NSManaged public var packagesResponse: WooShippingPackagesResponse?
+
+}
+
+extension WooShippingCustomPackage: Identifiable {
+
+}

--- a/Storage/Storage/Model/WooShippingPackagesResponse+CoreDataClass.swift
+++ b/Storage/Storage/Model/WooShippingPackagesResponse+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(WooShippingPackagesResponse)
+public class WooShippingPackagesResponse: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/WooShippingPackagesResponse+CoreDataProperties.swift
+++ b/Storage/Storage/Model/WooShippingPackagesResponse+CoreDataProperties.swift
@@ -1,0 +1,89 @@
+import Foundation
+import CoreData
+
+
+extension WooShippingPackagesResponse {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WooShippingPackagesResponse> {
+        return NSFetchRequest<WooShippingPackagesResponse>(entityName: "WooShippingPackagesResponse")
+    }
+
+    @NSManaged public var siteID: Int64
+    @NSManaged public var allPredefinedOptions: NSOrderedSet?
+    @NSManaged public var customPackages: Set<WooShippingCustomPackage>?
+    @NSManaged public var savedPredefinedPackages: Set<WooShippingSavedPredefinedPackage>?
+
+}
+
+// MARK: Generated accessors for allPredefinedOptions
+extension WooShippingPackagesResponse {
+
+    @objc(insertObject:inAllPredefinedOptionsAtIndex:)
+    @NSManaged public func insertIntoAllPredefinedOptions(_ value: WooShippingCarrierPredefinedOptions, at idx: Int)
+
+    @objc(removeObjectFromAllPredefinedOptionsAtIndex:)
+    @NSManaged public func removeFromAllPredefinedOptions(at idx: Int)
+
+    @objc(insertAllPredefinedOptions:atIndexes:)
+    @NSManaged public func insertIntoAllPredefinedOptions(_ values: [WooShippingCarrierPredefinedOptions], at indexes: NSIndexSet)
+
+    @objc(removeAllPredefinedOptionsAtIndexes:)
+    @NSManaged public func removeFromAllPredefinedOptions(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInAllPredefinedOptionsAtIndex:withObject:)
+    @NSManaged public func replaceAllPredefinedOptions(at idx: Int, with value: WooShippingCarrierPredefinedOptions)
+
+    @objc(replaceAllPredefinedOptionsAtIndexes:withAllPredefinedOptions:)
+    @NSManaged public func replaceAllPredefinedOptions(at indexes: NSIndexSet, with values: [WooShippingCarrierPredefinedOptions])
+
+    @objc(addAllPredefinedOptionsObject:)
+    @NSManaged public func addToAllPredefinedOptions(_ value: WooShippingCarrierPredefinedOptions)
+
+    @objc(removeAllPredefinedOptionsObject:)
+    @NSManaged public func removeFromAllPredefinedOptions(_ value: WooShippingCarrierPredefinedOptions)
+
+    @objc(addAllPredefinedOptions:)
+    @NSManaged public func addToAllPredefinedOptions(_ values: NSOrderedSet)
+
+    @objc(removeAllPredefinedOptions:)
+    @NSManaged public func removeFromAllPredefinedOptions(_ values: NSOrderedSet)
+
+}
+
+// MARK: Generated accessors for customPackages
+extension WooShippingPackagesResponse {
+
+    @objc(addCustomPackagesObject:)
+    @NSManaged public func addToCustomPackages(_ value: WooShippingCustomPackage)
+
+    @objc(removeCustomPackagesObject:)
+    @NSManaged public func removeFromCustomPackages(_ value: WooShippingCustomPackage)
+
+    @objc(addCustomPackages:)
+    @NSManaged public func addToCustomPackages(_ values: NSSet)
+
+    @objc(removeCustomPackages:)
+    @NSManaged public func removeFromCustomPackages(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for savedPredefinedPackages
+extension WooShippingPackagesResponse {
+
+    @objc(addSavedPredefinedPackagesObject:)
+    @NSManaged public func addToSavedPredefinedPackages(_ value: WooShippingSavedPredefinedPackage)
+
+    @objc(removeSavedPredefinedPackagesObject:)
+    @NSManaged public func removeFromSavedPredefinedPackages(_ value: WooShippingSavedPredefinedPackage)
+
+    @objc(addSavedPredefinedPackages:)
+    @NSManaged public func addToSavedPredefinedPackages(_ values: NSSet)
+
+    @objc(removeSavedPredefinedPackages:)
+    @NSManaged public func removeFromSavedPredefinedPackages(_ values: NSSet)
+
+}
+
+extension WooShippingPackagesResponse: Identifiable {
+
+}

--- a/Storage/Storage/Model/WooShippingPredefinedOption+CoreDataClass.swift
+++ b/Storage/Storage/Model/WooShippingPredefinedOption+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(WooShippingPredefinedOption)
+public class WooShippingPredefinedOption: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/WooShippingPredefinedOption+CoreDataProperties.swift
+++ b/Storage/Storage/Model/WooShippingPredefinedOption+CoreDataProperties.swift
@@ -1,0 +1,37 @@
+import Foundation
+import CoreData
+
+
+extension WooShippingPredefinedOption {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WooShippingPredefinedOption> {
+        return NSFetchRequest<WooShippingPredefinedOption>(entityName: "WooShippingPredefinedOption")
+    }
+
+    @NSManaged public var providerID: String?
+    @NSManaged public var title: String?
+    @NSManaged public var carrier: WooShippingCarrierPredefinedOptions?
+    @NSManaged public var predefinedPackages: Set<WooShippingPredefinedPackage>?
+
+}
+
+// MARK: Generated accessors for predefinedPackages
+extension WooShippingPredefinedOption {
+
+    @objc(addPredefinedPackagesObject:)
+    @NSManaged public func addToPredefinedPackages(_ value: WooShippingPredefinedPackage)
+
+    @objc(removePredefinedPackagesObject:)
+    @NSManaged public func removeFromPredefinedPackages(_ value: WooShippingPredefinedPackage)
+
+    @objc(addPredefinedPackages:)
+    @NSManaged public func addToPredefinedPackages(_ values: NSSet)
+
+    @objc(removePredefinedPackages:)
+    @NSManaged public func removeFromPredefinedPackages(_ values: NSSet)
+
+}
+
+extension WooShippingPredefinedOption: Identifiable {
+
+}

--- a/Storage/Storage/Model/WooShippingPredefinedPackage+CoreDataClass.swift
+++ b/Storage/Storage/Model/WooShippingPredefinedPackage+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(WooShippingPredefinedPackage)
+public class WooShippingPredefinedPackage: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/WooShippingPredefinedPackage+CoreDataProperties.swift
+++ b/Storage/Storage/Model/WooShippingPredefinedPackage+CoreDataProperties.swift
@@ -1,0 +1,24 @@
+import Foundation
+import CoreData
+
+
+extension WooShippingPredefinedPackage {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WooShippingPredefinedPackage> {
+        return NSFetchRequest<WooShippingPredefinedPackage>(entityName: "WooShippingPredefinedPackage")
+    }
+
+    @NSManaged public var boxWeight: String?
+    @NSManaged public var dimensions: String?
+    @NSManaged public var groupID: String?
+    @NSManaged public var id: String?
+    @NSManaged public var isLetter: Bool
+    @NSManaged public var name: String?
+    @NSManaged public var predefinedOption: WooShippingPredefinedOption?
+    @NSManaged public var savedPredefinedPackage: WooShippingSavedPredefinedPackage?
+
+}
+
+extension WooShippingPredefinedPackage: Identifiable {
+
+}

--- a/Storage/Storage/Model/WooShippingSavedPredefinedPackage+CoreDataClass.swift
+++ b/Storage/Storage/Model/WooShippingSavedPredefinedPackage+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(WooShippingSavedPredefinedPackage)
+public class WooShippingSavedPredefinedPackage: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/WooShippingSavedPredefinedPackage+CoreDataProperties.swift
+++ b/Storage/Storage/Model/WooShippingSavedPredefinedPackage+CoreDataProperties.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreData
+
+
+extension WooShippingSavedPredefinedPackage {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WooShippingSavedPredefinedPackage> {
+        return NSFetchRequest<WooShippingSavedPredefinedPackage>(entityName: "WooShippingSavedPredefinedPackage")
+    }
+
+    @NSManaged public var groupTitle: String?
+    @NSManaged public var providerID: String?
+    @NSManaged public var package: WooShippingPredefinedPackage?
+    @NSManaged public var packagesResponse: WooShippingPackagesResponse?
+
+}
+
+extension WooShippingSavedPredefinedPackage: Identifiable {
+
+}

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -3257,8 +3257,8 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(packagesResponse.value(forKey: "customPackages") as? NSSet, NSSet(array: [customPackage]))
         XCTAssertEqual(packagesResponse.value(forKey: "savedPredefinedPackages") as? NSSet, NSSet(array: [savedPredefinedPackage]))
         XCTAssertEqual(carrierPredefinedOptions.value(forKey: "predefinedOptions") as? NSOrderedSet, NSOrderedSet(array: [predefinedOption]))
-        XCTAssertEqual(predefinedOption.value(forKey: "carrier") as? WooShippingCarrierPredefinedOptions, carrierPredefinedOptions)
         XCTAssertEqual(predefinedOption.value(forKey: "predefinedPackages") as? NSSet, NSSet(array: [predefinedPackage]))
+        XCTAssertEqual(savedPredefinedPackage.value(forKey: "package") as? WooShippingPredefinedPackage, predefinedPackage)
     }
 }
 

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -3146,6 +3146,120 @@ final class MigrationTests: XCTestCase {
 		let savedGlobalUniqueID = try XCTUnwrap(migratedProductVariation.value(forKey: "globalUniqueID") as? String)
 		XCTAssertEqual(savedGlobalUniqueID, globalUniqueID)
 	}
+
+    func test_migrating_from_118_to_119_adds_woo_shipping_entities() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 118")
+        let sourceContext = sourceContainer.viewContext
+
+        try sourceContext.save()
+
+        // Confidence Check. These entities should not exist in Model 118
+        XCTAssertNil(NSEntityDescription.entity(forEntityName: "WooShippingPackagesResponse", in: sourceContext))
+        XCTAssertNil(NSEntityDescription.entity(forEntityName: "WooShippingCarrierPredefinedOptions", in: sourceContext))
+        XCTAssertNil(NSEntityDescription.entity(forEntityName: "WooShippingCustomPackage", in: sourceContext))
+        XCTAssertNil(NSEntityDescription.entity(forEntityName: "WooShippingPredefinedOption", in: sourceContext))
+        XCTAssertNil(NSEntityDescription.entity(forEntityName: "WooShippingPredefinedPackage", in: sourceContext))
+        XCTAssertNil(NSEntityDescription.entity(forEntityName: "WooShippingSavedPredefinedPackage", in: sourceContext))
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 119")
+
+        // Then
+        let targetContext = targetContainer.viewContext
+
+        // These entities should exist in Model 119
+        XCTAssertNotNil(NSEntityDescription.entity(forEntityName: "WooShippingPackagesResponse", in: targetContext))
+        XCTAssertNotNil(NSEntityDescription.entity(forEntityName: "WooShippingCarrierPredefinedOptions", in: targetContext))
+        XCTAssertNotNil(NSEntityDescription.entity(forEntityName: "WooShippingCustomPackage", in: targetContext))
+        XCTAssertNotNil(NSEntityDescription.entity(forEntityName: "WooShippingPredefinedOption", in: targetContext))
+        XCTAssertNotNil(NSEntityDescription.entity(forEntityName: "WooShippingPredefinedPackage", in: targetContext))
+        XCTAssertNotNil(NSEntityDescription.entity(forEntityName: "WooShippingSavedPredefinedPackage", in: targetContext))
+
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingPackagesResponse"), 0)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingCarrierPredefinedOptions"), 0)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingCustomPackage"), 0)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingPredefinedOption"), 0)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingPredefinedPackage"), 0)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingSavedPredefinedPackage"), 0)
+
+        // Insert a new WooShippingCarrierPackagesResponse
+        let packagesResponse = insertWooShippingPackagesResponse(to: targetContext)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingPackagesResponse"), 1)
+
+        // Check all attributes and relationships
+        XCTAssertNotNil(packagesResponse.entity.attributesByName["siteID"])
+        XCTAssertNotNil(packagesResponse.entity.relationshipsByName["allPredefinedOptions"])
+        XCTAssertNotNil(packagesResponse.entity.relationshipsByName["customPackages"])
+        XCTAssertNotNil(packagesResponse.entity.relationshipsByName["savedPredefinedPackages"])
+
+        // Insert a new WooShippingCarrierPredefinedOptions
+        let carrierPredefinedOptions = insertWooShippingCarrierPredefinedOptions(to: targetContext)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingCarrierPredefinedOptions"), 1)
+
+        // Check all attributes and relationships
+        XCTAssertNotNil(carrierPredefinedOptions.entity.attributesByName["carrierID"])
+        XCTAssertNotNil(carrierPredefinedOptions.entity.relationshipsByName["predefinedOptions"])
+
+        // Insert a new WooShippingPredefinedOption
+        let predefinedOption = insertWooShippingPredefinedOption(to: targetContext)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingPredefinedOption"), 1)
+
+        // Check all attributes and relationships
+        XCTAssertNotNil(predefinedOption.entity.attributesByName["providerID"])
+        XCTAssertNotNil(predefinedOption.entity.attributesByName["title"])
+        XCTAssertNotNil(predefinedOption.entity.relationshipsByName["carrier"])
+        XCTAssertNotNil(predefinedOption.entity.relationshipsByName["predefinedPackages"])
+
+        // Insert a new WooShippingPredefinedPackage
+        let predefinedPackage = insertWooShippingPredefinedPackage(to: targetContext)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingPredefinedPackage"), 1)
+
+        // Check all attributes and relationships
+        XCTAssertNotNil(predefinedPackage.entity.attributesByName["id"])
+        XCTAssertNotNil(predefinedPackage.entity.attributesByName["groupID"])
+        XCTAssertNotNil(predefinedPackage.entity.attributesByName["name"])
+        XCTAssertNotNil(predefinedPackage.entity.attributesByName["dimensions"])
+        XCTAssertNotNil(predefinedPackage.entity.attributesByName["isLetter"])
+        XCTAssertNotNil(predefinedPackage.entity.attributesByName["boxWeight"])
+        XCTAssertNotNil(predefinedPackage.entity.relationshipsByName["predefinedOption"])
+        XCTAssertNotNil(predefinedPackage.entity.relationshipsByName["savedPredefinedPackage"])
+
+        // Insert a new WooShippingSavedPredefinedPackage
+        let savedPredefinedPackage = insertWooShippingSavedPredefinedPackage(to: targetContext)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingSavedPredefinedPackage"), 1)
+
+        // Check all attributes and relationships
+        XCTAssertNotNil(savedPredefinedPackage.entity.attributesByName["providerID"])
+        XCTAssertNotNil(savedPredefinedPackage.entity.attributesByName["groupTitle"])
+        XCTAssertNotNil(savedPredefinedPackage.entity.relationshipsByName["package"])
+
+        // Insert a new WooShippingCustomPackage
+        let customPackage = insertWooShippingCustomPackage(to: targetContext)
+        XCTAssertEqual(try targetContext.count(entityName: "WooShippingCustomPackage"), 1)
+
+        // Check all attributes
+        XCTAssertNotNil(customPackage.entity.attributesByName["id"])
+        XCTAssertNotNil(customPackage.entity.attributesByName["name"])
+        XCTAssertNotNil(customPackage.entity.attributesByName["dimensions"])
+        XCTAssertNotNil(customPackage.entity.attributesByName["rawType"])
+        XCTAssertNotNil(customPackage.entity.attributesByName["boxWeight"])
+
+        // Check all relationships
+        packagesResponse.setValue(NSOrderedSet(array: [carrierPredefinedOptions]), forKey: "allPredefinedOptions")
+        packagesResponse.setValue(NSSet(array: [customPackage]), forKey: "customPackages")
+        packagesResponse.setValue(NSSet(array: [savedPredefinedPackage]), forKey: "savedPredefinedPackages")
+        carrierPredefinedOptions.setValue(NSOrderedSet(array: [predefinedOption]), forKey: "predefinedOptions")
+        predefinedOption.setValue(NSSet(array: [predefinedPackage]), forKey: "predefinedPackages")
+        savedPredefinedPackage.setValue(predefinedPackage, forKey: "package")
+        try targetContext.save()
+        XCTAssertEqual(packagesResponse.value(forKey: "allPredefinedOptions") as? NSOrderedSet, NSOrderedSet(array: [carrierPredefinedOptions]))
+        XCTAssertEqual(packagesResponse.value(forKey: "customPackages") as? NSSet, NSSet(array: [customPackage]))
+        XCTAssertEqual(packagesResponse.value(forKey: "savedPredefinedPackages") as? NSSet, NSSet(array: [savedPredefinedPackage]))
+        XCTAssertEqual(carrierPredefinedOptions.value(forKey: "predefinedOptions") as? NSOrderedSet, NSOrderedSet(array: [predefinedOption]))
+        XCTAssertEqual(predefinedOption.value(forKey: "carrier") as? WooShippingCarrierPredefinedOptions, carrierPredefinedOptions)
+        XCTAssertEqual(predefinedOption.value(forKey: "predefinedPackages") as? NSSet, NSSet(array: [predefinedPackage]))
+    }
 }
 
 // MARK: - Persistent Store Setup and Migrations
@@ -3990,6 +4104,59 @@ private extension MigrationTests {
             "metadataID": 18149,
             "key": "New Metadata Key",
             "value": "New Metadata Value"
+        ])
+    }
+
+    @discardableResult
+    func insertWooShippingPackagesResponse(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "WooShippingPackagesResponse", properties: [
+            "siteID": 1,
+        ])
+    }
+
+    @discardableResult
+    func insertWooShippingCarrierPredefinedOptions(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "WooShippingCarrierPredefinedOptions", properties: [
+            "carrierID": "usps",
+        ])
+    }
+
+    @discardableResult
+    func insertWooShippingCustomPackage(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "WooShippingCustomPackage", properties: [
+            "id": "abc123",
+            "name": "Custom Box",
+            "dimensions": "12.0 x 12.0 x 12.0",
+            "rawType": "box",
+            "boxWeight": 1.0,
+        ])
+    }
+
+    @discardableResult
+    func insertWooShippingPredefinedOption(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "WooShippingPredefinedOption", properties: [
+            "providerID": "usps",
+            "title": "USPS Priority Mail Boxes"
+        ])
+    }
+
+    @discardableResult
+    func insertWooShippingPredefinedPackage(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "WooShippingPredefinedPackage", properties: [
+            "id": "usps",
+            "groupID": "pri_flat_boxes",
+            "name": "Small Flat Rate Box",
+            "dimensions": "8.63 x 5.38 x 1.63",
+            "isLetter": false,
+            "boxWeight": "0",
+        ])
+    }
+
+    @discardableResult
+    func insertWooShippingSavedPredefinedPackage(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "WooShippingSavedPredefinedPackage", properties: [
+            "providerID": "usps",
+            "groupTitle": "USPS Priority Mail Flat Rate Boxes",
         ])
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522 
⚠️ Depends on #14687 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are going to cache the packages response (`WooShippingPackagesResponse`) so we can fetch packages from storage during Woo Shipping label creation.

This PR updates Core Data to handle storing the packages response, adding the following new storage entities:

* `WooShippingPackagesResponse`
* `WooShippingCarrierPredefinedOptions`
* `WooShippingPredefinedOption`
* `WooShippingPredefinedPackage`
* `WooShippingCustomPackage`
* `WooShippingSavedPredefinedPackage`

(Note: Most of the lines of changes come from [841f463](https://github.com/woocommerce/woocommerce-ios/pull/14688/commits/841f4637f9688bbdf8a8f4cc74a7fbab55acfa20), which only generated the new model. All changes to the model are in subsequent commits.)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Install this version over a previous one to verify that it migrates the database without any problem.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.