### PR TITLE
[Shipping labels] Upsert packages response after fetching from remote

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -545,6 +545,62 @@ public extension StorageType {
         return firstObject(ofType: ShippingLabelSettings.self, matching: predicate)
     }
 
+    // MARK: - Woo Shipping
+
+    /// Returns all stored Woo Shipping packages for a site.
+    ///
+    func loadPackages(siteID: Int64) -> WooShippingPackagesResponse? {
+        let predicate = \WooShippingPackagesResponse.siteID == siteID
+        return firstObject(ofType: WooShippingPackagesResponse.self, matching: predicate)
+    }
+
+    /// Returns all stored Woo Shipping carrier predefined options for a given `WooShippingPackagesResponse`.
+    ///
+    func loadAllPredefinedOptions(packagesResponse: WooShippingPackagesResponse) -> [WooShippingCarrierPredefinedOptions] {
+        let predicate = \WooShippingCarrierPredefinedOptions.packagesResponse == packagesResponse
+        let descriptor = NSSortDescriptor(keyPath: \WooShippingCarrierPredefinedOptions.carrierID, ascending: true)
+        return allObjects(ofType: WooShippingCarrierPredefinedOptions.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Returns all stored Woo Shipping predefined options for a given `WooShippingCarrierPredefinedOptions`.
+    ///
+    func predefinedOptions(carrier: WooShippingCarrierPredefinedOptions) -> [WooShippingPredefinedOption] {
+        let predicate = \WooShippingPredefinedOption.carrier == carrier
+        let descriptor = NSSortDescriptor(keyPath: \WooShippingPredefinedOption.title, ascending: true)
+        return allObjects(ofType: WooShippingPredefinedOption.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Returns all stored Woo Shipping predefined packages for a given `WooShippingPredefinedOption`.
+    ///
+    func predefinedPackages(predefinedOption: WooShippingPredefinedOption) -> [WooShippingPredefinedPackage] {
+        let predicate = \WooShippingPredefinedPackage.predefinedOption == predefinedOption
+        let descriptor = NSSortDescriptor(keyPath: \WooShippingPredefinedPackage.id, ascending: true)
+        return allObjects(ofType: WooShippingPredefinedPackage.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Returns all stored Woo Shipping saved predefined packages for a given `WooShippingPackagesResponse`.
+    ///
+    func loadSavedPredefinedPackages(packagesResponse: WooShippingPackagesResponse) -> [WooShippingSavedPredefinedPackage] {
+        let predicate = \WooShippingSavedPredefinedPackage.packagesResponse == packagesResponse
+        let descriptor = NSSortDescriptor(keyPath: \WooShippingSavedPredefinedPackage.providerID, ascending: true)
+        return allObjects(ofType: WooShippingSavedPredefinedPackage.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Returns stored Woo Shipping predefined package for a given `WooShippingSavedPredefinedPackage`.
+    ///
+    func loadPredefinedPackage(savedPredefinedPackage: WooShippingSavedPredefinedPackage) -> WooShippingPredefinedPackage? {
+        let predicate = \WooShippingPredefinedPackage.savedPredefinedPackage == savedPredefinedPackage
+        return firstObject(ofType: WooShippingPredefinedPackage.self, matching: predicate)
+    }
+
+    /// Returns all stored Woo Shipping custom packages for a given `WooShippingPackagesResponse`.
+    ///
+    func loadCustomPackages(packagesResponse: WooShippingPackagesResponse) -> [WooShippingCustomPackage] {
+        let predicate = \WooShippingCustomPackage.packagesResponse == packagesResponse
+        let descriptor = NSSortDescriptor(keyPath: \WooShippingCustomPackage.id, ascending: true)
+        return allObjects(ofType: WooShippingCustomPackage.self, matching: predicate, sortedBy: [descriptor])
+    }
+
     // MARK: - BlazeCampaignListItem
 
     /// Returns a single BlazeCampaignListItem given a `siteID` and `campaignID`

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -386,6 +386,12 @@
 		CCE5F39D29F0165900087332 /* SubscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE5F39C29F0165900087332 /* SubscriptionStore.swift */; };
 		CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */; };
 		CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */; };
+		CE0FBB1D2D0C5DE3008B7789 /* WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB1C2D0C5DD7008B7789 /* WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift */; };
+		CE0FBB1F2D0C65A3008B7789 /* WooShippingPredefinedOption+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB1E2D0C6598008B7789 /* WooShippingPredefinedOption+ReadOnlyConvertible.swift */; };
+		CE0FBB212D0C65B9008B7789 /* WooShippingPredefinedPackage+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB202D0C65B1008B7789 /* WooShippingPredefinedPackage+ReadOnlyConvertible.swift */; };
+		CE0FBB232D0C65C8008B7789 /* WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB222D0C65C0008B7789 /* WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift */; };
+		CE0FBB252D0C65EB008B7789 /* WooShippingCustomPackage+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB242D0C65DF008B7789 /* WooShippingCustomPackage+ReadOnlyConvertible.swift */; };
+		CE0FBB2B2D0CAFCB008B7789 /* WooShippingPackagesResponse+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0FBB2A2D0CAFC7008B7789 /* WooShippingPackagesResponse+ReadOnlyConvertible.swift */; };
 		CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */; };
 		CE179D55235F4E1700C24EB3 /* RefundAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE179D54235F4E1700C24EB3 /* RefundAction.swift */; };
 		CE179D57235F4E7500C24EB3 /* RefundStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE179D56235F4E7500C24EB3 /* RefundStore.swift */; };
@@ -916,6 +922,12 @@
 		CCE5F39C29F0165900087332 /* SubscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStore.swift; sourceTree = "<group>"; };
 		CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+ReadOnlyType.swift"; sourceTree = "<group>"; };
 		CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderRefundCondensed+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CE0FBB1C2D0C5DD7008B7789 /* WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CE0FBB1E2D0C6598008B7789 /* WooShippingPredefinedOption+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPredefinedOption+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CE0FBB202D0C65B1008B7789 /* WooShippingPredefinedPackage+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPredefinedPackage+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CE0FBB222D0C65C0008B7789 /* WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CE0FBB242D0C65DF008B7789 /* WooShippingCustomPackage+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingCustomPackage+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CE0FBB2A2D0CAFC7008B7789 /* WooShippingPackagesResponse+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingPackagesResponse+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatus+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CE179D54235F4E1700C24EB3 /* RefundAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundAction.swift; sourceTree = "<group>"; };
 		CE179D56235F4E7500C24EB3 /* RefundStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundStore.swift; sourceTree = "<group>"; };
@@ -1595,6 +1607,12 @@
 				031C1EAF27B1879C00298699 /* WCPayCardPaymentDetails+ReadOnlyConvertible.swift */,
 				031C1EAD27B1877000298699 /* WCPayCardPresentPaymentDetails+ReadOnlyConvertible.swift */,
 				6889089E28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift */,
+				CE0FBB1C2D0C5DD7008B7789 /* WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift */,
+				CE0FBB1E2D0C6598008B7789 /* WooShippingPredefinedOption+ReadOnlyConvertible.swift */,
+				CE0FBB202D0C65B1008B7789 /* WooShippingPredefinedPackage+ReadOnlyConvertible.swift */,
+				CE0FBB222D0C65C0008B7789 /* WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift */,
+				CE0FBB242D0C65DF008B7789 /* WooShippingCustomPackage+ReadOnlyConvertible.swift */,
+				CE0FBB2A2D0CAFC7008B7789 /* WooShippingPackagesResponse+ReadOnlyConvertible.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -2282,6 +2300,7 @@
 				E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */,
 				02E3B625290267F2007E0F13 /* AccountCreationAction.swift in Sources */,
 				02C254FA2563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift in Sources */,
+				CE0FBB2B2D0CAFCB008B7789 /* WooShippingPackagesResponse+ReadOnlyConvertible.swift in Sources */,
 				CECE6BBE2BA9DE3200A57C1F /* WCAnalyticsCustomer+ReadOnlyConvertible.swift in Sources */,
 				02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */,
 				03F3AFE728097D6400E328BE /* CardPresentPaymentsPlugin.swift in Sources */,
@@ -2343,6 +2362,7 @@
 				0218B4EE242E08B20083A847 /* MediaType.swift in Sources */,
 				247CE7C42582DE5300F9D9D1 /* ProductStockStatus+Mocks.swift in Sources */,
 				DE3404FC28BC5E7800CF0D97 /* JetpackConnectionAction.swift in Sources */,
+				CE0FBB252D0C65EB008B7789 /* WooShippingCustomPackage+ReadOnlyConvertible.swift in Sources */,
 				CE3B7AD72225ECA90050FE4B /* OrderStatusStore.swift in Sources */,
 				B5631ECD2114DF8C008D3535 /* EntityListener.swift in Sources */,
 				D80F758A223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift in Sources */,
@@ -2394,6 +2414,7 @@
 				B9C0C1082A3C666A00DF84EA /* ProductVariationStorageManager.swift in Sources */,
 				CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */,
 				24163BA8257F41C500F94EC3 /* SessionManagerProtocol.swift in Sources */,
+				CE0FBB1F2D0C65A3008B7789 /* WooShippingPredefinedOption+ReadOnlyConvertible.swift in Sources */,
 				D83B093925DECFD900B21F45 /* CardPresentPaymentStore.swift in Sources */,
 				DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */,
 				0271E1662509CF0100633F7A /* AnyError.swift in Sources */,
@@ -2503,6 +2524,7 @@
 				DE34050828BC706B00CF0D97 /* DeauthenticatedStore.swift in Sources */,
 				749375042249691D007D85D1 /* Product+ReadOnlyConvertible.swift in Sources */,
 				D4CBAE6426D4464500BBE6D1 /* AnnouncementsAction.swift in Sources */,
+				CE0FBB212D0C65B9008B7789 /* WooShippingPredefinedPackage+ReadOnlyConvertible.swift in Sources */,
 				EEB4E2C929B0489800371C3C /* StoreOnboardingTasksStore.swift in Sources */,
 				CE43A90222A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift in Sources */,
 				CEC7D5972CDE35AD00111B79 /* WooShippingAction.swift in Sources */,
@@ -2526,6 +2548,7 @@
 				DEB387822C2AB4370025256E /* GoogleAdsStore.swift in Sources */,
 				3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */,
 				02EF1668292DB68C00D90AD6 /* PaymentAction.swift in Sources */,
+				CE0FBB232D0C65C8008B7789 /* WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift in Sources */,
 				B5C9DE162087FF0E006B910A /* Store.swift in Sources */,
 				02FF056123D98FD40058E6E7 /* ImageSourceWriter.swift in Sources */,
 				0212AC5E242C67FA00C51F6C /* ProductsSortOrder.swift in Sources */,
@@ -2565,6 +2588,7 @@
 				45182D1F27B54D3000B4C05C /* InboxNote+ReadOnlyConvertible.swift in Sources */,
 				022F00C224726090008CD97F /* SiteNotificationCountFileContents.swift in Sources */,
 				247CE7BC2582DC1E00F9D9D1 /* MockCustomer.swift in Sources */,
+				CE0FBB1D2D0C5DE3008B7789 /* WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift in Sources */,
 				029F44CB28D310BA00FCF439 /* ProductSearchFilter.swift in Sources */,
 				03EB998C2906F1D300F06A39 /* JustInTimeMessageAction.swift in Sources */,
 				D87F614C22657B150031A13B /* AppSettingsStore.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -319,6 +319,7 @@ public typealias FeatureAnnouncementCampaign = Storage.FeatureAnnouncementCampai
 public typealias FeatureAnnouncementCampaignSettings = Storage.FeatureAnnouncementCampaignSettings
 public typealias AnalyticsCard = Storage.AnalyticsCard
 public typealias DashboardCard = Storage.DashboardCard
+public typealias StorageWooShippingPackagesResponse = Storage.WooShippingPackagesResponse
 
 // MARK: - Internal ReadOnly Models
 

--- a/Yosemite/Yosemite/Model/Storage/WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Storage
+
+extension Storage.WooShippingCarrierPredefinedOptions {
+    var predefinedOptionsArray: [Storage.WooShippingPredefinedOption] {
+        return predefinedOptions?.toArray() ?? []
+    }
+}
+
+// Storage.WooShippingCarrierPredefinedOptions: ReadOnlyConvertible Conformance.
+//
+extension Storage.WooShippingCarrierPredefinedOptions: ReadOnlyConvertible {
+    /// Updates the Storage.WooShippingCarrierPredefinedOptions with the a ReadOnly WooShippingCarrierPredefinedOptions.
+    ///
+    public func update(with carrierPredefinedOptions: Yosemite.WooShippingCarrierPredefinedOptions) {
+        self.carrierID = carrierPredefinedOptions.carrierID
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.WooShippingCarrierPredefinedOptions {
+        .init(carrierID: carrierID ?? "",
+              predefinedOptions: predefinedOptionsArray.map { $0.toReadOnly() })
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/WooShippingCustomPackage+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WooShippingCustomPackage+ReadOnlyConvertible.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Storage
+
+// Storage.WooShippingCustomPackage: ReadOnlyConvertible Conformance.
+//
+extension Storage.WooShippingCustomPackage: ReadOnlyConvertible {
+    /// Updates the Storage.WooShippingCustomPackage with the a ReadOnly WooShippingCustomPackage.
+    ///
+    public func update(with customPackage: Yosemite.WooShippingCustomPackage) {
+        self.id = customPackage.id
+        self.name = customPackage.name
+        self.dimensions = customPackage.dimensions
+        self.boxWeight = customPackage.boxWeight
+        self.rawType = customPackage.rawType
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.WooShippingCustomPackage {
+        .init(id: id ?? "",
+              name: name ?? "",
+              rawType: rawType ?? "box",
+              dimensions: dimensions ?? "",
+              boxWeight: boxWeight)
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/WooShippingPackagesResponse+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WooShippingPackagesResponse+ReadOnlyConvertible.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Storage
+
+extension Storage.WooShippingPackagesResponse {
+    var allPredefinedOptionsArray: [Storage.WooShippingCarrierPredefinedOptions] {
+        return allPredefinedOptions?.toArray() ?? []
+    }
+}
+
+// Storage.WooShippingPackagesResponse: ReadOnlyConvertible Conformance.
+//
+extension Storage.WooShippingPackagesResponse: ReadOnlyConvertible {
+    /// Updates the Storage.WooShippingPackagesResponse with the a ReadOnly WooShippingPackagesResponse.
+    ///
+    public func update(with packages: Yosemite.WooShippingPackagesResponse) {
+        self.siteID = packages.siteID
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.WooShippingPackagesResponse {
+        .init(siteID: siteID,
+              customPackages: customPackages?.map { $0.toReadOnly() } ?? [],
+              savedPredefinedPackages: savedPredefinedPackages?.map { $0.toReadOnly() } ?? [],
+              allPredefinedOptions: allPredefinedOptionsArray.map { $0.toReadOnly() })
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/WooShippingPredefinedOption+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WooShippingPredefinedOption+ReadOnlyConvertible.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Storage
+
+// Storage.WooShippingPredefinedOption: ReadOnlyConvertible Conformance.
+//
+extension Storage.WooShippingPredefinedOption: ReadOnlyConvertible {
+    /// Updates the Storage.WooShippingPredefinedOption with the a ReadOnly WooShippingPredefinedOption.
+    ///
+    public func update(with option: Yosemite.WooShippingPredefinedOption) {
+        self.title = option.title
+        self.providerID = option.providerID
+
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.WooShippingPredefinedOption {
+        .init(title: title ?? "",
+              providerID: providerID ?? "",
+              predefinedPackages: predefinedPackages?.map { $0.toReadOnly() } ?? [])
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/WooShippingPredefinedPackage+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WooShippingPredefinedPackage+ReadOnlyConvertible.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Storage
+
+// Storage.WooShippingPredefinedPackage: ReadOnlyConvertible Conformance.
+//
+extension Storage.WooShippingPredefinedPackage: ReadOnlyConvertible {
+    /// Updates the Storage.WooShippingPredefinedPackage with the a ReadOnly WooShippingPredefinedPackage.
+    ///
+    public func update(with predefinedPackage: Yosemite.WooShippingPredefinedPackage) {
+        self.id = predefinedPackage.id
+        self.name = predefinedPackage.name
+        self.isLetter = predefinedPackage.isLetter
+        self.dimensions = predefinedPackage.dimensions
+        self.boxWeight = predefinedPackage.boxWeight
+        self.groupID = predefinedPackage.groupId
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.WooShippingPredefinedPackage {
+        .init(id: id ?? "",
+              name: name ?? "",
+              isLetter: isLetter,
+              dimensions: dimensions ?? "",
+              boxWeight: boxWeight ?? "",
+              groupId: groupID ?? "")
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Storage
+
+// Storage.WooShippingSavedPredefinedPackage: ReadOnlyConvertible Conformance.
+//
+extension Storage.WooShippingSavedPredefinedPackage: ReadOnlyConvertible {
+    /// Updates the Storage.WooShippingSavedPredefinedPackage with the a ReadOnly WooShippingSavedPredefinedPackage.
+    ///
+    public func update(with savedPackage: Yosemite.WooShippingSavedPredefinedPackage) {
+        self.groupTitle = savedPackage.groupTitle
+        self.providerID = savedPackage.providerID
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.WooShippingSavedPredefinedPackage {
+        .init(groupTitle: groupTitle ?? "",
+              providerID: providerID ?? "",
+              package: createReadOnlyPackage())
+    }
+
+    // MARK: Private helpers
+
+    private func createReadOnlyPackage() -> Yosemite.WooShippingPredefinedPackage {
+        guard let package else {
+            return WooShippingPredefinedPackage(id: "", name: "", isLetter: false, dimensions: "", boxWeight: "", groupId: "")
+        }
+
+        return package.toReadOnly()
+    }
+}

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -98,7 +98,16 @@ private extension WooShippingStore {
 
     func loadPackages(siteID: Int64,
                       completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void) {
-        remote.loadPackages(siteID: siteID, completion: completion)
+        remote.loadPackages(siteID: siteID) { [weak self] result in
+            switch result {
+            case .success(let packages):
+                self?.upsertPackagesResponseInBackground(readOnlyPackages: packages, siteID: siteID) {
+                    completion(.success(packages))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
 
     func loadAccountSettings(siteID: Int64,
@@ -213,6 +222,166 @@ private extension WooShippingStore {
                     completion(.failure(error))
                 }
             }
+        }
+    }
+}
+
+// MARK: - Storage
+private extension WooShippingStore {
+    /// Updates (OR Inserts) the specified ReadOnly WooShippingPackagesResponse Entities *in a background thread*.
+    /// Also deletes existing packages if requested.
+    /// `onCompletion` will be called on the main thread!
+    ///
+    func upsertPackagesResponseInBackground(readOnlyPackages: Networking.WooShippingPackagesResponse,
+                                            siteID: Int64,
+                                            onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ [weak self] storage in
+            guard let self else { return }
+            upsertPackagesResponse(readOnlyPackages: readOnlyPackages, in: storage)
+        }, completion: onCompletion, on: .main)
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly `WooShippingPackagesResponse` Entities into the Storage Layer.
+    ///
+    /// - Parameters:
+    ///     - readOnlyPackages: Remote `WooShippingPackagesResponse` to be persisted.
+    ///     - storage: Where we should save all the things!
+    ///
+    func upsertPackagesResponse(readOnlyPackages: Networking.WooShippingPackagesResponse, in storage: StorageType) {
+        let storagePackages = storage.loadPackages(siteID: readOnlyPackages.siteID) ??
+        storage.insertNewObject(ofType: Storage.WooShippingPackagesResponse.self)
+
+        storagePackages.update(with: readOnlyPackages)
+        handleAllPredefinedOptions(readOnlyPackages, storagePackages, storage)
+        handleCustomPackages(readOnlyPackages, storagePackages, storage)
+        handleSavedPredefinedPackages(readOnlyPackages, storagePackages, storage)
+    }
+
+    /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's allPredefinedOptions
+    /// using the provided read-only WooShippingPackagesResponse's allPredefinedOptions
+    ///
+    func handleAllPredefinedOptions(_ readOnlyPackages: Networking.WooShippingPackagesResponse,
+                                    _ storagePackages: Storage.WooShippingPackagesResponse,
+                                    _ storage: StorageType) {
+        // Remove all previous predefined options, they will be deleted as they have the `cascade` delete rule
+        if let allPredefinedOptions = storagePackages.allPredefinedOptions {
+            storagePackages.removeFromAllPredefinedOptions(allPredefinedOptions)
+        }
+
+        // Creates and adds `storageAllPredefinedOptions` from `readOnlyPackages.allPredefinedOptions`
+        let storageAllPredefinedOptions = readOnlyPackages.allPredefinedOptions.map { readOnlyCarrierOptions -> Storage.WooShippingCarrierPredefinedOptions in
+            let storageCarrierOptions = storage.insertNewObject(ofType: Storage.WooShippingCarrierPredefinedOptions.self)
+            storageCarrierOptions.update(with: readOnlyCarrierOptions)
+            handlePredefinedOptions(readOnlyCarrierOptions, storageCarrierOptions, storage)
+            return storageCarrierOptions
+        }
+        storagePackages.addToAllPredefinedOptions(NSOrderedSet(array: storageAllPredefinedOptions))
+    }
+
+    /// Updates, inserts, or prunes the provided Storage.WooShippingCarrierPredefinedOptions's predefinedOptions
+    /// using the provided read-only WooShippingCarrierPredefinedOptions's predefinedOptions
+    func handlePredefinedOptions(_ readOnlyCarrierOptions: Networking.WooShippingCarrierPredefinedOptions,
+                                 _ storageCarrierOptions: Storage.WooShippingCarrierPredefinedOptions,
+                                 _ storage: StorageType) {
+        // Remove all previous predefined options, they will be deleted as they have the `cascade` delete rule
+        if let predefinedOptions = storageCarrierOptions.predefinedOptions {
+            storageCarrierOptions.removeFromPredefinedOptions(predefinedOptions)
+        }
+
+        // Creates and adds `storagePredefinedOptions` from `readOnlyCarriers.predefinedOptions`
+        let storagePredefinedOptions = readOnlyCarrierOptions.predefinedOptions.map { readOnlyOption -> Storage.WooShippingPredefinedOption in
+            let storageOption = storage.insertNewObject(ofType: Storage.WooShippingPredefinedOption.self)
+            storageOption.update(with: readOnlyOption)
+            handlePredefinedPackages(readOnlyOption, storageOption, storage)
+            return storageOption
+        }
+        storageCarrierOptions.addToPredefinedOptions(NSOrderedSet(array: storagePredefinedOptions))
+    }
+
+    /// Updates, inserts, or prunes the provided Storage.WooShippingPredefinedOption's predefinedPackages
+    /// using the provided read-only WooShippingPredefinedOption's predefinedPackages
+    func handlePredefinedPackages(_ readOnlyOption: Networking.WooShippingPredefinedOption,
+                                  _ storageOption: Storage.WooShippingPredefinedOption,
+                                  _ storage: StorageType) {
+        // Remove all previous predefined packages, they will be deleted as they have the `cascade` delete rule
+        if let predefinedPackages = storageOption.predefinedPackages {
+            for package in predefinedPackages {
+                storageOption.removeFromPredefinedPackages(package)
+            }
+        }
+
+        // Creates and adds `storagePredefinedPackages` from `readOnlyOption.predefinedPackages`
+        let storagePredefinedPackages = readOnlyOption.predefinedPackages.map { readOnlyPackage -> Storage.WooShippingPredefinedPackage in
+            let storagePackage = storage.insertNewObject(ofType: Storage.WooShippingPredefinedPackage.self)
+            storagePackage.update(with: readOnlyPackage)
+            return storagePackage
+        }
+        for storagePredefinedPackage in storagePredefinedPackages {
+            storageOption.addToPredefinedPackages(storagePredefinedPackage)
+        }
+    }
+
+    /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's customPackages
+    /// using the provided read-only WooShippingPackagesResponse's customPackages
+    ///
+    func handleCustomPackages(_ readOnlyPackages: Networking.WooShippingPackagesResponse,
+                              _ storagePackages: Storage.WooShippingPackagesResponse,
+                              _ storage: StorageType) {
+        // Remove all previous custom packages, they will be deleted as they have the `cascade` delete rule
+        if let customPackages = storagePackages.customPackages {
+            for customPackage in customPackages {
+                storagePackages.removeFromCustomPackages(customPackage)
+            }
+        }
+
+        // Creates and adds `storageCustomPackages` from `readOnlyPackages.customPackages`
+        let storageCustomPackages = readOnlyPackages.customPackages.map { readOnlyPackage -> Storage.WooShippingCustomPackage in
+            let storagePackage = storage.insertNewObject(ofType: Storage.WooShippingCustomPackage.self)
+            storagePackage.update(with: readOnlyPackage)
+            return storagePackage
+        }
+        for storageCustomPackage in storageCustomPackages {
+            storagePackages.addToCustomPackages(storageCustomPackage)
+        }
+    }
+
+    /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's savedPredefinedPackages
+    /// using the provided read-only WooShippingPackagesResponse's savedPredefinedPackages
+    ///
+    func handleSavedPredefinedPackages(_ readOnlyPackages: Networking.WooShippingPackagesResponse,
+                                       _ storagePackages: Storage.WooShippingPackagesResponse,
+                                       _ storage: StorageType) {
+        // Remove all previous saved predefined packages, they will be deleted as they have the `cascade` delete rule
+        if let savedPredefinedPackages = storagePackages.savedPredefinedPackages {
+            for savedPackage in savedPredefinedPackages {
+                storagePackages.removeFromSavedPredefinedPackages(savedPackage)
+            }
+        }
+
+        // Creates and adds `storageSavedPredefinedPackages` from `readOnlyPackages.savedPredefinedPackages`
+        let storageSavedPredefinedPackages = readOnlyPackages.savedPredefinedPackages.map { readOnlyPackage -> Storage.WooShippingSavedPredefinedPackage in
+            let storagePackage = storage.insertNewObject(ofType: Storage.WooShippingSavedPredefinedPackage.self)
+            storagePackage.update(with: readOnlyPackage)
+            handlePredefinedPackage(readOnlyPackage, storagePackage, storage)
+            return storagePackage
+        }
+        for storageSavedPackage in storageSavedPredefinedPackages {
+            storagePackages.addToSavedPredefinedPackages(storageSavedPackage)
+        }
+    }
+
+    /// Updates or inserts the provided Storage.WooShippingSavedPredefinedPackage's package
+    /// using the provided read-only WooShippingSavedPredefinedPackage's package
+    ///
+    func handlePredefinedPackage(_ readOnlySavedPackage: Networking.WooShippingSavedPredefinedPackage,
+                                 _ storageSavedPackage: Storage.WooShippingSavedPredefinedPackage,
+                                 _ storage: StorageType) {
+        if let existingPredefinedPackage = storageSavedPackage.package {
+            existingPredefinedPackage.update(with: readOnlySavedPackage.package)
+        } else {
+            let newStoragePredefinedPackage = storage.insertNewObject(ofType: Storage.WooShippingPredefinedPackage.self)
+            newStoragePredefinedPackage.update(with: readOnlySavedPackage.package)
+            storageSavedPackage.package = newStoragePredefinedPackage
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -305,9 +305,7 @@ private extension WooShippingStore {
                                   _ storage: StorageType) {
         // Remove all previous predefined packages, they will be deleted as they have the `cascade` delete rule
         if let predefinedPackages = storageOption.predefinedPackages {
-            for package in predefinedPackages {
-                storageOption.removeFromPredefinedPackages(package)
-            }
+            storageOption.removeFromPredefinedPackages(NSSet(set: predefinedPackages))
         }
 
         // Creates and adds `storagePredefinedPackages` from `readOnlyOption.predefinedPackages`
@@ -316,9 +314,7 @@ private extension WooShippingStore {
             storagePackage.update(with: readOnlyPackage)
             return storagePackage
         }
-        for storagePredefinedPackage in storagePredefinedPackages {
-            storageOption.addToPredefinedPackages(storagePredefinedPackage)
-        }
+        storageOption.addToPredefinedPackages(NSSet(array: storagePredefinedPackages))
     }
 
     /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's customPackages
@@ -329,9 +325,7 @@ private extension WooShippingStore {
                               _ storage: StorageType) {
         // Remove all previous custom packages, they will be deleted as they have the `cascade` delete rule
         if let customPackages = storagePackages.customPackages {
-            for customPackage in customPackages {
-                storagePackages.removeFromCustomPackages(customPackage)
-            }
+            storagePackages.removeFromCustomPackages(NSSet(set: customPackages))
         }
 
         // Creates and adds `storageCustomPackages` from `readOnlyPackages.customPackages`
@@ -340,9 +334,7 @@ private extension WooShippingStore {
             storagePackage.update(with: readOnlyPackage)
             return storagePackage
         }
-        for storageCustomPackage in storageCustomPackages {
-            storagePackages.addToCustomPackages(storageCustomPackage)
-        }
+        storagePackages.addToCustomPackages(NSSet(array: storageCustomPackages))
     }
 
     /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's savedPredefinedPackages
@@ -353,9 +345,7 @@ private extension WooShippingStore {
                                        _ storage: StorageType) {
         // Remove all previous saved predefined packages, they will be deleted as they have the `cascade` delete rule
         if let savedPredefinedPackages = storagePackages.savedPredefinedPackages {
-            for savedPackage in savedPredefinedPackages {
-                storagePackages.removeFromSavedPredefinedPackages(savedPackage)
-            }
+            storagePackages.removeFromSavedPredefinedPackages(NSSet(set: savedPredefinedPackages))
         }
 
         // Creates and adds `storageSavedPredefinedPackages` from `readOnlyPackages.savedPredefinedPackages`
@@ -365,9 +355,7 @@ private extension WooShippingStore {
             handlePredefinedPackage(readOnlyPackage, storagePackage, storage)
             return storagePackage
         }
-        for storageSavedPackage in storageSavedPredefinedPackages {
-            storagePackages.addToSavedPredefinedPackages(storageSavedPackage)
-        }
+        storagePackages.addToSavedPredefinedPackages(NSSet(array: storageSavedPredefinedPackages))
     }
 
     /// Updates or inserts the provided Storage.WooShippingSavedPredefinedPackage's package
@@ -376,13 +364,9 @@ private extension WooShippingStore {
     func handlePredefinedPackage(_ readOnlySavedPackage: Networking.WooShippingSavedPredefinedPackage,
                                  _ storageSavedPackage: Storage.WooShippingSavedPredefinedPackage,
                                  _ storage: StorageType) {
-        if let existingPredefinedPackage = storageSavedPackage.package {
-            existingPredefinedPackage.update(with: readOnlySavedPackage.package)
-        } else {
-            let newStoragePredefinedPackage = storage.insertNewObject(ofType: Storage.WooShippingPredefinedPackage.self)
-            newStoragePredefinedPackage.update(with: readOnlySavedPackage.package)
-            storageSavedPackage.package = newStoragePredefinedPackage
-        }
+        let predefinedPackage = storageSavedPackage.package ?? storage.insertNewObject(ofType: Storage.WooShippingPredefinedPackage.self)
+        predefinedPackage.update(with: readOnlySavedPackage.package)
+        storageSavedPackage.package = predefinedPackage
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -154,6 +154,36 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertEqual(actualResponse, response)
     }
 
+    func test_loadPackages_when_successful_then_upserts_packages_into_storage() throws {
+        // Given
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-get-packages-success")
+
+        // Confidence check
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageWooShippingPackagesResponse.self), 0)
+
+        // When
+        let onSuccess: Bool = waitFor { promise in
+            let action = WooShippingAction.loadPackages(siteID: self.sampleSiteID) { result in
+                promise(result.isSuccess)
+            }
+            store.onAction(action)
+        }
+
+        let storedPackages = try XCTUnwrap(storageManager.viewStorage.firstObject(ofType: StorageWooShippingPackagesResponse.self)).toReadOnly()
+
+        // Then
+        XCTAssertTrue(onSuccess)
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageWooShippingPackagesResponse.self), 1)
+        XCTAssertEqual(storedPackages.siteID, sampleSiteID)
+        XCTAssertEqual(storedPackages.allPredefinedOptions.count, 2)
+        XCTAssertEqual(storedPackages.allPredefinedOptions.first?.predefinedOptions.count, 1)
+        XCTAssertEqual(storedPackages.allPredefinedOptions.first?.predefinedOptions.first?.predefinedPackages.count, 2)
+        XCTAssertEqual(storedPackages.customPackages.count, 1)
+        XCTAssertEqual(storedPackages.savedPredefinedPackages.count, 2)
+        XCTAssertTrue(storedPackages.savedPredefinedPackages.contains(where: { $0.package.id == "small_flat_box" }))
+    }
+
     func test_loadPackages_returns_error_on_failure() throws {
         // Given
         let remote = MockWooShippingRemote()
@@ -420,5 +450,13 @@ private extension WooShippingStoreTests {
                                  isPickupFree: false,
                                  deliveryDays: 7,
                                  deliveryDateGuaranteed: false)
+    }
+
+    func sampleCustomPackage() -> WooShippingCustomPackage {
+        WooShippingCustomPackage(id: "849225dc153",
+                                 name: "Custom name",
+                                 rawType: "box",
+                                 dimensions: "12 x 12 x 12",
+                                 boxWeight: 0.01)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522
⚠️ Depends on #14688 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR caches the packages response so we can fetch packages from storage during Woo Shipping label creation:

* Adds `ReadOnlyConvertible` extensions to each storage entity.
* Adds caching to `WooShippingStore`:
   * Adds helpers to upsert the packages response in storage.
   * Updates `loadPackages(siteID:completion:)` to upsert the response from remote.

Note: I considered splitting up this PR, but the `ReadOnlyConvertible` extensions are in support of the changes to `WooShippingStore`, and all of those changes are tested collectively in the new unit test in `WooShippingStoreTests`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Confirm unit tests pass. You can also confirm the packages response continues to work as expected:

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Immediately tap "Select a Package."
8. Select each tab and confirm the expected packages appear.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.