### PR TITLE
Store picker: Add edit button to show/hide sites

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -99,6 +99,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .variableProductsInPointOfSale:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .hideSitesInStorePicker:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -211,4 +211,8 @@ public enum FeatureFlag: Int {
     /// Supports variable products in POS.
     ///
     case variableProductsInPointOfSale
+
+    /// Supports hiding sites from the store picker
+    ///
+    case hideSitesInStorePicker
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -157,6 +157,13 @@ final class StorePickerViewController: UIViewController {
         self?.restartAuthentication()
     }
 
+    private lazy var editListButton: UIBarButtonItem = {
+        UIBarButtonItem(title: Localization.editListButton,
+                        style: .plain,
+                        target: self,
+                        action: #selector(editList))
+    }()
+
     private let appleIDCredentialChecker: AppleIDCredentialCheckerProtocol
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
@@ -266,6 +273,9 @@ private extension StorePickerViewController {
                                                            style: .plain,
                                                            target: self,
                                                            action: #selector(dismissStorePicker))
+        if featureFlagService.isFeatureFlagEnabled(.hideSitesInStorePicker) {
+            navigationItem.rightBarButtonItem = editListButton
+        }
     }
 
     func setupNavigationForListOfConnectedStores() {
@@ -647,6 +657,10 @@ private extension StorePickerViewController {
     @IBAction func secondaryActionWasPressed() {
         restartAuthentication()
     }
+
+    @objc func editList() {
+        // TODO
+    }
 }
 
 
@@ -816,6 +830,12 @@ private extension StorePickerViewController {
         static let addStoreButton = NSLocalizedString("storePickerViewController.addStoreButton",
                                                       value: "Connect existing store",
                                                       comment: "Button title on the store picker for store connection")
+        static let editListButton = NSLocalizedString(
+            "storePicker.editList",
+            value: "Edit",
+            comment: "Button to edit the items to be displayed on the store picker"
+        )
+
         enum ActionMenu {
             static let logOut = NSLocalizedString("Log out",
                                                   comment: "Button to log out from the current account from the store picker")

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -449,8 +449,10 @@ private extension StorePickerViewController {
             updateActionButtonAndTableState(animating: false, enabled: false)
             addStoreButton.isHidden = false
             secondaryActionButton.isHidden = true
+            editListButton.isHidden = true
         case .available(let sites):
             addStoreButton.isHidden = true
+            editListButton.isHidden = sites.filter { $0.isWooCommerceActive }.count <= 1
             if sites.allSatisfy({ $0.isWooCommerceActive == false }) {
                 updateActionButtonAndTableState(animating: false, enabled: false)
             }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -68,7 +68,7 @@ final class StorePickerViewController: UIViewController {
     ///
     private let viewModel: StorePickerViewModel
 
-    private var stateSubscription: AnyCancellable?
+    private var subscriptions: Set<AnyCancellable> = []
 
     private lazy var requirementsChecker = RequirementsChecker()
 
@@ -157,12 +157,7 @@ final class StorePickerViewController: UIViewController {
         self?.restartAuthentication()
     }
 
-    private lazy var editListButton: UIBarButtonItem = {
-        UIBarButtonItem(title: Localization.editListButton,
-                        style: .plain,
-                        target: self,
-                        action: #selector(editList))
-    }()
+    private var editListButton: UIBarButtonItem?
 
     private let appleIDCredentialChecker: AppleIDCredentialCheckerProtocol
     private let stores: StoresManager
@@ -273,9 +268,6 @@ private extension StorePickerViewController {
                                                            style: .plain,
                                                            target: self,
                                                            action: #selector(dismissStorePicker))
-        if featureFlagService.isFeatureFlagEnabled(.hideSitesInStorePicker) {
-            navigationItem.rightBarButtonItem = editListButton
-        }
     }
 
     func setupNavigationForListOfConnectedStores() {
@@ -303,12 +295,20 @@ private extension StorePickerViewController {
     }
 
     func observeStateChange() {
-        stateSubscription = viewModel.$state.sink { [weak self] _ in
+        viewModel.$state.sink { [weak self] _ in
             guard let self = self else { return }
             self.preselectStoreIfPossible()
             self.reloadInterface()
             self.updateFooterViewIfNeeded()
-        }
+        }.store(in: &subscriptions)
+
+        viewModel.$shouldEnableHidingStores.sink { [weak self] shouldEnable in
+            guard let self else { return }
+            navigationItem.rightBarButtonItem = !shouldEnable ? nil : UIBarButtonItem(title: Localization.editListButton,
+                                                                                      style: .plain,
+                                                                                      target: self,
+                                                                                      action: #selector(editList))
+        }.store(in: &subscriptions)
     }
 
     func backgroundColor() -> UIColor {
@@ -449,10 +449,8 @@ private extension StorePickerViewController {
             updateActionButtonAndTableState(animating: false, enabled: false)
             addStoreButton.isHidden = false
             secondaryActionButton.isHidden = true
-            editListButton.isHidden = true
         case .available(let sites):
             addStoreButton.isHidden = true
-            editListButton.isHidden = sites.filter { $0.isWooCommerceActive }.count <= 1
             if sites.allSatisfy({ $0.isWooCommerceActive == false }) {
                 updateActionButtonAndTableState(animating: false, enabled: false)
             }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -157,8 +157,6 @@ final class StorePickerViewController: UIViewController {
         self?.restartAuthentication()
     }
 
-    private var editListButton: UIBarButtonItem?
-
     private let appleIDCredentialChecker: AppleIDCredentialCheckerProtocol
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Experiments
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics
@@ -9,6 +10,8 @@ final class StorePickerViewModel {
     /// Represents the internal StorePicker State
     ///
     @Published private(set) var state: StorePickerState = .empty
+
+    @Published private(set) var shouldEnableHidingStores = false
 
     /// ResultsController: Loads Sites from the Storage Layer.
     ///
@@ -27,14 +30,17 @@ final class StorePickerViewModel {
     private let stores: StoresManager
     private let analytics: Analytics
     private let roleEligibilityUseCase: RoleEligibilityUseCase
+    private let featureFlagService: FeatureFlagService
 
     init(configuration: StorePickerConfiguration,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          analytics: Analytics = ServiceLocator.analytics) {
         self.configuration = configuration
         self.stores = stores
         self.storageManager = storageManager
+        self.featureFlagService = featureFlagService
         self.analytics = analytics
         self.roleEligibilityUseCase = RoleEligibilityUseCase(stores: stores)
     }
@@ -85,9 +91,20 @@ private extension StorePickerViewModel {
         do {
             try resultsController.performFetch()
             state = StorePickerState(sites: resultsController.fetchedObjects)
+            updateEditButton()
         } catch {
             DDLogError("⛔️ Unable to re-fetch sites and update state: \(error)")
         }
+    }
+
+    func updateEditButton() {
+        shouldEnableHidingStores = {
+            guard featureFlagService.isFeatureFlagEnabled(.hideSitesInStorePicker),
+                  configuration == .switchingStores else {
+                return false
+            }
+            return resultsController.fetchedObjects.filter { $0.isWooCommerceActive }.count > 1
+        }()
     }
 
     func synchronizeSites(selectedSiteID: Int64?, onCompletion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -90,14 +90,14 @@ private extension StorePickerViewModel {
     func refetchSitesAndUpdateState() {
         do {
             try resultsController.performFetch()
+            checkIfHidingStoresShouldBeEnabled()
             state = StorePickerState(sites: resultsController.fetchedObjects)
-            updateEditButton()
         } catch {
             DDLogError("⛔️ Unable to re-fetch sites and update state: \(error)")
         }
     }
 
-    func updateEditButton() {
+    func checkIfHidingStoresShouldBeEnabled() {
         shouldEnableHidingStores = {
             guard featureFlagService.isFeatureFlagEnabled(.hideSitesInStorePicker),
                   configuration == .switchingStores else {

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
@@ -177,6 +177,124 @@ final class StorePickerViewModelTests: XCTestCase {
         XCTAssertEqual(properties["num_of_stores"] as? Int, 2)
         XCTAssertEqual(properties["num_of_non_woo_sites"] as? Int, 1)
     }
+
+    @MainActor
+    func test_shouldEnableHidingStores_returns_false_if_feature_flag_is_disabled() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(hideSitesInStorePicker: false)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        let viewModel = StorePickerViewModel(configuration: .switchingStores,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             featureFlagService: featureFlagService)
+
+        // When
+        await viewModel.refreshSites(currentlySelectedSiteID: nil)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldEnableHidingStores)
+    }
+
+    @MainActor
+    func test_shouldEnableHidingStores_returns_false_if_configuration_is_not_switchingStores() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(hideSitesInStorePicker: true)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        let viewModel = StorePickerViewModel(configuration: .standard,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             featureFlagService: featureFlagService)
+
+        // When
+        await viewModel.refreshSites(currentlySelectedSiteID: nil)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldEnableHidingStores)
+    }
+
+    @MainActor
+    func test_shouldEnableHidingStores_returns_false_if_there_is_only_one_fetched_store() async {
+        // Given
+        let testSite1 = Site.fake().copy(siteID: 123, name: "abc", isWooCommerceActive: true)
+        storageManager.insertSampleSite(readOnlySite: testSite1)
+
+        let featureFlagService = MockFeatureFlagService(hideSitesInStorePicker: true)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        let viewModel = StorePickerViewModel(configuration: .switchingStores,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             featureFlagService: featureFlagService)
+
+        // When
+        await viewModel.refreshSites(currentlySelectedSiteID: nil)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldEnableHidingStores)
+    }
+
+    @MainActor
+    func test_shouldEnableHidingStores_returns_true_with_enabled_feature_flag_and_switchingStore_config_and_more_than_one_fetched_store() async {
+        // Given
+        let testSite1 = Site.fake().copy(siteID: 123, name: "abc", isWooCommerceActive: true)
+        let testSite2 = Site.fake().copy(siteID: 124, name: "def", isWooCommerceActive: true)
+        let testSite3 = Site.fake().copy(siteID: 055, name: "hello", isWooCommerceActive: false)
+        storageManager.insertSampleSite(readOnlySite: testSite1)
+        storageManager.insertSampleSite(readOnlySite: testSite2)
+        storageManager.insertSampleSite(readOnlySite: testSite3)
+
+        let featureFlagService = MockFeatureFlagService(hideSitesInStorePicker: true)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        let viewModel = StorePickerViewModel(configuration: .switchingStores,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             featureFlagService: featureFlagService)
+
+        // When
+        await viewModel.refreshSites(currentlySelectedSiteID: nil)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldEnableHidingStores)
+    }
 }
 
 private extension StorePickerViewModelTests {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -27,6 +27,7 @@ final class MockFeatureFlagService: FeatureFlagService {
     var isSendReceiptAfterPaymentEnabled: Bool
     var tapToPayEducation: Bool
     var receiptsForPOS: Bool
+    var hideSitesInStorePicker: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -52,7 +53,8 @@ final class MockFeatureFlagService: FeatureFlagService {
          isProductGlobalUniqueIdentifierSupported: Bool = false,
          isSendReceiptAfterPaymentEnabled: Bool = false,
          tapToPayEducation: Bool = false,
-         receiptsForPOS: Bool = false) {
+         receiptsForPOS: Bool = false,
+         hideSitesInStorePicker: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -78,6 +80,7 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.isSendReceiptAfterPaymentEnabled = isSendReceiptAfterPaymentEnabled
         self.tapToPayEducation = tapToPayEducation
         self.receiptsForPOS = receiptsForPOS
+        self.hideSitesInStorePicker = hideSitesInStorePicker
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -132,6 +135,8 @@ final class MockFeatureFlagService: FeatureFlagService {
             return tapToPayEducation
         case .sendReceiptsForPointOfSale:
             return receiptsForPOS
+        case .hideSitesInStorePicker:
+            return hideSitesInStorePicker
         default:
             return false
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14658
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new feature flag for hiding sites in the store picker. A new button "Edit" has also been added to the top left of the screen when the feature flag is enabled.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Enable the feature flag `hideSitesInStorePicker` and build the app.
- Log in to a store and select the Menu tab.
- Open the store picker and confirm that the Edit button is available on the top right. The action for the button will be handled in a future PR.
- Disable the feature flag `hideSitesInStorePicker` and rebuild the app.
- Select the store picker again and ensure that the Edit button is no longer available.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.1 and confirm that the new Edit button is available only when the feature flag `hideSitesInStorePicker` is enabled.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/888dbc4e-51fb-45f5-8cab-4f9a19be2e8e" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
