### PR TITLE
[Woo POS] [Cash & Receipts] Enable receipts M1 flag. Add cash M2 flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -94,7 +94,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .sendReceiptAfterPayment:
             return false
         case .sendReceiptsForPointOfSale:
-            return false
+            return true
         case .tapToPayEducation:
             return false
         case .variableProductsInPointOfSale:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,6 +95,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .sendReceiptsForPointOfSale:
             return true
+        case .acceptCashForPointOfSale:
+            return false
         case .tapToPayEducation:
             return false
         case .variableProductsInPointOfSale:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -204,6 +204,10 @@ public enum FeatureFlag: Int {
     ///
     case sendReceiptsForPointOfSale
 
+    /// Adds support for  accepting cash as payment for POS
+    ///
+    case acceptCashForPointOfSale
+
     /// Enables new Tap to Pay onboarding and education features
     ///
     case tapToPayEducation


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14676 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR enables `.sendReceiptsForPointOfSale` (cash & receipts M1) flag, and adds a new `.acceptCashForPointOfSale` (cash & receipts M2)

## Testing
- Switch the build configuration to `release`
- In release, the POS row will only show for whitelisted accounts, if you're testing under a non-whitelisted account you can switch `.pointOfSale` to true for testing easiness.
- Go through a successful POS transaction. Observe that the `Email receipt` button is rendered along the rest of elements:

![simulator_screenshot_CC8F2490-40A2-4008-A537-34FAA2CC7145](https://github.com/user-attachments/assets/dee64dc2-c59d-4f8f-b6f1-b567e6dbd2a7)

There are no functional changes to the underlying receipts functionality, feel free to test further or not 🙇 


<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
