### PR TITLE
Store Picker: Add UI for new screen to edit store list

### DIFF
--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a WordPress.com Site.
 ///
-public struct Site: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, GeneratedCopiable {
 
     /// WordPress.com Site Identifier.
     ///

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -45,26 +45,51 @@ struct EditStoreListView: View {
                         .disabled(viewModel.isLastSelected(item))
                     }
                 } footer: {
-                    Text("Stores that are not selected will be excluded from the store picker")
+                    Text(Localization.listFooter)
                 }
             }
             .listStyle(.grouped)
-            .navigationTitle("Visible Stores")
+            .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
+                    Button(Localization.cancelButton) {
                         onDismiss()
                     }
                 }
 
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
+                    Button(Localization.saveButton) {
                         viewModel.didSaveChanges()
                     }
                     .disabled(viewModel.hasChanges == false)
                 }
             }
         }
+    }
+}
+
+private extension EditStoreListView {
+    enum Localization {
+        static let listFooter = NSLocalizedString(
+            "editStoreListView.listFooter",
+            value: "Stores that are not selected will be excluded from the store picker",
+            comment: "Label at the end of the Edit Store List view"
+        )
+        static let cancelButton = NSLocalizedString(
+            "editStoreListView.cancelButton",
+            value: "Cancel",
+            comment: "Button to dismiss the Edit Store List view"
+        )
+        static let saveButton = NSLocalizedString(
+            "editStoreListView.saveButton",
+            value: "Save",
+            comment: "Button to save changes in the Edit Store List view"
+        )
+        static let title = NSLocalizedString(
+            "editStoreListView.title",
+            value: "Visible Stores",
+            comment: "Title of the Edit Store List view"
+        )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -3,8 +3,50 @@ import SwiftUI
 /// View to edit the items to be displayed on the store picker
 ///
 struct EditStoreListView: View {
+    @ObservedObject var viewModel: EditStoreListViewModel
+
+    private let onDismiss: () -> Void
+
+    init(viewModel: EditStoreListViewModel, onDismiss: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.onDismiss = onDismiss
+    }
+
     var body: some View {
-        EmptyView()
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(viewModel.availableSites, id: \.siteID) { item in
+                        SelectableItemRow(title: item.name,
+                                          subtitle: item.url,
+                                          selected: viewModel.isSelected(item),
+                                          displayMode: .full,
+                                          selectionStyle: .checkcircle)
+                        .listRowInsets(.zero)
+                        .onTapGesture {
+                            viewModel.toggleSelection(item)
+                        }
+                        .disabled(viewModel.isLastSelected(item))
+                    }
+                } footer: {
+                    Text("Stores that are not selected will be excluded from the store picker")
+                }
+                
+            }
+            .listStyle(.plain)
+            .navigationTitle("Visible Stores")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Cancel") {
+                        onDismiss()
+                    }
+
+                    Button("Save") {
+                        viewModel.didSaveChanges()
+                    }
+                    .disabled(viewModel.hasChanges == false)
+                }
+            }
+        }
     }
 }
-

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -1,15 +1,30 @@
 import SwiftUI
 
+/// Hosting controller for `EditStoreListView`
+///
+final class EditStoreListViewController: UIHostingController<EditStoreListView> {
+    init(viewModel: EditStoreListViewModel) {
+        super.init(rootView: EditStoreListView(viewModel: viewModel))
+        rootView.onDismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+    }
+
+    @MainActor @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// View to edit the items to be displayed on the store picker
 ///
 struct EditStoreListView: View {
     @ObservedObject var viewModel: EditStoreListViewModel
 
-    private let onDismiss: () -> Void
+    /// To be set externally in the hosting controller
+    var onDismiss: () -> Void = {}
 
-    init(viewModel: EditStoreListViewModel, onDismiss: @escaping () -> Void) {
+    init(viewModel: EditStoreListViewModel) {
         self.viewModel = viewModel
-        self.onDismiss = onDismiss
     }
 
     var body: some View {
@@ -20,7 +35,7 @@ struct EditStoreListView: View {
                         SelectableItemRow(title: item.name,
                                           subtitle: item.url,
                                           selected: viewModel.isSelected(item),
-                                          displayMode: .full,
+                                          displayMode: .compact,
                                           selectionStyle: .checkcircle)
                         .listRowInsets(.zero)
                         .onTapGesture {
@@ -31,16 +46,18 @@ struct EditStoreListView: View {
                 } footer: {
                     Text("Stores that are not selected will be excluded from the store picker")
                 }
-                
             }
             .listStyle(.plain)
             .navigationTitle("Visible Stores")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
                         onDismiss()
                     }
+                }
 
+                ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
                         viewModel.didSaveChanges()
                     }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+/// View to edit the items to be displayed on the store picker
+///
+struct EditStoreListView: View {
+    var body: some View {
+        EmptyView()
+    }
+}
+

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -36,6 +36,7 @@ struct EditStoreListView: View {
                                           subtitle: item.url,
                                           selected: viewModel.isSelected(item),
                                           displayMode: .compact,
+                                          verticalSpacing: 0,
                                           selectionStyle: .checkcircle)
                         .listRowInsets(.zero)
                         .onTapGesture {
@@ -47,7 +48,7 @@ struct EditStoreListView: View {
                     Text("Stores that are not selected will be excluded from the store picker")
                 }
             }
-            .listStyle(.plain)
+            .listStyle(.grouped)
             .navigationTitle("Visible Stores")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -30,6 +30,22 @@ struct EditStoreListView: View {
     var body: some View {
         NavigationStack {
             List {
+                if let site = viewModel.currentlySelectedSite {
+                    Section {
+                        VStack(alignment: .leading) {
+                            Text(site.name)
+                                .bodyStyle()
+                            Text(site.url)
+                                .footnoteStyle()
+                        }
+                        .multilineTextAlignment(.leading)
+                    } header: {
+                        Text(Localization.currentStoreHeader)
+                    } footer: {
+                        Text(Localization.currentStoreFooter)
+                    }
+                }
+
                 Section {
                     ForEach(viewModel.availableSites, id: \.siteID) { item in
                         SelectableItemRow(title: item.name,
@@ -44,8 +60,10 @@ struct EditStoreListView: View {
                         }
                         .disabled(viewModel.isLastSelected(item))
                     }
+                } header: {
+                    Text(Localization.otherStoresHeader)
                 } footer: {
-                    Text(Localization.listFooter)
+                    Text(Localization.otherStoresFooter)
                 }
             }
             .listStyle(.grouped)
@@ -71,11 +89,6 @@ struct EditStoreListView: View {
 
 private extension EditStoreListView {
     enum Localization {
-        static let listFooter = NSLocalizedString(
-            "editStoreListView.listFooter",
-            value: "Stores that are not selected will be excluded from the store picker",
-            comment: "Label at the end of the Edit Store List view"
-        )
         static let cancelButton = NSLocalizedString(
             "editStoreListView.cancelButton",
             value: "Cancel",
@@ -90,6 +103,26 @@ private extension EditStoreListView {
             "editStoreListView.title",
             value: "Visible Stores",
             comment: "Title of the Edit Store List view"
+        )
+        static let currentStoreHeader = NSLocalizedString(
+            "editStoreListView.currentStoreHeader",
+            value: "Current store",
+            comment: "Header of the Current Store section of the the Edit Store List view"
+        )
+        static let currentStoreFooter = NSLocalizedString(
+            "editStoreListView.currentStoreFooter",
+            value: "Please switch to another store before hiding this store",
+            comment: "Footer of the Current Store section of the the Edit Store List view"
+        )
+        static let otherStoresHeader = NSLocalizedString(
+            "editStoreListView.otherStoresHeader",
+            value: "Other stores",
+            comment: "Header of the Other Stores section on the Edit Store List view"
+        )
+        static let otherStoresFooter = NSLocalizedString(
+            "editStoreListView.otherStoresFooter",
+            value: "Stores that are not selected will be excluded from the store picker",
+            comment: "Footer of the Other Stores section on the Edit Store List view"
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Yosemite
+import protocol WooFoundation.Analytics
+
+/// View model for `EditStoreListView`
+///
+final class EditStoreListViewModel: ObservableObject {
+    /// All available sites to be displayed on the store picker
+    let availableSites: [Site]
+
+    /// Sites selected to be displayed on the store picker
+    @Published var selectedSites: [Site]
+
+    private let analytics: Analytics
+    private let onCompletion: (_ selectedSites: [Site]) -> Void
+
+    init(availableSites: [Site],
+         selectedSites: [Site],
+         analytics: Analytics = ServiceLocator.analytics,
+         onCompletion: @escaping (_ selectedSites: [Site]) -> Void) {
+        self.availableSites = availableSites
+        self.selectedSites = selectedSites
+        self.analytics = analytics
+        self.onCompletion = onCompletion
+    }
+
+    func didSaveChanges() {
+        onCompletion(selectedSites)
+    }
+}
+

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -9,28 +9,52 @@ final class EditStoreListViewModel: ObservableObject {
     let availableSites: [Site]
 
     /// Sites selected to be displayed on the store picker
-    @Published var selectedSites: [Site]
+    @Published var selectedSites: Set<Site>
 
     var hasChanges: Bool {
-        Set(selectedSites) != Set(originalSelectedSites)
+        selectedSites != Set(originalSelectedSites)
     }
 
     private let originalSelectedSites: [Site]
     private let analytics: Analytics
-    private let onCompletion: (_ selectedSites: [Site]) -> Void
+    private let onCompletion: (_ selectedSites: Set<Site>) -> Void
 
     init(availableSites: [Site],
          selectedSites: [Site],
          analytics: Analytics = ServiceLocator.analytics,
-         onCompletion: @escaping (_ selectedSites: [Site]) -> Void) {
+         onCompletion: @escaping (_ selectedSites: Set<Site>) -> Void) {
         self.availableSites = availableSites
         self.originalSelectedSites = selectedSites
-        self.selectedSites = selectedSites
+        self.selectedSites = Set(selectedSites)
         self.analytics = analytics
         self.onCompletion = onCompletion
     }
 
     func didSaveChanges() {
         onCompletion(selectedSites)
+    }
+}
+
+// MARK: - Helper methods for selection
+extension EditStoreListViewModel {
+
+    /// Checks if the given site is selected.
+    func isSelected(_ site: Site) -> Bool {
+        selectedSites.contains(site)
+    }
+
+    /// Checks if the given site is the last selected item.
+    /// This is used to disable that row, so it can't be deselected.
+    func isLastSelected(_ site: Site) -> Bool {
+        isSelected(site) && selectedSites.count == 1
+    }
+
+    /// Selects or deselects the given site.
+    func toggleSelection(_ site: Site) {
+        if selectedSites.contains(site) {
+            selectedSites.remove(site)
+        } else {
+            selectedSites.insert(site)
+        }
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -11,6 +11,11 @@ final class EditStoreListViewModel: ObservableObject {
     /// Sites selected to be displayed on the store picker
     @Published var selectedSites: [Site]
 
+    var hasChanges: Bool {
+        Set(selectedSites) != Set(originalSelectedSites)
+    }
+
+    private let originalSelectedSites: [Site]
     private let analytics: Analytics
     private let onCompletion: (_ selectedSites: [Site]) -> Void
 
@@ -19,6 +24,7 @@ final class EditStoreListViewModel: ObservableObject {
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping (_ selectedSites: [Site]) -> Void) {
         self.availableSites = availableSites
+        self.originalSelectedSites = selectedSites
         self.selectedSites = selectedSites
         self.analytics = analytics
         self.onCompletion = onCompletion
@@ -28,4 +34,3 @@ final class EditStoreListViewModel: ObservableObject {
         onCompletion(selectedSites)
     }
 }
-

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -8,6 +8,8 @@ final class EditStoreListViewModel: ObservableObject {
     /// All available sites to be displayed on the store picker
     let availableSites: [Site]
 
+    let currentlySelectedSite: Site?
+
     /// Sites selected to be displayed on the store picker
     @Published var selectedSites: Set<Site>
 
@@ -17,21 +19,23 @@ final class EditStoreListViewModel: ObservableObject {
 
     private let originalSelectedSites: [Site]
     private let analytics: Analytics
-    private let onCompletion: (_ selectedSites: Set<Site>) -> Void
+    private let onCompletion: () -> Void
 
     init(availableSites: [Site],
-         selectedSites: [Site],
+         displayedSites: [Site],
+         currentlySelectedSite: Site?,
          analytics: Analytics = ServiceLocator.analytics,
-         onCompletion: @escaping (_ selectedSites: Set<Site>) -> Void) {
-        self.availableSites = availableSites
-        self.originalSelectedSites = selectedSites
-        self.selectedSites = Set(selectedSites)
+         onCompletion: @escaping () -> Void) {
+        self.availableSites = availableSites.filter { $0.siteID != currentlySelectedSite?.siteID }
+        self.currentlySelectedSite = currentlySelectedSite
+        self.originalSelectedSites = displayedSites
+        self.selectedSites = Set(displayedSites)
         self.analytics = analytics
         self.onCompletion = onCompletion
     }
 
     func didSaveChanges() {
-        onCompletion(selectedSites)
+        onCompletion()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -660,8 +660,9 @@ private extension StorePickerViewController {
 
     @objc func editList() {
         if case let .available(sites) = viewModel.state {
-            let viewModel = EditStoreListViewModel(availableSites: sites, selectedSites: sites, onCompletion: { selectedSites in
+            let viewModel = EditStoreListViewModel(availableSites: sites, selectedSites: sites, onCompletion: { [weak self] selectedSites in
                 // TODO
+                self?.presentedViewController?.dismiss(animated: true)
             })
             let viewController = EditStoreListViewController(viewModel: viewModel)
             present(viewController, animated: true)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -659,7 +659,13 @@ private extension StorePickerViewController {
     }
 
     @objc func editList() {
-        // TODO
+        if case let .available(sites) = viewModel.state {
+            let viewModel = EditStoreListViewModel(availableSites: sites, selectedSites: sites, onCompletion: { selectedSites in
+                // TODO
+            })
+            let viewController = EditStoreListViewController(viewModel: viewModel)
+            present(viewController, animated: true)
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -662,7 +662,10 @@ private extension StorePickerViewController {
 
     @objc func editList() {
         if case let .available(sites) = viewModel.state {
-            let viewModel = EditStoreListViewModel(availableSites: sites, selectedSites: sites, onCompletion: { [weak self] selectedSites in
+            let viewModel = EditStoreListViewModel(availableSites: sites,
+                                                   displayedSites: sites,
+                                                   currentlySelectedSite: currentlySelectedSite,
+                                                   onCompletion: { [weak self] in
                 // TODO
                 self?.presentedViewController?.dismiss(animated: true)
             })

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
@@ -7,6 +7,7 @@ struct SelectableItemRow: View {
     private let selected: Bool
     private let displayMode: DisplayMode
     private let alignment: Alignment
+    private let verticalSpacing: CGFloat
     private let selectionStyle: SelectionStyle
     @Environment(\.isEnabled) private var isEnabled
 
@@ -15,12 +16,14 @@ struct SelectableItemRow: View {
          selected: Bool,
          displayMode: DisplayMode = .full,
          alignment: Alignment = .leading,
+         verticalSpacing: CGFloat = 16,
          selectionStyle: SelectionStyle = .checkmark) {
         self.title = title
         self.subtitle = subtitle
         self.selected = selected
         self.displayMode = displayMode
         self.alignment = alignment
+        self.verticalSpacing = verticalSpacing
         self.selectionStyle = selectionStyle
     }
     var body: some View {
@@ -29,14 +32,13 @@ struct SelectableItemRow: View {
                 selectionIcon
             }
 
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: verticalSpacing) {
                 Text(title)
                     .bodyStyle(isEnabled)
                     .multilineTextAlignment(.leading)
                 subtitle.map {
                     Text($0)
                         .footnoteStyle(isEnabled: isEnabled)
-                        .padding(.top, 8)
                 }
             }
             .padding(.leading, alignment.leadingSpace)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2774,6 +2774,7 @@
 		DEE183F1292E0ED0008818AB /* JetpackSetupInterruptedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */; };
 		DEE2152D2D113EF1004A11F3 /* EditStoreListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */; };
 		DEE215302D113F89004A11F3 /* EditStoreListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */; };
+		DEE215322D116FBB004A11F3 /* EditStoreListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE215312D116FBB004A11F3 /* EditStoreListViewModelTests.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */; };
@@ -5890,6 +5891,7 @@
 		DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupInterruptedView.swift; sourceTree = "<group>"; };
 		DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListView.swift; sourceTree = "<group>"; };
 		DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListViewModel.swift; sourceTree = "<group>"; };
+		DEE215312D116FBB004A11F3 /* EditStoreListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListViewModelTests.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginUseCase.swift; sourceTree = "<group>"; };
@@ -9416,6 +9418,7 @@
 				DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */,
 				DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */,
 				DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */,
+				DEE215312D116FBB004A11F3 /* EditStoreListViewModelTests.swift */,
 				DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */,
 				DE50295228BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift */,
 				020D0BFC2914E92800BB3DCE /* StorePickerCoordinatorTests.swift */,
@@ -17037,6 +17040,7 @@
 				31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */,
 				86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */,
 				CC3B35DF28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift in Sources */,
+				DEE215322D116FBB004A11F3 /* EditStoreListViewModelTests.swift in Sources */,
 				DE4D23A029B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift in Sources */,
 				02F5F80E246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift in Sources */,
 				021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2772,6 +2772,7 @@
 		DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */; };
 		DEE183ED292BD900008818AB /* JetpackSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */; };
 		DEE183F1292E0ED0008818AB /* JetpackSetupInterruptedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */; };
+		DEE2152D2D113EF1004A11F3 /* EditStoreListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */; };
@@ -5886,6 +5887,7 @@
 		DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageAttributes.swift; sourceTree = "<group>"; };
 		DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupViewModelTests.swift; sourceTree = "<group>"; };
 		DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupInterruptedView.swift; sourceTree = "<group>"; };
+		DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListView.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginUseCase.swift; sourceTree = "<group>"; };
@@ -10701,6 +10703,7 @@
 		B5D1AFC420BC7B3000DB0E8C /* Epilogue */ = {
 			isa = PBXGroup;
 			children = (
+				DEE2152E2D113F61004A11F3 /* EditStoreList */,
 				B57C743C20F5493300EEFC87 /* AccountHeaderView.swift */,
 				B57C744220F54F1C00EEFC87 /* AccountHeaderView.xib */,
 				B57C744920F5649300EEFC87 /* EmptyStoresTableViewCell.swift */,
@@ -13180,6 +13183,14 @@
 				DEDA8DBD2B19952B0076BF0F /* ThemeSettingViewModel.swift */,
 			);
 			path = Themes;
+			sourceTree = "<group>";
+		};
+		DEE2152E2D113F61004A11F3 /* EditStoreList */ = {
+			isa = PBXGroup;
+			children = (
+				DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */,
+			);
+			path = EditStoreList;
 			sourceTree = "<group>";
 		};
 		DEE4BBCA27FED9390002C818 /* ProductListSelector */ = {
@@ -16509,6 +16520,7 @@
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */,
 				458BAC6E2C57CDA6009440EA /* ProductPasswordEligibilityUseCase.swift in Sources */,
+				DEE2152D2D113EF1004A11F3 /* EditStoreListView.swift in Sources */,
 				0388E1A829E04687007DF84D /* DeepLinkNavigator.swift in Sources */,
 				B6A10E9C292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2773,6 +2773,7 @@
 		DEE183ED292BD900008818AB /* JetpackSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */; };
 		DEE183F1292E0ED0008818AB /* JetpackSetupInterruptedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */; };
 		DEE2152D2D113EF1004A11F3 /* EditStoreListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */; };
+		DEE215302D113F89004A11F3 /* EditStoreListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */; };
@@ -5888,6 +5889,7 @@
 		DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupViewModelTests.swift; sourceTree = "<group>"; };
 		DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupInterruptedView.swift; sourceTree = "<group>"; };
 		DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListView.swift; sourceTree = "<group>"; };
+		DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListViewModel.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginUseCase.swift; sourceTree = "<group>"; };
@@ -13188,6 +13190,7 @@
 		DEE2152E2D113F61004A11F3 /* EditStoreList */ = {
 			isa = PBXGroup;
 			children = (
+				DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */,
 				DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */,
 			);
 			path = EditStoreList;
@@ -15082,6 +15085,7 @@
 				CC13C0CB278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift in Sources */,
 				020732042988AB7B000A53C2 /* DomainContactInfoForm.swift in Sources */,
 				026826AD2BF59DF70036F959 /* PointOfSaleDashboardView.swift in Sources */,
+				DEE215302D113F89004A11F3 /* EditStoreListViewModel.swift in Sources */,
 				DE2FE595292737330018040A /* JetpackSetupView.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import struct Yosemite.Site
+@testable import WooCommerce
+
+struct EditStoreListViewModelTests {
+    // Given
+    private let site1 = Site.fake().copy(siteID: 123)
+    private let site2 = Site.fake().copy(siteID: 135)
+    
+
+    @Test func hasChanges_returns_correct_values() {
+        // Given
+        let availableSites = [site1, site2]
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               selectedSites: [site1, site2],
+                                               onCompletion: { _ in })
+
+        // Then
+        #expect(viewModel.hasChanges == false)
+
+        // When
+        viewModel.selectedSites = Set([site1])
+
+        // Then
+        #expect(viewModel.hasChanges == true)
+    }
+
+    @Test func isSelected_returns_correct_values() {
+        // Given
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               selectedSites: [site1, site2],
+                                               onCompletion: { _ in })
+
+        // Then
+        #expect(viewModel.isSelected(site1) == true)
+        #expect(viewModel.isSelected(site2) == true)
+
+        // When
+        viewModel.selectedSites = Set([site1])
+
+        // Then
+        #expect(viewModel.isSelected(site1) == true)
+        #expect(viewModel.isSelected(site2) == false)
+    }
+
+    @Test func isLastSelected_returns_correct_values() {
+        // Given
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               selectedSites: [site1, site2],
+                                               onCompletion: { _ in })
+
+        // Then
+        #expect(viewModel.isLastSelected(site1) == false)
+
+        // When
+        viewModel.selectedSites = Set([site1])
+
+        // Then
+        #expect(viewModel.isLastSelected(site1) == true)
+    }
+
+    @Test func toggleSelection_works_correctly() {
+        // Given
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               selectedSites: [site1, site2],
+                                               onCompletion: { _ in })
+
+        // When
+        viewModel.toggleSelection(site1)
+
+        // Then
+        #expect(viewModel.selectedSites.contains(site1) == false)
+
+        // When
+        viewModel.toggleSelection(site1)
+
+        // Then
+        #expect(viewModel.selectedSites.contains(site1) == true)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -6,7 +6,6 @@ struct EditStoreListViewModelTests {
     // Given
     private let site1 = Site.fake().copy(siteID: 123)
     private let site2 = Site.fake().copy(siteID: 135)
-    
 
     @Test func hasChanges_returns_correct_values() {
         // Given

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -11,8 +11,9 @@ struct EditStoreListViewModelTests {
         // Given
         let availableSites = [site1, site2]
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // Then
         #expect(viewModel.hasChanges == false)
@@ -27,8 +28,9 @@ struct EditStoreListViewModelTests {
     @Test func isSelected_returns_correct_values() {
         // Given
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // Then
         #expect(viewModel.isSelected(site1) == true)
@@ -45,8 +47,9 @@ struct EditStoreListViewModelTests {
     @Test func isLastSelected_returns_correct_values() {
         // Given
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // Then
         #expect(viewModel.isLastSelected(site1) == false)
@@ -61,8 +64,9 @@ struct EditStoreListViewModelTests {
     @Test func toggleSelection_works_correctly() {
         // Given
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // When
         viewModel.toggleSelection(site1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14658 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the UI for the Edit Store List view. The UI follows the mockup in #14658 but I updated the layout a bit to better match the iOS platform style.

The actual logic for saving selections will be handled in a future PR. 


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Enable the feature flag `hideSitesInStorePicker` and build the app.
- Log in to a test store and navigate to the menu tab.
- Select Edit on the top right.
- Confirm that a new screen is presented with the list of all stores and checkboxes to select stores to display except for the currently selected store. 
- Tap Save or Dismiss and confirm that the screen is dismissed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 16 Pro and iPad Mini iOS 18.1 in light and dark mode and confirmed that the layout looks good.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
iPhone | iPad
--- | ---
<img src="https://github.com/user-attachments/assets/67c27066-428a-4020-927f-f033180c6399" width=320 /> | <img src="https://github.com/user-attachments/assets/cd3f7cce-04e7-4bb8-a81d-b1ea197f3b68" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.