### PR TITLE
[Shipping labels] Upsert create packages response after saving packages remotely

### DIFF
--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -320,6 +320,11 @@ public typealias FeatureAnnouncementCampaignSettings = Storage.FeatureAnnounceme
 public typealias AnalyticsCard = Storage.AnalyticsCard
 public typealias DashboardCard = Storage.DashboardCard
 public typealias StorageWooShippingPackagesResponse = Storage.WooShippingPackagesResponse
+public typealias StorageWooShippingCarrierPredefinedOptions = Storage.WooShippingCarrierPredefinedOptions
+public typealias StorageWooShippingPredefinedOption = Storage.WooShippingPredefinedOption
+public typealias StorageWooShippingPredefinedPackage = Storage.WooShippingPredefinedPackage
+public typealias StorageWooShippingCustomPackage = Storage.WooShippingCustomPackage
+public typealias StorageWooShippingSavedPredefinedPackage = Storage.WooShippingSavedPredefinedPackage
 
 // MARK: - Internal ReadOnly Models
 

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -253,8 +253,22 @@ private extension WooShippingStore {
 
         storagePackages.update(with: readOnlyPackages)
         handleAllPredefinedOptions(readOnlyPackages, storagePackages, storage)
-        handleCustomPackages(readOnlyPackages, storagePackages, storage)
+        handleCustomPackages(readOnlyPackages.customPackages, storagePackages, storage)
         handleSavedPredefinedPackages(readOnlyPackages, storagePackages, storage)
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly `WooShippingCreatePackageResponse` Entities into the Storage Layer.
+    ///
+    /// - Parameters:
+    ///     - readOnlyPackages: Remote `WooShippingCreatePackageResponse` to be persisted.
+    ///     - siteID: Site ID to be associated with the packages.
+    ///     - storage: Where we should save all the things!
+    ///
+    func upsertCreatePackageResponse(readOnlyPackages: Networking.WooShippingCreatePackageResponse, siteID: Int64, in storage: StorageType) {
+        let storagePackages = storage.loadPackages(siteID: siteID) ?? storage.insertNewObject(ofType: Storage.WooShippingPackagesResponse.self)
+        storagePackages.siteID = siteID
+
+        handleCustomPackages(readOnlyPackages.customPackages, storagePackages, storage)
     }
 
     /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's allPredefinedOptions
@@ -318,9 +332,9 @@ private extension WooShippingStore {
     }
 
     /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's customPackages
-    /// using the provided read-only WooShippingPackagesResponse's customPackages
+    /// using the provided read-only WooShippingCustomPackages
     ///
-    func handleCustomPackages(_ readOnlyPackages: Networking.WooShippingPackagesResponse,
+    func handleCustomPackages(_ readOnlyCustomPackages: [Networking.WooShippingCustomPackage],
                               _ storagePackages: Storage.WooShippingPackagesResponse,
                               _ storage: StorageType) {
         // Remove all previous custom packages, they will be deleted as they have the `cascade` delete rule
@@ -329,7 +343,7 @@ private extension WooShippingStore {
         }
 
         // Creates and adds `storageCustomPackages` from `readOnlyPackages.customPackages`
-        let storageCustomPackages = readOnlyPackages.customPackages.map { readOnlyPackage -> Storage.WooShippingCustomPackage in
+        let storageCustomPackages = readOnlyCustomPackages.map { readOnlyPackage -> Storage.WooShippingCustomPackage in
             let storagePackage = storage.insertNewObject(ofType: Storage.WooShippingCustomPackage.self)
             storagePackage.update(with: readOnlyPackage)
             return storagePackage

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -72,10 +72,12 @@ private extension WooShippingStore {
                        customPackage: WooShippingCustomPackage? = nil,
                        predefinedOption: WooShippingPredefinedSavedOption? = nil,
                        completion: @escaping (Result<WooShippingCreatePackageResponse, PackageCreationError>) -> Void) {
-        remote.createPackage(siteID: siteID, customPackage: customPackage, predefinedOption: predefinedOption) { result in
+        remote.createPackage(siteID: siteID, customPackage: customPackage, predefinedOption: predefinedOption) { [weak self] result in
             switch result {
             case .success(let packages):
-                completion(.success(packages))
+                self?.upsertCreatePackagesResponseInBackground(readOnlyPackages: packages, siteID: siteID, onCompletion: {
+                    completion(.success(packages))
+                })
             case .failure(let error):
                 completion(.failure(PackageCreationError(error: error)))
             }
@@ -229,7 +231,6 @@ private extension WooShippingStore {
 // MARK: - Storage
 private extension WooShippingStore {
     /// Updates (OR Inserts) the specified ReadOnly WooShippingPackagesResponse Entities *in a background thread*.
-    /// Also deletes existing packages if requested.
     /// `onCompletion` will be called on the main thread!
     ///
     func upsertPackagesResponseInBackground(readOnlyPackages: Networking.WooShippingPackagesResponse,
@@ -238,6 +239,18 @@ private extension WooShippingStore {
         storageManager.performAndSave({ [weak self] storage in
             guard let self else { return }
             upsertPackagesResponse(readOnlyPackages: readOnlyPackages, in: storage)
+        }, completion: onCompletion, on: .main)
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly WooShippingCreatePackageResponse Entities *in a background thread*.
+    /// `onCompletion` will be called on the main thread!
+    ///
+    func upsertCreatePackagesResponseInBackground(readOnlyPackages: Networking.WooShippingCreatePackageResponse,
+                                                  siteID: Int64,
+                                                  onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ [weak self] storage in
+            guard let self else { return }
+            upsertCreatePackageResponse(readOnlyPackages: readOnlyPackages, siteID: siteID, in: storage)
         }, completion: onCompletion, on: .main)
     }
 

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -254,7 +254,7 @@ private extension WooShippingStore {
         storagePackages.update(with: readOnlyPackages)
         handleAllPredefinedOptions(readOnlyPackages, storagePackages, storage)
         handleCustomPackages(readOnlyPackages.customPackages, storagePackages, storage)
-        handleSavedPredefinedPackages(readOnlyPackages, storagePackages, storage)
+        handleSavedPredefinedPackages(readOnlyPackages.savedPredefinedPackages, storagePackages, storage)
     }
 
     /// Updates (OR Inserts) the specified ReadOnly `WooShippingCreatePackageResponse` Entities into the Storage Layer.
@@ -269,6 +269,7 @@ private extension WooShippingStore {
         storagePackages.siteID = siteID
 
         handleCustomPackages(readOnlyPackages.customPackages, storagePackages, storage)
+        handleSavedPredefinedOptions(readOnlyPackages.predefinedOptions, storagePackages, storage)
     }
 
     /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's allPredefinedOptions
@@ -354,7 +355,7 @@ private extension WooShippingStore {
     /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's savedPredefinedPackages
     /// using the provided read-only WooShippingPackagesResponse's savedPredefinedPackages
     ///
-    func handleSavedPredefinedPackages(_ readOnlyPackages: Networking.WooShippingPackagesResponse,
+    func handleSavedPredefinedPackages(_ readOnlySavedPackages: [Networking.WooShippingSavedPredefinedPackage],
                                        _ storagePackages: Storage.WooShippingPackagesResponse,
                                        _ storage: StorageType) {
         // Remove all previous saved predefined packages, they will be deleted as they have the `cascade` delete rule
@@ -363,13 +364,61 @@ private extension WooShippingStore {
         }
 
         // Creates and adds `storageSavedPredefinedPackages` from `readOnlyPackages.savedPredefinedPackages`
-        let storageSavedPredefinedPackages = readOnlyPackages.savedPredefinedPackages.map { readOnlyPackage -> Storage.WooShippingSavedPredefinedPackage in
+        let storageSavedPredefinedPackages = readOnlySavedPackages.map { readOnlyPackage -> Storage.WooShippingSavedPredefinedPackage in
             let storagePackage = storage.insertNewObject(ofType: Storage.WooShippingSavedPredefinedPackage.self)
             storagePackage.update(with: readOnlyPackage)
             handlePredefinedPackage(readOnlyPackage, storagePackage, storage)
             return storagePackage
         }
         storagePackages.addToSavedPredefinedPackages(NSSet(array: storageSavedPredefinedPackages))
+    }
+
+    /// Updates, inserts, or prunes the provided Storage.WooShippingPackagesResponse's savedPredefinedPackages
+    /// using the provided read-only WooShippingPredefinedSavedOptions
+    ///
+    func handleSavedPredefinedOptions(_ readOnlySavedOptions: [WooShippingPredefinedSavedOption],
+                                      _ storagePackages: Storage.WooShippingPackagesResponse,
+                                      _ storage: StorageType) {
+        guard let storagePredefinedOptions: [StorageWooShippingCarrierPredefinedOptions] = storagePackages.allPredefinedOptions?.toArray() else {
+            return
+        }
+        let readOnlyPredefinedOptions = storagePredefinedOptions.map({ $0.toReadOnly() })
+        let savedPackages = transformSavedPredefinedOptions(readOnlySavedOptions, allPredefinedOptions: readOnlyPredefinedOptions)
+        handleSavedPredefinedPackages(savedPackages, storagePackages, storage)
+    }
+
+    /// Transforms the provided `WooShippingPredefinedSavedOption`s into `WooShippingSavedPredefinedPackage`s to save in storage.
+    ///
+    func transformSavedPredefinedOptions(_ options: [WooShippingPredefinedSavedOption],
+                                         allPredefinedOptions: [WooShippingCarrierPredefinedOptions]) -> [WooShippingSavedPredefinedPackage] {
+        // helper function for creating jointIDs for easier checking if package should be used or not
+        func jointID(carrierID: String, packageID: String) -> String {
+            return "\(carrierID)-\(packageID)"
+        }
+
+        var jointIDs: [String] = []
+        for option in options {
+            for packageID in option.predefinedPackageIDs {
+                jointIDs.append(jointID(carrierID: option.id, packageID: packageID))
+            }
+        }
+
+        var allSavedOptions: [WooShippingSavedPredefinedPackage] = []
+
+        // use predefined saved packages from list of all packages
+        // since the response gives us IDs we need to get them manually from the list
+        for carrier in allPredefinedOptions {
+            let carrierID = carrier.carrierID
+            for option in carrier.predefinedOptions {
+                for package in option.predefinedPackages {
+                    if jointIDs.contains(jointID(carrierID: carrierID, packageID: package.id)) {
+                        allSavedOptions.append(WooShippingSavedPredefinedPackage(groupTitle: option.title, providerID: option.providerID, package: package))
+                    }
+                }
+            }
+        }
+
+        return allSavedOptions
     }
 
     /// Updates or inserts the provided Storage.WooShippingSavedPredefinedPackage's package

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -248,4 +248,38 @@ extension MockStorageManager {
 
         return newNote
     }
+
+    /// Inserts a new sample Woo Shipping packages response into the specified content.
+    ///
+    @discardableResult
+    func insertSamplePackages(readOnlyPackages: WooShippingPackagesResponse) -> StorageWooShippingPackagesResponse {
+        let newPackages = viewStorage.insertNewObject(ofType: StorageWooShippingPackagesResponse.self)
+        newPackages.update(with: readOnlyPackages)
+        readOnlyPackages.allPredefinedOptions.forEach { carrierOption in
+            let newCarrierOption = viewStorage.insertNewObject(ofType: StorageWooShippingCarrierPredefinedOptions.self)
+            newCarrierOption.update(with: carrierOption)
+            newPackages.addToAllPredefinedOptions(newCarrierOption)
+            carrierOption.predefinedOptions.forEach { predefinedOption in
+                let newPredefinedOption = viewStorage.insertNewObject(ofType: StorageWooShippingPredefinedOption.self)
+                newPredefinedOption.update(with: predefinedOption)
+                newCarrierOption.addToPredefinedOptions(newPredefinedOption)
+                predefinedOption.predefinedPackages.forEach { package in
+                    let newPackage = viewStorage.insertNewObject(ofType: StorageWooShippingPredefinedPackage.self)
+                    newPackage.update(with: package)
+                    newPredefinedOption.addToPredefinedPackages(newPackage)
+                }
+            }
+        }
+        readOnlyPackages.customPackages.forEach { customPackage in
+            let newCustomPackage = viewStorage.insertNewObject(ofType: StorageWooShippingCustomPackage.self)
+            newCustomPackage.update(with: customPackage)
+            newPackages.addToCustomPackages(newCustomPackage)
+        }
+        readOnlyPackages.savedPredefinedPackages.forEach { savedPackage in
+            let newSavedPackage = viewStorage.insertNewObject(ofType: StorageWooShippingSavedPredefinedPackage.self)
+            newSavedPackage.update(with: savedPackage)
+            newPackages.addToSavedPredefinedPackages(newSavedPackage)
+        }
+        return newPackages
+    }
 }

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -79,6 +79,40 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertEqual(result.failure, .duplicatePackageNames)
     }
 
+    func test_createPackage_when_successful_then_upserts_packages_into_storage() throws {
+        // Given
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-create-package-success")
+        storageManager.insertSamplePackages(readOnlyPackages: .init(siteID: sampleSiteID,
+                                                                    customPackages: [],
+                                                                    savedPredefinedPackages: [],
+                                                                    allPredefinedOptions: [sampleCarrierPredefinedOptions()]))
+
+        // Confidence check
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageWooShippingCustomPackage.self), 0)
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageWooShippingSavedPredefinedPackage.self), 0)
+
+        // When
+        let onSuccess: Bool = waitFor { promise in
+            let action = WooShippingAction.createPackage(siteID: self.sampleSiteID,
+                                                         customPackage: .fake(),
+                                                         predefinedOption: .fake()) { result in
+                promise(result.isSuccess)
+            }
+            store.onAction(action)
+        }
+
+        let storedPackages = try XCTUnwrap(storageManager.viewStorage.firstObject(ofType: StorageWooShippingPackagesResponse.self)).toReadOnly()
+
+        // Then
+        XCTAssertTrue(onSuccess)
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageWooShippingCustomPackage.self), 5)
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageWooShippingSavedPredefinedPackage.self), 2)
+        XCTAssertEqual(storedPackages.siteID, sampleSiteID)
+        XCTAssertEqual(storedPackages.customPackages.count, 5)
+        XCTAssertEqual(storedPackages.savedPredefinedPackages.count, 2)
+    }
+
     // MARK: `loadLabelRates`
 
     func test_loadLabelRates_returns_success_response_with_rates() throws {
@@ -458,5 +492,33 @@ private extension WooShippingStoreTests {
                                  rawType: "box",
                                  dimensions: "12 x 12 x 12",
                                  boxWeight: 0.01)
+    }
+
+    func sampleCarrierPredefinedOptions() -> WooShippingCarrierPredefinedOptions {
+        WooShippingCarrierPredefinedOptions(carrierID: "usps",
+                                            predefinedOptions: [.init(title: "pri_flat_boxes",
+                                                                      providerID: "usps",
+                                                                      predefinedPackages: [.init(id: "small_flat_box",
+                                                                                                 name: "",
+                                                                                                 isLetter: false,
+                                                                                                 dimensions: "",
+                                                                                                 boxWeight: "",
+                                                                                                 groupId: "")]),
+                                                                .init(title: "pri_flat_envelopes",
+                                                                      providerID: "usps",
+                                                                      predefinedPackages: [.init(id: "flat_envelope",
+                                                                                                 name: "",
+                                                                                                 isLetter: true,
+                                                                                                 dimensions: "",
+                                                                                                 boxWeight: "",
+                                                                                                 groupId: "")]),
+                                                                .init(title: "pri_flat_boxes",
+                                                                      providerID: "usps",
+                                                                      predefinedPackages: [.init(id: "medium_flat_box_top",
+                                                                                                 name: "",
+                                                                                                 isLetter: false,
+                                                                                                 dimensions: "",
+                                                                                                 boxWeight: "",
+                                                                                                 groupId: "")])])
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14522
⚠️ Depends on #14690 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR caches the saved packages received from remote after saving (starring) a package, so we can fetch those saved packages from storage during Woo Shipping label creation:

* Updates `WooShippingStore.createPackage(siteID:customPackage:predefinedOption:completion:)` to upsert the response received from remote:
   * Adds methods to upsert `WooShippingCreatePackageResponse` in the background by handling the custom packages and saved predefined package IDs in that response.
   * Updates the methods that upsert custom packages and saved predefined packages, so they take those package arrays as parameters instead of a complete packages response. This way we can reuse those storage methods when we receive a `WooShippingCreatePackageResponse`.
   * Adds a method to transform the saved predefined package IDs into saved packages for storage. (This uses the logic from `WooShippingAddPackageViewModel`, where we were previously doing this transformation.)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Confirm unit tests pass. You can also confirm the packages response continues to work as expected:

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Immediately tap "Select a Package."
8. Select the Saved tab and confirm the expected packages appear.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
