### PR TITLE
Move Tap to Pay to be the first payment method

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -38,6 +38,7 @@
 - [*] Widgets: Show revenue compact amount in widgets, instead of $123,456,789 (and being truncated) we show $123,5m. [https://github.com/woocommerce/woocommerce-ios/pull/14634]
 - [*] Google Ads: Fix issue displaying campaign list for stores with existing campaigns from the hub menu entry point [https://github.com/woocommerce/woocommerce-ios/pull/14661]
 - [*] Payments: Improved the card reader connection process by introducing a location permission pre-alert and earlier location request, ensuring greater clarity for users. [https://github.com/woocommerce/woocommerce-ios/pull/14672]
+- [*] Payments: Tap to Pay is now the first payment method for eligible merchants. [https://github.com/woocommerce/woocommerce-ios/pull/14717]
 
 21.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -44,6 +44,16 @@ struct PaymentMethodsView: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     VStack(alignment: .leading, spacing: Layout.noSpacing) {
+                        if viewModel.showTapToPayRow {
+                            MethodRow(icon: .tapToPayOnIPhoneIcon,
+                                      title: Localization.tapToPay,
+                                      accessibilityID: Accessibility.tapToPayMethod) {
+                                viewModel.collectPayment(using: .localMobile, on: rootViewController, onSuccess: dismiss, onFailure: dismiss)
+                            }
+
+                            Divider()
+                        }
+
                         MethodRow(icon: .priceImage, title: Localization.cash, accessibilityID: Accessibility.cashMethod) {
                             showingCashAlert = true
                             viewModel.trackCollectByCash()
@@ -54,16 +64,6 @@ struct PaymentMethodsView: View {
 
                             MethodRow(icon: .creditCardImage, title: Localization.card, accessibilityID: Accessibility.cardMethod) {
                                 viewModel.collectPayment(using: .bluetoothScan, on: rootViewController, onSuccess: dismiss, onFailure: dismiss)
-                            }
-                        }
-
-                        if viewModel.showTapToPayRow {
-                            Divider()
-
-                            MethodRow(icon: .tapToPayOnIPhoneIcon,
-                                      title: Localization.tapToPay,
-                                      accessibilityID: Accessibility.tapToPayMethod) {
-                                viewModel.collectPayment(using: .localMobile, on: rootViewController, onSuccess: dismiss, onFailure: dismiss)
                             }
                         }
 


### PR DESCRIPTION
Closes: #14162
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Move Tap to Pay to be the first payment method to comply with Apple's requirements

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### TTP eligible device and site

1. Use the TTP eligible site / device
2. Make an Order and Collect Payment
3. Confirm TTP appears at the top of the list

### TTP ineligible device or site

1. Use the TTP ineligible device and site 
2. Make an Order and Collect Payment
3. Confirm that Cash appears at the top of the list


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This is a fairly simple change. Confirmed that it looks and works well with eligible and illegible devices/sites.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| With TTP | Without TTP |
|----------|-------------|
| ![Simulator Screenshot - iPhone 16 - 2024-12-17 at 19 43 53](https://github.com/user-attachments/assets/f9caa59e-e7b3-43ba-9ff5-26c1334c4f59) | ![Simulator Screenshot - iPhone 16 - 2024-12-17 at 19 44 06](https://github.com/user-attachments/assets/23e86a40-a95a-4c0a-95ce-7ca38a492afb) |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.