### PR TITLE
[Woo POS] [Variable products] Add POSItem enum for product types

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Combine
-import protocol Yosemite.POSDisplayableItem
+import enum Yosemite.POSItem
 import protocol Yosemite.PointOfSaleItemServiceProtocol
 import enum Yosemite.PointOfSaleProductServiceError
 
@@ -14,7 +14,7 @@ protocol PointOfSaleItemsControllerProtocol {
 class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     private(set) var itemListStatePublisher: any Publisher<ItemListState, Never>
     private var itemListStateSubject: PassthroughSubject<ItemListState, Never> = .init()
-    private var allItems: [POSDisplayableItem] = []
+    private var allItems: [POSItem] = []
     private var currentPage: Int = Constants.initialPage
     private var mightHaveMorePages: Bool = true
     private let itemProvider: PointOfSaleItemServiceProtocol
@@ -76,7 +76,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     private func fetchItems(pageNumber: Int) async throws {
         let newItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
         let uniqueNewItems = newItems.filter { newItem in
-            !allItems.contains(where: { $0.isEqual(to: newItem) })
+            !allItems.contains(newItem)
         }
         allItems.append(contentsOf: uniqueNewItems)
     }

--- a/WooCommerce/Classes/POS/Models/ItemListState.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListState.swift
@@ -1,32 +1,17 @@
-import protocol Yosemite.POSDisplayableItem
+import enum Yosemite.POSItem
 import protocol Yosemite.POSOrderableItem
 
 enum ItemListState: Equatable {
     case empty
     case initialLoading
-    case loading(_ currentItems: [POSDisplayableItem])
-    case loaded(_ items: [POSDisplayableItem])
+    case loading(_ currentItems: [POSItem])
+    case loaded(_ items: [POSItem])
     case error(PointOfSaleErrorState)
 
     var isLoadingAfterInitialLoad: Bool {
         switch self {
         case .loading:
             return true
-        default:
-            return false
-        }
-    }
-
-    static func == (lhs: ItemListState, rhs: ItemListState) -> Bool {
-        switch (lhs, rhs) {
-        case (.empty, .empty),
-            (.initialLoading, .initialLoading):
-            return true
-        case (.loading(let lhsItems), .loading(let rhsItems)),
-            (.loaded(let lhsItems), .loaded(let rhsItems)):
-            return lhsItems.isEqual(to: rhsItems)
-        case (.error(let lhsError), .error(let rhsError)):
-            return lhsError == rhsError
         default:
             return false
         }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import protocol Yosemite.POSDisplayableItem
+import enum Yosemite.POSItem
 import protocol Yosemite.POSOrderableItem
 
 struct ItemListView: View {
@@ -124,13 +124,13 @@ private extension ItemListView {
     }
 
     @ViewBuilder
-    func listView(_ items: [POSDisplayableItem]) -> some View {
+    func listView(_ items: [POSItem]) -> some View {
         ScrollView {
             VStack {
                 if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                     bannerCardView
                 }
-                ForEach(items, id: \.id) { item in
+                ForEach(items) { item in
                     listRow(item: item)
                 }
                 GhostItemCardView()
@@ -158,15 +158,14 @@ private extension ItemListView {
     }
 
     @ViewBuilder
-    func listRow(item: POSDisplayableItem) -> some View {
-        if let item = item as? POSOrderableItem {
-            Button(action: {
-                posModel.addToCart(item)
-            }, label: {
-                ItemCardView(item: item)
-            })
-        } else {
-            ItemCardView(item: item)
+    func listRow(item: POSItem) -> some View {
+        switch item {
+        case .simpleProduct(let simpleProduct):
+            Button {
+                posModel.addToCart(simpleProduct)
+            } label: {
+                SimpleProductCardView(product: simpleProduct)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
@@ -1,19 +1,19 @@
-import protocol Yosemite.POSDisplayableItem
+import struct Yosemite.POSSimpleProduct
 import SwiftUI
 
-struct ItemCardView: View {
-    private let item: POSDisplayableItem
+struct SimpleProductCardView: View {
+    private let product: POSSimpleProduct
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
-    init(item: POSDisplayableItem) {
-        self.item = item
+    init(product: POSSimpleProduct) {
+        self.product = product
     }
 
     var body: some View {
         HStack(spacing: Constants.cardSpacing) {
-            if let imageSource = item.productImageSource {
+            if let imageSource = product.productImageSource {
                 ProductImageThumbnail(productImageURL: URL(string: imageSource),
                                       productImageSize: Constants.productCardSize * scale,
                                       scale: scale,
@@ -31,13 +31,13 @@ struct ItemCardView: View {
 
             DynamicHStack(spacing: Constants.textSpacing) {
                 Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
-                Text(item.name)
+                Text(product.name)
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemNameFont)
                 Spacer()
-                Text(item.formattedPrice)
+                Text(product.formattedPrice)
                     .foregroundStyle(Color.posPrimaryText)
                     .font(Constants.itemPriceFont)
                 Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
@@ -57,7 +57,7 @@ struct ItemCardView: View {
     }
 }
 
-private extension ItemCardView {
+private extension SimpleProductCardView {
     enum Constants {
         static let productCardSize: CGFloat = 112
         static let maximumProductCardSize: CGFloat = Constants.productCardSize * 2
@@ -76,6 +76,10 @@ private extension ItemCardView {
 
 #if DEBUG
 #Preview {
-    ItemCardView(item: PointOfSalePreviewItemService().providePointOfSaleItem())
+    SimpleProductCardView(product: POSSimpleProduct(id: UUID(),
+                                                    name: "Product name",
+                                                    formattedPrice: "$3.00",
+                                                    productID: 123,
+                                                    price: "3.00"))
 }
 #endif

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -2,7 +2,8 @@
 
 import Foundation
 import protocol Yosemite.PointOfSaleItemServiceProtocol
-import protocol Yosemite.POSDisplayableItem
+import enum Yosemite.POSItem
+import struct Yosemite.POSSimpleProduct
 import protocol Yosemite.POSOrderableItem
 import protocol Yosemite.OrderSyncProductTypeProtocol
 import struct Yosemite.OrderSyncProductInput
@@ -36,11 +37,11 @@ struct POSProductPreview: POSOrderableItem, Equatable {
 }
 
 final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSDisplayableItem] {
+    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSItem] {
         []
     }
 
-    func providePointOfSaleItems() -> [POSDisplayableItem] {
+    func providePointOfSaleItems() -> [POSItem] {
         return mockItems
     }
 
@@ -55,7 +56,7 @@ final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtoco
     @Published var itemListState: ItemListState = .initialLoading
     var itemListStatePublisher: any Publisher<ItemListState, Never> { $itemListState }
 
-    var allItems: [POSDisplayableItem] = []
+    var allItems: [POSItem] = []
 
     func loadInitialItems() async {
         itemListState = .loaded(mockItems)
@@ -70,12 +71,12 @@ final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtoco
     }
 }
 
-private var mockItems: [POSDisplayableItem] {
+private var mockItems: [POSItem] {
     return [
-        POSProductPreview(id: UUID(), name: "Product 1", formattedPrice: "$1.00"),
-        POSProductPreview(id: UUID(), name: "Product 2", formattedPrice: "$2.00"),
-        POSProductPreview(id: UUID(), name: "Product 3", formattedPrice: "$3.00"),
-        POSProductPreview(id: UUID(), name: "Product 4", formattedPrice: "$4.00")
+        .simpleProduct(POSSimpleProduct(id: UUID(), name: "Product 1", formattedPrice: "$1.00", productID: 1, price: "1.00")),
+        .simpleProduct(POSSimpleProduct(id: UUID(), name: "Product 2", formattedPrice: "$2.00", productID: 2, price: "2.00")),
+        .simpleProduct(POSSimpleProduct(id: UUID(), name: "Product 3", formattedPrice: "$3.00", productID: 3, price: "3.00")),
+        .simpleProduct(POSSimpleProduct(id: UUID(), name: "Product 4", formattedPrice: "$4.00", productID: 4, price: "4.00"))
     ]
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 		026826992BF59DA90036F959 /* Color+WooCommercePOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826982BF59DA80036F959 /* Color+WooCommercePOS.swift */; };
 		026826AA2BF59DF70036F959 /* CartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826A32BF59DF60036F959 /* CartView.swift */; };
 		026826AB2BF59DF70036F959 /* ItemRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826A22BF59DF60036F959 /* ItemRowView.swift */; };
-		026826AC2BF59DF70036F959 /* ItemCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826A42BF59DF60036F959 /* ItemCardView.swift */; };
+		026826AC2BF59DF70036F959 /* SimpleProductCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826A42BF59DF60036F959 /* SimpleProductCardView.swift */; };
 		026826AD2BF59DF70036F959 /* PointOfSaleDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826A52BF59DF60036F959 /* PointOfSaleDashboardView.swift */; };
 		026826AF2BF59DF70036F959 /* PointOfSaleEntryPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */; };
 		026826B52BF59E330036F959 /* CardReaderConnectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826B32BF59E320036F959 /* CardReaderConnectionStatusView.swift */; };
@@ -3463,7 +3463,7 @@
 		026826982BF59DA80036F959 /* Color+WooCommercePOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Color+WooCommercePOS.swift"; sourceTree = "<group>"; };
 		026826A22BF59DF60036F959 /* ItemRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRowView.swift; sourceTree = "<group>"; };
 		026826A32BF59DF60036F959 /* CartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartView.swift; sourceTree = "<group>"; };
-		026826A42BF59DF60036F959 /* ItemCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCardView.swift; sourceTree = "<group>"; };
+		026826A42BF59DF60036F959 /* SimpleProductCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleProductCardView.swift; sourceTree = "<group>"; };
 		026826A52BF59DF60036F959 /* PointOfSaleDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboardView.swift; sourceTree = "<group>"; };
 		026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleEntryPointView.swift; sourceTree = "<group>"; };
 		026826B32BF59E320036F959 /* CardReaderConnectionStatusView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionStatusView.swift; sourceTree = "<group>"; };
@@ -6959,7 +6959,7 @@
 				68C53CBD2C1FE59B00C6D80B /* ItemListView.swift */,
 				026826A32BF59DF60036F959 /* CartView.swift */,
 				026826A22BF59DF60036F959 /* ItemRowView.swift */,
-				026826A42BF59DF60036F959 /* ItemCardView.swift */,
+				026826A42BF59DF60036F959 /* SimpleProductCardView.swift */,
 				68D8FBD02BFEF9C700477C42 /* TotalsView.swift */,
 				68AF3C3A2D01481A006F1ED2 /* POSReceiptEligibilityBanner.swift */,
 				DA1D68C12C36F0980097859A /* PointOfSaleAssets.swift */,
@@ -15310,7 +15310,7 @@
 				B98DA0AE2B275F45008A3607 /* ProductLoaderView.swift in Sources */,
 				02B1AFEC24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift in Sources */,
 				0206E296299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift in Sources */,
-				026826AC2BF59DF70036F959 /* ItemCardView.swift in Sources */,
+				026826AC2BF59DF70036F959 /* SimpleProductCardView.swift in Sources */,
 				26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */,
 				451A04EC2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift in Sources */,
 				02DD81F9242CAA400060E50B /* WordPressMediaLibraryPickerViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -180,8 +180,8 @@ private func makeItem(name: String = "",
                       quantity: Int = 1,
                       orderItemsToMatch: [OrderItem] = []) -> CartItem {
     return CartItem(id: UUID(),
-                    item: MockPOSItem(name: name,
-                                      formattedPrice: formattedPrice,
-                                      orderItemsToMatch: orderItemsToMatch),
+                    item: MockPOSOrderableItem(name: name,
+                                               formattedPrice: formattedPrice,
+                                               orderItemsToMatch: orderItemsToMatch),
                     quantity: quantity)
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 import protocol Yosemite.PointOfSaleItemServiceProtocol
 import protocol Yosemite.POSDisplayableItem
-@testable import struct Yosemite.POSProduct
+@testable import struct Yosemite.POSSimpleProduct
 
 final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     var items: [POSDisplayableItem] = []

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -1,17 +1,18 @@
 import Foundation
 import protocol Yosemite.PointOfSaleItemServiceProtocol
-import protocol Yosemite.POSDisplayableItem
+import enum Yosemite.POSItem
+import protocol Yosemite.POSOrderableItem
 @testable import struct Yosemite.POSSimpleProduct
 
 final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
-    var items: [POSDisplayableItem] = []
+    var items: [POSItem] = []
     var shouldThrowError = false
     var shouldReturnZeroItems = false
     var shouldSimulateTwoPages = false
     private var isPageOutOfRange = false
 
     var spyLastRequestedPageNumber: Int?
-    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSDisplayableItem] {
+    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSItem] {
         if isPageOutOfRange {
             throw MockError.pageOutOfRange
         }
@@ -40,36 +41,40 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
 }
 
 extension MockPointOfSaleItemService {
-    static func makeInitialItems() -> [POSDisplayableItem] {
+    static func makeInitialItems() -> [POSItem] {
         let fakeUUID1 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E84E") ?? UUID()
         let fakeUUID2 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E84A") ?? UUID()
-
-        let product1 = MockPOSItem(name: "Choco",
-                                   id: fakeUUID1,
-                                   formattedPrice: "$2.00",
-                                   productImageSource: nil)
-
-        let product2 = MockPOSItem(name: "Vanilla",
-                                   id: fakeUUID2,
-                                   formattedPrice: "$3.00",
-                                   productImageSource: nil)
-        return [product1, product2]
+        
+        let product1 = POSSimpleProduct(id: fakeUUID1,
+                                        name: "Choco",
+                                        formattedPrice: "$2.00",
+                                        productID: 1,
+                                        price: "2.00")
+        
+        let product2 = POSSimpleProduct(id: fakeUUID2,
+                                        name: "Vanilla",
+                                        formattedPrice: "$3.00",
+                                        productID: 1,
+                                        price: "2.00")
+        return [.simpleProduct(product1), .simpleProduct(product2)]
     }
-
-    static func makeSecondPageItems() -> [POSDisplayableItem] {
+    
+    static func makeSecondPageItems() -> [POSItem] {
         let fakeUUID3 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E86D") ?? UUID()
         let fakeUUID4 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E86F") ?? UUID()
-
-        let product3 = MockPOSItem(name: "Strawberry",
-                                   id: fakeUUID3,
-                                   formattedPrice: "$2.00",
-                                   productImageSource: nil)
-
-        let product4 = MockPOSItem(name: "Pistachio",
-                                   id: fakeUUID4,
-                                   formattedPrice: "$3.00",
-                                   productImageSource: nil)
-        return [product3, product4]
+        
+        let product3 = POSSimpleProduct(id: fakeUUID3,
+                                        name: "Strawberry",
+                                        formattedPrice: "$2.00",
+                                        productID: 1,
+                                        price: "2.00")
+        
+        let product4 = POSSimpleProduct(id: fakeUUID4,
+                                        name: "Pistachio",
+                                        formattedPrice: "$3.00",
+                                        productID: 1,
+                                        price: "2.00")
+        return [.simpleProduct(product3), .simpleProduct(product4)]
     }
 
     enum MockError: Error {

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -44,13 +44,13 @@ extension MockPointOfSaleItemService {
     static func makeInitialItems() -> [POSItem] {
         let fakeUUID1 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E84E") ?? UUID()
         let fakeUUID2 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E84A") ?? UUID()
-        
+
         let product1 = POSSimpleProduct(id: fakeUUID1,
                                         name: "Choco",
                                         formattedPrice: "$2.00",
                                         productID: 1,
                                         price: "2.00")
-        
+
         let product2 = POSSimpleProduct(id: fakeUUID2,
                                         name: "Vanilla",
                                         formattedPrice: "$3.00",
@@ -58,17 +58,17 @@ extension MockPointOfSaleItemService {
                                         price: "2.00")
         return [.simpleProduct(product1), .simpleProduct(product2)]
     }
-    
+
     static func makeSecondPageItems() -> [POSItem] {
         let fakeUUID3 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E86D") ?? UUID()
         let fakeUUID4 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E86F") ?? UUID()
-        
+
         let product3 = POSSimpleProduct(id: fakeUUID3,
                                         name: "Strawberry",
                                         formattedPrice: "$2.00",
                                         productID: 1,
                                         price: "2.00")
-        
+
         let product4 = POSSimpleProduct(id: fakeUUID4,
                                         name: "Pistachio",
                                         formattedPrice: "$3.00",

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
@@ -1,12 +1,12 @@
 import Foundation
 import Combine
 @testable import WooCommerce
-import protocol Yosemite.POSDisplayableItem
+import enum Yosemite.POSItem
 
 final class MockPointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     var itemListStatePublisher: any Publisher<WooCommerce.ItemListState, Never> = Empty()
 
-    var allItems: [POSDisplayableItem] = []
+    var allItems: [POSItem] = []
 
     func loadInitialItems() async { }
 

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -480,7 +480,7 @@ struct PointOfSaleAggregateModelTests {
 }
 
 private func makeItem(name: String = "") -> POSOrderableItem {
-    return MockPOSItem(name: name, formattedPrice: "")
+    return MockPOSOrderableItem(name: name, formattedPrice: "")
 }
 
 private func makeLoadedOrderState(cartTotal: String = "",

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -2,7 +2,7 @@ import Testing
 import Foundation
 @testable import WooCommerce
 import protocol Yosemite.POSOrderableItem
-@testable import struct Yosemite.POSProduct
+@testable import struct Yosemite.POSSimpleProduct
 import struct Yosemite.Order
 import Combine
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewHelperTests.swift
@@ -84,5 +84,5 @@ struct CartViewHelperTests {
 }
 
 private func makeItem() -> CartItem {
-    CartItem(id: UUID(), item: MockPOSItem(name: "Item", formattedPrice: "$1.00"), quantity: 1)
+    CartItem(id: UUID(), item: MockPOSOrderableItem(name: "Item", formattedPrice: "$1.00"), quantity: 1)
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -269,7 +269,7 @@
 		68A70DD22D0BF6F60013B807 /* POSReceiptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A70DD12D0BF6F30013B807 /* POSReceiptService.swift */; };
 		68BD37B528DB2E9800C2A517 /* CustomerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD37B428DB2E9800C2A517 /* CustomerStore.swift */; };
 		68BD37B928DB323D00C2A517 /* CustomerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD37B828DB323D00C2A517 /* CustomerStoreTests.swift */; };
-		68EA25342C08734900C49AE2 /* POSProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25332C08734800C49AE2 /* POSProduct.swift */; };
+		68EA25342C08734900C49AE2 /* POSSimpleProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */; };
 		68EA25382C0876DF00C49AE2 /* PointOfSaleProductService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
 		741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34812195EA71005F5BD9 /* CommentStore.swift */; };
@@ -793,7 +793,7 @@
 		68A70DD12D0BF6F30013B807 /* POSReceiptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSReceiptService.swift; sourceTree = "<group>"; };
 		68BD37B428DB2E9800C2A517 /* CustomerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerStore.swift; sourceTree = "<group>"; };
 		68BD37B828DB323D00C2A517 /* CustomerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerStoreTests.swift; sourceTree = "<group>"; };
-		68EA25332C08734800C49AE2 /* POSProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProduct.swift; sourceTree = "<group>"; };
+		68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSimpleProduct.swift; sourceTree = "<group>"; };
 		68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleProductService.swift; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
 		741F34812195EA71005F5BD9 /* CommentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentStore.swift; sourceTree = "<group>"; };
@@ -1500,7 +1500,7 @@
 			isa = PBXGroup;
 			children = (
 				6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */,
-				68EA25332C08734800C49AE2 /* POSProduct.swift */,
+				68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */,
 				68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */,
 			);
 			path = PointOfSale;
@@ -2448,7 +2448,7 @@
 				B505254C20EE6491008090F5 /* Site+ReadOnlyConvertible.swift in Sources */,
 				26E5A07E25A6640E000DF8F6 /* ProductAttributeTermAction.swift in Sources */,
 				45ED6092257E72F4007B4AC6 /* ProductAttributeAction.swift in Sources */,
-				68EA25342C08734900C49AE2 /* POSProduct.swift in Sources */,
+				68EA25342C08734900C49AE2 /* POSSimpleProduct.swift in Sources */,
 				B52E002B2119E64800700FDE /* ManagedObjectsDidChangeNotification.swift in Sources */,
 				93E7507A226E2D6C00BAF88A /* AccountSettings+ReadOnlyConvertible.swift in Sources */,
 				749374FE2249601F007D85D1 /* ProductStore.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSSimpleProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSSimpleProduct.swift
@@ -1,25 +1,34 @@
 import WooFoundation
 
-struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol, Equatable {
+public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol, Equatable {
     // POSOrderableItem
-    let id: UUID
-    let name: String
-    let formattedPrice: String
-    var productImageSource: String?
+    public let id: UUID
+    public let name: String
+    public let formattedPrice: String
+    public var productImageSource: String?
 
     // OrderSyncProductTypeProtocol
-    let productID: Int64
-    let price: String
-    let productType: ProductType = .simple
-    let bundledItems: [ProductBundleItem] = []
+    public let productID: Int64
+    public let price: String
+    public let productType: ProductType = .simple
+    public let bundledItems: [ProductBundleItem] = []
+
+    public init(id: UUID, name: String, formattedPrice: String, productImageSource: String? = nil, productID: Int64, price: String) {
+        self.id = id
+        self.name = name
+        self.formattedPrice = formattedPrice
+        self.productImageSource = productImageSource
+        self.productID = productID
+        self.price = price
+    }
 }
 
 extension POSSimpleProduct: Hashable {
-    func toOrderSyncProductInput(quantity: Decimal) -> OrderSyncProductInput {
+    public func toOrderSyncProductInput(quantity: Decimal) -> OrderSyncProductInput {
         OrderSyncProductInput(product: .product(self), quantity: quantity)
     }
 
-    func matches(orderItem: OrderItem) -> Bool {
+    public func matches(orderItem: OrderItem) -> Bool {
         // TODO: https://github.com/woocommerce/woocommerce-ios/pull/13328/files#r1687631533
         // - we should also add a logic to compare prices
         // - but we should be aware of the fact that some

--- a/Yosemite/Yosemite/PointOfSale/POSSimpleProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSSimpleProduct.swift
@@ -1,6 +1,6 @@
 import WooFoundation
 
-struct POSProduct: POSOrderableItem, OrderSyncProductTypeProtocol, Equatable {
+struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol, Equatable {
     // POSOrderableItem
     let id: UUID
     let name: String
@@ -14,7 +14,7 @@ struct POSProduct: POSOrderableItem, OrderSyncProductTypeProtocol, Equatable {
     let bundledItems: [ProductBundleItem] = []
 }
 
-extension POSProduct: Hashable {
+extension POSSimpleProduct: Hashable {
     func toOrderSyncProductInput(quantity: Decimal) -> OrderSyncProductInput {
         OrderSyncProductInput(product: .product(self), quantity: quantity)
     }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -1,23 +1,37 @@
-/// POSDisplayableItem contains only the properties required to show an item in the Point Of Sale.
-/// The item may only be visible, not neccesarily something you can add to the cart.
-/// This protocol will become less specific in future; e.g. not all items in the POS necessarily have a price.
-public protocol POSDisplayableItem {
-    var id: UUID { get }
-    var name: String { get }
-    var formattedPrice: String { get }
-    var productImageSource: String? { get }
+public enum POSItem: Equatable, Identifiable {
+    case simpleProduct(POSSimpleProduct)
 
-    func isEqual(to other: POSDisplayableItem) -> Bool
+    public var id: UUID {
+        switch self {
+        case .simpleProduct(let product):
+            return product.id
+        }
+    }
 }
 
-public extension POSDisplayableItem where Self: Equatable {
-    func isEqual(to other: POSDisplayableItem) -> Bool {
+/// POSOrderableItem extends a displayable item with the functions required for using it in an order.
+/// This currently includes adding it, and checking whether it's already in an order.
+/// This may need to become less specific in future, e.g. we currently convert it to a product input, but
+/// other order items might be added as fees or similar. at that point, we will need a different function requirement here.
+public protocol POSOrderableItem {
+    var id: UUID { get }
+    var name: String { get }
+    var productImageSource: String? { get }
+    var formattedPrice: String { get }
+
+    func toOrderSyncProductInput(quantity: Decimal) -> OrderSyncProductInput
+    func matches(orderItem: OrderItem) -> Bool
+    func isEqual(to other: POSOrderableItem) -> Bool
+}
+
+public extension POSOrderableItem where Self: Equatable {
+    func isEqual(to other: POSOrderableItem) -> Bool {
         guard let other = other as? Self else { return false }
         return self == other
     }
 }
 
-public extension Sequence where Element == POSDisplayableItem {
+public extension Sequence where Element == POSOrderableItem {
     func isEqual(to other: any Sequence<Element>) -> Bool {
         let lhsArray = Array(self)
         let rhsArray = Array(other)
@@ -30,25 +44,14 @@ public extension Sequence where Element == POSDisplayableItem {
     }
 }
 
-/// POSOrderableItem extends a displayable item with the functions required for using it in an order.
-/// This currently includes adding it, and checking whether it's already in an order.
-/// This may need to become less specific in future, e.g. we currently convert it to a product input, but
-/// other order items might be added as fees or similar. at that point, we will need a different function requirement here.
-public protocol POSOrderableItem: POSDisplayableItem & PointOfSaleItemOrderItemConvertable {}
-
-public protocol PointOfSaleItemOrderItemConvertable {
-    func toOrderSyncProductInput(quantity: Decimal) -> OrderSyncProductInput
-    func matches(orderItem: OrderItem) -> Bool
-}
-
 public protocol PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSDisplayableItem]
+    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSItem]
 }
 
 // Default implementation for convenience, so we do not need to pass the first page explicitly
 // if no pageNumber is given.
 extension PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSDisplayableItem] {
+    func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSItem] {
         try await providePointOfSaleItems(pageNumber: pageNumber)
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -41,7 +41,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     ///
     /// - pageNumber: Number of the page that should be retrieved. If none given, defaults to 1
     ///
-    public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSDisplayableItem] {
+    public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSItem] {
         let productTypes: [ProductType] = isVariableProductsFeatureEnabled ?
         [.simple, .variable] : [.simple]
         let products = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
@@ -60,21 +60,21 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
         return mapProductsToPOSItems(products: filteredProducts)
     }
 
-    // Maps result to POSSimpleProduct, and populate the output with:
+    // Maps result to POSItem, and populate the output with:
     // - Formatted price based on store's currency settings.
     // - Product thumbnail, if any.
-    private func mapProductsToPOSItems(products: [Product]) -> [POSOrderableItem] {
+    private func mapProductsToPOSItems(products: [Product]) -> [POSItem] {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         return products.map { product in
             let formattedPrice = currencyFormatter.formatAmount(product.price) ?? "-"
             let thumbnailSource = product.images.first?.src
 
-            return POSSimpleProduct(id: UUID(),
-                              name: product.name,
-                              formattedPrice: formattedPrice,
-                              productImageSource: thumbnailSource,
-                              productID: product.productID,
-                              price: product.price)
+            return .simpleProduct(POSSimpleProduct(id: UUID(),
+                                                   name: product.name,
+                                                   formattedPrice: formattedPrice,
+                                                   productImageSource: thumbnailSource,
+                                                   productID: product.productID,
+                                                   price: product.price))
         }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -60,7 +60,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
         return mapProductsToPOSItems(products: filteredProducts)
     }
 
-    // Maps result to POSProduct, and populate the output with:
+    // Maps result to POSSimpleProduct, and populate the output with:
     // - Formatted price based on store's currency settings.
     // - Product thumbnail, if any.
     private func mapProductsToPOSItems(products: [Product]) -> [POSOrderableItem] {
@@ -69,7 +69,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
             let formattedPrice = currencyFormatter.formatAmount(product.price) ?? "-"
             let thumbnailSource = product.images.first?.src
 
-            return POSProduct(id: UUID(),
+            return POSSimpleProduct(id: UUID(),
                               name: product.name,
                               formattedPrice: formattedPrice,
                               productImageSource: thumbnailSource,

--- a/Yosemite/YosemiteTests/Mocks/MockPOSOrderableItem.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockPOSOrderableItem.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import Yosemite
 
-final class MockPOSItem: POSOrderableItem, Equatable {
+final class MockPOSOrderableItem: POSOrderableItem, Equatable {
     var name: String
     var id: UUID
     var formattedPrice: String
@@ -44,7 +44,7 @@ final class MockPOSItem: POSOrderableItem, Equatable {
         return true
     }
 
-    static func == (lhs: MockPOSItem, rhs: MockPOSItem) -> Bool {
+    static func == (lhs: MockPOSOrderableItem, rhs: MockPOSOrderableItem) -> Bool {
         return lhs.name == rhs.name &&
         lhs.id == rhs.id &&
         lhs.formattedPrice == rhs.formattedPrice &&

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -76,18 +76,15 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         let expectedItems = try await itemProvider.providePointOfSaleItems()
 
         // Then
-        guard let item = expectedItems.first else {
+        guard let item = expectedItems.first,
+            case .simpleProduct(let simpleProduct) = item else {
             return XCTFail("No eligible products")
         }
         XCTAssertEqual(expectedItems.count, expectedNumberOfEligibleProducts)
-        XCTAssertEqual(item.name, expectedProductName)
-        XCTAssertEqual(item.formattedPrice, expectedFormattedPrice)
-
-        guard let product = item as? POSSimpleProduct else {
-            return XCTFail("Expected a POSSimpleProduct")
-        }
-        XCTAssertEqual(product.price, expectedProductPrice)
-        XCTAssertEqual(product.productID, expectedProductID)
+        XCTAssertEqual(simpleProduct.name, expectedProductName)
+        XCTAssertEqual(simpleProduct.formattedPrice, expectedFormattedPrice)
+        XCTAssertEqual(simpleProduct.price, expectedProductPrice)
+        XCTAssertEqual(simpleProduct.productID, expectedProductID)
     }
 
     func test_PointOfSaleItemServiceProtocol_when_eligibility_criteria_applies_then_returns_correct_number_of_items() async throws {
@@ -102,12 +99,12 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedItems.count, expectedNumberOfItems)
 
-        guard let firstEligibleItem = expectedItems.first,
-              let secondEligibleItem = expectedItems.last else {
+        guard case .simpleProduct(let firstEligibleSimpleProduct) = expectedItems.first,
+              case .simpleProduct(let secondEligibleSimpleProduct) = expectedItems.last else {
             return XCTFail("Expected \(expectedNumberOfItems) eligible items. Got \(expectedItems.count) instead.")
         }
-        XCTAssertEqual(firstEligibleItem.name, expectedItemNames.first)
-        XCTAssertEqual(secondEligibleItem.name, expectedItemNames.last)
+        XCTAssertEqual(firstEligibleSimpleProduct.name, expectedItemNames.first)
+        XCTAssertEqual(secondEligibleSimpleProduct.name, expectedItemNames.last)
     }
 
     // MARK: - Query Parameters

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -83,8 +83,8 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         XCTAssertEqual(item.name, expectedProductName)
         XCTAssertEqual(item.formattedPrice, expectedFormattedPrice)
 
-        guard let product = item as? POSProduct else {
-            return XCTFail("Expected a POSProduct")
+        guard let product = item as? POSSimpleProduct else {
+            return XCTFail("Expected a POSSimpleProduct")
         }
         XCTAssertEqual(product.price, expectedProductPrice)
         XCTAssertEqual(product.productID, expectedProductID)

--- a/Yosemite/YosemiteTests/Tools/POS/POSCartItemTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSCartItemTests.swift
@@ -101,7 +101,12 @@ struct POSCartItemTests {
     }
 
     private func makeCartItem(id: UUID = UUID(), quantity: Decimal, matching: [OrderItem] = [], matcher: ((OrderItem) -> Bool)? = nil) -> POSCartItem {
-        return POSCartItem(item: MockPOSOrderableItem(name: "", id: id, formattedPrice: "", productImageSource: nil, orderItemsToMatch: matching, matcher: matcher),
+        return POSCartItem(item: MockPOSOrderableItem(name: "",
+                                                      id: id,
+                                                      formattedPrice: "",
+                                                      productImageSource: nil,
+                                                      orderItemsToMatch: matching,
+                                                      matcher: matcher),
                            quantity: quantity)
     }
 }

--- a/Yosemite/YosemiteTests/Tools/POS/POSCartItemTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSCartItemTests.swift
@@ -101,7 +101,7 @@ struct POSCartItemTests {
     }
 
     private func makeCartItem(id: UUID = UUID(), quantity: Decimal, matching: [OrderItem] = [], matcher: ((OrderItem) -> Bool)? = nil) -> POSCartItem {
-        return POSCartItem(item: MockPOSItem(name: "", id: id, formattedPrice: "", productImageSource: nil, orderItemsToMatch: matching, matcher: matcher),
+        return POSCartItem(item: MockPOSOrderableItem(name: "", id: id, formattedPrice: "", productImageSource: nil, orderItemsToMatch: matching, matcher: matcher),
                            quantity: quantity)
     }
 }

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -115,7 +115,7 @@ private func makePOSCartItem(
     productID: Int64,
     quantity: Decimal) -> POSCartItem {
         return POSCartItem(
-            item: POSProduct(id: UUID(),
+            item: POSSimpleProduct(id: UUID(),
                              name: "",
                              formattedPrice: "",
                              productID: productID,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14692
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces the `POSDisplayableItem` protocol with a POSItem enum, which will contain the various types of displayable items for POS.

Initially, this is only `simpleProduct`, with the renamed `POSProduct`(now `POSSimpleProduct`) as an associated value.

To continue to support generic treatment of items in the cart, some of the `POSDisplayableItem` properties have been moved to the `POSOrderableItem` protocol.

Context: pdfdoF-61P-p2

There's no functional change in this PR.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test that you can still load products, add them to a cart, and edit the cart as you'd expect.

In particular, I've tested that the POS correctly updates or ignores changes to the cart when editing one which has been transformed to an order by going to checkout. If the cart is changed after going back, the order should be synced again. If there's no (effective) change, it should go straight to card preparation. Removing an item then adding it back is not treated as a change.

I've tested on an iPad Air running iOS 17.7

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ce5f3a93-0d33-4a66-ad1f-fa2461dd6e69

---


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.