### PR TITLE
Store Picker: Handle saving hidden stores

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -30,6 +30,22 @@ struct EditStoreListView: View {
     var body: some View {
         NavigationStack {
             List {
+                if let site = viewModel.currentlySelectedSite {
+                    Section {
+                        VStack(alignment: .leading) {
+                            Text(site.name)
+                                .bodyStyle()
+                            Text(site.url)
+                                .footnoteStyle()
+                        }
+                        .multilineTextAlignment(.leading)
+                    } header: {
+                        Text(Localization.currentStoreHeader)
+                    } footer: {
+                        Text(Localization.currentStoreFooter)
+                    }
+                }
+
                 Section {
                     ForEach(viewModel.availableSites, id: \.siteID) { item in
                         SelectableItemRow(title: item.name,
@@ -44,8 +60,10 @@ struct EditStoreListView: View {
                         }
                         .disabled(viewModel.isLastSelected(item))
                     }
+                } header: {
+                    Text(Localization.otherStoresHeader)
                 } footer: {
-                    Text(Localization.listFooter)
+                    Text(Localization.otherStoresFooter)
                 }
             }
             .listStyle(.grouped)
@@ -71,11 +89,6 @@ struct EditStoreListView: View {
 
 private extension EditStoreListView {
     enum Localization {
-        static let listFooter = NSLocalizedString(
-            "editStoreListView.listFooter",
-            value: "Stores that are not selected will be excluded from the store picker",
-            comment: "Label at the end of the Edit Store List view"
-        )
         static let cancelButton = NSLocalizedString(
             "editStoreListView.cancelButton",
             value: "Cancel",
@@ -90,6 +103,26 @@ private extension EditStoreListView {
             "editStoreListView.title",
             value: "Visible Stores",
             comment: "Title of the Edit Store List view"
+        )
+        static let currentStoreHeader = NSLocalizedString(
+            "editStoreListView.currentStoreHeader",
+            value: "Current store",
+            comment: "Header of the Current Store section of the the Edit Store List view"
+        )
+        static let currentStoreFooter = NSLocalizedString(
+            "editStoreListView.currentStoreFooter",
+            value: "Please switch to another store before hiding this store",
+            comment: "Footer of the Current Store section of the the Edit Store List view"
+        )
+        static let otherStoresHeader = NSLocalizedString(
+            "editStoreListView.otherStoresHeader",
+            value: "Other stores",
+            comment: "Header of the Other Stores section on the Edit Store List view"
+        )
+        static let otherStoresFooter = NSLocalizedString(
+            "editStoreListView.otherStoresFooter",
+            value: "Stores that are not selected will be excluded from the store picker",
+            comment: "Footer of the Other Stores section on the Edit Store List view"
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -8,6 +8,8 @@ final class EditStoreListViewModel: ObservableObject {
     /// All available sites to be displayed on the store picker
     let availableSites: [Site]
 
+    let currentlySelectedSite: Site?
+
     /// Sites selected to be displayed on the store picker
     @Published var selectedSites: Set<Site>
 
@@ -21,13 +23,15 @@ final class EditStoreListViewModel: ObservableObject {
     private let onCompletion: () -> Void
 
     init(availableSites: [Site],
-         selectedSites: [Site],
+         displayedSites: [Site],
+         currentlySelectedSite: Site?,
          userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping () -> Void) {
-        self.availableSites = availableSites
-        self.originalSelectedSites = selectedSites
-        self.selectedSites = Set(selectedSites)
+        self.availableSites = availableSites.filter { $0.siteID != currentlySelectedSite?.siteID }
+        self.currentlySelectedSite = currentlySelectedSite
+        self.originalSelectedSites = displayedSites
+        self.selectedSites = Set(displayedSites)
         self.userDefaults = userDefaults
         self.analytics = analytics
         self.onCompletion = onCompletion

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -16,22 +16,28 @@ final class EditStoreListViewModel: ObservableObject {
     }
 
     private let originalSelectedSites: [Site]
+    private let userDefaults: UserDefaults
     private let analytics: Analytics
-    private let onCompletion: (_ selectedSites: Set<Site>) -> Void
+    private let onCompletion: () -> Void
 
     init(availableSites: [Site],
          selectedSites: [Site],
+         userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
-         onCompletion: @escaping (_ selectedSites: Set<Site>) -> Void) {
+         onCompletion: @escaping () -> Void) {
         self.availableSites = availableSites
         self.originalSelectedSites = selectedSites
         self.selectedSites = Set(selectedSites)
+        self.userDefaults = userDefaults
         self.analytics = analytics
         self.onCompletion = onCompletion
     }
 
     func didSaveChanges() {
-        onCompletion(selectedSites)
+        let hiddenSites = Set(availableSites).subtracting(selectedSites)
+        let hiddenSiteIDs = Array(hiddenSites).map { $0.siteID }
+        userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
+        onCompletion()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/UserDefaults+EditStoreList.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/UserDefaults+EditStoreList.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Edit store list helpers
+//
+extension UserDefaults {
+    @objc dynamic var hiddenStoreIDs: [Int64] {
+        array(forKey: Key.hiddenStoreIDs.rawValue) as? [Int64] ?? []
+    }
+
+    /// Saves objective ID for future Blaze campaigns
+    ///
+    func saveHiddenStoreIDs(_ ids: [Int64]) {
+        self[.hiddenStoreIDs] = ids
+    }
+}

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -662,7 +662,11 @@ private extension StorePickerViewController {
 
     @objc func editList() {
         if case let .available(sites) = viewModel.state {
-            let editViewModel = EditStoreListViewModel(availableSites: sites, selectedSites: sites, onCompletion: { [weak self] in
+            let editViewModel = EditStoreListViewModel(availableSites: sites,
+                                                       displayedSites: sites,
+                                                       currentlySelectedSite: currentlySelectedSite,
+                                                       onCompletion: { [weak self] in
+                // TODO
                 self?.presentedViewController?.dismiss(animated: true)
             })
             let viewController = EditStoreListViewController(viewModel: editViewModel)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -661,17 +661,17 @@ private extension StorePickerViewController {
     }
 
     @objc func editList() {
-        if case let .available(sites) = viewModel.state {
-            let editViewModel = EditStoreListViewModel(availableSites: sites,
-                                                       displayedSites: sites,
-                                                       currentlySelectedSite: currentlySelectedSite,
-                                                       onCompletion: { [weak self] in
-                // TODO
-                self?.presentedViewController?.dismiss(animated: true)
-            })
-            let viewController = EditStoreListViewController(viewModel: editViewModel)
-            present(viewController, animated: true)
-        }
+        let editViewModel = EditStoreListViewModel(availableSites: viewModel.allFetchedSites,
+                                                   displayedSites: viewModel.displayedStores,
+                                                   currentlySelectedSite: currentlySelectedSite,
+                                                   onCompletion: { [weak self] in
+            guard let self else { return }
+            viewModel.updateDisplayedStores()
+            tableView.reloadData()
+            presentedViewController?.dismiss(animated: true)
+        })
+        let viewController = EditStoreListViewController(viewModel: editViewModel)
+        present(viewController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -662,11 +662,10 @@ private extension StorePickerViewController {
 
     @objc func editList() {
         if case let .available(sites) = viewModel.state {
-            let viewModel = EditStoreListViewModel(availableSites: sites, selectedSites: sites, onCompletion: { [weak self] selectedSites in
-                // TODO
+            let editViewModel = EditStoreListViewModel(availableSites: sites, selectedSites: sites, onCompletion: { [weak self] in
                 self?.presentedViewController?.dismiss(animated: true)
             })
-            let viewController = EditStoreListViewController(viewModel: viewModel)
+            let viewController = EditStoreListViewController(viewModel: editViewModel)
             present(viewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -95,9 +95,7 @@ final class StorePickerViewModel {
 
     func updateDisplayedStores() {
         let hiddenStoreIDs = userDefaults.hiddenStoreIDs
-        displayedStores = allFetchedSites
-            .filter { $0.isWooCommerceActive }
-            .filter { hiddenStoreIDs.contains($0.siteID) == false }
+        displayedStores = allFetchedSites.filter { hiddenStoreIDs.contains($0.siteID) == false }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -10,6 +10,12 @@ final class StorePickerViewModel {
     ///
     @Published private(set) var state: StorePickerState = .empty
 
+    var allFetchedSites: [Site] {
+        resultsController.fetchedObjects
+    }
+
+    private(set) var displayedStores: [Site] = []
+
     /// ResultsController: Loads Sites from the Storage Layer.
     ///
     private lazy var resultsController: ResultsController<StorageSite> = {
@@ -25,16 +31,19 @@ final class StorePickerViewModel {
 
     private let storageManager: StorageManagerType
     private let stores: StoresManager
+    private let userDefaults: UserDefaults
     private let analytics: Analytics
     private let roleEligibilityUseCase: RoleEligibilityUseCase
 
     init(configuration: StorePickerConfiguration,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
+         userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics) {
         self.configuration = configuration
         self.stores = stores
         self.storageManager = storageManager
+        self.userDefaults = userDefaults
         self.analytics = analytics
         self.roleEligibilityUseCase = RoleEligibilityUseCase(stores: stores)
     }
@@ -77,14 +86,23 @@ final class StorePickerViewModel {
     func checkEligibility(for storeID: Int64, completion: @escaping (Result<Void, RoleEligibilityError>) -> Void) {
         roleEligibilityUseCase.checkEligibility(for: storeID, completion: completion)
     }
+
+    func updateDisplayedStores() {
+        let hiddenStoreIDs = userDefaults.hiddenStoreIDs
+        displayedStores = allFetchedSites
+            .filter { $0.isWooCommerceActive }
+            .filter { hiddenStoreIDs.contains($0.siteID) == false }
+    }
 }
 
 // MARK: - Private helpers
 private extension StorePickerViewModel {
+
     func refetchSitesAndUpdateState() {
         do {
             try resultsController.performFetch()
-            state = StorePickerState(sites: resultsController.fetchedObjects)
+            updateDisplayedStores()
+            state = StorePickerState(sites: allFetchedSites)
         } catch {
             DDLogError("⛔️ Unable to re-fetch sites and update state: \(error)")
         }
@@ -163,6 +181,9 @@ extension StorePickerViewModel {
         guard resultsController.numberOfObjects > 0 else {
             return 1
         }
+        if configuration == .switchingStores {
+            return displayedStores.count
+        }
         return resultsController.sections[safe: sectionIndex]?.objects.count ?? 0
     }
 
@@ -171,6 +192,9 @@ extension StorePickerViewModel {
     func site(at indexPath: IndexPath) -> Site? {
         guard resultsController.numberOfObjects > 0 else {
             return nil
+        }
+        if configuration == .switchingStores {
+            return displayedStores[safe: indexPath.row]
         }
         return resultsController.safeObject(at: indexPath)
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -183,9 +183,16 @@ extension StorePickerViewModel {
         // The value is returned as either 0 or 1 in String,
         // so the trick is to convert it to NSString and get the `boolValue`.
         let isWooCommerceActive = (rawStatus as NSString).boolValue
-        if isWooCommerceActive {
-            return multipleStoresAvailable ? Localization.pickStore : Localization.connectedStore
-        } else {
+        switch (isWooCommerceActive, multipleStoresAvailable) {
+        case (true, true):
+            let hiddenStoreCount = userDefaults.hiddenStoreIDs.count
+            if hiddenStoreCount > 0, shouldEnableHidingStores {
+                return String(format: Localization.pickStoreWithHiddenStoreCount, hiddenStoreCount)
+            }
+            return Localization.pickStore
+        case (true, false):
+            return Localization.connectedStore
+        case (false, _):
             return Localization.otherSites
         }
     }
@@ -250,6 +257,13 @@ private extension StorePickerViewModel {
         static let otherSites = NSLocalizedString(
             "Other Sites",
             comment: "Store Picker's Section Title: Displayed when there are sites without WooCommerce"
+        )
+        static let pickStoreWithHiddenStoreCount = NSLocalizedString(
+            "storePickerViewModel.pickStoreWithHiddenStoreCount",
+            value: "Pick Store to Connect (%1$d hidden)",
+            comment: "Store Picker's Section Title: Displayed whenever there are multiple Stores. " +
+            "The content inside the bracket indicates the number of stores hidden from the store picker. " +
+            "The placeholder is a number. Reads as: 'Pick Store to Connect (3 hidden)'"
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -198,7 +198,7 @@ extension StorePickerViewModel {
         guard resultsController.numberOfObjects > 0 else {
             return 1
         }
-        if configuration == .switchingStores {
+        if shouldEnableHidingStores {
             return displayedStores.count
         }
         return resultsController.sections[safe: sectionIndex]?.objects.count ?? 0
@@ -210,7 +210,7 @@ extension StorePickerViewModel {
         guard resultsController.numberOfObjects > 0 else {
             return nil
         }
-        if configuration == .switchingStores {
+        if shouldEnableHidingStores {
             return displayedStores[safe: indexPath.row]
         }
         return resultsController.safeObject(at: indexPath)

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -69,6 +69,9 @@ extension UserDefaults {
         // Tap to Pay awareness moment
         case tapToPayAwarenessMomentPresented
         case tapToPayAwarenessMomentFirstLaunchCompleted
+
+        // Hide stores from store picker
+        case hiddenStoreIDs
     }
 }
 

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -49,10 +49,6 @@ extension UserDefaults {
         // Theme installation
         case themesPendingInstall
 
-        // Store Creation
-        case siteIDPendingStoreSwitch
-        case expectedStoreNamePendingStoreSwitch
-
         // Watch
         case watchDependencies
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -209,8 +209,6 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.numberOfTimesProductCreationAISurveySuggested] = nil
         defaults[.didStartProductCreationAISurvey] = nil
         defaults[.themesPendingInstall] = nil
-        defaults[.siteIDPendingStoreSwitch] = nil
-        defaults[.expectedStoreNamePendingStoreSwitch] = nil
         defaults[.blazeNoCampaignReminderOpened] = nil
         defaults[.blazeAbandonedCampaignCreationReminderOpened] = nil
         defaults[.blazeSelectedCampaignObjective] = nil

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -209,6 +209,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.numberOfTimesProductCreationAISurveySuggested] = nil
         defaults[.didStartProductCreationAISurvey] = nil
         defaults[.themesPendingInstall] = nil
+        defaults[.hiddenStoreIDs] = nil
         defaults[.blazeNoCampaignReminderOpened] = nil
         defaults[.blazeAbandonedCampaignCreationReminderOpened] = nil
         defaults[.blazeSelectedCampaignObjective] = nil

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2775,6 +2775,7 @@
 		DEE2152D2D113EF1004A11F3 /* EditStoreListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */; };
 		DEE215302D113F89004A11F3 /* EditStoreListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */; };
 		DEE215322D116FBB004A11F3 /* EditStoreListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE215312D116FBB004A11F3 /* EditStoreListViewModelTests.swift */; };
+		DEE215342D1297CD004A11F3 /* UserDefaults+EditStoreList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE215332D1297CD004A11F3 /* UserDefaults+EditStoreList.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */; };
@@ -5892,6 +5893,7 @@
 		DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListView.swift; sourceTree = "<group>"; };
 		DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListViewModel.swift; sourceTree = "<group>"; };
 		DEE215312D116FBB004A11F3 /* EditStoreListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreListViewModelTests.swift; sourceTree = "<group>"; };
+		DEE215332D1297CD004A11F3 /* UserDefaults+EditStoreList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+EditStoreList.swift"; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginUseCase.swift; sourceTree = "<group>"; };
@@ -13193,6 +13195,7 @@
 		DEE2152E2D113F61004A11F3 /* EditStoreList */ = {
 			isa = PBXGroup;
 			children = (
+				DEE215332D1297CD004A11F3 /* UserDefaults+EditStoreList.swift */,
 				DEE2152F2D113F84004A11F3 /* EditStoreListViewModel.swift */,
 				DEE2152C2D113EF1004A11F3 /* EditStoreListView.swift */,
 			);
@@ -16009,6 +16012,7 @@
 				DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */,
 				26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
+				DEE215342D1297CD004A11F3 /* UserDefaults+EditStoreList.swift in Sources */,
 				CE63024E2BAC664900E3325C /* EmailView.swift in Sources */,
 				DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */,
 				02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -11,8 +11,9 @@ struct EditStoreListViewModelTests {
         // Given
         let availableSites = [site1, site2]
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // Then
         #expect(viewModel.hasChanges == false)
@@ -27,8 +28,9 @@ struct EditStoreListViewModelTests {
     @Test func isSelected_returns_correct_values() {
         // Given
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // Then
         #expect(viewModel.isSelected(site1) == true)
@@ -45,8 +47,9 @@ struct EditStoreListViewModelTests {
     @Test func isLastSelected_returns_correct_values() {
         // Given
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // Then
         #expect(viewModel.isLastSelected(site1) == false)
@@ -61,8 +64,9 @@ struct EditStoreListViewModelTests {
     @Test func toggleSelection_works_correctly() {
         // Given
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               selectedSites: [site1, site2],
-                                               onCompletion: { _ in })
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               onCompletion: {})
 
         // When
         viewModel.toggleSelection(site1)

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import struct Yosemite.Site
 @testable import WooCommerce
@@ -79,5 +80,24 @@ struct EditStoreListViewModelTests {
 
         // Then
         #expect(viewModel.selectedSites.contains(site1) == true)
+    }
+
+    @Test func didSaveChanges_saves_hidden_store_ids_to_user_defaults_and_triggers_completion() {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        var completionTriggered = false
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               userDefaults: userDefaults,
+                                               onCompletion: { completionTriggered = true })
+
+        // When
+        viewModel.toggleSelection(site1)
+        viewModel.didSaveChanges()
+
+        // Then
+        #expect(userDefaults.hiddenStoreIDs == [site1.siteID])
+        #expect(completionTriggered == true)
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
@@ -295,6 +295,38 @@ final class StorePickerViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.shouldEnableHidingStores)
     }
+
+    @MainActor
+    func test_displayedStores_filters_out_hidden_stores() async throws {
+        // Given
+        let testSite1 = Site.fake().copy(siteID: 123, name: "abc", isWooCommerceActive: true)
+        let testSite2 = Site.fake().copy(siteID: 124, name: "def", isWooCommerceActive: true)
+        storageManager.insertSampleSite(readOnlySite: testSite1)
+        storageManager.insertSampleSite(readOnlySite: testSite2)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+        let viewModel = StorePickerViewModel(configuration: .switchingStores,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             userDefaults: userDefaults)
+
+        // When
+        userDefaults.saveHiddenStoreIDs([testSite1.siteID])
+        await viewModel.refreshSites(currentlySelectedSiteID: nil)
+
+        // Then
+        XCTAssertEqual(viewModel.displayedStores, [testSite2])
+    }
 }
 
 private extension StorePickerViewModelTests {

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -340,50 +340,6 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[.themesPendingInstall])
     }
 
-    /// Verifies that `siteIDPendingStoreSwitch` is set to `nil` upon reset
-    ///
-    func test_siteIDPendingStoreSwitch_is_set_to_nil_upon_reset() throws {
-        // Given
-        let uuid = UUID().uuidString
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
-        let siteID: Int64 = 123
-
-        // When
-        defaults[.siteIDPendingStoreSwitch] = siteID
-
-        // Then
-        XCTAssertEqual(try XCTUnwrap(defaults[.siteIDPendingStoreSwitch] as? Int64), siteID)
-
-        // When
-        sut.reset()
-
-        // Then
-        XCTAssertNil(defaults[.siteIDPendingStoreSwitch])
-    }
-
-    /// Verifies that `expectedStoreNamePendingStoreSwitch` is set to `nil` upon reset
-    ///
-    func test_expectedStoreNamePendingStoreSwitch_is_set_to_nil_upon_reset() throws {
-        // Given
-        let uuid = UUID().uuidString
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
-        let storeName = "My Woo Store"
-
-        // When
-        defaults[.expectedStoreNamePendingStoreSwitch] = storeName
-
-        // Then
-        XCTAssertEqual(try XCTUnwrap(defaults[.expectedStoreNamePendingStoreSwitch] as? String), storeName)
-
-        // When
-        sut.reset()
-
-        // Then
-        XCTAssertNil(defaults[.expectedStoreNamePendingStoreSwitch])
-    }
-
     /// Verifies that `blazeNoCampaignReminderOpened` is set to `nil` upon reset
     ///
     func test_blazeNoCampaignReminderOpened_is_set_to_nil_upon_reset() throws {

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -340,6 +340,27 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[.themesPendingInstall])
     }
 
+    /// Verifies that `hiddenStoreIDs` is set to `nil` upon reset
+    ///
+    func test_hiddenStoreIDs_is_set_to_nil_upon_reset() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[.hiddenStoreIDs] = [Int64]([123, 666])
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults[.hiddenStoreIDs] as? [Int64]), [123, 666])
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[.hiddenStoreIDs])
+    }
+
     /// Verifies that `blazeNoCampaignReminderOpened` is set to `nil` upon reset
     ///
     func test_blazeNoCampaignReminderOpened_is_set_to_nil_upon_reset() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14658 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the saving of store list updates. Changes include:
- Added a new `UserDefaults` key for hidden store IDs (also removed the deprecated keys from store creation)
- Updated the hidden store IDs in `UserDefaults` when saving the Edit store list view changes.
- A new property in `StorePickerViewModel` was added for displayed stores.
- Updated the section header to display the number of hidden stores.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Ensure that the `hideSitesInStorePicker` feature flag is enabled before building the app.
- Log in to a test store with an account that is connected to more than 1 store.
- Navigate to the Menu tab > open the store picker > tap Edit.
- Disable one or more stores on the list and tap Save.
- Confirm that the store picker now displays only stores that are not hidden.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.1 and confirmed that the saving hidden stores successfully updated the store picker accordingly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/da5e4622-967a-4eea-96c4-20fc2e55a8dd



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.