### PR TITLE
[Shipping label] Improve selected package view for unsaved custom package

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -87,6 +87,10 @@ extension WooShippingPackageDataRepresentable {
         }
         return "\(weight) \(unit)"
     }
+
+    var displayName: String {
+        name.isNotEmpty ? name : source.userFriendlyDescription
+    }
 }
 
 struct WooSavedPackagesSelectionView: View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -81,7 +81,10 @@ extension WooShippingPackageDataRepresentable {
         return "\(length) x \(width) x \(height) \( unit)"
     }
 
-    func weightDescription(unit: String) -> String {
+    func weightDescription(unit: String) -> String? {
+        guard weight.isNotEmpty else {
+            return nil
+        }
         return "\(weight) \(unit)"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
@@ -32,7 +32,7 @@ struct WooShippingPackageOptionView: View {
                             .font(.caption)
                             .foregroundStyle(Color(.secondaryLabel))
                     }
-                    Text(package.name)
+                    Text(package.displayName)
                         .bodyStyle()
                     HStack {
                         Text(package.dimensionsDescription(unit: dimensionsUnit))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
@@ -36,8 +36,10 @@ struct WooShippingPackageOptionView: View {
                         .bodyStyle()
                     HStack {
                         Text(package.dimensionsDescription(unit: dimensionsUnit))
-                        Text("•")
-                        Text(package.weightDescription(unit: weightUnit))
+                        if let weight = package.weightDescription(unit: weightUnit) {
+                            Text("•")
+                            Text(weight)
+                        }
                     }
                     .font(.subheadline)
                     .foregroundStyle(Color(.text))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
@@ -62,7 +62,7 @@ private extension WooShippingSelectedPackageView {
     }
 }
 
-#Preview {
+#Preview("Carrier package") {
     WooShippingSelectedPackageView(package: WooShippingPackageData(name: "Small Flat Rate Box",
                                                                    length: "12",
                                                                    width: "6",
@@ -71,4 +71,19 @@ private extension WooShippingSelectedPackageView {
                                                                    source: .predefined(sourceTitle: "USPS Priority Mail Flat Rate Boxes", sourceID: "usps"),
                                                                    packageType: "box"),
                                    totalWeight: .constant("6"))
+    .shippingDimensionsUnit("in")
+    .shippingWeightUnit("lb")
+}
+
+#Preview("Unsaved custom package") {
+    WooShippingSelectedPackageView(package: WooShippingPackageData(name: "",
+                                                                   length: "12",
+                                                                   width: "6",
+                                                                   height: "6",
+                                                                   weight: "",
+                                                                   source: .custom,
+                                                                   packageType: "box"),
+                                   totalWeight: .constant("6"))
+    .shippingDimensionsUnit("in")
+    .shippingWeightUnit("lb")
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -50,6 +50,7 @@ struct WooShippingServiceView: View {
             .redacted(reason: viewModel.loadingState == .loading ? .placeholder : [])
             .shimmering(active: viewModel.loadingState == .loading)
         }
+        .padding(.vertical)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14522
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This cleans up the selected package view, in particular when a custom package is selected but not saved as a template. Changes:

* If the package has no weight, the weight description is hidden (only package dimensions are shown)
* If the package has no name, the source description is shown (e.g. "Custom Package" for a custom package)
* Also adds vertical padding to the Shipping Service view

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Tap "Select a Package."
8. Select and add a package.
9. Confirm the selected package details appear as expected.

Scenarios to test:

* Custom package not saved as a template
* Custom package saved as a template (either newly saved or selected from the Saved tab)
* Carrier package

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

/|Before|After
-|-|-
Carrier package|![Carrier-Before](https://github.com/user-attachments/assets/0937477d-ed3f-49e5-bcf4-3bb255261ab0)|![Carrier-After](https://github.com/user-attachments/assets/b2f7ad2b-dc7c-4c68-b676-3427427b1929)
Saved custom package|![Saved-Before](https://github.com/user-attachments/assets/56cf1b75-d860-4973-94b1-705bad968ece)|![Saved-After](https://github.com/user-attachments/assets/e42d47f9-19f2-4140-999e-484dbfe03d92)
Unsaved custom package|![Custom-Before](https://github.com/user-attachments/assets/fd5b848e-bd57-4466-82cb-42c104497216)|![Custom-After](https://github.com/user-attachments/assets/d8ef94d3-b02f-40bb-97aa-2bb38d3bad0c)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.