### PR TITLE
Fix tests after WooShippingPackagesResponse model properties changed

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -79,7 +79,7 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
                                                                      predefinedPackages: [predefinedPackage])]
                 let allPredefinedOptions = [WooShippingCarrierPredefinedOptions(carrierID: "usps",
                                                                                 predefinedOptions: predefinedOptions)]
-                completion(.success(WooShippingPackagesResponse(storeOptions: ShippingLabelStoreOptions.fake(),
+                completion(.success(WooShippingPackagesResponse(siteID: siteID,
                                                                 customPackages: [customPackage],
                                                                 savedPredefinedPackages: [predefinedSavedPackage],
                                                                 allPredefinedOptions: allPredefinedOptions)))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There was a build failure in `trunk` due to a conflict between the tests added in https://github.com/woocommerce/woocommerce-ios/pull/14591 and the changes to `WooShippingPackagesResponse` in https://github.com/woocommerce/woocommerce-ios/pull/14687. This updates the tests to match the model changes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Confirm the app builds for testing and unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.