### PR TITLE
[Shipping Labels] Custom package weight sometimes as box_weight sometimes as boxWeight

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
@@ -74,6 +74,13 @@ extension WooShippingCustomPackage: Codable {
                 let boxWeightDouble = Double(boxWeightString) {
             boxWeight = boxWeightDouble
         }
+        else if let boxWeightDouble = try? container.decodeIfPresent(Double.self, forKey: .boxWeightAlternate) {
+            boxWeight = boxWeightDouble
+        }
+        else if let boxWeightString = try? container.decodeIfPresent(String.self, forKey: .boxWeightAlternate),
+                let boxWeightDouble = Double(boxWeightString) {
+            boxWeight = boxWeightDouble
+        }
 
         self.init(id: id, name: name, rawType: type, dimensions: dimensions, boxWeight: boxWeight)
     }
@@ -92,6 +99,7 @@ extension WooShippingCustomPackage: Codable {
         case name
         case type
         case dimensions
-        case boxWeight = "box_weight"
+        case boxWeight
+        case boxWeightAlternate = "box_weight"
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
@@ -67,6 +67,7 @@ extension WooShippingCustomPackage: Codable {
 
         var boxWeight: Double = 0.0
         // Looks like some endpoints have boxWeight as String and some as Double
+        // and some endpoints have it as box_weight and some as boxWeight
         if let boxWeightDouble = try? container.decodeIfPresent(Double.self, forKey: .boxWeight) {
             boxWeight = boxWeightDouble
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14725
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Looks like that the endpoint for creating custom package returns the weight as `boxWeight` and general endpoint for getting packages returns custom packages with weight as `box_weight` so we need to handle both cases since we use same struct for both responses.
- If in the future backend uses same naming convention for those endpoints we can remove this logic

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Tap "Select a Package."
8. Fill in all the values for the package, including weight and name and tap "Add Package"
9. Check that on the Create Shipping Labels screen the newly created package is shown, with proper name, dimensions and weight

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
|   ![Simulator Screenshot - iPhone 16 Pro - 2024-12-18 at 16 11 39](https://github.com/user-attachments/assets/b55f7419-e9ce-44db-a4c9-cfc8e85fa44e)    |   ![Simulator Screenshot - iPhone 16 Pro - 2024-12-18 at 16 13 22](https://github.com/user-attachments/assets/f6b98401-b6b4-440d-8d7b-0cf6ba9b8c66)  |

### Before

When we created new package with weight, the weight would not show in the UI because endpoint for creating the package would return the weight with a different parameter name.

https://github.com/user-attachments/assets/e2578353-3e4e-43d0-b21b-9617d2129236

### After

https://github.com/user-attachments/assets/489788da-e062-4fba-b021-1b8cd727a504

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
