### PR TITLE
[Woo POS] [Variable Products] Use pagination headers for loading products

### DIFF
--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -84,22 +84,20 @@ public class AlamofireNetwork: Network {
             }
     }
 
-    public func responseDataAndHeaders(for request: URLRequestConvertible,
-                                       completion: @escaping (Swift.Result<(Data, ResponseHeaders), Error>) -> Void) {
+    public func responseDataAndHeaders(for request: URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
         let request = requestConverter.convert(request)
-        alamofireSession.request(request)
+        let sessionRequest = alamofireSession.request(request)
             .validateIfRestRequest(for: request)
-            .responseData { response in
-                if let error = response.networkingError {
-                    completion(.failure(error))
-                } else if let data = response.data, let headers = response.response?.headers {
-                    completion(.success((data, headers.dictionary)))
-                } else {
-//                    completion(response.result.mapError { $0 })
-                    // TODO
-                    completion(.failure(NetworkError.unacceptableStatusCode(statusCode: response.response?.statusCode ?? 0, response: response.data)))
-                }
-            }
+        let response = await sessionRequest.serializingData().response
+        if let error = response.networkingError {
+            throw error
+        }
+        switch response.result {
+            case .success(let data):
+                return (data, response.response?.headers.dictionary)
+            case .failure(let error):
+                throw error
+        }
     }
 
     /// Executes the specified Network Request. Upon completion, the payload or error will be emitted to the publisher.

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -84,6 +84,24 @@ public class AlamofireNetwork: Network {
             }
     }
 
+    public func responseDataAndHeaders(for request: URLRequestConvertible,
+                                       completion: @escaping (Swift.Result<(Data, ResponseHeaders), Error>) -> Void) {
+        let request = requestConverter.convert(request)
+        alamofireSession.request(request)
+            .validateIfRestRequest(for: request)
+            .responseData { response in
+                if let error = response.networkingError {
+                    completion(.failure(error))
+                } else if let data = response.data, let headers = response.response?.headers {
+                    completion(.success((data, headers.dictionary)))
+                } else {
+//                    completion(response.result.mapError { $0 })
+                    // TODO
+                    completion(.failure(NetworkError.unacceptableStatusCode(statusCode: response.response?.statusCode ?? 0, response: response.data)))
+                }
+            }
+    }
+
     /// Executes the specified Network Request. Upon completion, the payload or error will be emitted to the publisher.
     /// Only one value will be emitted and the request cannot be retried.
     ///

--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -78,8 +78,9 @@ class MockNetwork: Network {
         completion(.success(data))
     }
 
-    func responseDataAndHeaders(for request: any URLRequestConvertible, completion: @escaping (Result<(Data, ResponseHeaders), any Error>) -> Void) {
-        
+    func responseDataAndHeaders(for request: any URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
+        // TODO
+        throw NetworkError.notFound()
     }
 
     func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {

--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -79,8 +79,17 @@ class MockNetwork: Network {
     }
 
     func responseDataAndHeaders(for request: any URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
-        // TODO
-        throw NetworkError.notFound()
+        requestsForResponseData.append(request)
+
+        if let error = error(for: request) {
+            throw error
+        }
+
+        guard let name = filename(for: request), let data = Loader.contentsOf(name) else {
+            throw NetworkError.notFound()
+        }
+
+        return (data, nil)
     }
 
     func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {

--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -27,6 +27,9 @@ class MockNetwork: Network {
     ///
     var requestsForResponseData = [URLRequestConvertible]()
 
+    /// Response headers to be returned with the response data.
+    var responseHeaders: [String: String]?
+
     /// Number of notification objects in notifications-load-all.json file.
     ///
     static let notificationLoadAllJSONCount = 46
@@ -89,7 +92,7 @@ class MockNetwork: Network {
             throw NetworkError.notFound()
         }
 
-        return (data, nil)
+        return (data, responseHeaders)
     }
 
     func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {

--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -78,6 +78,10 @@ class MockNetwork: Network {
         completion(.success(data))
     }
 
+    func responseDataAndHeaders(for request: any URLRequestConvertible, completion: @escaping (Result<(Data, ResponseHeaders), any Error>) -> Void) {
+        
+    }
+
     func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
         requestsForResponseData.append(request)
 

--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -40,8 +40,7 @@ public protocol Network {
     func responseData(for request: URLRequestConvertible,
                       completion: @escaping (Swift.Result<Data, Error>) -> Void)
 
-    func responseDataAndHeaders(for request: URLRequestConvertible,
-                                completion: @escaping (Swift.Result<(Data, ResponseHeaders), Error>) -> Void)
+    func responseDataAndHeaders(for request: URLRequestConvertible) async throws -> (Data, ResponseHeaders?)
 
     /// Executes the specified Network Request. Upon completion, the payload or error will be emitted to the publisher.
     ///

--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -18,6 +18,7 @@ public protocol MultipartFormData {
 /// Unit Testing target, and inject mocked up responses.
 ///
 public protocol Network {
+    typealias ResponseHeaders = [String: String]
 
     var session: URLSession { get }
 
@@ -38,6 +39,9 @@ public protocol Network {
     ///
     func responseData(for request: URLRequestConvertible,
                       completion: @escaping (Swift.Result<Data, Error>) -> Void)
+
+    func responseDataAndHeaders(for request: URLRequestConvertible,
+                                completion: @escaping (Swift.Result<(Data, ResponseHeaders), Error>) -> Void)
 
     /// Executes the specified Network Request. Upon completion, the payload or error will be emitted to the publisher.
     ///

--- a/Networking/Networking/Network/NullNetwork.swift
+++ b/Networking/Networking/Network/NullNetwork.swift
@@ -19,8 +19,8 @@ public final class NullNetwork: Network {
 
     }
 
-    public func responseDataAndHeaders(for request: any URLRequestConvertible, completion: @escaping (Result<(Data, ResponseHeaders), any Error>) -> Void) {
-        
+    public func responseDataAndHeaders(for request: any URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
+        throw NetworkError.notFound()
     }
 
     public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {

--- a/Networking/Networking/Network/NullNetwork.swift
+++ b/Networking/Networking/Network/NullNetwork.swift
@@ -19,6 +19,10 @@ public final class NullNetwork: Network {
 
     }
 
+    public func responseDataAndHeaders(for request: any URLRequestConvertible, completion: @escaping (Result<(Data, ResponseHeaders), any Error>) -> Void) {
+        
+    }
+
     public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
         Empty<Swift.Result<Data, Error>, Never>().eraseToAnyPublisher()
     }

--- a/Networking/Networking/Network/WordPressOrgNetwork.swift
+++ b/Networking/Networking/Network/WordPressOrgNetwork.swift
@@ -104,6 +104,10 @@ public final class WordPressOrgNetwork: Network {
             }
     }
 
+    public func responseDataAndHeaders(for request: URLRequestConvertible, completion: @escaping (Result<(Data, ResponseHeaders), any Error>) -> Void) {
+        // TODO
+    }
+
     /// Executes the specified Network Request. Upon completion, the payload or error will be emitted to the publisher.
     /// Only one value will be emitted and the request cannot be retried.
     ///

--- a/Networking/Networking/Network/WordPressOrgNetwork.swift
+++ b/Networking/Networking/Network/WordPressOrgNetwork.swift
@@ -104,8 +104,20 @@ public final class WordPressOrgNetwork: Network {
             }
     }
 
-    public func responseDataAndHeaders(for request: URLRequestConvertible, completion: @escaping (Result<(Data, ResponseHeaders), any Error>) -> Void) {
-        // TODO
+    public func responseDataAndHeaders(for request: URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
+        let sessionRequest = alamofireSession.request(request).validate()
+        let response = await sessionRequest.serializingData().response
+        do {
+            try validateResponse(response.data)
+            switch response.result {
+                case .success(let data):
+                    return (data, response.response?.headers.dictionary)
+                case .failure(let error):
+                    throw error
+            }
+        } catch {
+            throw error
+        }
     }
 
     /// Executes the specified Network Request. Upon completion, the payload or error will be emitted to the publisher.

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -204,7 +204,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - productTypes: A list of product types to be included in the results.
     /// - pageNumber: Number of page that should be retrieved.
     ///
-    public func loadProductsForPointOfSale(for siteID: Int64, productTypes: [ProductType] = [.simple], pageNumber: Int = 1) async throws -> [Product] {
+    public func loadProductsForPointOfSale(for siteID: Int64, productTypes: [ProductType] = [.simple], pageNumber: Int = 1) async throws -> (products: [Product], totalPagesCount: Int?) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: POSConstants.productsPerPage,
@@ -222,7 +222,15 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
         let mapper = ProductListMapper(siteID: siteID)
-        return try await enqueue(request, mapper: mapper)
+
+        let (products, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
+
+        // Extracts the total number of pages from the response headers.
+        // Response header names are case insensitive.
+        let totalPages = responseHeaders.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalPagesCount.lowercased() })
+            .flatMap { Int($0.value) }
+
+        return (products: products, totalPagesCount: totalPages)
     }
 
     /// Retrieves a specific list of `Product`s by `productID`.

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -227,7 +227,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
 
         // Extracts the total number of pages from the response headers.
         // Response header names are case insensitive.
-        let totalPages = responseHeaders.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalPagesCount.lowercased() })
+        let totalPages = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalPagesCount.lowercased() })
             .flatMap { Int($0.value) }
 
         return (products: products, totalPagesCount: totalPages)

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -206,7 +206,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func loadProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType] = [.simple],
-                                           pageNumber: Int = 1) async throws -> (products: [Product], totalPagesCount: Int?) {
+                                           pageNumber: Int = 1) async throws -> PagedItems<Product> {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: POSConstants.productsPerPage,
@@ -231,8 +231,9 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         // Response header names are case insensitive.
         let totalPages = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalPagesCount.lowercased() })
             .flatMap { Int($0.value) }
+        let hasMorePages = totalPages.map { pageNumber < $0 } ?? true
 
-        return (products: products, totalPagesCount: totalPages)
+        return .init(items: products, hasMorePages: hasMorePages)
     }
 
     /// Retrieves a specific list of `Product`s by `productID`.

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -204,7 +204,9 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - productTypes: A list of product types to be included in the results.
     /// - pageNumber: Number of page that should be retrieved.
     ///
-    public func loadProductsForPointOfSale(for siteID: Int64, productTypes: [ProductType] = [.simple], pageNumber: Int = 1) async throws -> (products: [Product], totalPagesCount: Int?) {
+    public func loadProductsForPointOfSale(for siteID: Int64,
+                                           productTypes: [ProductType] = [.simple],
+                                           pageNumber: Int = 1) async throws -> (products: [Product], totalPagesCount: Int?) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: POSConstants.productsPerPage,

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -259,32 +259,32 @@ public class Remote: NSObject {
         }
     }
 
-    func enqueueWithResponseHeaders<M: Mapper>(_ request: Request, mapper: M) async throws -> (data: M.Output, headers: [String: String]) {
-        try await withCheckedThrowingContinuation { continuation in
-            network.responseDataAndHeaders(for: request) { [weak self] (result: Swift.Result<(Data, Network.ResponseHeaders), Error>) in
-                guard let self else { return }
-
-                switch result {
-                case .success(let (data, headers)):
-                    do {
-                        let validator = request.responseDataValidator()
-                        try validator.validate(data: data)
-                        let parsed = try mapper.map(response: data)
-                        continuation.resume(returning: (parsed, headers))
-                    } catch {
-                        DDLogError("<> Mapping Error: \(error)")
-                        self.handleResponseError(error: error, for: request)
-                        self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: self.mapNetworkError(error: error, for: request))
-                }
-            }
+    func enqueueWithResponseHeaders<M: Mapper>(_ request: Request, mapper: M) async throws -> (data: M.Output, headers: [String: String]?) {
+        do {
+            let (data, headers) = try await network.responseDataAndHeaders(for: request)
+            let validator = request.responseDataValidator()
+            let parsedData = try validateAndParseData(data, request: request, validator: validator, mapper: mapper)
+            return (data: parsedData, headers: headers)
+        } catch {
+            handleResponseError(error: error, for: request)
+            throw mapNetworkError(error: error, for: request)
         }
     }
 }
 
+private extension Remote {
+    // Validation and parsing of the response data is separated so that the decoding error can be handled separately from network error.
+    func validateAndParseData<M: Mapper>(_ data: Data, request: Request, validator: ResponseDataValidator, mapper: M) throws -> M.Output {
+        do {
+            try validator.validate(data: data)
+            return try mapper.map(response: data)
+        } catch {
+            DDLogError("<> Mapping Error: \(error)")
+            handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+            throw error
+        }
+    }
+}
 
 // MARK: - Private Methods
 //

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -370,6 +370,11 @@ private extension Remote {
 public struct PagedItems<T> {
     public let items: [T]
     public let hasMorePages: Bool
+
+    public init(items: [T], hasMorePages: Bool) {
+        self.items = items
+        self.hasMorePages = hasMorePages
+    }
 }
 
 // MARK: - Constants!

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -366,6 +366,12 @@ private extension Remote {
     }
 }
 
+/// Contains the result of a paginated request.
+public struct PagedItems<T> {
+    public let items: [T]
+    public let hasMorePages: Bool
+}
+
 // MARK: - Constants!
 //
 public extension Remote {

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -258,6 +258,31 @@ public class Remote: NSObject {
             }
         }
     }
+
+    func enqueueWithResponseHeaders<M: Mapper>(_ request: Request, mapper: M) async throws -> (data: M.Output, headers: [String: String]) {
+        try await withCheckedThrowingContinuation { continuation in
+            network.responseDataAndHeaders(for: request) { [weak self] (result: Swift.Result<(Data, Network.ResponseHeaders), Error>) in
+                guard let self else { return }
+
+                switch result {
+                case .success(let (data, headers)):
+                    do {
+                        let validator = request.responseDataValidator()
+                        try validator.validate(data: data)
+                        let parsed = try mapper.map(response: data)
+                        continuation.resume(returning: (parsed, headers))
+                    } catch {
+                        DDLogError("<> Mapping Error: \(error)")
+                        self.handleResponseError(error: error, for: request)
+                        self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: self.mapNetworkError(error: error, for: request))
+                }
+            }
+        }
+    }
 }
 
 
@@ -347,6 +372,10 @@ public extension Remote {
 
     enum Default {
         public static let firstPageNumber: Int = 1
+    }
+
+    enum PaginationHeaderKey {
+        static let totalPagesCount = "x-wp-totalpages"
     }
 
     enum JSONParsingErrorUserInfoKey {

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -940,7 +940,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
 
-        let products = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
+        let (products, _) = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
 
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)
@@ -970,7 +970,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
 
-        let products = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: initialPageNumber)
+        let (products, _) = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: initialPageNumber)
 
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)
@@ -988,7 +988,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
 
-        let products = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
+        let (products, _) = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
 
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -993,6 +993,20 @@ final class ProductsRemoteTests: XCTestCase {
         // Then
         XCTAssertEqual(products.count, expectedProductsFromResponse)
     }
+
+    func test_loadProductsForPointOfSale_returns_total_pages_count_from_headers_case_insensitive_name() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        network.responseHeaders = ["X-WP-TotalPages": "17"]
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+
+        let (_, totalPagesCount) = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: 2)
+
+        // Then
+        XCTAssertEqual(totalPagesCount, 17)
+    }
 }
 
 // MARK: - Private Helpers

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -940,9 +940,10 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
 
-        let (products, _) = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
+        let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
 
         // Then
+        let products = pagedProducts.items
         XCTAssertEqual(products.count, expectedProductsFromResponse)
         for product in products {
             XCTAssertEqual(try XCTUnwrap(product).productType, .simple)
@@ -970,9 +971,10 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
 
-        let (products, _) = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: initialPageNumber)
+        let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: initialPageNumber)
 
         // Then
+        let products = pagedProducts.items
         XCTAssertEqual(products.count, expectedProductsFromResponse)
         for product in products {
             XCTAssertEqual(try XCTUnwrap(product).productType, .simple)
@@ -988,24 +990,46 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
 
-        let (products, _) = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
+        let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
 
         // Then
-        XCTAssertEqual(products.count, expectedProductsFromResponse)
+        XCTAssertEqual(pagedProducts.items.count, expectedProductsFromResponse)
     }
 
-    func test_loadProductsForPointOfSale_returns_total_pages_count_from_headers_case_insensitive_name() async throws {
+    func test_loadProductsForPointOfSale_returns_hasMorePages_based_on_header_with_case_insensitive_name() async throws {
         // Given
         let remote = ProductsRemote(network: network)
-
-        // When
-        network.responseHeaders = ["X-WP-TotalPages": "17"]
+        network.responseHeaders = ["X-WP-TotalPages": "5"]
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
 
-        let (_, totalPagesCount) = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: 2)
+        // When loading page 1 to 4
+        for pageNumber in 1...4 {
+            let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
+
+            // Then
+            XCTAssertTrue(pagedProducts.hasMorePages)
+        }
+
+        // When loading page 17
+        let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: 5)
 
         // Then
-        XCTAssertEqual(totalPagesCount, 17)
+        XCTAssertFalse(pagedProducts.hasMorePages)
+    }
+
+    func test_loadProductsForPointOfSale_returns_hasMorePages_true_when_header_is_not_set() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.responseHeaders = nil
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+
+        // When loading the first 5 pages
+        for pageNumber in 1...5 {
+            let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID, pageNumber: pageNumber)
+
+            // Then
+            XCTAssertTrue(pagedProducts.hasMorePages)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -68,19 +68,23 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
         // control is released. Using a separate task ensures the reload async task is not canceled when the refresh control is released.
         reloadTask?.cancel()
         reloadTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            allItems.removeAll()
-            itemListStateSubject.send(.loading(allItems))
-            do {
-                try await paginationTracker.resync { [weak self] pageNumber in
-                    guard let self else { return true }
-                    return try await fetchItems(pageNumber: pageNumber)
-                }
-                updateItemListStateAfterLoadAttempt()
-            } catch {
-                // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
-                itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
+            await self?.resyncItems()
+        }
+    }
+
+    @MainActor
+    func resyncItems() async {
+        allItems.removeAll()
+        itemListStateSubject.send(.loading(allItems))
+        do {
+            try await paginationTracker.resync { [weak self] pageNumber in
+                guard let self else { return true }
+                return try await fetchItems(pageNumber: pageNumber)
             }
+            updateItemListStateAfterLoadAttempt()
+        } catch {
+            // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
+            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
         }
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -15,55 +15,41 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     private(set) var itemListStatePublisher: any Publisher<ItemListState, Never>
     private var itemListStateSubject: PassthroughSubject<ItemListState, Never> = .init()
     private var allItems: [POSItem] = []
-    private var currentPage: Int = Constants.initialPage
-    private var mightHaveMorePages: Bool = true
+    private let paginationTracker: PaginationTracker
     private let itemProvider: PointOfSaleItemServiceProtocol
 
     init(itemProvider: PointOfSaleItemServiceProtocol) {
         self.itemProvider = itemProvider
+        self.paginationTracker = .init(pageFirstIndex: Constants.initialPage)
         itemListStatePublisher = itemListStateSubject.eraseToAnyPublisher()
+
+        paginationTracker.delegate = self
     }
 
     @MainActor
     func loadInitialItems() async {
-        mightHaveMorePages = true
         itemListStateSubject.send(.initialLoading)
-        try? await load(pageNumber: Constants.initialPage)
+        paginationTracker.syncFirstPage()
     }
 
     @MainActor
     func loadNextItems() async {
-        do {
-            guard mightHaveMorePages else {
-                return
-            }
-            itemListStateSubject.send(.loading(allItems))
-
-            let nextPage = currentPage + 1
-            try await load(pageNumber: nextPage)
-            currentPage = nextPage
-        } catch {
-            // Handle errors without incrementing currentPage.
-        }
+        paginationTracker.ensureNextPageIsSynced()
     }
 
     @MainActor
     func reload() async {
         allItems.removeAll()
-        currentPage = Constants.initialPage
-        mightHaveMorePages = true
         itemListStateSubject.send(.loading(allItems))
-        try? await load(pageNumber: currentPage)
+        paginationTracker.resync()
     }
 
     @MainActor
     private func load(pageNumber: Int) async throws {
         do {
             try await fetchItems(pageNumber: pageNumber)
-            mightHaveMorePages = true
             updateItemListStateAfterLoadAttempt()
         } catch PointOfSaleProductServiceError.pageOutOfRange {
-            mightHaveMorePages = false
             updateItemListStateAfterLoadAttempt()
             throw PointOfSaleProductServiceError.pageOutOfRange
         } catch {
@@ -71,14 +57,18 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
             throw error
         }
     }
-
+    
+    /// <#Description#>
+    /// - Parameter pageNumber: <#pageNumber description#>
+    /// - Returns: A boolean that indicates whether there is next page for the paginated items.
     @MainActor
-    private func fetchItems(pageNumber: Int) async throws {
-        let newItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
+    private func fetchItems(pageNumber: Int) async throws -> Bool {
+        let (newItems, hasNextPage) = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
         let uniqueNewItems = newItems.filter { newItem in
             !allItems.contains(newItem)
         }
         allItems.append(contentsOf: uniqueNewItems)
+        return hasNextPage
     }
 
     private func updateItemListStateAfterLoadAttempt() {
@@ -91,5 +81,25 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     private enum Constants {
         static let initialPage: Int = 1
+    }
+}
+
+extension PointOfSaleItemsController: PaginationTrackerDelegate {
+    func sync(pageNumber: Int, pageSize: Int, reason: String?, onCompletion: SyncCompletion?) {
+        itemListStateSubject.send(.loading(allItems))
+        Task { @MainActor in
+            do {
+                let hasNextPage = try await fetchItems(pageNumber: pageNumber)
+                updateItemListStateAfterLoadAttempt()
+                onCompletion?(.success(hasNextPage))
+            } catch PointOfSaleProductServiceError.pageOutOfRange {
+                updateItemListStateAfterLoadAttempt()
+                onCompletion?(.failure(PointOfSaleProductServiceError.pageOutOfRange))
+            } catch {
+                itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
+                onCompletion?(.failure(error))
+            }
+            itemListStateSubject.send(.loaded(allItems))
+        }
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -79,12 +79,13 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     /// - Returns: A boolean that indicates whether there is next page for the paginated items.
     @MainActor
     private func fetchItems(pageNumber: Int) async throws -> Bool {
-        let (newItems, hasNextPage) = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
+        let pagedItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
+        let newItems = pagedItems.items
         let uniqueNewItems = newItems.filter { newItem in
             !allItems.contains(newItem)
         }
         allItems.append(contentsOf: uniqueNewItems)
-        return hasNextPage
+        return pagedItems.hasMorePages
     }
 
     private func updateItemListStateAfterLoadAttempt() {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -15,6 +15,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     private(set) var itemListStatePublisher: any Publisher<ItemListState, Never>
     private var itemListStateSubject: PassthroughSubject<ItemListState, Never> = .init()
     private var allItems: [POSItem] = []
+    private var reloadTask: Task<Void, Never>?
     private let paginationTracker: AsyncPaginationTracker
     private let itemProvider: PointOfSaleItemServiceProtocol
 
@@ -60,17 +61,23 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     func reload() async {
-        allItems.removeAll()
-        itemListStateSubject.send(.loading(allItems))
-        do {
-            try await paginationTracker.resync { [weak self] pageNumber in
-                guard let self else { return true }
-                return try await fetchItems(pageNumber: pageNumber)
+        // Reload is invoked when pulling to refresh as the SwiftUI `refreshable` async action, and it is canceled when the refresh
+        // control is released. Using a separate task ensures the reload async task is not canceled when the refresh control is released.
+        reloadTask?.cancel()
+        reloadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            allItems.removeAll()
+            itemListStateSubject.send(.loading(allItems))
+            do {
+                try await paginationTracker.resync { [weak self] pageNumber in
+                    guard let self else { return true }
+                    return try await fetchItems(pageNumber: pageNumber)
+                }
+                updateItemListStateAfterLoadAttempt()
+            } catch {
+                // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
+                itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
             }
-            updateItemListStateAfterLoadAttempt()
-        } catch {
-            // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
-            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
         }
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -20,7 +20,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     init(itemProvider: PointOfSaleItemServiceProtocol) {
         self.itemProvider = itemProvider
-        self.paginationTracker = .init(pageFirstIndex: Constants.initialPage)
+        self.paginationTracker = .init()
         itemListStatePublisher = itemListStateSubject.eraseToAnyPublisher()
     }
 
@@ -94,9 +94,5 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
         } else {
             itemListStateSubject.send(.loaded(allItems))
         }
-    }
-
-    private enum Constants {
-        static let initialPage: Int = 1
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -41,6 +41,9 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     func loadNextItems() async {
+        guard paginationTracker.hasNextPage else {
+            return
+        }
         itemListStateSubject.send(.loading(allItems))
         do {
             let nextPageState = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -54,7 +54,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
             }
         } catch {
             // TODO: 14694 - Handle error from loading the next page, like showing an error UI at the end or as an overlay.
-            updateItemListStateAfterLoadAttempt()
+            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
         }
     }
 
@@ -70,6 +70,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
             updateItemListStateAfterLoadAttempt()
         } catch {
             // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
+            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
         }
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -15,7 +15,6 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     private(set) var itemListStatePublisher: any Publisher<ItemListState, Never>
     private var itemListStateSubject: PassthroughSubject<ItemListState, Never> = .init()
     private var allItems: [POSItem] = []
-    private var reloadTask: Task<Void, Never>?
     private let paginationTracker: AsyncPaginationTracker
     private let itemProvider: PointOfSaleItemServiceProtocol
 
@@ -64,23 +63,16 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     func reload() async {
-        // Reload is invoked when pulling to refresh as the SwiftUI `refreshable` async action, and it is canceled when the refresh
-        // control is released. Using a separate task ensures the reload async task is not canceled when the refresh control is released.
-        reloadTask?.cancel()
-        reloadTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            allItems.removeAll()
-            itemListStateSubject.send(.loading(allItems))
-            do {
-                try await paginationTracker.resync { [weak self] pageNumber in
-                    guard let self else { return true }
-                    return try await fetchItems(pageNumber: pageNumber)
-                }
-                updateItemListStateAfterLoadAttempt()
-            } catch {
-                // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
-                itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
+        allItems.removeAll()
+        do {
+            try await paginationTracker.resync { [weak self] pageNumber in
+                guard let self else { return true }
+                return try await fetchItems(pageNumber: pageNumber)
             }
+            updateItemListStateAfterLoadAttempt()
+        } catch {
+            // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
+            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
         }
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -68,23 +68,19 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
         // control is released. Using a separate task ensures the reload async task is not canceled when the refresh control is released.
         reloadTask?.cancel()
         reloadTask = Task { @MainActor [weak self] in
-            await self?.resyncItems()
-        }
-    }
-
-    @MainActor
-    func resyncItems() async {
-        allItems.removeAll()
-        itemListStateSubject.send(.loading(allItems))
-        do {
-            try await paginationTracker.resync { [weak self] pageNumber in
-                guard let self else { return true }
-                return try await fetchItems(pageNumber: pageNumber)
+            guard let self else { return }
+            allItems.removeAll()
+            itemListStateSubject.send(.loading(allItems))
+            do {
+                try await paginationTracker.resync { [weak self] pageNumber in
+                    guard let self else { return true }
+                    return try await fetchItems(pageNumber: pageNumber)
+                }
+                updateItemListStateAfterLoadAttempt()
+            } catch {
+                // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
+                itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
             }
-            updateItemListStateAfterLoadAttempt()
-        } catch {
-            // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
-            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
         }
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -15,36 +15,66 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     private(set) var itemListStatePublisher: any Publisher<ItemListState, Never>
     private var itemListStateSubject: PassthroughSubject<ItemListState, Never> = .init()
     private var allItems: [POSItem] = []
-    private var isInitialLoading: Bool = true
-    private let paginationTracker: PaginationTracker
+    private let paginationTracker: AsyncPaginationTracker
     private let itemProvider: PointOfSaleItemServiceProtocol
 
     init(itemProvider: PointOfSaleItemServiceProtocol) {
         self.itemProvider = itemProvider
         self.paginationTracker = .init(pageFirstIndex: Constants.initialPage)
         itemListStatePublisher = itemListStateSubject.eraseToAnyPublisher()
-
-        paginationTracker.delegate = self
     }
 
     @MainActor
     func loadInitialItems() async {
-        paginationTracker.syncFirstPage()
+        itemListStateSubject.send(.initialLoading)
+        do {
+            try await paginationTracker.syncFirstPage { [weak self] pageNumber in
+                guard let self else { return true }
+                return try await fetchItems(pageNumber: pageNumber)
+            }
+            updateItemListStateAfterLoadAttempt()
+        } catch {
+            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
+        }
     }
 
     @MainActor
     func loadNextItems() async {
-        paginationTracker.ensureNextPageIsSynced()
+        itemListStateSubject.send(.loading(allItems))
+        do {
+            let nextPageState = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
+                guard let self else { return true }
+                return try await fetchItems(pageNumber: pageNumber)
+            }
+            switch nextPageState {
+                case .noNextPage, .synced:
+                    updateItemListStateAfterLoadAttempt()
+                case .syncing:
+                    break
+            }
+        } catch {
+            // TODO: 14694 - Handle error from loading the next page, like showing an error UI at the end or as an overlay.
+            updateItemListStateAfterLoadAttempt()
+        }
     }
 
     @MainActor
     func reload() async {
         allItems.removeAll()
-        paginationTracker.resync()
+        itemListStateSubject.send(.loading(allItems))
+        do {
+            try await paginationTracker.resync { [weak self] pageNumber in
+                guard let self else { return true }
+                return try await fetchItems(pageNumber: pageNumber)
+            }
+            updateItemListStateAfterLoadAttempt()
+        } catch {
+            // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
+        }
     }
 
-    /// <#Description#>
-    /// - Parameter pageNumber: <#pageNumber description#>
+    /// Fetches items given a page number and appends new unique items to the `allItems` array.
+    /// - Parameter pageNumber: Page number to fetch items from.
     /// - Returns: A boolean that indicates whether there is next page for the paginated items.
     @MainActor
     private func fetchItems(pageNumber: Int) async throws -> Bool {
@@ -66,29 +96,5 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     private enum Constants {
         static let initialPage: Int = 1
-    }
-}
-
-extension PointOfSaleItemsController: PaginationTrackerDelegate {
-    func sync(pageNumber: Int, pageSize: Int, reason: String?, onCompletion: SyncCompletion?) {
-        if isInitialLoading {
-            isInitialLoading = false
-            itemListStateSubject.send(.initialLoading)
-        } else {
-            itemListStateSubject.send(.loading(allItems))
-        }
-        Task { @MainActor in
-            do {
-                let hasNextPage = try await fetchItems(pageNumber: pageNumber)
-                updateItemListStateAfterLoadAttempt()
-                onCompletion?(.success(hasNextPage))
-            } catch PointOfSaleProductServiceError.pageOutOfRange {
-                updateItemListStateAfterLoadAttempt()
-                onCompletion?(.failure(PointOfSaleProductServiceError.pageOutOfRange))
-            } catch {
-                itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
-                onCompletion?(.failure(error))
-            }
-        }
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -15,6 +15,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     private(set) var itemListStatePublisher: any Publisher<ItemListState, Never>
     private var itemListStateSubject: PassthroughSubject<ItemListState, Never> = .init()
     private var allItems: [POSItem] = []
+    private var isInitialLoading: Bool = true
     private let paginationTracker: PaginationTracker
     private let itemProvider: PointOfSaleItemServiceProtocol
 
@@ -28,7 +29,6 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     func loadInitialItems() async {
-        itemListStateSubject.send(.initialLoading)
         paginationTracker.syncFirstPage()
     }
 
@@ -40,24 +40,9 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     @MainActor
     func reload() async {
         allItems.removeAll()
-        itemListStateSubject.send(.loading(allItems))
         paginationTracker.resync()
     }
 
-    @MainActor
-    private func load(pageNumber: Int) async throws {
-        do {
-            try await fetchItems(pageNumber: pageNumber)
-            updateItemListStateAfterLoadAttempt()
-        } catch PointOfSaleProductServiceError.pageOutOfRange {
-            updateItemListStateAfterLoadAttempt()
-            throw PointOfSaleProductServiceError.pageOutOfRange
-        } catch {
-            itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
-            throw error
-        }
-    }
-    
     /// <#Description#>
     /// - Parameter pageNumber: <#pageNumber description#>
     /// - Returns: A boolean that indicates whether there is next page for the paginated items.
@@ -86,7 +71,12 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
 extension PointOfSaleItemsController: PaginationTrackerDelegate {
     func sync(pageNumber: Int, pageSize: Int, reason: String?, onCompletion: SyncCompletion?) {
-        itemListStateSubject.send(.loading(allItems))
+        if isInitialLoading {
+            isInitialLoading = false
+            itemListStateSubject.send(.initialLoading)
+        } else {
+            itemListStateSubject.send(.loading(allItems))
+        }
         Task { @MainActor in
             do {
                 let hasNextPage = try await fetchItems(pageNumber: pageNumber)
@@ -99,7 +89,6 @@ extension PointOfSaleItemsController: PaginationTrackerDelegate {
                 itemListStateSubject.send(.error(PointOfSaleErrorState.errorOnLoadingProducts()))
                 onCompletion?(.failure(error))
             }
-            itemListStateSubject.send(.loaded(allItems))
         }
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -61,6 +61,7 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
 
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
+    private var reloadTask: Task<Void, Never>?
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -100,7 +101,10 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func reload() async {
-        await itemsController.reload()
+        reloadTask?.cancel()
+        reloadTask = Task { @MainActor in
+            await itemsController.reload()
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -61,7 +61,6 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
 
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
-    private var reloadTask: Task<Void, Never>?
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -101,10 +100,7 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func reload() async {
-        reloadTask?.cancel()
-        reloadTask = Task { @MainActor in
-            await itemsController.reload()
-        }
+        await itemsController.reload()
     }
 }
 

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -37,8 +37,8 @@ struct POSProductPreview: POSOrderableItem, Equatable {
 }
 
 final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSItem] {
-        []
+    func providePointOfSaleItems(pageNumber: Int) async throws -> (items: [POSItem], hasNextPage: Bool) {
+        (items: [], hasNextPage: true)
     }
 
     func providePointOfSaleItems() -> [POSItem] {

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -8,6 +8,7 @@ import protocol Yosemite.POSOrderableItem
 import protocol Yosemite.OrderSyncProductTypeProtocol
 import struct Yosemite.OrderSyncProductInput
 import enum Yosemite.ProductType
+import struct Yosemite.PagedItems
 import struct Yosemite.ProductBundleItem
 import struct Yosemite.OrderItem
 import Combine
@@ -37,8 +38,8 @@ struct POSProductPreview: POSOrderableItem, Equatable {
 }
 
 final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int) async throws -> (items: [POSItem], hasNextPage: Bool) {
-        (items: [], hasNextPage: true)
+    func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
+        .init(items: [], hasMorePages: true)
     }
 
     func providePointOfSaleItems() -> [POSItem] {

--- a/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
@@ -1,6 +1,6 @@
 import Yosemite
 
-/// Keeps track of the pagination for API syncing to support infinite scroll.
+/// Keeps track of the pagination for API syncing to support infinite scroll and pull-to-refresh.
 final class AsyncPaginationTracker {
     typealias SyncFunction = (_ pageNumber: Int) async throws -> Bool
 
@@ -25,7 +25,7 @@ final class AsyncPaginationTracker {
     /// Indexes of the pages being currently synced.
     private var pagesBeingSynced = IndexSet()
 
-    /// Whether there might be more pages to fetch from the API, set by the sync completion.
+    /// Whether there might be more pages to fetch from the API, set by the sync function.
     private var hasNextPage: Bool = true
 
     /// Returns the highest page number that has been successfully synced, if any.
@@ -45,9 +45,9 @@ final class AsyncPaginationTracker {
 
     /// Should be called whenever a scroll position is approaching the end of the list for infinite scroll support.
     /// This method will:
-    ///     1.  Proceed only if a given element is the last one in its page
-    ///     2.  Verify if the next page isn't currently being synced
-    ///     3.  Proceed syncing the next page, if possible / needed
+    ///     1.  Proceed only if there is next page to sync.
+    ///     2.  Verify if the next page isn't currently being synced.
+    ///     3.  Proceed syncing the next page.
     func ensureNextPageIsSynced(syncFunction: @escaping SyncFunction) async throws -> NextPageSyncState {
         guard hasNextPage else {
             return .noNextPage

--- a/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
@@ -57,8 +57,12 @@ final class AsyncPaginationTracker {
         guard !isPageBeingSynced(pageNumber: nextPage) else {
             return .syncing
         }
-        try await sync(pageNumber: nextPage, syncFunction: syncFunction)
-        return .synced
+        do {
+            try await sync(pageNumber: nextPage, syncFunction: syncFunction)
+            return .synced
+        } catch {
+            throw error
+        }
     }
 
     /// Resets internal states and resyncs the first page of results.
@@ -83,14 +87,15 @@ private extension AsyncPaginationTracker {
         markAsBeingSynced(pageNumber: pageNumber)
 
         do {
+            defer {
+                unmarkAsBeingSynced(pageNumber: pageNumber)
+            }
             let hasNextPage = try await syncFunction(pageNumber)
             self.hasNextPage = hasNextPage
             markAsSynced(pageNumber: pageNumber)
         } catch {
             throw error
         }
-
-        unmarkAsBeingSynced(pageNumber: pageNumber)
     }
 }
 

--- a/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
@@ -27,7 +27,7 @@ final class AsyncPaginationTracker {
     private var pagesBeingSynced = IndexSet()
 
     /// Whether there might be more pages to fetch from the API, set by the sync function.
-    private var hasNextPage: Bool = true
+    private(set) var hasNextPage: Bool = true
 
     /// Returns the highest page number that has been successfully synced, if any.
     private var highestPageSynced: Int? {

--- a/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
@@ -1,5 +1,6 @@
 import Yosemite
 
+/// Async/await version of `PaginationTracker`, consider renaming `PaginationTracker` as deprecated and this class to `PaginationTracker`.
 /// Keeps track of the pagination for API syncing to support infinite scroll and pull-to-refresh.
 final class AsyncPaginationTracker {
     typealias SyncFunction = (_ pageNumber: Int) async throws -> Bool

--- a/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
@@ -1,0 +1,126 @@
+import Yosemite
+
+/// Keeps track of the pagination for API syncing to support infinite scroll.
+final class AsyncPaginationTracker {
+    typealias SyncFunction = (_ pageNumber: Int) async throws -> Bool
+
+    /// State of loading the next page in `ensureNextPageIsSynced`.
+    enum NextPageSyncState {
+        case syncing
+        case synced
+        case noNextPage
+    }
+
+    /// Default pagination settings.
+    enum Defaults {
+        static let pageFirstIndex = Store.Default.firstPageNumber
+    }
+
+    /// The index of the first page in the API. So far, both Woo and WP.com API have the first page index at 1.
+    private let pageFirstIndex: Int
+
+    /// Indexes of the pages that have been successfully synced.
+    private var pagesSynced = IndexSet()
+
+    /// Indexes of the pages being currently synced.
+    private var pagesBeingSynced = IndexSet()
+
+    /// Whether there might be more pages to fetch from the API, set by the sync completion.
+    private var hasNextPage: Bool = true
+
+    /// Returns the highest page number that has been successfully synced, if any.
+    private var highestPageSynced: Int? {
+        pagesSynced.max()
+    }
+
+    /// Returns the highest page number that is currently being synced, if any.
+    private var highestPageBeingSynced: Int? {
+        pagesBeingSynced.max()
+    }
+
+    /// Designated Initializer
+    init(pageFirstIndex: Int = Defaults.pageFirstIndex) {
+        self.pageFirstIndex = pageFirstIndex
+    }
+
+    /// Should be called whenever a scroll position is approaching the end of the list for infinite scroll support.
+    /// This method will:
+    ///     1.  Proceed only if a given element is the last one in its page
+    ///     2.  Verify if the next page isn't currently being synced
+    ///     3.  Proceed syncing the next page, if possible / needed
+    func ensureNextPageIsSynced(syncFunction: @escaping SyncFunction) async throws -> NextPageSyncState {
+        guard hasNextPage else {
+            return .noNextPage
+        }
+
+        let nextPage = (highestPageSynced ?? pageFirstIndex - 1) + 1
+        guard !isPageBeingSynced(pageNumber: nextPage) else {
+            return .syncing
+        }
+        try await sync(pageNumber: nextPage, syncFunction: syncFunction)
+        return .synced
+    }
+
+    /// Resets internal states and resyncs the first page of results.
+    ///
+    func resync(syncFunction: @escaping SyncFunction) async throws {
+        resetInternalState()
+        try await syncFirstPage( syncFunction: syncFunction)
+    }
+
+    /// Syncs the first page of results.
+    ///
+    func syncFirstPage(syncFunction: @escaping SyncFunction) async throws {
+        try await sync(pageNumber: pageFirstIndex, syncFunction: syncFunction)
+    }
+}
+
+// MARK: - Syncing Core
+//
+private extension AsyncPaginationTracker {
+    /// Syncs a given page number.
+    func sync(pageNumber: Int, syncFunction: @escaping SyncFunction) async throws {
+        markAsBeingSynced(pageNumber: pageNumber)
+
+        do {
+            let hasNextPage = try await syncFunction(pageNumber)
+            self.hasNextPage = hasNextPage
+            markAsSynced(pageNumber: pageNumber)
+        } catch {
+            throw error
+        }
+
+        unmarkAsBeingSynced(pageNumber: pageNumber)
+    }
+}
+
+// MARK: - Private Methods
+//
+private extension AsyncPaginationTracker {
+    /// Resets all of the internal structures.
+    func resetInternalState() {
+        pagesBeingSynced.removeAll()
+        pagesSynced.removeAll()
+        hasNextPage = true
+    }
+
+    /// Indicates if a given page number is currently being synced.
+    func isPageBeingSynced(pageNumber: Int) -> Bool {
+        return pagesBeingSynced.contains(pageNumber)
+    }
+
+    /// Marks the specified page number as synced with the current date.
+    func markAsSynced(pageNumber: Int) {
+        pagesSynced.insert(pageNumber)
+    }
+
+    /// Marks the specified page number as being synced.
+    func markAsBeingSynced(pageNumber: Int) {
+        pagesBeingSynced.insert(pageNumber)
+    }
+
+    /// Removes the specified page number from the "In Sync" collection.
+    func unmarkAsBeingSynced(pageNumber: Int) {
+        pagesBeingSynced.remove(pageNumber)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		0230B4D62C33454900F2F660 /* PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230B4D52C33454900F2F660 /* PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift */; };
 		0230B4D82C3345DF00F2F660 /* PointOfSaleCardPresentPaymentCaptureFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230B4D72C3345DF00F2F660 /* PointOfSaleCardPresentPaymentCaptureFailedView.swift */; };
 		02312797277D4F650060E180 /* StoreStatsPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02312796277D4F640060E180 /* StoreStatsPeriodViewModel.swift */; };
+		02335E492D13BA42000B6ECE /* AsyncPaginationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02335E482D13BA42000B6ECE /* AsyncPaginationTracker.swift */; };
 		023453F22579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */; };
 		0234680A282CEA5F00CFC503 /* LegacyReceiptViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02346809282CEA5F00CFC503 /* LegacyReceiptViewModelTests.swift */; };
 		0235354E2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */; };
@@ -3329,6 +3330,7 @@
 		0230B4D52C33454900F2F660 /* PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift; sourceTree = "<group>"; };
 		0230B4D72C3345DF00F2F660 /* PointOfSaleCardPresentPaymentCaptureFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCaptureFailedView.swift; sourceTree = "<group>"; };
 		02312796277D4F640060E180 /* StoreStatsPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsPeriodViewModel.swift; sourceTree = "<group>"; };
+		02335E482D13BA42000B6ECE /* AsyncPaginationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncPaginationTracker.swift; sourceTree = "<group>"; };
 		023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingInstructionsViewController.swift; sourceTree = "<group>"; };
 		02346809282CEA5F00CFC503 /* LegacyReceiptViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyReceiptViewModelTests.swift; sourceTree = "<group>"; };
 		0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -7248,6 +7250,7 @@
 			children = (
 				02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */,
 				029700EB24FE38C900D242F8 /* ScrollWatcher.swift */,
+				02335E482D13BA42000B6ECE /* AsyncPaginationTracker.swift */,
 			);
 			path = InfiniteScroll;
 			sourceTree = "<group>";
@@ -15790,6 +15793,7 @@
 				268D7C9C2984752A00D38709 /* SupportForm.swift in Sources */,
 				02A275BA23FE50AA005C560F /* ProductUIImageLoader.swift in Sources */,
 				02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */,
+				02335E492D13BA42000B6ECE /* AsyncPaginationTracker.swift in Sources */,
 				B5D6DC54214802740003E48A /* SyncCoordinator.swift in Sources */,
 				205B7EBD2C19FB6600D14A36 /* PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift in Sources */,
 				018D5C7E2CA6B4A60085EBEE /* CurrencySettings+Sanitized.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -54,13 +54,13 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == expectedItems.count)
     }
 
-    @Test func reload_results_in_loaded_state() async throws {
+    @Test func resyncItems_results_in_loaded_state() async throws {
         // Given
         try #require(itemListState == .initialLoading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.reload()
+        await sut.resyncItems()
 
         // Then
         guard case .loaded(let items) = itemListState else {
@@ -70,15 +70,15 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == expectedItems.count)
     }
 
-    @Test func reload_when_called_multiple_times_then_items_are_not_duplicated() async throws {
+    @Test func resyncItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
         // Given
         try #require(itemListState == .initialLoading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.reload()
-        await sut.reload()
-        await sut.reload()
+        await sut.resyncItems()
+        await sut.resyncItems()
+        await sut.resyncItems()
 
         // Then
         guard case .loaded(let items) = itemListState else {
@@ -215,19 +215,19 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
     }
 
-    @Test func reload_results_in_state_loaded_with_expected_items() async throws {
+    @Test func resyncItems_results_in_state_loaded_with_expected_items() async throws {
         // Given
         try #require(itemListState == .initialLoading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.reload()
+        await sut.resyncItems()
 
         // Then
         #expect(itemListState == .loaded(expectedItems))
     }
 
-    @Test func reload_requests_first_page() async throws {
+    @Test func resyncItems_requests_first_page() async throws {
         // Given
         itemProvider.shouldSimulateTwoPages = true
         await sut.loadInitialItems()
@@ -236,7 +236,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
 
         // When
-        await sut.reload()
+        await sut.resyncItems()
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
@@ -268,7 +268,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
     }
 
-    @Test func reload_when_itemProvider_throws_error_then_state_is_error() async throws {
+    @Test func resyncItems_when_itemProvider_throws_error_then_state_is_error() async throws {
         // Given
         itemProvider.shouldThrowError = true
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
@@ -278,7 +278,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemListState == .initialLoading)
 
         // When
-        await sut.reload()
+        await sut.resyncItems()
 
         // Then
         #expect(itemListState == .error(expectedError))

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -125,6 +125,7 @@ final class PointOfSaleItemsControllerTests {
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
         itemProvider.items = initialItems
         itemProvider.shouldSimulateTwoPages = true
+        await sut.loadInitialItems()
 
         // When
         await sut.loadNextItems()
@@ -140,6 +141,8 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadNextItems_requests_second_page() async throws {
         // Given
         try #require(itemListState == .initialLoading)
+        itemProvider.shouldSimulateTwoPages = true
+        await sut.loadInitialItems()
 
         // When
         await sut.loadNextItems()
@@ -178,11 +181,15 @@ final class PointOfSaleItemsControllerTests {
 
     @Test func loadNextItems_when_itemProvider_throws_error_then_state_is_error() async throws {
         // Given
+        try #require(itemListState == .initialLoading)
+
+        itemProvider.shouldSimulateTwoPages = true
+        await sut.loadInitialItems()
+
         itemProvider.shouldThrowError = true
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
                                                   subtitle: "Give it another go?",
                                                   buttonText: "Retry")
-        try #require(itemListState == .initialLoading)
 
         // When
         await sut.loadNextItems()
@@ -193,6 +200,9 @@ final class PointOfSaleItemsControllerTests {
 
     @Test func loadNextItems_after_itemProvider_throws_error_then_the_same_page_is_requested_next() async throws {
         // Given
+        itemProvider.shouldSimulateTwoPages = true
+        await sut.loadInitialItems()
+
         itemProvider.shouldThrowError = true
         await sut.loadNextItems()
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
@@ -219,6 +229,9 @@ final class PointOfSaleItemsControllerTests {
 
     @Test func reload_requests_first_page() async throws {
         // Given
+        itemProvider.shouldSimulateTwoPages = true
+        await sut.loadInitialItems()
+
         await sut.loadNextItems()
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
 
@@ -229,33 +242,26 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
     }
 
-    @Test func loadNextItems_when_next_page_is_out_of_range_then_receives_error() async throws {
+    @Test func loadNextItems_when_next_page_is_empty_then_state_is_loaded() async throws {
         // Given
         await sut.loadInitialItems()
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
-        let expectedError = PointOfSaleErrorState(title: "Error loading products",
-                                                  subtitle: "Give it another go?",
-                                                  buttonText: "Retry")
 
         // When
-        itemProvider.simulateNextPageIsOutOfRange()
+        itemProvider.shouldReturnZeroItems = true
         await sut.loadNextItems()
 
         // Then
-        guard case .error = itemListState else {
-            Issue.record("Expected error state, but got \(itemListState)")
-            return
-        }
-        #expect(itemListState == .error(expectedError))
+        #expect(itemListState == .loaded(MockPointOfSaleItemService.makeInitialItems()))
     }
 
-    @Test func loadNextItems_when_next_page_is_out_of_range_then_the_same_page_is_requested_next() async throws {
+    @Test func loadNextItems_when_next_page_is_empty_then_the_same_page_is_requested_next() async throws {
         // Given
         await sut.loadInitialItems()
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
         // When
-        itemProvider.simulateNextPageIsOutOfRange()
+        itemProvider.shouldReturnZeroItems = true
         await sut.loadNextItems()
 
         // Then

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -54,13 +54,13 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == expectedItems.count)
     }
 
-    @Test func resyncItems_results_in_loaded_state() async throws {
+    @Test func reload_results_in_loaded_state() async throws {
         // Given
         try #require(itemListState == .initialLoading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.resyncItems()
+        await sut.reload()
 
         // Then
         guard case .loaded(let items) = itemListState else {
@@ -70,15 +70,15 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == expectedItems.count)
     }
 
-    @Test func resyncItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
+    @Test func reload_when_called_multiple_times_then_items_are_not_duplicated() async throws {
         // Given
         try #require(itemListState == .initialLoading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.resyncItems()
-        await sut.resyncItems()
-        await sut.resyncItems()
+        await sut.reload()
+        await sut.reload()
+        await sut.reload()
 
         // Then
         guard case .loaded(let items) = itemListState else {
@@ -215,19 +215,19 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
     }
 
-    @Test func resyncItems_results_in_state_loaded_with_expected_items() async throws {
+    @Test func reload_results_in_state_loaded_with_expected_items() async throws {
         // Given
         try #require(itemListState == .initialLoading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.resyncItems()
+        await sut.reload()
 
         // Then
         #expect(itemListState == .loaded(expectedItems))
     }
 
-    @Test func resyncItems_requests_first_page() async throws {
+    @Test func reload_requests_first_page() async throws {
         // Given
         itemProvider.shouldSimulateTwoPages = true
         await sut.loadInitialItems()
@@ -236,7 +236,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
 
         // When
-        await sut.resyncItems()
+        await sut.reload()
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
@@ -268,7 +268,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
     }
 
-    @Test func resyncItems_when_itemProvider_throws_error_then_state_is_error() async throws {
+    @Test func reload_when_itemProvider_throws_error_then_state_is_error() async throws {
         // Given
         itemProvider.shouldThrowError = true
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
@@ -278,7 +278,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemListState == .initialLoading)
 
         // When
-        await sut.resyncItems()
+        await sut.reload()
 
         // Then
         #expect(itemListState == .error(expectedError))

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -9,13 +9,9 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     var shouldThrowError = false
     var shouldReturnZeroItems = false
     var shouldSimulateTwoPages = false
-    private var isPageOutOfRange = false
 
     var spyLastRequestedPageNumber: Int?
     func providePointOfSaleItems(pageNumber: Int) async throws -> (items: [POSItem], hasNextPage: Bool) {
-        if isPageOutOfRange {
-            throw MockError.pageOutOfRange
-        }
         spyLastRequestedPageNumber = pageNumber
         if shouldThrowError {
             throw MockError.requestFailed
@@ -25,18 +21,9 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
         }
         if shouldSimulateTwoPages,
             pageNumber > 1 {
-            simulateFetchNextPage()
-            return (items, true)
+            return (MockPointOfSaleItemService.makeSecondPageItems(), false)
         }
-        return (MockPointOfSaleItemService.makeInitialItems(), false)
-    }
-
-    func simulateFetchNextPage() {
-        items.append(contentsOf: MockPointOfSaleItemService.makeSecondPageItems())
-    }
-
-    func simulateNextPageIsOutOfRange() {
-        isPageOutOfRange = true
+        return (MockPointOfSaleItemService.makeInitialItems(), shouldSimulateTwoPages)
     }
 }
 
@@ -79,6 +66,5 @@ extension MockPointOfSaleItemService {
 
     enum MockError: Error {
         case requestFailed
-        case pageOutOfRange
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -3,6 +3,7 @@ import protocol Yosemite.PointOfSaleItemServiceProtocol
 import enum Yosemite.POSItem
 import protocol Yosemite.POSOrderableItem
 @testable import struct Yosemite.POSSimpleProduct
+import struct Yosemite.PagedItems
 
 final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     var items: [POSItem] = []
@@ -11,19 +12,19 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     var shouldSimulateTwoPages = false
 
     var spyLastRequestedPageNumber: Int?
-    func providePointOfSaleItems(pageNumber: Int) async throws -> (items: [POSItem], hasNextPage: Bool) {
+    func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
         spyLastRequestedPageNumber = pageNumber
         if shouldThrowError {
             throw MockError.requestFailed
         }
         if shouldReturnZeroItems {
-            return ([], false)
+            return .init(items: [], hasMorePages: false)
         }
         if shouldSimulateTwoPages,
             pageNumber > 1 {
-            return (MockPointOfSaleItemService.makeSecondPageItems(), false)
+            return .init(items: MockPointOfSaleItemService.makeSecondPageItems(), hasMorePages: false)
         }
-        return (MockPointOfSaleItemService.makeInitialItems(), shouldSimulateTwoPages)
+        return .init(items: MockPointOfSaleItemService.makeInitialItems(), hasMorePages: shouldSimulateTwoPages)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -12,7 +12,7 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     private var isPageOutOfRange = false
 
     var spyLastRequestedPageNumber: Int?
-    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSItem] {
+    func providePointOfSaleItems(pageNumber: Int) async throws -> (items: [POSItem], hasNextPage: Bool) {
         if isPageOutOfRange {
             throw MockError.pageOutOfRange
         }
@@ -21,14 +21,14 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
             throw MockError.requestFailed
         }
         if shouldReturnZeroItems {
-            return []
+            return ([], false)
         }
         if shouldSimulateTwoPages,
             pageNumber > 1 {
             simulateFetchNextPage()
-            return items
+            return (items, true)
         }
-        return MockPointOfSaleItemService.makeInitialItems()
+        return (MockPointOfSaleItemService.makeInitialItems(), false)
     }
 
     func simulateFetchNextPage() {

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -157,6 +157,7 @@ public typealias ShippingMethod = Networking.ShippingMethod
 public typealias Site = Networking.Site
 public typealias SiteVisibility = Networking.SiteVisibility
 public typealias SiteAPI = Networking.SiteAPI
+public typealias PagedItems = Networking.PagedItems
 public typealias Post = Networking.Post
 public typealias SitePlugin = Networking.SitePlugin
 public typealias SitePluginStatusEnum = Networking.SitePluginStatusEnum

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -1,3 +1,5 @@
+import struct Networking.PagedItems
+
 public enum POSItem: Equatable, Identifiable {
     case simpleProduct(POSSimpleProduct)
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -45,13 +45,13 @@ public extension Sequence where Element == POSOrderableItem {
 }
 
 public protocol PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int) async throws -> (items: [POSItem], hasNextPage: Bool)
+    func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem>
 }
 
 // Default implementation for convenience, so we do not need to pass the first page explicitly
 // if no pageNumber is given.
 extension PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int = 1) async throws -> (items: [POSItem], hasNextPage: Bool) {
+    func providePointOfSaleItems(pageNumber: Int = 1) async throws -> PagedItems<POSItem> {
         try await providePointOfSaleItems(pageNumber: pageNumber)
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -51,7 +51,7 @@ public protocol PointOfSaleItemServiceProtocol {
 // Default implementation for convenience, so we do not need to pass the first page explicitly
 // if no pageNumber is given.
 extension PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSItem] {
+    func providePointOfSaleItems(pageNumber: Int = 1) async throws -> (items: [POSItem], hasNextPage: Bool) {
         try await providePointOfSaleItems(pageNumber: pageNumber)
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -45,7 +45,7 @@ public extension Sequence where Element == POSOrderableItem {
 }
 
 public protocol PointOfSaleItemServiceProtocol {
-    func providePointOfSaleItems(pageNumber: Int) async throws -> [POSItem]
+    func providePointOfSaleItems(pageNumber: Int) async throws -> (items: [POSItem], hasNextPage: Bool)
 }
 
 // Default implementation for convenience, so we do not need to pass the first page explicitly

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -43,7 +43,8 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> (items: [POSItem], hasNextPage: Bool) {
         let productTypes: [ProductType] = isVariableProductsFeatureEnabled ?
         [.simple, .variable] : [.simple]
-        let (products, totalPagesCount) = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
+        let pagedProducts = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
+        let products = pagedProducts.items
 
         if pageNumber != 1 && products.count == 0 {
             return ([], false)
@@ -56,8 +57,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
         ]
         let filteredProducts = filterProducts(products: products, using: eligibilityCriteria)
 
-        let hasNextPage = totalPagesCount.map { pageNumber < $0 } ?? true
-        return (items: mapProductsToPOSItems(products: filteredProducts), hasNextPage: hasNextPage)
+        return (items: mapProductsToPOSItems(products: filteredProducts), hasNextPage: pagedProducts.hasMorePages)
     }
 
     // Maps result to POSItem, and populate the output with:

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -41,10 +41,10 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     ///
     /// - pageNumber: Number of the page that should be retrieved. If none given, defaults to 1
     ///
-    public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> [POSItem] {
+    public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> (items: [POSItem], hasNextPage: Bool) {
         let productTypes: [ProductType] = isVariableProductsFeatureEnabled ?
         [.simple, .variable] : [.simple]
-        let products = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
+        let (products, totalPagesCount) = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
 
         if pageNumber != 1 && products.count == 0 {
             throw PointOfSaleProductServiceError.pageOutOfRange
@@ -57,7 +57,8 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
         ]
         let filteredProducts = filterProducts(products: products, using: eligibilityCriteria)
 
-        return mapProductsToPOSItems(products: filteredProducts)
+        let hasNextPage = totalPagesCount.map { pageNumber < $0 } ?? true
+        return (items: mapProductsToPOSItems(products: filteredProducts), hasNextPage: hasNextPage)
     }
 
     // Maps result to POSItem, and populate the output with:

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -7,7 +7,6 @@ import class WooFoundation.CurrencySettings
 
 public enum PointOfSaleProductServiceError: Error {
     case requestFailed
-    case pageOutOfRange
     case unknown
 }
 
@@ -47,7 +46,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
         let (products, totalPagesCount) = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
 
         if pageNumber != 1 && products.count == 0 {
-            throw PointOfSaleProductServiceError.pageOutOfRange
+            return ([], false)
         }
 
         let eligibilityCriteria: [(Product) -> Bool] = [

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -40,14 +40,14 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     ///
     /// - pageNumber: Number of the page that should be retrieved. If none given, defaults to 1
     ///
-    public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> (items: [POSItem], hasNextPage: Bool) {
+    public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> PagedItems<POSItem> {
         let productTypes: [ProductType] = isVariableProductsFeatureEnabled ?
         [.simple, .variable] : [.simple]
         let pagedProducts = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
         let products = pagedProducts.items
 
         if pageNumber != 1 && products.count == 0 {
-            return ([], false)
+            return .init(items: [], hasMorePages: false)
         }
 
         let eligibilityCriteria: [(Product) -> Bool] = [
@@ -57,7 +57,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
         ]
         let filteredProducts = filterProducts(products: products, using: eligibilityCriteria)
 
-        return (items: mapProductsToPOSItems(products: filteredProducts), hasNextPage: pagedProducts.hasMorePages)
+        return .init(items: mapProductsToPOSItems(products: filteredProducts), hasMorePages: pagedProducts.hasMorePages)
     }
 
     // Maps result to POSItem, and populate the output with:

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -40,24 +40,21 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         }
     }
 
-    func test_PointOfSaleItemServiceProtocol_when_fails_request_with_pageOutOfRange_then_throws_error() async throws {
-        let expectedError = PointOfSaleProductServiceError.pageOutOfRange
-        network.simulateError(requestUrlSuffix: "products", error: expectedError)
+    func test_PointOfSaleItemServiceProtocol_when_empty_data_for_non_first_page_then_returns_empty_items_and_no_next_page() async throws {
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
 
         // When
-        do {
-            _ = try await itemProvider.providePointOfSaleItems()
-            XCTFail("Expected an error, but got success.")
-        } catch {
-            // Then
-            XCTAssertEqual(error as? PointOfSaleProductServiceError, expectedError)
-        }
+        let (items, hasNextPage) = try await itemProvider.providePointOfSaleItems()
+
+        // Then
+        XCTAssertTrue(items.isEmpty)
+        XCTAssertFalse(hasNextPage)
     }
 
     func test_PointOfSaleItemServiceProtocol_provides_no_items_when_store_has_no_products() async throws {
         // Given/When
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
-        let expectedItems = try await itemProvider.providePointOfSaleItems()
+        let (expectedItems, _) = try await itemProvider.providePointOfSaleItems()
 
         // Then
         XCTAssertTrue(expectedItems.isEmpty)
@@ -73,7 +70,7 @@ final class PointOfSaleProductServiceTests: XCTestCase {
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
-        let expectedItems = try await itemProvider.providePointOfSaleItems()
+        let (expectedItems, _) = try await itemProvider.providePointOfSaleItems()
 
         // Then
         guard let item = expectedItems.first,
@@ -94,7 +91,7 @@ final class PointOfSaleProductServiceTests: XCTestCase {
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-for-eligibility-criteria")
-        let expectedItems = try await itemProvider.providePointOfSaleItems()
+        let (expectedItems, _) = try await itemProvider.providePointOfSaleItems()
 
         // Then
         XCTAssertEqual(expectedItems.count, expectedNumberOfItems)

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -45,20 +45,20 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
 
         // When
-        let (items, hasNextPage) = try await itemProvider.providePointOfSaleItems(pageNumber: 2)
+        let pagedItems = try await itemProvider.providePointOfSaleItems(pageNumber: 2)
 
         // Then
-        XCTAssertTrue(items.isEmpty)
-        XCTAssertFalse(hasNextPage)
+        XCTAssertTrue(pagedItems.items.isEmpty)
+        XCTAssertFalse(pagedItems.hasMorePages)
     }
 
     func test_PointOfSaleItemServiceProtocol_provides_no_items_when_store_has_no_products() async throws {
         // Given/When
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
-        let (expectedItems, _) = try await itemProvider.providePointOfSaleItems()
+        let pagedItems = try await itemProvider.providePointOfSaleItems()
 
         // Then
-        XCTAssertTrue(expectedItems.isEmpty)
+        XCTAssertTrue(pagedItems.items.isEmpty)
     }
 
     func test_PointOfSaleItemServiceProtocol_provides_items_when_store_has_eligible_products() async throws {
@@ -71,9 +71,10 @@ final class PointOfSaleProductServiceTests: XCTestCase {
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
-        let (expectedItems, _) = try await itemProvider.providePointOfSaleItems()
+        let pagedItems = try await itemProvider.providePointOfSaleItems()
 
         // Then
+        let expectedItems = pagedItems.items
         guard let item = expectedItems.first,
             case .simpleProduct(let simpleProduct) = item else {
             return XCTFail("No eligible products")
@@ -92,9 +93,10 @@ final class PointOfSaleProductServiceTests: XCTestCase {
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-for-eligibility-criteria")
-        let (expectedItems, _) = try await itemProvider.providePointOfSaleItems()
+        let pagedItems = try await itemProvider.providePointOfSaleItems()
 
         // Then
+        let expectedItems = pagedItems.items
         XCTAssertEqual(expectedItems.count, expectedNumberOfItems)
 
         guard case .simpleProduct(let firstEligibleSimpleProduct) = expectedItems.first,

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -41,10 +41,11 @@ final class PointOfSaleProductServiceTests: XCTestCase {
     }
 
     func test_PointOfSaleItemServiceProtocol_when_empty_data_for_non_first_page_then_returns_empty_items_and_no_next_page() async throws {
+        // Given
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
 
         // When
-        let (items, hasNextPage) = try await itemProvider.providePointOfSaleItems()
+        let (items, hasNextPage) = try await itemProvider.providePointOfSaleItems(pageNumber: 2)
 
         // Then
         XCTAssertTrue(items.isEmpty)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14699
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request introduces a new feature to handle response headers along with response data in network requests. It also includes changes to support paginated responses in the products loading functionality in POS. The most important changes include adding a new method to fetch response data and headers, updating the `ProductsRemote` class to handle paginated responses, and modifying relevant tests to accommodate these changes using a new async version of the pagination tracker.

### Network response handling:

* [`Networking/Networking/Network/AlamofireNetwork.swift`](diffhunk://#diff-e5de4f95ce59918843a27539494c0fe4cb56643666b6ba692a8598eadbb1a35cR87-R102): Added a new method `responseDataAndHeaders` to fetch both data and headers for a network request.
* [`Networking/Networking/Network/MockNetwork.swift`](diffhunk://#diff-b3daa535a62ca6de09b8f4077bc87980d04ee9e9e3dce0bda93e43fccd5b5d1bR30-R32): Added `responseDataAndHeaders` method and `responseHeaders` variable to mock network responses with headers. [[1]](diffhunk://#diff-b3daa535a62ca6de09b8f4077bc87980d04ee9e9e3dce0bda93e43fccd5b5d1bR30-R32) [[2]](diffhunk://#diff-b3daa535a62ca6de09b8f4077bc87980d04ee9e9e3dce0bda93e43fccd5b5d1bR84-R97)
* [`Networking/Networking/Network/Network.swift`](diffhunk://#diff-1241b41f6051bf98c4b482192989aee19ca092ba431b5447ea26da1bcf814f8eR21): Introduced `ResponseHeaders` typealias and added `responseDataAndHeaders` method to the `Network` protocol. [[1]](diffhunk://#diff-1241b41f6051bf98c4b482192989aee19ca092ba431b5447ea26da1bcf814f8eR21) [[2]](diffhunk://#diff-1241b41f6051bf98c4b482192989aee19ca092ba431b5447ea26da1bcf814f8eR43-R44)
* [`Networking/Networking/Network/NullNetwork.swift`](diffhunk://#diff-7e68cebf68a33ece6b704356f4e51455a456a905b72212595978af4534556982R22-R25): Implemented `responseDataAndHeaders` method to throw `NetworkError.notFound` as a placeholder implementation.
* [`Networking/Networking/Network/WordPressOrgNetwork.swift`](diffhunk://#diff-826ad9712487a498a6ea4a20fc0a240bfa7401526cceaa4410c1679f3526ff23R107-R122): Added `responseDataAndHeaders` method to handle response data and headers in unit tests.

### Paginated responses:

* [`Networking/Networking/Remote/ProductsRemote.swift`](diffhunk://#diff-dde78446a8994905cf951ddc694e4b3620a81a6dfd9e719f48afec2cd4c3e7b6L207-R209): Updated `loadProductsForPointOfSale` method to return `PagedItems` and handle pagination using response headers. [[1]](diffhunk://#diff-dde78446a8994905cf951ddc694e4b3620a81a6dfd9e719f48afec2cd4c3e7b6L207-R209) [[2]](diffhunk://#diff-dde78446a8994905cf951ddc694e4b3620a81a6dfd9e719f48afec2cd4c3e7b6L225-R236)
* [`Networking/Networking/Remote/Remote.swift`](diffhunk://#diff-867c8f6d7c2e8dd17faadda0483244aaf07ae31c1afecc9af3878a093d84d33bR261-R287): Added `enqueueWithResponseHeaders` method to handle responses with headers and introduced `PagedItems` struct to represent paginated results. [[1]](diffhunk://#diff-867c8f6d7c2e8dd17faadda0483244aaf07ae31c1afecc9af3878a093d84d33bR261-R287) [[2]](diffhunk://#diff-867c8f6d7c2e8dd17faadda0483244aaf07ae31c1afecc9af3878a093d84d33bR369-R379) [[3]](diffhunk://#diff-867c8f6d7c2e8dd17faadda0483244aaf07ae31c1afecc9af3878a093d84d33bR388-R391)

### Pagination Improvements:
* [`WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift`](diffhunk://#diff-fedbcd04a4fa1813ce8096c04245c0cfd6ebdb553891e153ce286062ab9a99fdR1-R131): Introduced the `AsyncPaginationTracker` class to manage pagination state and support infinite scroll and pull-to-refresh. Most of the implementation is based on the closure-based `PaginationTracker`.
* [`WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift`](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L18-R88): Refactored to use `AsyncPaginationTracker` for managing pagination state.

### Tests:

* [`Networking/NetworkingTests/Remote/ProductsRemoteTests.swift`](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL943-R946): Updated tests to handle `PagedItems` and verify pagination logic. [[1]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL943-R946) [[2]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL973-R977) [[3]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL991-R1032)

### Additional changes:

* [`WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift`](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cR64): Added a task to manage item reloads. [[1]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cR64) [[2]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cR104-R109)
* [`WooCommerce/Classes/POS/Utils/PreviewHelpers.swift`](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dR11): Updated mock service to return `PagedItems`. [[1]](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dR11) [[2]](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dL40-R42)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Switch to a store eligible for POS
- Go to Menu > Point of Sale mode --> the products should be loaded after the initial loading state
- Scroll toward the bottom --> if the store has more than 100 simple/variable published products, the next page of products should be loaded with a placeholder row at the bottom

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [x] @jaclync tests on stores with more than 1 page of products, and just 1 page of products.
- [ ] @jaclync tests on stores with site credentials login

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/eff17078-10fc-4932-9e90-0a15d28fb14e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.