### PR TITLE
Add customs row in WooShippingCreateLabelsView

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
@@ -27,6 +27,7 @@ struct WooShippingCustoms: View {
                 .padding(.horizontal, 10)
 
             PencilEditButton {
+                // TODO: Add action
             }
             .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import WooFoundation
+
+struct WooShippingCustoms: View {
+    let informationIsCompleted: Bool
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    var body: some View {
+        HStack {
+            // Title
+            Text(Localization.customsTitle)
+                .font(.system(size: Layout.customsTitleFontSize, weight: .medium))
+                .foregroundColor(.primary)
+
+            Spacer()
+
+            Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
+                .font(.system(size: Layout.statusBadgeFontSize, weight: .medium))
+                .foregroundColor(.black)
+                .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
+                .padding(.vertical, Layout.statusBadgeVerticalPadding)
+                .background(
+                    RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
+                        .fill(informationIsCompleted ?
+                              Color.withColorStudio(name: .green, shade: .shade5) :
+                                Color.withColorStudio(name: .red, shade: .shade10))
+                )
+                .padding(.horizontal, 10)
+
+            Button {
+            } label: {
+                Image(systemName: "pencil")
+                    .resizable()
+                    .frame(width: Layout.pencilButtonSizeDimensions * scale,
+                           height: Layout.pencilButtonSizeDimensions * scale)
+            }
+            .tint(Color(.primary))
+        }
+        .padding(Layout.borderPadding)
+        .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+    }
+}
+
+private extension WooShippingCustoms {
+    enum Layout {
+        static let borderCornerRadius: CGFloat = 8
+        static let borderWidth: CGFloat = 0.5
+        static let pencilButtonSizeDimensions: CGFloat = 22
+        static let customsTitleFontSize: CGFloat = 17
+        static let statusBadgeFontSize: CGFloat = 14
+        static let statusBadgeCornerRadius: CGFloat = 6
+        static let statusBadgeHorizontalPadding: CGFloat = 12
+        static let statusBadgeVerticalPadding: CGFloat = 6
+        static let borderPadding: CGFloat = 16
+    }
+}
+
+private extension WooShippingCustoms {
+    enum Localization {
+        static let customsTitle = NSLocalizedString("shippingLabels.customs.customsTitle",
+                                                    value: "Customs",
+                                                    comment: "Customs row title in the main Shipping Labels view")
+        static let completedStatus = NSLocalizedString("shippingLabels.customs.completedBadge",
+                                                       value: "Completed",
+                                                       comment: "Badge wording when the customs information is completed")
+        static let missingInfoStatus = NSLocalizedString("shippingLabels.customs.missingInfo",
+                                                         value: "Missing info",
+                                                         comment: "Badge wording when the customs information is missing")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
@@ -7,7 +7,6 @@ struct WooShippingCustoms: View {
 
     var body: some View {
         HStack {
-            // Title
             Text(Localization.customsTitle)
                 .font(.system(size: Layout.customsTitleFontSize, weight: .medium))
                 .foregroundColor(.primary)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
@@ -8,13 +8,13 @@ struct WooShippingCustoms: View {
     var body: some View {
         AdaptiveStack {
             Text(Localization.customsTitle)
-                .font(.system(size: Layout.customsTitleFontSize, weight: .medium))
+                .headlineStyle()
                 .foregroundColor(.primary)
 
             Spacer()
 
             Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
-                .font(.system(size: Layout.statusBadgeFontSize, weight: .medium))
+                .captionStyle()
                 .foregroundColor(.black)
                 .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
                 .padding(.vertical, Layout.statusBadgeVerticalPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
@@ -6,7 +6,7 @@ struct WooShippingCustoms: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     var body: some View {
-        HStack {
+        AdaptiveStack {
             Text(Localization.customsTitle)
                 .font(.system(size: Layout.customsTitleFontSize, weight: .medium))
                 .foregroundColor(.primary)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
@@ -62,6 +62,6 @@ private extension WooShippingCustoms {
                                                          comment: "Badge wording when the customs information is missing")
         static let editButtonAccessibilityLabel = NSLocalizedString("shippingLabels.customs.editButtonAccessibiliy",
                                                                       value: "Edit Shipping Labels Customs Info",
-                                                                      comment: "Accessibility label for the button to edit order status on the New Order screen")
+                                                                      comment: "Accessibility label for the button to edit the shipping labels customs")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustoms.swift
@@ -26,14 +26,9 @@ struct WooShippingCustoms: View {
                 )
                 .padding(.horizontal, 10)
 
-            Button {
-            } label: {
-                Image(systemName: "pencil")
-                    .resizable()
-                    .frame(width: Layout.pencilButtonSizeDimensions * scale,
-                           height: Layout.pencilButtonSizeDimensions * scale)
+            PencilEditButton {
             }
-            .tint(Color(.primary))
+            .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
         }
         .padding(Layout.borderPadding)
         .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
@@ -65,5 +60,8 @@ private extension WooShippingCustoms {
         static let missingInfoStatus = NSLocalizedString("shippingLabels.customs.missingInfo",
                                                          value: "Missing info",
                                                          comment: "Badge wording when the customs information is missing")
+        static let editButtonAccessibilityLabel = NSLocalizedString("shippingLabels.customs.editButtonAccessibiliy",
+                                                                      value: "Edit Shipping Labels Customs Info",
+                                                                      comment: "Accessibility label for the button to edit order status on the New Order screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -46,6 +46,9 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingHazmat(enabled: !viewModel.canViewLabel)
 
+                    WooShippingCustoms(informationIsCompleted: viewModel.customsInformationIsCompleted)
+                        .padding(.bottom, 16)
+
                     if viewModel.canViewLabel {
                         EmptyView()
                     } else if let package = viewModel.selectedPackage,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -23,8 +23,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         shippingLabel != nil
     }
 
-    /// Whether the custom information is completed or not
+    /// Whether the custom information is completed or not.
     var customsInformationIsCompleted: Bool {
+        // To be synced with real data
         true
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -23,6 +23,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         shippingLabel != nil
     }
 
+    /// Whether the custom information is completed or not
+    var customsInformationIsCompleted: Bool {
+        true
+    }
+
     /// View model for the section displayed after a shipping label is purchased.
     @Published private(set) var postPurchase: WooShippingPostPurchaseViewModel?
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1979,6 +1979,7 @@
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
 		B90DACC02A30AEF000365897 /* BarcodeScannerItemFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */; };
 		B90DACC22A31BBC800365897 /* BarcodeScannerProductFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */; };
+		B90DD08E2D12FAA400EFC06A /* WooShippingCustoms.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DD08D2D12FA9900EFC06A /* WooShippingCustoms.swift */; };
 		B90DDF7C2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DDF7B2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9151B3E2840EB330036180F /* WooFoundation.framework */; };
@@ -5089,6 +5090,7 @@
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
 		B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerItemFinder.swift; sourceTree = "<group>"; };
 		B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerProductFinderTests.swift; sourceTree = "<group>"; };
+		B90DD08D2D12FA9900EFC06A /* WooShippingCustoms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustoms.swift; sourceTree = "<group>"; };
 		B90DDF7B2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTaxRateSelectorView.swift; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B9151B3E2840EB330036180F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -10842,6 +10844,14 @@
 			path = Cash;
 			sourceTree = "<group>";
 		};
+		B90DD08C2D12FA6600EFC06A /* WooShipping Customs */ = {
+			isa = PBXGroup;
+			children = (
+				B90DD08D2D12FA9900EFC06A /* WooShippingCustoms.swift */,
+			);
+			path = "WooShipping Customs";
+			sourceTree = "<group>";
+		};
 		B912603F2940B2C400CACD4B /* JustInTimeMessages */ = {
 			isa = PBXGroup;
 			children = (
@@ -12078,6 +12088,7 @@
 		CEAB739A2C81E3A000A7EB39 /* WooShipping Create Shipping Labels */ = {
 			isa = PBXGroup;
 			children = (
+				B90DD08C2D12FA6600EFC06A /* WooShipping Customs */,
 				CE6E11092C91DA3D00563DD4 /* WooShipping Items Section */,
 				CE7B4A592CA1BF7800F764EB /* WooShipping Hazmat Section */,
 				CECEFA6B2CA2CE990071C7DB /* WooShipping Package and Rate Selection */,
@@ -15124,6 +15135,7 @@
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */,
 				CE6302412BAAFB5E00E3325C /* CustomersListViewModel.swift in Sources */,
+				B90DD08E2D12FAA400EFC06A /* WooShippingCustoms.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
 				029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the customs row in the Create Labels main view. This is only UI, the real customs logic will come in next PRs.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to orders
2. Tap on a Completed Order
3. Tap on Create Shipping Label
4. See the Customs row. You can change the completed value in `WooShippingCreateLabelsViewModel`, `customsInformationIsCompleted` property.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
N/A

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/6999cd36-67cd-4971-a6ec-6ee24d3bcaa9" width="375">
<img src="https://github.com/user-attachments/assets/404df834-43da-44da-9b04-eb38e6cbc184" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
