### PR TITLE
Integerate notification settings endpoint to disable notifications for hidden stores

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1054,6 +1054,7 @@
 		DE78DE4C2B2AED4C002E58DE /* WordPressPageMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE78DE4B2B2AED4C002E58DE /* WordPressPageMapperTests.swift */; };
 		DE78DE4E2B2BF0EA002E58DE /* product-subscription-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */; };
 		DE8BEF0B2D141DD9008B3A3F /* NotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEF0A2D141DD9008B3A3F /* NotificationSettings.swift */; };
+		DE8BEF0D2D151396008B3A3F /* notification-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = DE8BEF0C2D151396008B3A3F /* notification-settings.json */; };
 		DE970D842C23E3F60019EF42 /* product-report-string-stock-quantity.json in Resources */ = {isa = PBXBuildFile; fileRef = DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */; };
 		DE97C3922861B8E20042E973 /* CouponEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
@@ -2241,6 +2242,7 @@
 		DE78DE4B2B2AED4C002E58DE /* WordPressPageMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressPageMapperTests.swift; sourceTree = "<group>"; };
 		DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-subscription-alternative-types.json"; sourceTree = "<group>"; };
 		DE8BEF0A2D141DD9008B3A3F /* NotificationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettings.swift; sourceTree = "<group>"; };
+		DE8BEF0C2D151396008B3A3F /* notification-settings.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notification-settings.json"; sourceTree = "<group>"; };
 		DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-report-string-stock-quantity.json"; sourceTree = "<group>"; };
 		DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponEncoderTests.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
@@ -3085,6 +3087,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE8BEF0C2D151396008B3A3F /* notification-settings.json */,
 				EED25B1C2CF74B9800503657 /* media-upload.json */,
 				EE6C6B6F2C6A190500632BDA /* systemStatus-inconsistent-page-id-data-type.json */,
 				DEB3878E2C2D71A10025256E /* gla-campaign-list-with-data-envelope.json */,
@@ -4413,6 +4416,7 @@
 				743E84F422172D0A00FAC9D7 /* shipment_tracking_multiple.json in Resources */,
 				DEA493722B3997ED00EED015 /* blaze-target-languages.json in Resources */,
 				02698CF624C17FC1005337C4 /* product-alternative-types.json in Resources */,
+				DE8BEF0D2D151396008B3A3F /* notification-settings.json in Resources */,
 				03EB99962907F03000F06A39 /* empty-data-array.json in Resources */,
 				CE070A342BBC52B200017578 /* gift-card-stats-without-data.json in Resources */,
 				57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1053,6 +1053,7 @@
 		DE78DE4A2B2AEC7F002E58DE /* wp-page-list-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE78DE492B2AEC7F002E58DE /* wp-page-list-success.json */; };
 		DE78DE4C2B2AED4C002E58DE /* WordPressPageMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE78DE4B2B2AED4C002E58DE /* WordPressPageMapperTests.swift */; };
 		DE78DE4E2B2BF0EA002E58DE /* product-subscription-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */; };
+		DE8BEF0B2D141DD9008B3A3F /* NotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEF0A2D141DD9008B3A3F /* NotificationSettings.swift */; };
 		DE970D842C23E3F60019EF42 /* product-report-string-stock-quantity.json in Resources */ = {isa = PBXBuildFile; fileRef = DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */; };
 		DE97C3922861B8E20042E973 /* CouponEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
@@ -2239,6 +2240,7 @@
 		DE78DE492B2AEC7F002E58DE /* wp-page-list-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wp-page-list-success.json"; sourceTree = "<group>"; };
 		DE78DE4B2B2AED4C002E58DE /* WordPressPageMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressPageMapperTests.swift; sourceTree = "<group>"; };
 		DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-subscription-alternative-types.json"; sourceTree = "<group>"; };
+		DE8BEF0A2D141DD9008B3A3F /* NotificationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettings.swift; sourceTree = "<group>"; };
 		DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-report-string-stock-quantity.json"; sourceTree = "<group>"; };
 		DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponEncoderTests.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
@@ -3005,6 +3007,7 @@
 				B59325CF217E4206000B0E8E /* NoteMedia.swift */,
 				B59325D1217E4206000B0E8E /* NoteRange.swift */,
 				B554FA902180BCFC00C54DFF /* NoteHash.swift */,
+				DE8BEF0A2D141DD9008B3A3F /* NotificationSettings.swift */,
 				B557DA1C20979E7D005962F4 /* Order.swift */,
 				741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */,
 				D88E228F25AC990A0023F3B1 /* OrderFeeLine.swift */,
@@ -5324,6 +5327,7 @@
 				B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */,
 				CE606D912BE396D7001CB424 /* ShippingMethodsRemote.swift in Sources */,
 				EE1CB90B2B4BC8C500AD24D5 /* BlazeImpressionsMapper.swift in Sources */,
+				DE8BEF0B2D141DD9008B3A3F /* NotificationSettings.swift in Sources */,
 				D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */,
 				036563DB2906938600D84BFD /* JustInTimeMessage.swift in Sources */,
 				CCA1D60429437B2C00B40560 /* SiteSummaryStats.swift in Sources */,

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -7,16 +7,26 @@ public struct NotificationSettings: Equatable, Encodable {
     /// Settings for different blogs connected to the user.
     public let blogs: [Blog]
 
-    /// Helper method to create notification settings for a given site ID and device ID.
+    /// Helper method to create notification settings for a given device ID.
     ///
-    public static func createSettings(siteID: Int64, deviceID: Int64, notificationsEnabled: Bool) -> NotificationSettings {
-        NotificationSettings(blogs: [
+    public static func createSettings(deviceID: Int64, enabledSites: [Int64], disabledSites: [Int64]) -> NotificationSettings {
+        let enabledSiteSettings = enabledSites.map { siteID in
             Blog(blogID: siteID, devices: [
                 Device(deviceID: deviceID,
-                       newComment: notificationsEnabled,
-                       storeOrder: notificationsEnabled)
+                       newComment: true,
+                       storeOrder: true)
             ])
-        ])
+        }
+
+        let disabledSiteSettings = disabledSites.map { siteID in
+            Blog(blogID: siteID, devices: [
+                Device(deviceID: deviceID,
+                       newComment: false,
+                       storeOrder: false)
+            ])
+        }
+
+        return NotificationSettings(blogs: enabledSiteSettings + disabledSiteSettings)
     }
 
 }

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Notification settings for a user
+///
+public struct NotificationSettings: Equatable, Encodable {
+
+    /// Settings for different blogs connected to the user.
+    public let blogs: [Blog]
+}
+
+public extension NotificationSettings {
+    /// Notification settings for a blog
+    struct Blog: Equatable, Encodable {
+        /// ID of the blog
+        public let blogID: Int64
+
+        /// List of settings for registered devices
+        public let devices: [Device]
+
+        enum CodingKeys: String, CodingKey {
+            case blogID = "blog_id"
+            case devices
+        }
+    }
+
+    /// Notification settings for a device
+    struct Device: Equatable, Encodable {
+        /// Unique ID of the device
+        public let deviceID: Int64
+
+        /// Whether a notification should be sent when there is a new comment on the blog
+        public let newComment: Bool
+
+        /// Whether a notification should be sent when there is a new order on the store.
+        public let storeOrder: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case deviceID = "device_id"
+            case newComment = "new_comment"
+            case storeOrder = "store_order"
+        }
+    }
+}

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -6,6 +6,19 @@ public struct NotificationSettings: Equatable, Encodable {
 
     /// Settings for different blogs connected to the user.
     public let blogs: [Blog]
+
+    /// Helper method to create notification settings for a given site ID and device ID.
+    ///
+    public static func createSettings(siteID: Int64, deviceID: Int64, notificationsEnabled: Bool) -> NotificationSettings {
+        NotificationSettings(blogs: [
+            Blog(blogID: siteID, devices: [
+                Device(deviceID: deviceID,
+                       newComment: notificationsEnabled,
+                       storeOrder: notificationsEnabled)
+            ])
+        ])
+    }
+
 }
 
 public extension NotificationSettings {

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -9,7 +9,7 @@ public struct NotificationSettings: Equatable, Encodable {
 
     /// Helper method to create notification settings for a given device ID.
     ///
-    public static func createSettings(deviceID: Int64, enabledSites: [Int64], disabledSites: [Int64]) -> NotificationSettings {
+    public init(deviceID: Int64, enabledSites: [Int64], disabledSites: [Int64]) {
         let enabledSiteSettings = enabledSites.map { siteID in
             Blog(blogID: siteID, devices: [
                 Device(deviceID: deviceID,
@@ -26,9 +26,12 @@ public struct NotificationSettings: Equatable, Encodable {
             ])
         }
 
-        return NotificationSettings(blogs: enabledSiteSettings + disabledSiteSettings)
+        self.init(blogs: (enabledSiteSettings + disabledSiteSettings))
     }
 
+    public init(blogs: [Blog]) {
+        self.blogs = blogs
+    }
 }
 
 public extension NotificationSettings {

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -7,7 +7,7 @@ public struct NotificationSettings: Equatable, Encodable {
     /// Settings for different blogs connected to the user.
     public let blogs: [Blog]
 
-    /// Helper method to create notification settings for a given device ID.
+    /// Convenience init to create notification settings for a given device ID.
     ///
     public init(deviceID: Int64, enabledSites: [Int64], disabledSites: [Int64]) {
         let enabledSiteSettings = enabledSites.map { siteID in

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -15,6 +15,8 @@ public protocol AccountRemoteProtocol {
     func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void)
     func loadUsernameSuggestions(from text: String) async throws -> [String]
 
+    func updateNotificationSettings(with settings: NotificationSettings) async throws
+
     /// Creates a WPCOM account with the given email and password.
     /// - Parameters:
     ///   - email: user input email.
@@ -144,6 +146,13 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
         return suggestions
     }
 
+    public func updateNotificationSettings(with settings: NotificationSettings) async throws {
+        let path = Path.notificationSettings
+        let parameters = try settings.toDictionary()
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
+        return try await enqueue(request)
+    }
+
     public func createAccount(email: String,
                               username: String,
                               password: String,
@@ -201,6 +210,7 @@ private extension AccountRemote {
         static let usernameSuggestions = "users/username/suggestions"
         static let accountCreation = "users/new"
         static let closeAccount = "me/account/close"
+        static let notificationSettings = "me/notifications/settings"
     }
 }
 

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -1,4 +1,5 @@
 import Combine
+import Alamofire
 import Foundation
 
 /// Protocol for `AccountRemote` mainly used for mocking.
@@ -149,7 +150,7 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
     public func updateNotificationSettings(with settings: NotificationSettings) async throws {
         let path = Path.notificationSettings
         let parameters = try settings.toDictionary()
-        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters, encoding: JSONEncoding.default)
         return try await enqueue(request)
     }
 

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -275,6 +275,34 @@ final class AccountRemoteTests: XCTestCase {
 
     // MARK: - Notification settings
 
+    func test_updateNotificationSettings_sends_correct_parameters() async throws {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "me/notifications/settings", filename: "notification-settings")
+
+        // When
+        let notificationSettings = NotificationSettings(blogs: [
+            NotificationSettings.Blog(blogID: 194373765, devices: [
+                NotificationSettings.Device(deviceID: 58089781,
+                       newComment: false,
+                       storeOrder: false)
+            ])
+        ])
+        _ = try await remote.updateNotificationSettings(with: notificationSettings)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? DotcomRequest)
+
+        let actualParam = try XCTUnwrap(request.parameters?["blogs"] as? [[String: Any]])
+        XCTAssertEqual(actualParam.count, 1)
+        XCTAssertEqual(actualParam.first?["blog_id"] as? Int64, 194373765)
+
+        let deviceSettings = try XCTUnwrap(actualParam.first?["devices"] as? [[String: Any]])
+        XCTAssertEqual(deviceSettings.first?["device_id"] as? Int64, 58089781)
+        XCTAssertEqual(deviceSettings.first?["new_comment"] as? Bool, false)
+        XCTAssertEqual(deviceSettings.first?["store_order"] as? Bool, false)
+    }
+
     func test_updateNotificationSettings_succeeds_on_request_success() async {
         // Given
         let remote = AccountRemote(network: network)

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -281,7 +281,7 @@ final class AccountRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "me/notifications/settings", filename: "notification-settings")
 
         // When
-        let notificationSettings = NotificationSettings.createSettings(deviceID: 58089781, enabledSites: [], disabledSites: [194373765])
+        let notificationSettings = NotificationSettings(deviceID: 58089781, enabledSites: [], disabledSites: [194373765])
         _ = try await remote.updateNotificationSettings(with: notificationSettings)
 
         // Then
@@ -305,7 +305,7 @@ final class AccountRemoteTests: XCTestCase {
         // When
         var errorCaught: Error?
         do {
-            let notificationSettings = NotificationSettings.createSettings(deviceID: 58089781, enabledSites: [194373765], disabledSites: [])
+            let notificationSettings = NotificationSettings(deviceID: 58089781, enabledSites: [194373765], disabledSites: [])
             try await remote.updateNotificationSettings(with: notificationSettings)
         } catch {
             errorCaught = error
@@ -324,7 +324,7 @@ final class AccountRemoteTests: XCTestCase {
         // When
         var errorCaught: Error?
         do {
-            let notificationSettings = NotificationSettings.createSettings(deviceID: 58089781, enabledSites: [194373765], disabledSites: [])
+            let notificationSettings = NotificationSettings(deviceID: 58089781, enabledSites: [194373765], disabledSites: [])
             try await remote.updateNotificationSettings(with: notificationSettings)
         } catch {
             errorCaught = error

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -274,7 +274,7 @@ final class AccountRemoteTests: XCTestCase {
     }
 
     // MARK: - Notification settings
-    
+
     func test_updateNotificationSettings_succeeds_on_request_success() async {
         // Given
         let remote = AccountRemote(network: network)
@@ -283,7 +283,13 @@ final class AccountRemoteTests: XCTestCase {
         // When
         var errorCaught: Error?
         do {
-            let notificationSettings = NotificationSettings.createSettings(siteID: 194373765, deviceID: 58089781, notificationsEnabled: false)
+            let notificationSettings = NotificationSettings(blogs: [
+                NotificationSettings.Blog(blogID: 194373765, devices: [
+                    NotificationSettings.Device(deviceID: 58089781,
+                           newComment: false,
+                           storeOrder: false)
+                ])
+            ])
             try await remote.updateNotificationSettings(with: notificationSettings)
         } catch {
             errorCaught = error
@@ -302,7 +308,7 @@ final class AccountRemoteTests: XCTestCase {
         // When
         var errorCaught: Error?
         do {
-            let notificationSettings = NotificationSettings.createSettings(siteID: 194373765, deviceID: 58089781, notificationsEnabled: false)
+            let notificationSettings = NotificationSettings.createSettings(deviceID: 58089781, enabledSites: [194373765], disabledSites: [])
             try await remote.updateNotificationSettings(with: notificationSettings)
         } catch {
             errorCaught = error

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -281,13 +281,7 @@ final class AccountRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "me/notifications/settings", filename: "notification-settings")
 
         // When
-        let notificationSettings = NotificationSettings(blogs: [
-            NotificationSettings.Blog(blogID: 194373765, devices: [
-                NotificationSettings.Device(deviceID: 58089781,
-                       newComment: false,
-                       storeOrder: false)
-            ])
-        ])
+        let notificationSettings = NotificationSettings.createSettings(deviceID: 58089781, enabledSites: [], disabledSites: [194373765])
         _ = try await remote.updateNotificationSettings(with: notificationSettings)
 
         // Then
@@ -311,13 +305,7 @@ final class AccountRemoteTests: XCTestCase {
         // When
         var errorCaught: Error?
         do {
-            let notificationSettings = NotificationSettings(blogs: [
-                NotificationSettings.Blog(blogID: 194373765, devices: [
-                    NotificationSettings.Device(deviceID: 58089781,
-                           newComment: false,
-                           storeOrder: false)
-                ])
-            ])
+            let notificationSettings = NotificationSettings.createSettings(deviceID: 58089781, enabledSites: [194373765], disabledSites: [])
             try await remote.updateNotificationSettings(with: notificationSettings)
         } catch {
             errorCaught = error

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -272,4 +272,43 @@ final class AccountRemoteTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedError, errorCaught as? NetworkError)
     }
+
+    // MARK: - Notification settings
+    
+    func test_updateNotificationSettings_succeeds_on_request_success() async {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "me/notifications/settings", filename: "notification-settings")
+
+        // When
+        var errorCaught: Error?
+        do {
+            let notificationSettings = NotificationSettings.createSettings(siteID: 194373765, deviceID: 58089781, notificationsEnabled: false)
+            try await remote.updateNotificationSettings(with: notificationSettings)
+        } catch {
+            errorCaught = error
+        }
+
+        // Then
+        XCTAssertNil(errorCaught)
+    }
+
+    func test_updateNotificationSettings_relays_error_on_request_failure() async {
+        // Given
+        let remote = AccountRemote(network: network)
+        let expectedError = NetworkError.timeout()
+        network.simulateError(requestUrlSuffix: "me/notifications/settings", error: expectedError)
+
+        // When
+        var errorCaught: Error?
+        do {
+            let notificationSettings = NotificationSettings.createSettings(siteID: 194373765, deviceID: 58089781, notificationsEnabled: false)
+            try await remote.updateNotificationSettings(with: notificationSettings)
+        } catch {
+            errorCaught = error
+        }
+
+        // Then
+        XCTAssertEqual(expectedError, errorCaught as? NetworkError)
+    }
 }

--- a/Networking/NetworkingTests/Responses/notification-settings.json
+++ b/Networking/NetworkingTests/Responses/notification-settings.json
@@ -1,0 +1,114 @@
+{
+    "blogs": [
+        {
+            "blog_id": 190864441,
+            "timeline": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "email": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "devices": [
+                {
+                    "device_id": 58089781,
+                    "new_comment": true,
+                    "comment_like": true,
+                    "post_like": true,
+                    "follow": true,
+                    "achievement": true,
+                    "mentions": true,
+                    "scheduled_publicize": true,
+                    "store_order": true,
+                    "blogging_prompt": false,
+                    "draft_post_prompt": true
+                }
+            ]
+        },
+        {
+            "blog_id": 194373765,
+            "timeline": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "email": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "devices": [
+                {
+                    "device_id": 58089781,
+                    "new_comment": false,
+                    "comment_like": true,
+                    "post_like": true,
+                    "follow": true,
+                    "achievement": true,
+                    "mentions": true,
+                    "scheduled_publicize": true,
+                    "store_order": true,
+                    "blogging_prompt": false,
+                    "draft_post_prompt": true
+                }
+            ]
+        },
+        ]
+    },
+    "wpcom": {
+        "marketing": false,
+        "research": true,
+        "affiliates": true,
+        "community": true,
+        "promotion": false,
+        "news": true,
+        "digest": true,
+        "reports": true,
+        "news_developer": true,
+        "wpcom_spain": false,
+        "scheduled_updates": true,
+        "learn": false,
+        "a4a_agencies": true,
+        "jetpack_agencies": true,
+        "jetpack_manage_onboarding": true,
+        "jetpack_marketing": false,
+        "jetpack_research": true,
+        "jetpack_promotion": false,
+        "jetpack_news": true,
+        "jetpack_reports": true,
+        "akismet_marketing": false,
+        "woopay_marketing": true,
+        "gravatar_onboarding": true
+    }
+}

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -15,5 +15,6 @@ public enum AccountAction: Action {
     case synchronizeSitesAndReturnSelectedSiteInfo(siteAddress: String, onCompletion: (Result<Site, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
+    case updateNotificationSettings(notificationSettings: NotificationSettings, onCompletion: (Result<Void, Error>) -> Void)
     case closeAccount(onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -63,6 +63,7 @@ public typealias Note = Networking.Note
 public typealias NoteBlock = Networking.NoteBlock
 public typealias NoteMedia = Networking.NoteMedia
 public typealias NoteRange = Networking.NoteRange
+public typealias NotificationSettings = Networking.NotificationSettings
 public typealias Order = Networking.Order
 public typealias OrderItem = Networking.OrderItem
 public typealias OrderItemAttribute = Networking.OrderItemAttribute

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -56,6 +56,8 @@ public class AccountStore: Store {
             synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
         case .updateAccountSettings(let userID, let tracksOptOut, let onCompletion):
             updateAccountSettings(userID: userID, tracksOptOut: tracksOptOut, onCompletion: onCompletion)
+        case .updateNotificationSettings(let notificationSettings, let onCompletion):
+            updateNotificationSettings(notificationSettings: notificationSettings, onCompletion: onCompletion)
         case .closeAccount(let onCompletion):
             closeAccount(onCompletion: onCompletion)
         }
@@ -218,6 +220,17 @@ private extension AccountStore {
             case .success:
                 onCompletion(.success(()))
             case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func updateNotificationSettings(notificationSettings: NotificationSettings, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                try await remote.updateNotificationSettings(with: notificationSettings)
+                onCompletion(.success(()))
+            } catch {
                 onCompletion(.failure(error))
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -55,6 +55,11 @@ final class MockAccountRemote {
     func whenCreatingAccount(thenReturn result: Result<CreateAccountResult, CreateAccountError>) {
         createAccountResult = result
     }
+
+    /// Returns  the value when `updateNotificationSettings` is called.
+    func whenUpdatingNotificationSettings(thenReturn result: Result<Void, Error>) {
+        updateNotificationSettingsResult = result
+    }
 }
 
 extension MockAccountRemote {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -22,6 +22,9 @@ final class MockAccountRemote {
     /// The results to return based on the given site ID in `loadUsernameSuggestions`.
     private var loadUsernameSuggestionsResult: Result<[String], Error>?
 
+    /// Returns the value when `updateNotificationSettings` is called.
+    private var updateNotificationSettingsResult: Result<Void, Error> = .success(())
+
     /// The results to return based on the given site ID in `createAccount`.
     private var createAccountResult: Result<CreateAccountResult, CreateAccountError>?
 
@@ -113,6 +116,15 @@ extension MockAccountRemote: AccountRemoteProtocol {
         }
 
         return try result.get()
+    }
+
+    func updateNotificationSettings(with settings: NotificationSettings) async throws {
+        switch updateNotificationSettingsResult {
+        case .success:
+            break
+        case .failure(let error):
+            throw error
+        }
     }
 
     func createAccount(email: String,

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -899,7 +899,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let notificationSettings = NotificationSettings.createSettings(deviceID: 132, enabledSites: [23], disabledSites: [44, 66])
+            let notificationSettings = NotificationSettings(deviceID: 132, enabledSites: [23], disabledSites: [44, 66])
             let action = AccountAction.updateNotificationSettings(notificationSettings: notificationSettings) { result in
                 promise(result)
             }
@@ -923,7 +923,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let notificationSettings = NotificationSettings.createSettings(deviceID: 132, enabledSites: [23], disabledSites: [44, 66])
+            let notificationSettings = NotificationSettings(deviceID: 132, enabledSites: [23], disabledSites: [44, 66])
             let action = AccountAction.updateNotificationSettings(notificationSettings: notificationSettings) { result in
                 promise(result)
             }

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -884,6 +884,56 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as NSError?, error)
     }
+
+    // MARK: - updateNotificationSettings
+
+    func test_updateNotificationSettings_returns_success_upon_success() {
+        // Given
+        let network = MockNetwork()
+        let accountRemote = MockAccountRemote()
+        accountRemote.whenUpdatingNotificationSettings(thenReturn: .success(()))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: accountRemote)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let notificationSettings = NotificationSettings.createSettings(deviceID: 132, enabledSites: [23], disabledSites: [44, 66])
+            let action = AccountAction.updateNotificationSettings(notificationSettings: notificationSettings) { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_updateNotificationSettings_relays_error_upon_failure() {
+        // Given
+        let network = MockNetwork()
+        let accountRemote = MockAccountRemote()
+        let error = NSError(domain: "notifications", code: 33)
+        accountRemote.whenUpdatingNotificationSettings(thenReturn: .failure(error))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: accountRemote)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let notificationSettings = NotificationSettings.createSettings(deviceID: 132, enabledSites: [23], disabledSites: [44, 66])
+            let action = AccountAction.updateNotificationSettings(notificationSettings: notificationSettings) { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as NSError?, error)
+    }
 }
 
 // MARK: - Private Methods


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14658 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Networking and Yosemite to support updating notification settings for a device ID given site IDs and settings. This is necessary to disable notification settings for stores hidden from the store picker, which will be handled in a future PR.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
The new endpoint hasn't been used yet so just unit tests passing is sufficient.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
I added unit tests for the Networking and Yosemite layers to ensure everything works as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
