### PR TITLE
Store Picker: Update notification settings upon saving store list

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -90,7 +90,7 @@ struct EditStoreListView: View {
                     }
                 }
             }
-            .alert(viewModel.errorMessage, isPresented: $viewModel.shouldShowErrorAlert, actions: {
+            .alert(Localization.errorUpdatingNotificationSettings, isPresented: $viewModel.shouldShowErrorAlert, actions: {
                 Button(Localization.cancelButton) {}
                 Button(Localization.retryButton) {
                     Task {
@@ -143,6 +143,11 @@ private extension EditStoreListView {
             "editStoreListView.retryButton",
             value: "Retry",
             comment: "Button to retry saving changes in the Edit Store List view"
+        )
+        static let errorUpdatingNotificationSettings = NSLocalizedString(
+            "editStoreListView.errorUpdatingNotificationSettings",
+            value: "There was an error when updating notification settings. Please try again.",
+            comment: "Error message when updating notification settings fails when saving the store list for the store picker"
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -90,6 +90,14 @@ struct EditStoreListView: View {
                     }
                 }
             }
+            .alert(viewModel.errorMessage, isPresented: $viewModel.shouldShowErrorAlert, actions: {
+                Button(Localization.cancelButton) {}
+                Button(Localization.retryButton) {
+                    Task {
+                        await viewModel.saveChanges()
+                    }
+                }
+            })
         }
     }
 }
@@ -130,6 +138,11 @@ private extension EditStoreListView {
             "editStoreListView.otherStoresFooter",
             value: "Stores that are not selected will be excluded from the store picker",
             comment: "Footer of the Other Stores section on the Edit Store List view"
+        )
+        static let retryButton = NSLocalizedString(
+            "editStoreListView.retryButton",
+            value: "Retry",
+            comment: "Button to retry saving changes in the Edit Store List view"
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -77,10 +77,17 @@ struct EditStoreListView: View {
                 }
 
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.saveButton) {
-                        viewModel.didSaveChanges()
+                    if viewModel.isUpdatingNotificationSettings {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                    } else {
+                        Button(Localization.saveButton) {
+                            Task {
+                                await viewModel.saveChanges()
+                            }
+                        }
+                        .disabled(viewModel.hasChanges == false)
                     }
-                    .disabled(viewModel.hasChanges == false)
                 }
             }
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -15,8 +15,6 @@ final class EditStoreListViewModel: ObservableObject {
 
     @Published private(set) var isUpdatingNotificationSettings = false
 
-    @Published private(set) var errorMessage = ""
-
     @Published var shouldShowErrorAlert = false
 
     var hasChanges: Bool {
@@ -55,7 +53,6 @@ final class EditStoreListViewModel: ObservableObject {
         let hiddenSiteIDs = Array(hiddenSites).map { $0.siteID }
         let displayedSiteIDs = Array(selectedSites).map { $0.siteID }
 
-        errorMessage = ""
         shouldShowErrorAlert = false
         isUpdatingNotificationSettings = true
         do {
@@ -63,7 +60,6 @@ final class EditStoreListViewModel: ObservableObject {
             userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
             onCompletion()
         } catch {
-            errorMessage = Localization.errorUpdatingNotificationSettings
             shouldShowErrorAlert = true
         }
         isUpdatingNotificationSettings = false
@@ -112,15 +108,5 @@ private extension EditStoreListViewModel {
                 continuation.resume(with: result)
             }))
         }
-    }
-}
-
-private extension EditStoreListViewModel {
-    enum Localization {
-        static let errorUpdatingNotificationSettings = NSLocalizedString(
-            "editStoreListViewModel.errorUpdatingNotificationSettings",
-            value: "There was an error when updating notification settings. Please try again.",
-            comment: "Error message when updating notification settings fails when saving the store list for the store picker"
-        )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -18,6 +18,7 @@ final class EditStoreListViewModel: ObservableObject {
     }
 
     private let originalSelectedSites: [Site]
+    private let pushNotificationManager: PushNotesManager
     private let userDefaults: UserDefaults
     private let analytics: Analytics
     private let onCompletion: () -> Void
@@ -25,6 +26,7 @@ final class EditStoreListViewModel: ObservableObject {
     init(availableSites: [Site],
          displayedSites: [Site],
          currentlySelectedSite: Site?,
+         pushNotificationManager: PushNotesManager = ServiceLocator.pushNotesManager,
          userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping () -> Void) {
@@ -32,6 +34,7 @@ final class EditStoreListViewModel: ObservableObject {
         self.currentlySelectedSite = currentlySelectedSite
         self.originalSelectedSites = displayedSites
         self.selectedSites = Set(displayedSites)
+        self.pushNotificationManager = pushNotificationManager
         self.userDefaults = userDefaults
         self.analytics = analytics
         self.onCompletion = onCompletion

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -15,7 +15,9 @@ final class EditStoreListViewModel: ObservableObject {
 
     @Published private(set) var isUpdatingNotificationSettings = false
 
-    @Published private(set) var notificationSettingsError: Error?
+    @Published private(set) var errorMessage = ""
+
+    @Published var shouldShowErrorAlert = false
 
     var hasChanges: Bool {
         selectedSites != Set(originalSelectedSites)
@@ -53,13 +55,16 @@ final class EditStoreListViewModel: ObservableObject {
         let hiddenSiteIDs = Array(hiddenSites).map { $0.siteID }
         let displayedSiteIDs = Array(selectedSites).map { $0.siteID }
 
+        errorMessage = ""
+        shouldShowErrorAlert = false
+        isUpdatingNotificationSettings = true
         do {
-            isUpdatingNotificationSettings = true
             try await updateNotificationSettings(displayedSiteIDs: displayedSiteIDs, hiddenSiteIDs: hiddenSiteIDs)
             userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
             onCompletion()
         } catch {
-            notificationSettingsError = error
+            errorMessage = Localization.errorUpdatingNotificationSettings
+            shouldShowErrorAlert = true
         }
         isUpdatingNotificationSettings = false
     }
@@ -93,12 +98,10 @@ private extension EditStoreListViewModel {
     @MainActor
     func updateNotificationSettings(displayedSiteIDs: [Int64],
                                     hiddenSiteIDs: [Int64]) async throws {
-        guard let deviceID = pushNotificationManager.deviceID else {
-            throw NotificationSettingsError.deviceIDNotFound
-        }
-
-        guard let intDeviceID = Int64(deviceID) else {
-            throw NotificationSettingsError.malformedDeviceID
+        guard let deviceID = pushNotificationManager.deviceID,
+            let intDeviceID = Int64(deviceID) else {
+            /// skip updating notification settings if no device ID is found
+            return
         }
 
         let settings = NotificationSettings(deviceID: intDeviceID,
@@ -113,8 +116,11 @@ private extension EditStoreListViewModel {
 }
 
 private extension EditStoreListViewModel {
-    enum NotificationSettingsError: Error {
-        case deviceIDNotFound
-        case malformedDeviceID
+    enum Localization {
+        static let errorUpdatingNotificationSettings = NSLocalizedString(
+            "editStoreListViewModel.errorUpdatingNotificationSettings",
+            value: "There was an error when updating notification settings. Please try again.",
+            comment: "Error message when updating notification settings fails when saving the store list for the store picker"
+        )
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -13,11 +13,14 @@ final class EditStoreListViewModel: ObservableObject {
     /// Sites selected to be displayed on the store picker
     @Published var selectedSites: Set<Site>
 
+    @Published private(set) var isUpdatingNotificationSettings = false
+
     var hasChanges: Bool {
         selectedSites != Set(originalSelectedSites)
     }
 
     private let originalSelectedSites: [Site]
+    private let stores: StoresManager
     private let pushNotificationManager: PushNotesManager
     private let userDefaults: UserDefaults
     private let analytics: Analytics
@@ -26,6 +29,7 @@ final class EditStoreListViewModel: ObservableObject {
     init(availableSites: [Site],
          displayedSites: [Site],
          currentlySelectedSite: Site?,
+         stores: StoresManager = ServiceLocator.stores,
          pushNotificationManager: PushNotesManager = ServiceLocator.pushNotesManager,
          userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
@@ -34,17 +38,28 @@ final class EditStoreListViewModel: ObservableObject {
         self.currentlySelectedSite = currentlySelectedSite
         self.originalSelectedSites = displayedSites
         self.selectedSites = Set(displayedSites)
+        self.stores = stores
         self.pushNotificationManager = pushNotificationManager
         self.userDefaults = userDefaults
         self.analytics = analytics
         self.onCompletion = onCompletion
     }
 
-    func didSaveChanges() {
+    @MainActor
+    func didSaveChanges() async {
         let hiddenSites = Set(availableSites).subtracting(selectedSites)
         let hiddenSiteIDs = Array(hiddenSites).map { $0.siteID }
-        userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
-        onCompletion()
+        let displayedSiteIDs = Array(selectedSites).map { $0.siteID }
+
+        do {
+            isUpdatingNotificationSettings = true
+            try await updateNotificationSettings(displayedSiteIDs: displayedSiteIDs, hiddenSiteIDs: hiddenSiteIDs)
+            userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
+            onCompletion()
+        } catch {
+            // TODO: handle error
+        }
+        isUpdatingNotificationSettings = false
     }
 }
 
@@ -70,4 +85,35 @@ extension EditStoreListViewModel {
             selectedSites.insert(site)
         }
     }
+}
+
+private extension EditStoreListViewModel {
+    @MainActor
+    func updateNotificationSettings(displayedSiteIDs: [Int64],
+                                    hiddenSiteIDs: [Int64]) async throws {
+        guard let deviceID = pushNotificationManager.deviceID else {
+            throw NotificationSettingsError.deviceIDNotFound
+        }
+
+        guard let intDeviceID = Int64(deviceID) else {
+            throw NotificationSettingsError.malformedDeviceID
+        }
+
+        let settings = NotificationSettings(deviceID: intDeviceID,
+                                            enabledSites: displayedSiteIDs,
+                                            disabledSites: hiddenSiteIDs)
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: settings, onCompletion: { result in
+                continuation.resume(with: result)
+            }))
+        }
+    }
+}
+
+private extension EditStoreListViewModel {
+    enum NotificationSettingsError: Error {
+        case deviceIDNotFound
+        case malformedDeviceID
+    }
+    
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -15,6 +15,8 @@ final class EditStoreListViewModel: ObservableObject {
 
     @Published private(set) var isUpdatingNotificationSettings = false
 
+    @Published private(set) var notificationSettingsError: Error?
+
     var hasChanges: Bool {
         selectedSites != Set(originalSelectedSites)
     }
@@ -46,7 +48,7 @@ final class EditStoreListViewModel: ObservableObject {
     }
 
     @MainActor
-    func didSaveChanges() async {
+    func saveChanges() async {
         let hiddenSites = Set(availableSites).subtracting(selectedSites)
         let hiddenSiteIDs = Array(hiddenSites).map { $0.siteID }
         let displayedSiteIDs = Array(selectedSites).map { $0.siteID }
@@ -57,7 +59,7 @@ final class EditStoreListViewModel: ObservableObject {
             userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
             onCompletion()
         } catch {
-            // TODO: handle error
+            notificationSettingsError = error
         }
         isUpdatingNotificationSettings = false
     }
@@ -115,5 +117,4 @@ private extension EditStoreListViewModel {
         case deviceIDNotFound
         case malformedDeviceID
     }
-    
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -93,7 +93,7 @@ final class PushNotificationsManager: PushNotesManager {
 
     /// WordPress.com Device Identifier
     ///
-    private var deviceID: String? {
+    private(set) var deviceID: String? {
         get {
             return configuration.defaults.object(forKey: .deviceID)
         }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -29,6 +29,10 @@ protocol PushNotesManager {
     ///
     var localNotificationUserResponses: AnyPublisher<UNNotificationResponse, Never> { get }
 
+    /// WordPress.com Device Identifier
+    ///
+    var deviceID: String? { get }
+
     /// Resets the Badge Count.
     ///
     func resetBadgeCount(type: Note.Kind)

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -82,7 +82,8 @@ struct EditStoreListViewModelTests {
         #expect(viewModel.selectedSites.contains(site1) == true)
     }
 
-    @Test func didSaveChanges_saves_hidden_store_ids_to_user_defaults_and_triggers_completion() {
+    @MainActor
+    @Test func didSaveChanges_saves_hidden_store_ids_to_user_defaults_and_triggers_completion() async {
         // Given
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         var completionTriggered = false
@@ -94,7 +95,7 @@ struct EditStoreListViewModelTests {
 
         // When
         viewModel.toggleSelection(site1)
-        viewModel.didSaveChanges()
+        await viewModel.saveChanges()
 
         // Then
         #expect(userDefaults.hiddenStoreIDs == [site1.siteID])

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-import struct Yosemite.Site
+import Yosemite
 @testable import WooCommerce
 
 struct EditStoreListViewModelTests {
@@ -11,8 +11,8 @@ struct EditStoreListViewModelTests {
     @Test func hasChanges_returns_correct_values() {
         // Given
         let availableSites = [site1, site2]
-        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               displayedSites: [site1, site2],
+        let viewModel = EditStoreListViewModel(availableSites: availableSites,
+                                               displayedSites: availableSites,
                                                currentlySelectedSite: nil,
                                                onCompletion: {})
 
@@ -83,13 +83,17 @@ struct EditStoreListViewModelTests {
     }
 
     @MainActor
-    @Test func didSaveChanges_saves_hidden_store_ids_to_user_defaults_and_triggers_completion() async {
+    @Test func saveChanges_saves_hidden_store_ids_to_user_defaults_and_triggers_completion_if_there_is_no_deviceID() async {
         // Given
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         var completionTriggered = false
+
+        let notificationManager = MockPushNotificationsManager(mockedDeviceID: nil)
+
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
                                                displayedSites: [site1, site2],
                                                currentlySelectedSite: nil,
+                                               pushNotificationManager: notificationManager,
                                                userDefaults: userDefaults,
                                                onCompletion: { completionTriggered = true })
 
@@ -100,5 +104,79 @@ struct EditStoreListViewModelTests {
         // Then
         #expect(userDefaults.hiddenStoreIDs == [site1.siteID])
         #expect(completionTriggered == true)
+    }
+
+    @MainActor
+    @Test func saveChanges_succeeds_when_updating_notification_settings_succeeds() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        var completionTriggered = false
+
+        let deviceID = "13435352"
+        let notificationManager = MockPushNotificationsManager(mockedDeviceID: deviceID)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .updateNotificationSettings(_, let onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: { completionTriggered = true })
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then
+        #expect(userDefaults.hiddenStoreIDs == [site1.siteID])
+        #expect(completionTriggered == true)
+    }
+
+    @MainActor
+    @Test func saveChanges_fails_when_updating_notification_settings_fails() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        var completionTriggered = false
+
+        let deviceID = "13435352"
+        let notificationManager = MockPushNotificationsManager(mockedDeviceID: deviceID)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .updateNotificationSettings(_, let onCompletion):
+                let error = NSError(domain: "notification-settings-update-error", code: 501)
+                onCompletion(.failure(error))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: { completionTriggered = true })
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then
+        #expect(userDefaults.hiddenStoreIDs == [])
+        #expect(completionTriggered == false)
+        #expect(viewModel.shouldShowErrorAlert == true)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -5,6 +5,7 @@ import UIKit
 import Yosemite
 
 final class MockPushNotificationsManager: PushNotesManager {
+    
     func disableInAppNotifications() {
 
     }
@@ -41,6 +42,12 @@ final class MockPushNotificationsManager: PushNotesManager {
         localNotificationResponsesSubject.eraseToAnyPublisher()
     }
 
+    private let mockedDeviceID: String?
+
+    var deviceID: String? {
+        mockedDeviceID
+    }
+
     private let localNotificationResponsesSubject = PassthroughSubject<UNNotificationResponse, Never>()
 
     private(set) var requestedLocalNotifications: [LocalNotification] = []
@@ -49,6 +56,10 @@ final class MockPushNotificationsManager: PushNotesManager {
     private(set) var triggersForRequestedLocalNotificationsIfNeeded: [UNNotificationTrigger] = []
     private(set) var canceledLocalNotificationScenarios: [[LocalNotification.Scenario]] = []
     private(set) var resetBadgeCountKinds: [Note.Kind] = []
+
+    init(mockedDeviceID: String? = nil) {
+        self.mockedDeviceID = mockedDeviceID
+    }
 
     func resetBadgeCount(type: Note.Kind) {
         resetBadgeCountKinds.append(type)

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -5,7 +5,7 @@ import UIKit
 import Yosemite
 
 final class MockPushNotificationsManager: PushNotesManager {
-    
+
     func disableInAppNotifications() {
 
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14658 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the notification settings update as part of saving the site list in the store picker. Changes include:
- Added the trigger of notification settings update before saving the site list to the local storage.
- Added the loading indicator for when the update is in progress.
- Added error handling for when the update fails.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Pre-requisite: testing this PR requires a physical device to verify that push notifications work correctly.
- Remove the app from the device if it was installed before.
- Build and run the app on the device. Log in to a WPCom account connected to more than 1 store.
- When prompted for permission for push notifications, accept it.
- Navigate to the Menu tab > open the store picker > tap Edit button.- Navigate to the Menu tab > open the store picker > tap Edit button.
- Update the selection on the list and save the change. Confirm that saving takes a few seconds before completing.
- Put the app to the background then place an order or leave a review in one of the hidden stores. Confirm that you don't receive notifications for this store.
- Go back to the app and enable the hidden store again and save the change.
- Put the app to the background then place an order or leave a review in one of the hidden stores. Confirm that you receive notifications for this store again.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on iPhone 16 Pro iOS 18.1 and confirm that push notifications are disabled for hidden sites and enabled for displayed site. Progress and error states are displayed correctly.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/a024549c-c6d3-46b1-b3df-9ef7188d5ec0

<img src="https://github.com/user-attachments/assets/52585984-3bc3-444b-98be-7079cbc78ef0" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
