### PR TITLE
[Shipping labels] Scroll to selected package in packages list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -40,7 +40,6 @@ struct WooCarrierPackagesView: View {
                             },
                             starAction: {
                                 starAction(package.id)
-                                // Just temporary, will be replaced with proper logic
                             },
                             starred: starredPackages.contains(package.id)
                         )

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -26,39 +26,45 @@ struct WooCarrierPackagesView: View {
     let onRefresh: () async -> Void
 
     var body: some View {
-        List {
-            ForEach(carrierTab.packageGroups, id: \.id) { packageGroup in
-                Section {
-                    ForEach(packageGroup.packages, id: \.id) { package in
-                        WooShippingPackageOptionView(
-                            isSelected: selectedPackageId == package.id,
-                            package: package,
-                            showTopDivider: false,
-                            showSource: false,
-                            tapAction: {
-                                tapAction(package.id)
-                            },
-                            starAction: {
-                                starAction(package.id)
-                            },
-                            starred: starredPackages.contains(package.id)
-                        )
-                        .alignmentGuide(.listRowSeparatorLeading) { _ in
-                            return 16
+        ScrollViewReader { scroll in
+            List {
+                ForEach(carrierTab.packageGroups, id: \.id) { packageGroup in
+                    Section {
+                        ForEach(packageGroup.packages, id: \.id) { package in
+                            WooShippingPackageOptionView(
+                                isSelected: selectedPackageId == package.id,
+                                package: package,
+                                showTopDivider: false,
+                                showSource: false,
+                                tapAction: {
+                                    tapAction(package.id)
+                                },
+                                starAction: {
+                                    starAction(package.id)
+                                },
+                                starred: starredPackages.contains(package.id)
+                            )
+                            .alignmentGuide(.listRowSeparatorLeading) { _ in
+                                return 16
+                            }
+                            .id(package.id)
                         }
+                    } header: {
+                        HStack {
+                            Text(packageGroup.name.uppercased())
+                                .foregroundColor(.secondary)
+                                .captionStyle()
+                                .multilineTextAlignment(.leading)
+                            Spacer()
+                        }
+                        .padding(.horizontal)
+                        .background(Color.clear)
                     }
-                } header: {
-                    HStack {
-                        Text(packageGroup.name.uppercased())
-                            .foregroundColor(.secondary)
-                            .captionStyle()
-                            .multilineTextAlignment(.leading)
-                        Spacer()
-                    }
-                    .padding(.horizontal)
-                    .background(Color.clear)
+                    .listRowInsets(.zero)
                 }
-                .listRowInsets(.zero)
+            }
+            .task {
+                scroll.scrollTo(selectedPackageId)
             }
         }
         .listStyle(.plain)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -129,16 +129,21 @@ struct WooSavedPackagesSelectionView: View {
             }
             else {
                 Divider()
-                List {
-                    packagesSection(for: viewModel.customSavedPackages)
-                    packagesSection(for: viewModel.predefinedSavedPackages)
-                }
-                .listStyle(.plain)
-                .refreshable {
-                    await withCheckedContinuation { continuation in
-                        viewModel.loadPackages {
-                            continuation.resume()
+                ScrollViewReader { scroll in
+                    List {
+                        packagesSection(for: viewModel.customSavedPackages)
+                        packagesSection(for: viewModel.predefinedSavedPackages)
+                    }
+                    .listStyle(.plain)
+                    .refreshable {
+                        await withCheckedContinuation { continuation in
+                            viewModel.loadPackages {
+                                continuation.resume()
+                            }
                         }
+                    }
+                    .task {
+                        scroll.scrollTo(viewModel.selectedSavedPackageId)
                     }
                 }
                 Divider()
@@ -177,6 +182,7 @@ struct WooSavedPackagesSelectionView: View {
                     viewModel.selectedSavedPackageId = viewModel.selectedSavedPackageId == package.id ? nil : package.id
                 }
             )
+            .id(package.id)
             .alignmentGuide(.listRowSeparatorLeading) { _ in
                 return 16
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -140,10 +140,10 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         }
         let customSavedPackages = packages.customPackages.map {
             return $0.toPackageData()
-        }
+        }.sorted { $0.id < $1.id }
         let predefinedSavedPackages = packages.savedPredefinedPackages.map {
             return $0.toPackageData()
-        }
+        }.sorted { $0.id < $1.id }
         var carrierPackages: [WooShippingCarrierPackages] = packages.allPredefinedOptions.compactMap {
             return $0.toCarrierPackages()
         }
@@ -317,7 +317,7 @@ extension WooShippingCarrierPredefinedOptions {
         let packageGroups = predefinedOptions.compactMap { predefinedOption in
             let packages = predefinedOption.predefinedPackages.map { package in
                 return package.toPackageData(groupTitle: predefinedOption.title, sourceID: predefinedOption.providerID)
-            }
+            }.sorted { $0.id < $1.id }
             let group = WooPackageGroup(name: predefinedOption.title, packages: packages)
             return group
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -243,6 +243,84 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedPackageType, .saved)
         XCTAssertNotNil(viewModel.selectedSavedPackage)
     }
+
+    @MainActor
+    func test_it_keeps_order_after_reloads() async {
+        // Given
+        let siteID: Int64 = 1
+        let customPackages: [WooShippingCustomPackage] = [
+            .fake().copy(id: "Custom1"),
+            .fake().copy(id: "Custom2"),
+            .fake().copy(id: "Custom3"),
+           ]
+        let allPredefinedOptions = [sampleCarrierPredefinedOptions()]
+        let savedPredefinedPackages: [WooShippingSavedPredefinedPackage] = [
+            .init(groupTitle: "pri_flat_boxes",
+                  providerID: "usps",
+                  package: .init(id: "small_flat_box",
+                                 name: "Small Flat Rate Box",
+                                 isLetter: false,
+                                 dimensions: "",
+                                 boxWeight: "",
+                                 groupId: "pri_flat_boxes")),
+            .init(groupTitle: "pri_flat_boxes",
+                  providerID: "usps",
+                  package: .init(id: "large_flat_box",
+                                 name: "Large Flat Rate Box",
+                                 isLetter: false,
+                                 dimensions: "",
+                                 boxWeight: "",
+                                 groupId: "pri_flat_boxes")),
+            .init(groupTitle: "pri_flat_boxes",
+                  providerID: "usps",
+                  package: .init(id: "medium_flat_box_top",
+                                 name: "Medium Flat Rate Box",
+                                 isLetter: false,
+                                 dimensions: "",
+                                 boxWeight: "",
+                                 groupId: "pri_flat_boxes"))
+        ]
+        let packages = WooShippingPackagesResponse(siteID: siteID,
+                                                   customPackages: customPackages,
+                                                   savedPredefinedPackages: savedPredefinedPackages,
+                                                   allPredefinedOptions: allPredefinedOptions)
+        let storageManager = MockStorageManager()
+
+        storageManager.insertSamplePackages(readOnlyPackages: packages)
+
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadPackages(receivedSiteID, completion):
+                XCTAssertEqual(receivedSiteID, siteID)
+                completion(.success(packages))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+
+        let viewModel = WooShippingAddPackageViewModel(selectedPackage: nil, siteID: siteID, stores: mockStores, storage: storageManager)
+
+        // Do first load to get it sorted once
+        await viewModel.loadPackages()
+        let sortedPredefinedSavedPackages = viewModel.predefinedSavedPackages
+        let sortedCustomSavedPackages = viewModel.customSavedPackages
+
+        for _ in 0..<5 {
+            // When
+            await viewModel.loadPackages()
+            // Then
+            // check order
+            XCTAssertEqual(sortedPredefinedSavedPackages.count, viewModel.predefinedSavedPackages.count)
+            for (index, package) in sortedPredefinedSavedPackages.enumerated() {
+                XCTAssertEqual(package.id, viewModel.predefinedSavedPackages[index].id)
+            }
+            XCTAssertEqual(sortedCustomSavedPackages.count, viewModel.customSavedPackages.count)
+            for (index, package) in sortedCustomSavedPackages.enumerated() {
+                XCTAssertEqual(package.id, viewModel.customSavedPackages[index].id)
+            }
+        }
+    }
 }
 
 private extension WooShippingAddPackageViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14734
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR, when a selected package is edited in the Woo Shipping label creation flow, we scroll to the selected package in the list of packages.

This also adds consistent ordering for the packages in the list, so we're scrolling to the same place in the list of packages.

### How

* Adds a `ScrollViewReader` and scrolls to the selected package ID in both the carrier and saved packages views.
* Sorts each list of packages by ID.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Immediately tap "Select a Package."
8. Select a carrier/saved package or save a new custom package as a template and add the package.
9. Tap the pencil icon and confirm the add package view scrolls to the selected package in the list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/c0f25ba0-aa54-4a1a-b628-a0cbdd8abb04


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.