### PR TITLE
[Brand updates] Dark theme color changes

### DIFF
--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -126,10 +126,7 @@ public extension UIColor {
 
     /// Text.
     ///
-    static var textBrand: UIColor {
-        return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
-        dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
-    }
+    static var textBrand: UIColor = .accent
 
     /// Text Warning.
     ///

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -77,11 +77,9 @@ public extension UIColor {
 
 // MARK: - Text Colors.
 public extension UIColor {
-    /// Text link. Purple-50
+    /// Text link. resolves to accent, WooCommercePurple-40 (Light mode) and WooCommercePurple-30 (Dark mode)
     ///
-    static var textLink: UIColor {
-        return .accent
-    }
+    static var textLink: UIColor = .accent
 
     /// Text.
     ///

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -2,10 +2,11 @@ import UIKit
 
 // MARK: - Base colors.
 public extension UIColor {
-    /// Accent. WooCommercePurple-40
+    /// Accent. WooCommercePurple-40 (Light mode) and WooCommercePurple-30 (Dark mode)
     ///
     static var accent: UIColor {
-        return .withColorStudio(.wooCommercePurple, shade: .shade40)
+        return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade40),
+                       dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
     }
 
     /// Accent Dark. Purple-70 (Light Mode) and Purple-50 (Dark Mode)
@@ -26,11 +27,9 @@ public extension UIColor {
                         dark: withColorStudio(.red, shade: .shade30))
     }
 
-    /// Primary. WooCommercePurple-40
+    /// Primary. resolves to accent, WooCommercePurple-40 (Light mode) and WooCommercePurple-30 (Dark mode)
     ///
-    static var primary: UIColor {
-        return .withColorStudio(.wooCommercePurple, shade: .shade40)
-    }
+    static var primary: UIColor = .accent
 
     /// Warning. Orange-30 (< iOS 13 and Light Mode) and Orange-50 (Dark Mode)
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Continuation of: woocommerce/woomobile-private#382
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the color palette to align with the new requirement of using `purple_30` in dark theme as the accent and primary colors.

As discussed here p1734705352565459/1727138732.960149-slack-C07E7D0R761, we decided to keep using `purple_40` as the background of primary buttons, to keep a better contrast with the white color we use for the button text.

## Steps to reproduce
1. Switch your phone/simulator to dark theme.
2. Open the app.
3. Check different screens.

## Testing information
Confirm the new purple color is brighter than before and offers a better contrast.

Tested using iPhone 16 simulator, iOS 18.1.

## Screenshots
### Color changes
| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 - 2024-12-20 at 16 09 27](https://github.com/user-attachments/assets/56c3045f-8d64-4f88-9f6d-820cdb9022b2) | ![Simulator Screenshot - iPhone 16 - 2024-12-20 at 16 25 11](https://github.com/user-attachments/assets/295c9722-1d6d-4b1d-9677-465d10c72917) |
| ![Simulator Screenshot - iPhone 16 - 2024-12-20 at 16 09 51](https://github.com/user-attachments/assets/1e35e230-5a60-4556-a345-3b45563b41e3) | ![Simulator Screenshot - iPhone 16 - 2024-12-20 at 16 25 21](https://github.com/user-attachments/assets/8aadc4ef-378c-418a-ad52-ec19797ae84f) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.