### PR TITLE
[TTPReq] Improvements to TTP Awareness Moment modal presentation logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -19,6 +19,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     let configuration: CardPresentPaymentsConfiguration
     let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
     let connectivityObserver: ConnectivityObserver
+    private let tapToPayAwarenessMomentDeterminer: TapToPayAwarenessMomentDetermining
 
     private let onboardingStatePublisher: Published<CardPresentPaymentOnboardingState>.Publisher
     private let analytics: Analytics = ServiceLocator.analytics
@@ -40,7 +41,8 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
          onboardingStatePublisher: Published<CardPresentPaymentOnboardingState>.Publisher,
          connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker,
          connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         tapToPayAwarenessMomentDeterminer: TapToPayAwarenessMomentDetermining = TapToPayAwarenessMomentDeterminer()) {
         self.siteID = siteID
         self.configuration = configuration
         self.didChangeShouldShow = didChangeShouldShow
@@ -49,6 +51,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
         self.connectivityObserver = connectivityObserver
         self.onboardingStatePublisher = onboardingStatePublisher
         self.learnMoreURL = Self.learnMoreURL(for: .wcPay) // this will be updated when the onboarding state is known
+        self.tapToPayAwarenessMomentDeterminer = tapToPayAwarenessMomentDeterminer
 
         beginOnboardingStateObservation()
         beginConnectedReaderObservation()
@@ -132,6 +135,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
 
     func viewDidAppear() {
         NotificationCenter.default.post(name: .setUpTapToPayViewDidAppear, object: nil)
+        tapToPayAwarenessMomentDeterminer.setPresented()
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/Tap to Pay Education/TapToPayAwarenessMomentDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/Tap to Pay Education/TapToPayAwarenessMomentDeterminer.swift
@@ -42,7 +42,10 @@ struct TapToPayAwarenessMomentDeterminer: TapToPayAwarenessMomentDetermining {
             return false
         }
 
-        guard case .completed = cardPresentPaymentsOnboarding.state else {
+        switch cardPresentPaymentsOnboarding.state {
+        case .completed, .codPaymentGatewayNotSetUp:
+            break
+        default:
             return false
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayAwarenessMomentDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayAwarenessMomentDeterminerTests.swift
@@ -139,6 +139,23 @@ struct TapToPayAwarenessMomentDeterminerTests {
         #expect(shouldPresent)
     }
 
+    @Test func shouldPresent_when_noPreviousPresentation_secondAttempt_codPaymentGatewayNotSetUp_supportsTTP() async {
+        // Given
+        featureFlagService.tapToPayEducation = true
+        userDefaults.hasPreviousPresentation = false
+        userDefaults.hasFirstAttempt = true
+        cardPresentPaymentsOnboardingUseCase.state = .codPaymentGatewayNotSetUp(plugin: .wcPay)
+        cardReaderSupportDeterminer.shouldReturnDeviceSupportsLocalMobileReader = true
+        cardReaderSupportDeterminer.shouldReturnSiteSupportsLocalMobileReader = true
+        cardReaderSupportDeterminer.shouldReturnHasPreviousTapToPayUsage = false
+
+        // When
+        let shouldPresent = await sut.shouldPresent()
+
+        // Then
+        #expect(shouldPresent)
+    }
+
     // MARK: - Attempt
 
     @Test func hasFirstAttempt_when_shouldPresent() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There were two observations with TTP awareness moment modal from testing:
- Modal is not shown when the payment gateway is onboarded but cod (cash on delivery) is not configured. It should not be a blocker.
- Modal is shown even after Set Up is attempted. We should no longer show awareness moment if user has interacted with the setup process. Similar to the TTP badge. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Cash on Delivery not configured:
1. Pick a site that has a payment gateway set up but CoD disabled (WooCommerce -> Settings -> Payments -> Cash on delivery)
2. Fresh install the app and log in
3. Confirm the modal doesn't appear
4. Kill the app
5. Relaunch the app
6. Confirm the modal to try to tap to pay opens
7. Dismiss the modal
8. Kill & relaunch the app
9. Confirm the modal doesn't appear

### Setup attempted:
1. Pick a site that has a payment gateway set up
2. Fresh install the app and log in
3. Confirm the modal doesn't appear
4. Go to Menu -> Payments and tap 'Set up Tap to Pay on iPhone'
5. Kill & relaunch the app
6. Confirm the modal doesn't appear

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested these scenarios on iPhone 14 Pro 17.7. Also updated unit tests.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.