### PR TITLE
[Woo POS] [Variable Products] Add sub list hierarchy to the items controller

### DIFF
--- a/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
+++ b/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
@@ -52,12 +52,15 @@ extension WooCommerce.AggregateOrderItem {
 
 extension WooCommerce.ItemsStackState {
     func copy(
-        root: CopiableProp<ItemListState> = .copy
+        root: CopiableProp<ItemListState> = .copy,
+        itemStates: CopiableProp<[POSItem: ItemListState]> = .copy
     ) -> WooCommerce.ItemsStackState {
         let root = root ?? self.root
+        let itemStates = itemStates ?? self.itemStates
 
         return WooCommerce.ItemsStackState(
-            root: root
+            root: root,
+            itemStates: itemStates
         )
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -15,7 +15,8 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     let itemsViewStatePublisher: any Publisher<ItemsViewState, Never>
     private let itemsViewStateSubject: CurrentValueSubject<ItemsViewState, Never> =
         .init(ItemsViewState(containerState: .loading,
-                             itemsStack: ItemsStackState(root: .loading([]))) )
+                             itemsStack: ItemsStackState(root: .loading([]),
+                                                         itemStates: [:])) )
     private let paginationTracker: AsyncPaginationTracker
     private let itemProvider: PointOfSaleItemServiceProtocol
 
@@ -27,7 +28,8 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     func loadInitialItems() async {
-        itemsViewStateSubject.send(ItemsViewState(containerState: .loading, itemsStack: ItemsStackState(root: .loading([]))))
+        itemsViewStateSubject.send(ItemsViewState(containerState: .loading, itemsStack: ItemsStackState(root: .loading([]),
+                                                                                                        itemStates: [:])))
         do {
             try await paginationTracker.syncFirstPage { [weak self] pageNumber in
                 guard let self else { return true }
@@ -35,7 +37,8 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
             }
         } catch {
             itemsViewStateSubject.send(ItemsViewState(containerState: .error(PointOfSaleErrorState.errorOnLoadingProducts()),
-                                                      itemsStack: ItemsStackState(root: .loaded([]))))
+                                                      itemsStack: ItemsStackState(root: .loaded([]),
+                                                                                  itemStates: [:])))
         }
     }
 
@@ -45,7 +48,9 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
             return
         }
         let currentItems = itemsViewStateSubject.value.itemsStack.root.items
-        itemsViewStateSubject.send(ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loading(currentItems))))
+        let currentItemStates = itemsViewStateSubject.value.itemsStack.itemStates
+        itemsViewStateSubject.send(ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loading(currentItems),
+                                                                                                        itemStates: currentItemStates)))
         do {
             _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
                 guard let self else { return true }
@@ -54,7 +59,8 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
         } catch {
             // TODO: 14694 - Handle error from loading the next page, like showing an error UI at the end or as an overlay.
             itemsViewStateSubject.send(ItemsViewState(containerState: .error(PointOfSaleErrorState.errorOnLoadingProducts()),
-                                                      itemsStack: ItemsStackState(root: .loaded(currentItems))))
+                                                      itemsStack: ItemsStackState(root: .loaded(currentItems),
+                                                                                  itemStates: currentItemStates)))
         }
     }
 
@@ -68,7 +74,8 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
         } catch {
             // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
             itemsViewStateSubject.send(ItemsViewState(containerState: .error(PointOfSaleErrorState.errorOnLoadingProducts()),
-                                                      itemsStack: ItemsStackState(root: .loaded([]))))
+                                                      itemsStack: ItemsStackState(root: .loaded([]),
+                                                                                  itemStates: [:])))
         }
     }
 
@@ -88,10 +95,14 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
         allItems.append(contentsOf: uniqueNewItems)
         if allItems.isEmpty {
             itemsViewStateSubject.send(ItemsViewState(containerState: .empty,
-                                                      itemsStack: ItemsStackState(root: .loaded([]))))
+                                                      itemsStack: ItemsStackState(root: .loaded([]),
+                                                                                  itemStates: [:])))
         } else {
+            let itemStates = itemsViewStateSubject.value.itemsStack.itemStates
+                .filter { allItems.contains($0.key) }
             itemsViewStateSubject.send(ItemsViewState(containerState: .content,
-                                                      itemsStack: ItemsStackState(root: .loaded(allItems))))
+                                                      itemsStack: ItemsStackState(root: .loaded(allItems),
+                                                                                  itemStates: itemStates)))
         }
         return pagedItems.hasMorePages
     }

--- a/WooCommerce/Classes/POS/Models/ItemsStackState.swift
+++ b/WooCommerce/Classes/POS/Models/ItemsStackState.swift
@@ -1,8 +1,10 @@
 import Foundation
 import Codegen
+import enum Yosemite.POSItem
 
 struct ItemsStackState {
     let root: ItemListState
+    let itemStates: [POSItem: ItemListState]
 }
 
 extension ItemsStackState: Equatable, GeneratedCopiable {}

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -48,7 +48,8 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
     private var onOnboardingCancellation: (() -> Void)?
 
     @Published private(set) var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                                                itemsStack: ItemsStackState(root: .loading([])))
+                                                                                itemsStack: ItemsStackState(root: .loading([]),
+                                                                                                            itemStates: [:]))
 
     @Published private(set) var cart: [CartItem] = []
 

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -55,19 +55,23 @@ final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
 
 final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtocol {
     @Published var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                                   itemsStack: ItemsStackState(root: .loading([])))
+                                                                   itemsStack: ItemsStackState(root: .loading([]),
+                                                                                               itemStates: [:]))
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> { $itemsViewState }
 
     func loadInitialItems() async {
-        itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded(mockItems)))
+        itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded(mockItems),
+                                                                                              itemStates: [:]))
     }
 
     func loadNextItems() async {
-        itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loading(mockItems)))
+        itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loading(mockItems),
+                                                                                              itemStates: [:]))
     }
 
     func reload() async {
-        itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded([])))
+        itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded([]),
+                                                                                              itemStates: [:]))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -6,7 +6,8 @@ final class PointOfSaleItemsControllerTests {
     private let itemProvider: MockPointOfSaleItemService
     private let sut: PointOfSaleItemsController
     @Published var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                                   itemsStack: ItemsStackState(root: .loading([])))
+                                                                   itemsStack: ItemsStackState(root: .loading([]),
+                                                                                               itemStates: [:]))
 
     init() {
         itemProvider = MockPointOfSaleItemService()
@@ -35,7 +36,8 @@ final class PointOfSaleItemsControllerTests {
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
-                                                 itemsStack: ItemsStackState(root: .loaded(expectedItems))))
+                                                 itemsStack: ItemsStackState(root: .loaded(expectedItems),
+                                                                             itemStates: [:])))
     }
 
     @Test func loadInitialItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
@@ -120,7 +122,8 @@ final class PointOfSaleItemsControllerTests {
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
-                                                 itemsStack: ItemsStackState(root: .loaded(initialItems))))
+                                                 itemsStack: ItemsStackState(root: .loaded(initialItems),
+                                                                             itemStates: [:])))
     }
 
     @Test func loadItems_when_simulateFetchNextPage_then_state_is_loaded_with_expected_items() async throws {
@@ -228,7 +231,8 @@ final class PointOfSaleItemsControllerTests {
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
-                                                 itemsStack: ItemsStackState(root: .loaded(expectedItems))))
+                                                 itemsStack: ItemsStackState(root: .loaded(expectedItems),
+                                                                             itemStates: [:])))
     }
 
     @Test func reload_requests_first_page() async throws {
@@ -257,7 +261,8 @@ final class PointOfSaleItemsControllerTests {
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
-                                                 itemsStack: ItemsStackState(root: .loaded(MockPointOfSaleItemService.makeInitialItems()))))
+                                                 itemsStack: ItemsStackState(root: .loaded(MockPointOfSaleItemService.makeInitialItems()),
+                                                                             itemStates: [:])))
     }
 
     @Test func loadNextItems_when_next_page_is_empty_then_the_same_page_is_requested_next() async throws {

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -29,7 +29,8 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     var blockReturnToItemSelection: Bool = false
 
     init(cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected,
-         itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading, itemsStack: ItemsStackState(root: .loading([]))),
+         itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading, itemsStack: ItemsStackState(root: .loading([]),
+                                                                                                               itemStates: [:])),
          orderStage: PointOfSaleOrderStage = .building,
          orderState: PointOfSaleOrderState = .idle,
          paymentState: PointOfSalePaymentState = .idle) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14698 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request introduces changes to the `ItemsStackState` structure and its usage across various classes to include a new property `itemStates`. The most important changes include modifications to the `ItemsStackState` structure, updates to the `PointOfSaleItemsController` class, and adjustments to related models and services to support the new `itemStates` property. Please note that `itemStates` is not used yet, it paves the way when supporting tapping a variable product to show a list of variations where some decisions are pending in pdfdoF-62l-p2.

### Changes to `ItemsStackState` structure:

* [`WooCommerce/Classes/POS/Models/ItemsStackState.swift`](diffhunk://#diff-408e7976d7597eecc756ce0c72a03c0326b78fe3f1b4c9eee681f74ccc5027d7R3-R7): Added a new property `itemStates` to the `ItemsStackState` structure and updated its initializer.

### Updates to `PointOfSaleItemsController` class:

* [`WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift`](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L18-R19): Updated the `itemsViewStateSubject` initialization and various method calls to include the new `itemStates` property in the `ItemsStackState` structure. [[1]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L18-R19) [[2]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L30-R41) [[3]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L48-R53) [[4]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L57-R63) [[5]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L71-R78) [[6]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L91-R105)

### Adjustments to related models and services:

* [`WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift`](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL51-R52): Modified the `itemsViewState` initialization to include the new `itemStates` property in the `ItemsStackState` structure.
* [`WooCommerce/Classes/POS/Utils/PreviewHelpers.swift`](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dL58-R74): Updated the `itemsViewState` initialization and method calls in the `PointOfSalePreviewItemsController` class to include the new `itemStates` property.

### Additional changes to support `itemStates`:

* [`WooCommerce/Classes/Copiable/Models+Copiable.generated.swift`](diffhunk://#diff-c3cbcc274877be417f6493a9ee8a1d96a02e9dfbedef235c343eb3b657c5852aL55-R63): Modified the `copy` method in the `ItemsStackState` extension to include the new `itemStates` property.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The new property is not used yet. A confidence test on the following is still helpful:

- Switch to a store eligible for POS
- Go to Menu > Point of Sale mode --> the products should be loaded as before
- Add some items to the cart and check out
- Go back to the item selector, and change the items in the cart
- Check out --> cart and total should be expected
- Proceed with payment --> payment should succeed as before




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.