### PR TITLE
[Revamp Shipping Labels] Customs Form Part 1

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct WooShippingCustomsForm: View {
+    @State private var contentType: String = "Merchandise"
+    @State private var restrictionType: String = "None"
+    @State private var internationalTransactionNumber: String = ""
+    @State private var returnToSender: Bool = false
+    @State private var productDetails: [ProductDetail] = [
+        ProductDetail(name: "Little Nap Brazil 250g", type: "Coffee beans", origin: "Japan", weight: 0.3, price: 20.0),
+        ProductDetail(name: "Partners Brooklyn 250g", type: "", origin: "", weight: 0.0, price: 0.0)
+    ]
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Customs")) {
+                    Picker("Content Type", selection: $contentType) {
+                        Text("Merchandise").tag("Merchandise")
+                        // Add more content types as needed
+                    }
+                    Picker("Restriction Type", selection: $restrictionType) {
+                        Text("None").tag("None")
+                        // Add more restriction types as needed
+                    }
+                    TextField("International Transaction Number", text: $internationalTransactionNumber)
+                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
+                    Toggle("Return to sender if package is not able to be delivered", isOn: $returnToSender)
+                }
+
+                //                Section(header: Text("Product Details")) {
+                //                    ForEach($productDetails, id: \.$id) { $product in
+                //                        VStack(alignment: .leading) {
+                //                            Text(product.name)
+                //                                .font(.headline)
+                //                            Text("Type: \(product.type)")
+                //                            Text("Origin: \(product.origin)")
+                //                            Text("Weight: \(product.weight, specifier: "%.2f") kg")
+                //                            Text("Price: $\(product.price, specifier: "%.2f")")
+                //                        }
+                //                        .padding(.vertical, 5)
+                //                    }
+            }
+
+            Button(action: {
+                // Action for adding missing information
+            }) {
+                Text("Add Missing Information")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+            }
+        }
+        .navigationTitle("Customs Form")
+    }
+}
+
+
+struct ProductDetail: Identifiable {
+    let id = UUID()
+    var name: String
+    var type: String
+    var origin: String
+    var weight: Double
+    var price: Double
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -28,7 +28,7 @@ struct WooShippingCustomsForm: View {
             }
             .padding()
         }
-        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+        .roundedBorder(cornerRadius: Constants.borderCornerRadius, lineColor: Color(.separator), lineWidth: Constants.borderWidth)
     }
 
     private var restrictionTypeSelectionView: some View {
@@ -53,7 +53,7 @@ struct WooShippingCustomsForm: View {
             }
             .padding()
         }
-        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+        .roundedBorder(cornerRadius: Constants.borderCornerRadius, lineColor: Color(.separator), lineWidth: Constants.borderWidth)
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -1,6 +1,129 @@
 import SwiftUI
 
 struct WooShippingCustomsForm: View {
+    @Environment(\.presentationMode) var presentationMode
+    let contentType: WooShippingContentType = .merchandise
+    let restrictionType: WooShippingRestrictionType = .none
+
+    private var contentTypeSelectionView: some View {
+        Menu {
+            // show selection
+            ForEach(WooShippingContentType.allCases, id: \.self) { option in
+                Button {
+                } label: {
+                    Text(option.name)
+                        .bodyStyle()
+                    if contentType == option {
+                        Image(uiImage: .checkmarkStyledImage)
+                    }
+                }
+            }
+        } label: {
+            HStack {
+                Text(contentType.name)
+                    .bodyStyle()
+                Spacer()
+                Image(systemName: "chevron.up.chevron.down")
+            }
+            .padding()
+        }
+        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+    }
+
+    private var restrictionTypeSelectionView: some View {
+        Menu {
+            // show selection
+            ForEach(WooShippingRestrictionType.allCases, id: \.self) { option in
+                Button {
+                } label: {
+                    Text(option.name)
+                        .bodyStyle()
+                    if restrictionType == option {
+                        Image(uiImage: .checkmarkStyledImage)
+                    }
+                }
+            }
+        } label: {
+            HStack {
+                Text(restrictionType.name)
+                    .bodyStyle()
+                Spacer()
+                Image(systemName: "chevron.up.chevron.down")
+            }
+            .padding()
+        }
+        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+    }
+
+    var body: some View {
+        NavigationView {
+        GeometryReader { geometry in
+            ScrollViewReader { proxy in
+                ScrollView {
+                        VStack(alignment: .leading, spacing: Constants.defaultVerticalSpacing) {
+                            HStack {
+                                Text(Localization.contentType)
+                                    .font(.subheadline)
+                                Spacer()
+                            }
+
+                            contentTypeSelectionView
+
+                            HStack {
+                                Text(Localization.restrictionType)
+                                    .font(.subheadline)
+                                Spacer()
+                            }
+
+                            restrictionTypeSelectionView
+                        }
+                        .padding()
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button(action: {
+                                    presentationMode.wrappedValue.dismiss()
+                                }, label: {
+                                    Text(Localization.cancel)
+                                })
+                            }
+                        }
+                        .navigationTitle(Localization.customs)
+                        .navigationBarTitleDisplayMode(.inline)
+
+                        Spacer()
+                    }
+                    .navigationViewStyle(.stack)
+                }
+            }
+        }
+    }
+}
+
+extension WooShippingCustomsForm {
+    enum Localization {
+        static let cancel = NSLocalizedString("wooShipping.customs.cancel",
+                                              value: "Cancel",
+                                              comment: "Cancel button in navigation bar to dismiss the screen")
+        static let customs = NSLocalizedString("wooShipping.customs.title",
+                                                  value: "Customs",
+                                                  comment: "Title for the Customs screen")
+        static let contentType = NSLocalizedString("wooShipping.customs.contentType",
+                                                   value: "Content Type",
+                                                   comment: "Title for the Content Type menu in the Shipping Customs Menu")
+        static let restrictionType = NSLocalizedString("wooShipping.customs.restrictionType",
+                                                   value: "Restriction Type",
+                                                   comment: "Title for the Restriction Type menu in the Shipping Customs Menu")
+    }
+
+}
+
+extension WooShippingCustomsForm {
+    enum Constants {
+        static let defaultVerticalSpacing: CGFloat = 16.0
+    }
+}
+
+struct WooShippingCustomsFormOld: View {
     @State private var contentType: String = "Merchandise"
     @State private var restrictionType: String = "None"
     @State private var internationalTransactionNumber: String = ""
@@ -64,4 +187,84 @@ struct ProductDetail: Identifiable {
     var origin: String
     var weight: Double
     var price: Double
+}
+
+enum WooShippingContentType: String, CaseIterable {
+    case merchandise
+    case documents
+    case gift
+    case sample
+    case other
+    var name: String {
+        switch self {
+        case .merchandise:
+            return Localization.merchandise
+        case .documents:
+            return Localization.documents
+        case .gift:
+            return Localization.gift
+        case .sample:
+            return Localization.sample
+        case .other:
+            return Localization.other
+
+        }
+    }
+}
+
+extension WooShippingContentType {
+    enum Localization {
+        static let merchandise = NSLocalizedString("wooShipping.customs.contentType.merchandise",
+                                                   value: "Merchandise",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let documents = NSLocalizedString("wooShipping.customs.contentType.documents",
+                                                   value: "Documents",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let gift = NSLocalizedString("wooShipping.customs.contentType.gift",
+                                                   value: "Gift",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let sample = NSLocalizedString("wooShipping.customs.contentType.sample",
+                                                   value: "Sample",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let other = NSLocalizedString("wooShipping.customs.contentType.other",
+                                                   value: "Other",
+                                                   comment: "Info label for shipping content type merchandise")
+    }
+}
+
+enum WooShippingRestrictionType: String, CaseIterable {
+    case none
+    case quarantine
+    case sanitary
+    case other
+    var name: String {
+        switch self {
+        case .none:
+            return Localization.none
+        case .quarantine:
+            return Localization.quarantine
+        case .sanitary:
+            return Localization.sanitary
+        case .other:
+            return Localization.other
+
+        }
+    }
+}
+
+extension WooShippingRestrictionType {
+    enum Localization {
+        static let none = NSLocalizedString("wooShipping.customs.restrictionType.none",
+                                                   value: "None",
+                                                   comment: "Info label for shipping restriction type none")
+        static let quarantine = NSLocalizedString("wooShipping.customs.restrictionType.quarantine",
+                                                   value: "Quarantine",
+                                                   comment: "Info label for shipping restriction type quarantine")
+        static let sanitary = NSLocalizedString("wooShipping.customs.restrictionType.sanitary",
+                                                   value: "Sanitary",
+                                                   comment: "Info label for shipping restriction type sanitary")
+        static let other = NSLocalizedString("wooShipping.customs.restrictionType.other",
+                                                   value: "Other",
+                                                   comment: "Info label for shipping restriction type other")
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -1,9 +1,10 @@
 import SwiftUI
+import WooFoundation
 
 struct WooShippingCustomsForm: View {
     @Environment(\.presentationMode) var presentationMode
-    let contentType: WooShippingContentType = .merchandise
-    let restrictionType: WooShippingRestrictionType = .none
+    @ObservedObject var viewModel: WooShippingCustomsFormViewModel
+    @State private var isShowingITNInfoWebView = false
 
     private var contentTypeSelectionView: some View {
         Menu {
@@ -13,14 +14,14 @@ struct WooShippingCustomsForm: View {
                 } label: {
                     Text(option.name)
                         .bodyStyle()
-                    if contentType == option {
+                    if viewModel.contentType == option {
                         Image(uiImage: .checkmarkStyledImage)
                     }
                 }
             }
         } label: {
             HStack {
-                Text(contentType.name)
+                Text(viewModel.contentType.name)
                     .bodyStyle()
                 Spacer()
                 Image(systemName: "chevron.up.chevron.down")
@@ -38,14 +39,14 @@ struct WooShippingCustomsForm: View {
                 } label: {
                     Text(option.name)
                         .bodyStyle()
-                    if restrictionType == option {
+                    if viewModel.restrictionType == option {
                         Image(uiImage: .checkmarkStyledImage)
                     }
                 }
             }
         } label: {
             HStack {
-                Text(restrictionType.name)
+                Text(viewModel.restrictionType.name)
                     .bodyStyle()
                 Spacer()
                 Image(systemName: "chevron.up.chevron.down")
@@ -76,6 +77,33 @@ struct WooShippingCustomsForm: View {
                             }
 
                             restrictionTypeSelectionView
+
+                            HStack {
+                                Text(Localization.internationalTransactionNumber)
+                                    .font(.subheadline)
+                                Spacer()
+                            }
+
+                            TextField("", text: $viewModel.internationalTransactionNumber)
+                                .padding(Constants.borderPadding)
+                                .roundedBorder(cornerRadius: Constants.borderCornerRadius, lineColor: Color(.separator), lineWidth: Constants.borderWidth)
+
+                            Button {
+                                isShowingITNInfoWebView = true
+                            } label: {
+                                HStack(alignment: .top, spacing: Constants.intoButtonHorizontalSpacing) {
+                                    Image(systemName: "info.circle")
+                                    Text(Localization.infoText)
+                                }
+                                .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                                .footnoteStyle()
+                            }
+
+                            Toggle(isOn: $viewModel.returnToSenderIfNotDelivered) {
+                                Text(Localization.returnToSenderMessage)
+                                    .font(.subheadline)
+                            }
+                            .tint(Color.accentColor)
                         }
                         .padding()
                         .toolbar {
@@ -93,6 +121,7 @@ struct WooShippingCustomsForm: View {
                         Spacer()
                     }
                     .navigationViewStyle(.stack)
+                    .safariSheet(isPresented: $isShowingITNInfoWebView, url: viewModel.itnInfoURL)
                 }
             }
         }
@@ -109,10 +138,19 @@ extension WooShippingCustomsForm {
                                                   comment: "Title for the Customs screen")
         static let contentType = NSLocalizedString("wooShipping.customs.contentType",
                                                    value: "Content Type",
-                                                   comment: "Title for the Content Type menu in the Shipping Customs Menu")
+                                                   comment: "Title for the Content Type menu in the Shipping Customs Form")
         static let restrictionType = NSLocalizedString("wooShipping.customs.restrictionType",
                                                    value: "Restriction Type",
-                                                   comment: "Title for the Restriction Type menu in the Shipping Customs Menu")
+                                                   comment: "Title for the Restriction Type menu in the Shipping Customs Form")
+        static let internationalTransactionNumber = NSLocalizedString("wooShipping.customs.internationalTransactionNumber",
+                                                   value: "International Transaction Number",
+                                                   comment: "Title for the Internaction Transaction Number in the Shipping Customs Form")
+        static let infoText = NSLocalizedString("wooShipping.customs.internationalTransactionNumber.infoText",
+                                                value: "More info about ITN",
+                                                comment: "Explanatory text for the international transaction number in customs")
+        static let returnToSenderMessage = NSLocalizedString("wooShipping.customs.returnToSenderMessage",
+                                                              value: "Return to sender if package is not able to be delivered",
+                                                              comment: "Info label for a toggle to return the package to a sender if necessary toggle")
     }
 
 }
@@ -120,151 +158,9 @@ extension WooShippingCustomsForm {
 extension WooShippingCustomsForm {
     enum Constants {
         static let defaultVerticalSpacing: CGFloat = 16.0
-    }
-}
-
-struct WooShippingCustomsFormOld: View {
-    @State private var contentType: String = "Merchandise"
-    @State private var restrictionType: String = "None"
-    @State private var internationalTransactionNumber: String = ""
-    @State private var returnToSender: Bool = false
-    @State private var productDetails: [ProductDetail] = [
-        ProductDetail(name: "Little Nap Brazil 250g", type: "Coffee beans", origin: "Japan", weight: 0.3, price: 20.0),
-        ProductDetail(name: "Partners Brooklyn 250g", type: "", origin: "", weight: 0.0, price: 0.0)
-    ]
-
-    var body: some View {
-        NavigationView {
-            Form {
-                Section(header: Text("Customs")) {
-                    Picker("Content Type", selection: $contentType) {
-                        Text("Merchandise").tag("Merchandise")
-                        // Add more content types as needed
-                    }
-                    Picker("Restriction Type", selection: $restrictionType) {
-                        Text("None").tag("None")
-                        // Add more restriction types as needed
-                    }
-                    TextField("International Transaction Number", text: $internationalTransactionNumber)
-                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
-                    Toggle("Return to sender if package is not able to be delivered", isOn: $returnToSender)
-                }
-
-                //                Section(header: Text("Product Details")) {
-                //                    ForEach($productDetails, id: \.$id) { $product in
-                //                        VStack(alignment: .leading) {
-                //                            Text(product.name)
-                //                                .font(.headline)
-                //                            Text("Type: \(product.type)")
-                //                            Text("Origin: \(product.origin)")
-                //                            Text("Weight: \(product.weight, specifier: "%.2f") kg")
-                //                            Text("Price: $\(product.price, specifier: "%.2f")")
-                //                        }
-                //                        .padding(.vertical, 5)
-                //                    }
-            }
-
-            Button(action: {
-                // Action for adding missing information
-            }) {
-                Text("Add Missing Information")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(8)
-            }
-        }
-        .navigationTitle("Customs Form")
-    }
-}
-
-
-struct ProductDetail: Identifiable {
-    let id = UUID()
-    var name: String
-    var type: String
-    var origin: String
-    var weight: Double
-    var price: Double
-}
-
-enum WooShippingContentType: String, CaseIterable {
-    case merchandise
-    case documents
-    case gift
-    case sample
-    case other
-    var name: String {
-        switch self {
-        case .merchandise:
-            return Localization.merchandise
-        case .documents:
-            return Localization.documents
-        case .gift:
-            return Localization.gift
-        case .sample:
-            return Localization.sample
-        case .other:
-            return Localization.other
-
-        }
-    }
-}
-
-extension WooShippingContentType {
-    enum Localization {
-        static let merchandise = NSLocalizedString("wooShipping.customs.contentType.merchandise",
-                                                   value: "Merchandise",
-                                                   comment: "Info label for shipping content type merchandise")
-        static let documents = NSLocalizedString("wooShipping.customs.contentType.documents",
-                                                   value: "Documents",
-                                                   comment: "Info label for shipping content type merchandise")
-        static let gift = NSLocalizedString("wooShipping.customs.contentType.gift",
-                                                   value: "Gift",
-                                                   comment: "Info label for shipping content type merchandise")
-        static let sample = NSLocalizedString("wooShipping.customs.contentType.sample",
-                                                   value: "Sample",
-                                                   comment: "Info label for shipping content type merchandise")
-        static let other = NSLocalizedString("wooShipping.customs.contentType.other",
-                                                   value: "Other",
-                                                   comment: "Info label for shipping content type merchandise")
-    }
-}
-
-enum WooShippingRestrictionType: String, CaseIterable {
-    case none
-    case quarantine
-    case sanitary
-    case other
-    var name: String {
-        switch self {
-        case .none:
-            return Localization.none
-        case .quarantine:
-            return Localization.quarantine
-        case .sanitary:
-            return Localization.sanitary
-        case .other:
-            return Localization.other
-
-        }
-    }
-}
-
-extension WooShippingRestrictionType {
-    enum Localization {
-        static let none = NSLocalizedString("wooShipping.customs.restrictionType.none",
-                                                   value: "None",
-                                                   comment: "Info label for shipping restriction type none")
-        static let quarantine = NSLocalizedString("wooShipping.customs.restrictionType.quarantine",
-                                                   value: "Quarantine",
-                                                   comment: "Info label for shipping restriction type quarantine")
-        static let sanitary = NSLocalizedString("wooShipping.customs.restrictionType.sanitary",
-                                                   value: "Sanitary",
-                                                   comment: "Info label for shipping restriction type sanitary")
-        static let other = NSLocalizedString("wooShipping.customs.restrictionType.other",
-                                                   value: "Other",
-                                                   comment: "Info label for shipping restriction type other")
+        static let borderCornerRadius: CGFloat = 8
+        static let borderWidth: CGFloat = 1
+        static let borderPadding: CGFloat = 16
+        static let intoButtonHorizontalSpacing: CGFloat = 8
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+final class WooShippingCustomsFormViewModel: ObservableObject {
+    @Published var internationalTransactionNumber: String
+    @Published var returnToSenderIfNotDelivered: Bool
+
+    let contentType: WooShippingContentType = .merchandise
+    let restrictionType: WooShippingRestrictionType = .none
+
+    let itnInfoURL = URL(string: "https://pe.usps.com/text/imm/immc5_010.htm")
+
+    init(internationalTransactionNumber: String, returnToSenderIfNotDelivered: Bool) {
+        self.internationalTransactionNumber = internationalTransactionNumber
+        self.returnToSenderIfNotDelivered = returnToSenderIfNotDelivered
+    }
+}
+
+enum WooShippingRestrictionType: String, CaseIterable {
+    case none
+    case quarantine
+    case sanitary
+    case other
+    var name: String {
+        switch self {
+        case .none:
+            return Localization.none
+        case .quarantine:
+            return Localization.quarantine
+        case .sanitary:
+            return Localization.sanitary
+        case .other:
+            return Localization.other
+
+        }
+    }
+}
+
+extension WooShippingRestrictionType {
+    enum Localization {
+        static let none = NSLocalizedString("wooShipping.customs.restrictionType.none",
+                                                   value: "None",
+                                                   comment: "Info label for shipping restriction type none")
+        static let quarantine = NSLocalizedString("wooShipping.customs.restrictionType.quarantine",
+                                                   value: "Quarantine",
+                                                   comment: "Info label for shipping restriction type quarantine")
+        static let sanitary = NSLocalizedString("wooShipping.customs.restrictionType.sanitary",
+                                                   value: "Sanitary/Phitosanitary Inspection",
+                                                   comment: "Info label for shipping restriction type sanitary")
+        static let other = NSLocalizedString("wooShipping.customs.restrictionType.other",
+                                                   value: "Other",
+                                                   comment: "Info label for shipping restriction type other")
+    }
+}
+
+enum WooShippingContentType: String, CaseIterable {
+    case merchandise
+    case gift
+    case returnedGoods
+    case sample
+    case documents
+    case other
+    var name: String {
+        switch self {
+        case .merchandise:
+            return Localization.merchandise
+        case .returnedGoods:
+            return Localization.returnedGoods
+        case .documents:
+            return Localization.documents
+        case .gift:
+            return Localization.gift
+        case .sample:
+            return Localization.sample
+        case .other:
+            return Localization.other
+        }
+    }
+}
+
+extension WooShippingContentType {
+    enum Localization {
+        static let merchandise = NSLocalizedString("wooShipping.customs.contentType.merchandise",
+                                                   value: "Merchandise",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let returnedGoods = NSLocalizedString("wooShipping.customs.contentType.returnedGoods",
+                                                     value: "Returned Goods",
+                                                     comment: "Info label for shipping content type returned goods")
+        static let documents = NSLocalizedString("wooShipping.customs.contentType.documents",
+                                                   value: "Documents",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let gift = NSLocalizedString("wooShipping.customs.contentType.gift",
+                                                   value: "Gift",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let sample = NSLocalizedString("wooShipping.customs.contentType.sample",
+                                                   value: "Sample",
+                                                   comment: "Info label for shipping content type merchandise")
+        static let other = NSLocalizedString("wooShipping.customs.contentType.other",
+                                                   value: "Other...",
+                                                   comment: "Info label for shipping content type merchandise")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -37,9 +37,7 @@ struct WooShippingCustomsRow: View {
         .sheet(isPresented: $showCustomsForm) {
             WooShippingCustomsForm(viewModel: WooShippingCustomsFormViewModel(internationalTransactionNumber: "123",
                                                                               returnToSenderIfNotDelivered: true))
-
         }
-
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -35,7 +35,8 @@ struct WooShippingCustomsRow: View {
         .padding(Layout.borderPadding)
         .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
         .sheet(isPresented: $showCustomsForm) {
-            WooShippingCustomsForm()
+            WooShippingCustomsForm(viewModel: WooShippingCustomsFormViewModel(internationalTransactionNumber: "123",
+                                                                              returnToSenderIfNotDelivered: true))
 
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 import WooFoundation
 
-struct WooShippingCustoms: View {
+struct WooShippingCustomsRow: View {
     let informationIsCompleted: Bool
     @ScaledMetric private var scale: CGFloat = 1.0
+
+    @State private var showCustomsForm: Bool = false
 
     var body: some View {
         HStack {
@@ -27,6 +29,7 @@ struct WooShippingCustoms: View {
                 .padding(.horizontal, 10)
 
             Button {
+                showCustomsForm.toggle()
             } label: {
                 Image(systemName: "pencil")
                     .resizable()
@@ -37,10 +40,14 @@ struct WooShippingCustoms: View {
         }
         .padding(Layout.borderPadding)
         .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+        .sheet(isPresented: $showCustomsForm) {
+            WooShippingCustomsForm()
+
+        }
     }
 }
 
-private extension WooShippingCustoms {
+private extension WooShippingCustomsRow {
     enum Layout {
         static let borderCornerRadius: CGFloat = 8
         static let borderWidth: CGFloat = 0.5
@@ -54,7 +61,7 @@ private extension WooShippingCustoms {
     }
 }
 
-private extension WooShippingCustoms {
+private extension WooShippingCustomsRow {
     enum Localization {
         static let customsTitle = NSLocalizedString("shippingLabels.customs.customsTitle",
                                                     value: "Customs",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -46,7 +46,7 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingHazmat(enabled: !viewModel.canViewLabel)
 
-                    WooShippingCustoms(informationIsCompleted: viewModel.customsInformationIsCompleted)
+                    WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted)
                         .padding(.bottom, 16)
 
                     if viewModel.canViewLabel {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1982,6 +1982,7 @@
 		B90C65CD29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */; };
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
 		B90D21762D14269200ED60ED /* WooShippingCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */; };
+		B90D21782D15B72900ED60ED /* WooShippingCustomsFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90D21772D15B72700ED60ED /* WooShippingCustomsFormViewModel.swift */; };
 		B90DACC02A30AEF000365897 /* BarcodeScannerItemFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */; };
 		B90DACC22A31BBC800365897 /* BarcodeScannerProductFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */; };
 		B90DD08E2D12FAA400EFC06A /* WooShippingCustomsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */; };
@@ -5102,6 +5103,7 @@
 		B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentOnboardingStateCache.swift; sourceTree = "<group>"; };
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
 		B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsForm.swift; sourceTree = "<group>"; };
+		B90D21772D15B72700ED60ED /* WooShippingCustomsFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsFormViewModel.swift; sourceTree = "<group>"; };
 		B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerItemFinder.swift; sourceTree = "<group>"; };
 		B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerProductFinderTests.swift; sourceTree = "<group>"; };
 		B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsRow.swift; sourceTree = "<group>"; };
@@ -10871,6 +10873,7 @@
 		B90DD08C2D12FA6600EFC06A /* WooShipping Customs */ = {
 			isa = PBXGroup;
 			children = (
+				B90D21772D15B72700ED60ED /* WooShippingCustomsFormViewModel.swift */,
 				B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */,
 				B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */,
 			);
@@ -16387,6 +16390,7 @@
 				DECEA4472C81778300C28C10 /* ProductImagePickerView.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
+				B90D21782D15B72900ED60ED /* WooShippingCustomsFormViewModel.swift in Sources */,
 				03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,
 				016C6B972C74AB17000D86FD /* POSConnectivityView.swift in Sources */,
 				EE45E2B72A409BA40085F227 /* Tooltip.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1977,9 +1977,10 @@
 		B9001CE42B1E11A300EC87B2 /* CashPaymentTenderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9001CE32B1E11A300EC87B2 /* CashPaymentTenderViewModelTests.swift */; };
 		B90C65CD29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */; };
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
+		B90D21762D14269200ED60ED /* WooShippingCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */; };
 		B90DACC02A30AEF000365897 /* BarcodeScannerItemFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */; };
 		B90DACC22A31BBC800365897 /* BarcodeScannerProductFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */; };
-		B90DD08E2D12FAA400EFC06A /* WooShippingCustoms.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DD08D2D12FA9900EFC06A /* WooShippingCustoms.swift */; };
+		B90DD08E2D12FAA400EFC06A /* WooShippingCustomsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */; };
 		B90DDF7C2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DDF7B2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift */; };
 		B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B910685F27F1F28F00AD0575 /* GhostableViewController.swift */; };
 		B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9151B3E2840EB330036180F /* WooFoundation.framework */; };
@@ -5088,9 +5089,10 @@
 		B9001CE32B1E11A300EC87B2 /* CashPaymentTenderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashPaymentTenderViewModelTests.swift; sourceTree = "<group>"; };
 		B90C65CC29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentOnboardingStateCache.swift; sourceTree = "<group>"; };
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
+		B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsForm.swift; sourceTree = "<group>"; };
 		B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerItemFinder.swift; sourceTree = "<group>"; };
 		B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerProductFinderTests.swift; sourceTree = "<group>"; };
-		B90DD08D2D12FA9900EFC06A /* WooShippingCustoms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustoms.swift; sourceTree = "<group>"; };
+		B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsRow.swift; sourceTree = "<group>"; };
 		B90DDF7B2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTaxRateSelectorView.swift; sourceTree = "<group>"; };
 		B910685F27F1F28F00AD0575 /* GhostableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostableViewController.swift; sourceTree = "<group>"; };
 		B9151B3E2840EB330036180F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -10847,7 +10849,8 @@
 		B90DD08C2D12FA6600EFC06A /* WooShipping Customs */ = {
 			isa = PBXGroup;
 			children = (
-				B90DD08D2D12FA9900EFC06A /* WooShippingCustoms.swift */,
+				B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */,
+				B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */,
 			);
 			path = "WooShipping Customs";
 			sourceTree = "<group>";
@@ -15135,7 +15138,7 @@
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */,
 				CE6302412BAAFB5E00E3325C /* CustomersListViewModel.swift in Sources */,
-				B90DD08E2D12FAA400EFC06A /* WooShippingCustoms.swift in Sources */,
+				B90DD08E2D12FAA400EFC06A /* WooShippingCustomsRow.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
 				029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
@@ -16638,6 +16641,7 @@
 				DE6F997E2BEE00C50007B2DD /* InboxDashboardCard.swift in Sources */,
 				4590B6A8261F0F8300A6FCE0 /* SegmentedView.swift in Sources */,
 				DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */,
+				B90D21762D14269200ED60ED /* WooShippingCustomsForm.swift in Sources */,
 				B6930BDA293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift in Sources */,
 				26F115AF2C49A9250019CD73 /* DashboardSyncBackgroundTask.swift in Sources */,
 				02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the first part of the Customs screen UI. The Products Details UI and the business logic will come in subsequent PRs.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to orders
2. Tap on a completed order eligible for shipping labels purchase
3. Tap on Create Shipping Labels
4. Tap on the Customs Row
5. See that the UI is there
( See video)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d0fe3835-05c0-4fab-befd-7a92622cca4c

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
