### PR TITLE
[Shipping Labels] Use failsafeDecodeIfPresent for decoding package weight

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/WooShippingCustomPackage.swift
@@ -68,18 +68,15 @@ extension WooShippingCustomPackage: Codable {
         var boxWeight: Double = 0.0
         // Looks like some endpoints have boxWeight as String and some as Double
         // and some endpoints have it as box_weight and some as boxWeight
-        if let boxWeightDouble = try? container.decodeIfPresent(Double.self, forKey: .boxWeight) {
+        let weightTransformer = AlternativeDecodingType.string { Double($0) ?? 0.0 }
+        if let boxWeightDouble = container.failsafeDecodeIfPresent(targetType: Double.self,
+                                                                   forKey: .boxWeight,
+                                                                   alternativeTypes: [weightTransformer]) {
             boxWeight = boxWeightDouble
         }
-        else if let boxWeightString = try? container.decodeIfPresent(String.self, forKey: .boxWeight),
-                let boxWeightDouble = Double(boxWeightString) {
-            boxWeight = boxWeightDouble
-        }
-        else if let boxWeightDouble = try? container.decodeIfPresent(Double.self, forKey: .boxWeightAlternate) {
-            boxWeight = boxWeightDouble
-        }
-        else if let boxWeightString = try? container.decodeIfPresent(String.self, forKey: .boxWeightAlternate),
-                let boxWeightDouble = Double(boxWeightString) {
+        else if let boxWeightDouble = container.failsafeDecodeIfPresent(targetType: Double.self,
+                                                                        forKey: .boxWeightAlternate,
+                                                                        alternativeTypes: [weightTransformer]) {
             boxWeight = boxWeightDouble
         }
 

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -38,7 +38,7 @@ final class WooShippingRemoteTests: XCTestCase {
 
         // Then
         let packagesResponse = try XCTUnwrap(result.get())
-        XCTAssertEqual(packagesResponse.customPackages.count, 5)
+        XCTAssertEqual(packagesResponse.customPackages.count, 2)
         XCTAssertEqual(packagesResponse.customPackages.first?.id, "69d7052f934a7c218329de9c1abe3858")
         XCTAssertEqual(packagesResponse.customPackages.first?.name, "WCS&T Box")
         XCTAssertEqual(packagesResponse.customPackages.first?.dimensions, "15 x 15 x 15")

--- a/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-create-package-success.json
@@ -11,7 +11,7 @@
                 "id": "69d7052f934a7c218329de9c1abe3858",
                 "name": "WCS&T Box",
                 "dimensions": "15 x 15 x 15",
-                "box_weight": 0.25,
+                "boxWeight": 0.25,
                 "max_weight": 0,
                 "type": "box",
                 "is_user_defined": true
@@ -20,34 +20,7 @@
                 "id": "517116d2f2d929115f6e081ba780b84e",
                 "name": "WCS&T Envelope",
                 "dimensions": "30 x 10 x 1",
-                "box_weight": 0.1,
-                "max_weight": 0,
-                "type": "envelope",
-                "is_user_defined": true
-            },
-            {
-                "id": "a344e7fa99e8bb88b15feb13141bf62c",
-                "name": "WCShip Envelope",
-                "dimensions": "100 x 10 x 1",
                 "box_weight": 0.25,
-                "max_weight": 0,
-                "type": "envelope",
-                "is_user_defined": true
-            },
-            {
-                "id": "22025742fbfaf4d7e73da11caaff9a2a",
-                "name": "WCShip Box",
-                "dimensions": "10 x 10 x 10",
-                "box_weight": 1,
-                "max_weight": 0,
-                "type": "box",
-                "is_user_defined": true
-            },
-            {
-                "id": "dd58dcd5dc044b6c56540c557c231c4f",
-                "name": "WCShip Envelope 2",
-                "dimensions": "10 x 10 x 1",
-                "box_weight": 1,
                 "max_weight": 0,
                 "type": "envelope",
                 "is_user_defined": true

--- a/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-get-packages-success.json
@@ -34,7 +34,7 @@
                   {
                     "inner_dimensions": "8.63 x 5.38 x 1.63",
                     "outer_dimensions": "8.63 x 5.38 x 1.63",
-                    "box_weight": 0,
+                    "boxWeight": 0,
                     "is_flat_rate": true,
                     "id": "small_flat_box",
                     "name": "Small Flat Rate Box",
@@ -47,7 +47,7 @@
                   {
                     "inner_dimensions": "11 x 8.5 x 5.5",
                     "outer_dimensions": "11.25 x 8.75 x 6",
-                    "box_weight": 0,
+                    "boxWeight": 0,
                     "is_flat_rate": true,
                     "id": "medium_flat_box_top",
                     "name": "Medium Flat Rate Box 1, Top Loading",

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -104,7 +104,9 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertTrue(onSuccess)
         let storedPackages = try XCTUnwrap(storageManager.viewStorage.firstObject(ofType: StorageWooShippingPackagesResponse.self)).toReadOnly()
         XCTAssertEqual(storedPackages.siteID, sampleSiteID)
-        XCTAssertEqual(storedPackages.customPackages.count, 5)
+        XCTAssertEqual(storedPackages.customPackages.count, 2)
+        XCTAssertEqual(storedPackages.customPackages.first?.boxWeight, 0.25)
+        XCTAssertEqual(storedPackages.customPackages.last?.boxWeight, 0.25)
         XCTAssertEqual(storedPackages.savedPredefinedPackages.count, 2)
     }
 
@@ -298,6 +300,11 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertEqual(storedPackages.allPredefinedOptions.first?.predefinedOptions.count, 1)
         XCTAssertEqual(storedPackages.allPredefinedOptions.first?.predefinedOptions.first?.predefinedPackages.count, 2)
         XCTAssertEqual(storedPackages.customPackages.count, 1)
+        XCTAssertEqual(storedPackages.customPackages.first?.name, "Custom name")
+        XCTAssertEqual(storedPackages.customPackages.first?.boxWeight, 0.01)
+        XCTAssertEqual(storedPackages.customPackages.first?.id, "849225dc153")
+        XCTAssertEqual(storedPackages.customPackages.first?.type, .box)
+        XCTAssertEqual(storedPackages.customPackages.first?.dimensions, "12 x 12 x 12")
         XCTAssertEqual(storedPackages.savedPredefinedPackages.count, 2)
         XCTAssertTrue(storedPackages.savedPredefinedPackages.contains(where: { $0.package.id == "small_flat_box" }))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14751
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Use failsafeDecodeIfPresent for decoding package weight, to reduce code https://github.com/woocommerce/woocommerce-ios/pull/14726#pullrequestreview-2517326688

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7. Tap "Select a Package."
8. Switch to Carrier and Saved tabs and check that the packages are loaded and showing correct data
9. Switch to Custom tab
10. Fill in all the values for the package, including weight and name and tap "Add Package"
11. Check that on the Create Shipping Labels screen the newly created package is shown, with proper name, dimensions and weight

## Screenshots

https://github.com/user-attachments/assets/a2b6d7b6-d234-4708-8729-ce0fffbc9ba4

<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
