### PR TITLE
[Brand Updates] POS theme updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
@@ -17,8 +17,7 @@ struct POSProgressViewStyle: ProgressViewStyle {
                 lineWidth: lineWidth,
                 lineCap: .butt,
                 circleColor: Color(.wooCommercePurple(.shade10)),
-                fillColor: Color(UIColor(light: .wooCommercePurple(.shade40),
-                                         dark: .wooCommercePurple(.shade30)))
+                fillColor: Color.accent
             ))
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
@@ -17,7 +17,8 @@ struct POSProgressViewStyle: ProgressViewStyle {
                 lineWidth: lineWidth,
                 lineCap: .butt,
                 circleColor: Color(.wooCommercePurple(.shade10)),
-                fillColor: Color(.wooCommercePurple(.shade50))
+                fillColor: Color(UIColor(light: .wooCommercePurple(.shade40),
+                                         dark: .wooCommercePurple(.shade30)))
             ))
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSecondaryButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSecondaryButtonStyle.swift
@@ -11,9 +11,9 @@ struct POSSecondaryButtonStyle: ButtonStyle {
         .font(.posBodyEmphasized)
         .background(
             RoundedRectangle(cornerRadius: POSButtonStyleConstants.framedButtonCornerRadius)
-                .stroke(Color.posPrimaryButtonBackground,
+                .stroke(Color.posSecondaryButtonForeground,
                         lineWidth: POSButtonStyleConstants.secondaryButtonBorderStrokeWidth)
                 .background(Color.posPrimaryBackground))
-        .foregroundColor(.posPrimaryButtonBackground)
+        .foregroundColor(.posSecondaryButtonForeground)
     }
 }

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -90,18 +90,13 @@ extension Color {
     // MARK: - Buttons
 
     static var posPrimaryButtonBackground: Color {
-        return Color(
-            UIColor(
-                light: .withColorStudio(.wooCommercePurple, shade: .shade50),
-                dark: .withColorStudio(.wooCommercePurple, shade: .shade30)
-            )
-        )
+        return Color(.withColorStudio(.wooCommercePurple, shade: .shade40))
     }
 
     static var posTextButtonForeground: Color {
         return Color(
             UIColor(
-                light: .withColorStudio(.wooCommercePurple, shade: .shade50),
+                light: .withColorStudio(.wooCommercePurple, shade: .shade40),
                 dark: .withColorStudio(.wooCommercePurple, shade: .shade30)
             )
         )

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -2,6 +2,15 @@ import SwiftUI
 
 extension Color {
 
+    static var accent: Color {
+        return Color(
+            UIColor(
+                light: .withColorStudio(.wooCommercePurple, shade: .shade40),
+                dark: .withColorStudio(.wooCommercePurple, shade: .shade30)
+            )
+        )
+    }
+
     // MARK: - Background
 
     /* POS Background colors are defined in a similar philosophy as system background colors:
@@ -89,18 +98,11 @@ extension Color {
 
     // MARK: - Buttons
 
-    static var posPrimaryButtonBackground: Color {
-        return Color(.withColorStudio(.wooCommercePurple, shade: .shade40))
-    }
+    static var posPrimaryButtonBackground: Color = .accent
 
-    static var posTextButtonForeground: Color {
-        return Color(
-            UIColor(
-                light: .withColorStudio(.wooCommercePurple, shade: .shade40),
-                dark: .withColorStudio(.wooCommercePurple, shade: .shade30)
-            )
-        )
-    }
+    static var posSecondaryButtonForeground: Color = .accent
+
+    static var posTextButtonForeground: Color = .accent
 
     static var posTextButtonForegroundPressed: Color {
         return Color(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: woocommerce/woomobile-private#382
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the POS theme colors to match the new brand, it introduces a new `accent` color that uses `purple_40` in light theme and `purple_30` in dark theme, and updates the different components to use it.

**Note:** If we are worried this update might break something, I'm fine with dropping it of the project.

## Steps to reproduce
1. Use a tablet.
2. Open the More menu, and tap on "Point of Sale mode"
3. Check different screens on different themes.

## Testing information
- Confirm the new colors matches the new brand.

Tested using iPad Air simulator, iOS 18.1

## Screenshots
| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 22 43](https://github.com/user-attachments/assets/aaadc4b0-4d86-46d7-8f98-35c23d5cc945) | ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 20 46](https://github.com/user-attachments/assets/58e8571e-d5a0-477a-9d59-595246b809c7) |
| ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 22 47](https://github.com/user-attachments/assets/24252cb3-f096-46ac-bef5-195729e80b5e) | ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 20 52](https://github.com/user-attachments/assets/a98ab061-4edd-40e1-8588-03903c54b4d3) |
| ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 22 51](https://github.com/user-attachments/assets/07e8e9bd-2b6d-4c19-b4d1-de03fca46d77) | ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 20 57](https://github.com/user-attachments/assets/be3f9b4a-ea4d-433e-8adc-22dc02bdd70f) |
| ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 01 20](https://github.com/user-attachments/assets/fd94a6c0-f30e-44a9-9b81-daa8aa433ef0) | ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 12 59 42](https://github.com/user-attachments/assets/91ce688c-b1c4-454d-8388-f639315ec641) |
| ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 01 27](https://github.com/user-attachments/assets/c2cc8ebb-92e2-4ecc-812d-fbfffd649592) | ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 19 11](https://github.com/user-attachments/assets/c7a49088-5603-41fc-968d-87cff8220a2c) |
| ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 01 31](https://github.com/user-attachments/assets/cafc7ea7-1927-4783-a725-dbd65ed4a738) | ![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-12-23 at 13 19 20](https://github.com/user-attachments/assets/2f2cf7e4-6f72-4eea-9ae5-fc3d5418d46b) |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.