### PR TITLE
Store Picker: Add tracking for list editing

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2499,6 +2499,7 @@ extension WooAnalyticsEvent {
             case isJetpackInstalled = "is_jetpack_installed"
             case isJetpackActive = "is_jetpack_active"
             case isJetpackConnected = "is_jetpack_connected"
+            case hiddenSiteCount = "hidden_site_count"
         }
 
         /// Tracks when the result for site discovery is returned
@@ -2518,6 +2519,31 @@ extension WooAnalyticsEvent {
         ///
         static func newToWooTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .sitePickerNewToWooTapped, properties: [:])
+        }
+
+        /// Tracks when the user taps the Edit button on the top right.
+        ///
+        static func listEditTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .sitePickerListEditTapped, properties: [:])
+        }
+
+        /// Tracks when the user taps the Save button on the edit store list screen
+        ///
+        static func listEditSaveTapped(hiddenSiteCount: Int) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .sitePickerListEditSaveTapped,
+                              properties: [Key.hiddenSiteCount.rawValue: hiddenSiteCount])
+        }
+
+        /// Tracks when saving is successful
+        ///
+        static func listEditSavingSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .sitePickerListEditSavingSuccess, properties: [:])
+        }
+
+        /// Tracks when saving fails
+        ///
+        static func listEditSavingFailure(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .sitePickerListEditSavingFailure, properties: [:], error: error)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2535,7 +2535,7 @@ extension WooAnalyticsEvent {
 
         /// Tracks when the user taps the Save button on the edit store list screen
         ///
-        static func listEditSaveTapped(hiddenSiteCount: Int) -> WooAnalyticsEvent {
+        static func listSaveButtonTapped(hiddenSiteCount: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .sitePickerListSaveButtonTapped,
                               properties: [Key.hiddenSiteCount.rawValue: hiddenSiteCount])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2521,29 +2521,35 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .sitePickerNewToWooTapped, properties: [:])
         }
 
+        /// Tracks when the Edit button is shown on the top right.
+        ///
+        static func editButtonShown() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .sitePickerEditButtonShown, properties: [:])
+        }
+
         /// Tracks when the user taps the Edit button on the top right.
         ///
-        static func listEditTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .sitePickerListEditTapped, properties: [:])
+        static func editButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .sitePickerEditButtonTapped, properties: [:])
         }
 
         /// Tracks when the user taps the Save button on the edit store list screen
         ///
         static func listEditSaveTapped(hiddenSiteCount: Int) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .sitePickerListEditSaveTapped,
+            WooAnalyticsEvent(statName: .sitePickerListSaveButtonTapped,
                               properties: [Key.hiddenSiteCount.rawValue: hiddenSiteCount])
         }
 
         /// Tracks when saving is successful
         ///
         static func listEditSavingSuccess() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .sitePickerListEditSavingSuccess, properties: [:])
+            WooAnalyticsEvent(statName: .sitePickerListSavingSuccess, properties: [:])
         }
 
         /// Tracks when saving fails
         ///
         static func listEditSavingFailure(error: Error) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .sitePickerListEditSavingFailure, properties: [:], error: error)
+            WooAnalyticsEvent(statName: .sitePickerListSavingFailure, properties: [:], error: error)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -259,10 +259,11 @@ enum WooAnalyticsStat: String {
     case sitePickerNewToWooTapped = "site_picker_new_to_woo_tapped"
     case sitePickerAddStoreTapped = "site_picker_add_a_store_tapped"
     case sitePickerConnectExistingStoreTapped = "site_picker_connect_existing_store_tapped"
-    case sitePickerListEditTapped = "site_picker_list_edit_tapped"
-    case sitePickerListEditSaveTapped = "site_picker_list_edit_save_tapped"
-    case sitePickerListEditSavingSuccess = "site_picker_list_edit_saving_success"
-    case sitePickerListEditSavingFailure = "site_picker_list_edit_saving_failure"
+    case sitePickerEditButtonShown = "site_picker_edit_button_shown"
+    case sitePickerEditButtonTapped = "site_picker_edit_button_tapped"
+    case sitePickerListSaveButtonTapped = "site_picker_list_save_button_tapped"
+    case sitePickerListSavingSuccess = "site_picker_list_saving_success"
+    case sitePickerListSavingFailure = "site_picker_list_saving_failure"
 
     // MARK: Site creation
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -259,6 +259,10 @@ enum WooAnalyticsStat: String {
     case sitePickerNewToWooTapped = "site_picker_new_to_woo_tapped"
     case sitePickerAddStoreTapped = "site_picker_add_a_store_tapped"
     case sitePickerConnectExistingStoreTapped = "site_picker_connect_existing_store_tapped"
+    case sitePickerListEditTapped = "site_picker_list_edit_tapped"
+    case sitePickerListEditSaveTapped = "site_picker_list_edit_save_tapped"
+    case sitePickerListEditSavingSuccess = "site_picker_list_edit_saving_success"
+    case sitePickerListEditSavingFailure = "site_picker_list_edit_saving_failure"
 
     // MARK: Site creation
     //

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -53,14 +53,17 @@ final class EditStoreListViewModel: ObservableObject {
         let hiddenSiteIDs = Array(hiddenSites).map { $0.siteID }
         let displayedSiteIDs = Array(selectedSites).map { $0.siteID }
 
+        analytics.track(event: .SitePicker.listSaveButtonTapped(hiddenSiteCount: hiddenSiteIDs.count))
         shouldShowErrorAlert = false
         isUpdatingNotificationSettings = true
         do {
             try await updateNotificationSettings(displayedSiteIDs: displayedSiteIDs, hiddenSiteIDs: hiddenSiteIDs)
             userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
+            analytics.track(event: .SitePicker.listEditSavingSuccess())
             onCompletion()
         } catch {
             shouldShowErrorAlert = true
+            analytics.track(event: .SitePicker.listEditSavingFailure(error: error))
         }
         isUpdatingNotificationSettings = false
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -300,13 +300,19 @@ private extension StorePickerViewController {
             self.updateFooterViewIfNeeded()
         }.store(in: &subscriptions)
 
-        viewModel.$shouldEnableHidingStores.sink { [weak self] shouldEnable in
-            guard let self else { return }
-            navigationItem.rightBarButtonItem = !shouldEnable ? nil : UIBarButtonItem(title: Localization.editListButton,
-                                                                                      style: .plain,
-                                                                                      target: self,
-                                                                                      action: #selector(editList))
-        }.store(in: &subscriptions)
+        viewModel.$shouldEnableHidingStores
+            .removeDuplicates()
+            .sink { [weak self] shouldEnable in
+                guard let self else { return }
+                if shouldEnable {
+                    ServiceLocator.analytics.track(event: .SitePicker.editButtonShown())
+                }
+                navigationItem.rightBarButtonItem = !shouldEnable ? nil : UIBarButtonItem(title: Localization.editListButton,
+                                                                                          style: .plain,
+                                                                                          target: self,
+                                                                                          action: #selector(editList))
+            }
+            .store(in: &subscriptions)
     }
 
     func backgroundColor() -> UIColor {
@@ -657,6 +663,7 @@ private extension StorePickerViewController {
     }
 
     @objc func editList() {
+        ServiceLocator.analytics.track(event: .SitePicker.editButtonTapped())
         let editViewModel = EditStoreListViewModel(availableSites: viewModel.allFetchedSites,
                                                    displayedSites: viewModel.displayedStores,
                                                    currentlySelectedSite: currentlySelectedSite,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14658
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking for the store picker update project:

Event | Trigger | Properties
--- | --- | ---
*_site_picker_edit_button_shown | When the Edit button is available on the site picker. | 
*_site_picker_edit_button_tapped | When the user taps the Edit button on the top right.| 
*_site_picker_list_save_button_tapped | When the user taps the Save button on the edit store list screen | hidden_site_count
*_site_picker_list_saving_success | When saving is successful | 
*_site_picker_list_saving_failure | When saving faills | Error details

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Build and run the app on a physical device.
- Log in to an account connected to more than one store.
- Navigate to Menu > Store Picker.
- Confirm that `site_picker_edit_button_shown` is tracked only once.
- Select the Edit button, confirm that `site_picker_edit_button_tapped` is tracked.
- De-select one or more stores in the list and tap Save. Confirm that `site_picker_list_save_button_tapped` is tracked with the correct value for `hidden_site_count`.
- After the saving succeeds, confirm that `site_picker_list_saving_success` is tracked.
- Disconnect the internet connection on the device and select Edit > update the selection > Save again.
- Confirm that `site_picker_list_saving_failure` is tracked with error details.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on iPhone 16 Pro iOS 18.1 and confirmed that tracking work as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.