### PR TITLE
[Brand Updates] Update promo screenshots colors

### DIFF
--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -61,7 +61,7 @@
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-01.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPhone 11 Pro Max-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
@@ -69,7 +69,7 @@
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-02.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPhone 11 Pro Max-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
@@ -77,7 +77,7 @@
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-03.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPhone 11 Pro Max-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
@@ -85,7 +85,7 @@
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-04.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPhone 11 Pro Max-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
@@ -93,7 +93,7 @@
 		{
 			"device": "iPhone 11 Pro Max",
 			"filename": "iPhone 11 Pro Max-05.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPhone 11 Pro Max-5-dark-order-notification.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
@@ -103,7 +103,7 @@
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-01.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPhone 8 Plus-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
@@ -111,7 +111,7 @@
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-02.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPhone 8 Plus-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
@@ -119,7 +119,7 @@
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-03.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPhone 8 Plus-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
@@ -127,7 +127,7 @@
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-04.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPhone 8 Plus-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
@@ -135,7 +135,7 @@
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-05.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPhone 8 Plus-5-dark-order-notification.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
@@ -146,7 +146,7 @@
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-01.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
@@ -154,7 +154,7 @@
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-02.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
@@ -162,7 +162,7 @@
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-03.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
@@ -170,7 +170,7 @@
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-04.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
@@ -178,7 +178,7 @@
 		{
 			"device": "iPad Pro 12.9 (2nd Generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-05.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-dark-order-notification.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
@@ -188,7 +188,7 @@
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-01.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-1-dark-order-dashboard.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
@@ -196,7 +196,7 @@
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-02.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-2-light-order-creation.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
@@ -204,7 +204,7 @@
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-03.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-dark-order-payment.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
@@ -212,7 +212,7 @@
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-04.png",
-			"background": "#C9356E",
+			"background": "#3C087E",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-4-light-product-add.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
@@ -220,7 +220,7 @@
 		{
 			"device": "iPad Pro 12.9 (3rd Generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-05.png",
-			"background": "#674399",
+			"background": "#873EFF",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-dark-order-notification.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: woocommerce/woomobile-private#399
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR updates the promo screenshots configuration to use the new backgrounds matching the new brand update (Ntkk0ER4hHt5y9KjEGIiGk-fi-2073_1004)

## Testing information
I don't think testing is required here, just code review and check the screenshots below.

## Screenshots
**(Uses old app screenshots)**

<img width=360 src=https://github.com/user-attachments/assets/061c0c17-fcf5-4603-862a-3bab0de68b4d />
<img width=360 src=https://github.com/user-attachments/assets/1084c9bb-b0da-4325-bd56-a5bab95475a6 />
<img width=360 src=https://github.com/user-attachments/assets/e660b13b-eccf-45b3-a706-b26d5ff3cc3e />
<img width=360 src=https://github.com/user-attachments/assets/bf60d2e8-84ec-4ae8-a19c-2b5ccf2fbb6a />
<img width=360 src=https://github.com/user-attachments/assets/925c4921-b066-4a57-8b73-eba74e138354 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.