### PR TITLE
[Shipping Labels - Customs Form] UI 2

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -360,6 +360,7 @@ extension WooConstants {
 
         case customFieldsProductLearnMore = "https://woocommerce.com/document/custom-product-fields/"
         case customFieldsOrderLearnMore = "https://woocommerce.com/document/managing-orders/view-edit-or-add-an-order/#custom-fields"
+        case hsTariffURL = "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
 
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -181,7 +181,7 @@ private extension ShippingLabelCustomsFormItemDetails {
     enum Constants {
         static let horizontalSpacing: CGFloat = 16
         static let verticalSpacing: CGFloat = 8
-        static let hsTariffURL: URL? = .init(string: "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29")
+        static let hsTariffURL = WooConstants.URLs.hsTariffURL.asURL()
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -112,11 +112,12 @@ struct WooShippingCustomsForm: View {
                                     .tertiaryTitleStyle()
 
                                 WooShippingCustomsItem(viewModel: WooShippingCustomsItemViewModel(
+                                    title: "Little Nap Brazil 250g",
                                     description: "Coffee Beans",
-                                    hsTariffNumber: "1234",
-                                    valuePerUnit: "",
-                                    weightPerUnit: "",
-                                    originCountry: Country(code: "VN", name: "Vietnam", states: []),
+                                    hsTariffNumber: "HS 14-1",
+                                    valuePerUnit: "$20.00",
+                                    weightPerUnit: "0.3kg",
+                                    originCountry: Country(code: "US", name: "United States", states: []),
                                     allCountries: [])
                                 )
                             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -71,6 +71,7 @@ struct WooShippingCustomsForm: View {
                                 }
 
                                 contentTypeSelectionView
+                                    .padding(.bottom, Constants.defaultVerticalSpacing)
 
                                 HStack {
                                     Text(Localization.restrictionType)
@@ -79,6 +80,7 @@ struct WooShippingCustomsForm: View {
                                 }
 
                                 restrictionTypeSelectionView
+                                    .padding(.bottom, Constants.defaultVerticalSpacing)
 
                                 HStack {
                                     Text(Localization.internationalTransactionNumber)
@@ -99,6 +101,7 @@ struct WooShippingCustomsForm: View {
                                     }
                                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
                                     .footnoteStyle()
+                                    .padding(.bottom, Constants.bottomButtonPadding)
                                 }
 
                                 Toggle(isOn: $viewModel.returnToSenderIfNotDelivered) {
@@ -108,8 +111,9 @@ struct WooShippingCustomsForm: View {
                                 .tint(Color.accentColor)
                                 .padding(.bottom, Constants.returnToSenderRowBottomPadding)
 
-                                Text("Product Details")
+                                Text(Localization.productDetailsTitle)
                                     .tertiaryTitleStyle()
+                                    .padding(.bottom, Constants.defaultVerticalSpacing)
 
                                 // Dummy data
                                 WooShippingCustomsItem(viewModel: WooShippingCustomsItemViewModel(
@@ -190,18 +194,21 @@ extension WooShippingCustomsForm {
         static let saveCustomsDetailsButtonTitle = NSLocalizedString("wooShipping.customs.saveCustomsDetails",
                                                               value: "Save Customs Details",
                                                               comment: "Customs button title when it's enabled and there's no info to add")
+        static let productDetailsTitle = NSLocalizedString("wooShipping.customs.productDetails",
+                                                           value: "Product Details",
+                                                           comment: "Product Details Section title")
     }
 
 }
 
 extension WooShippingCustomsForm {
     enum Constants {
-        static let defaultVerticalSpacing: CGFloat = 16.0
+        static let defaultVerticalSpacing: CGFloat = 8.0
         static let borderCornerRadius: CGFloat = 8
         static let borderWidth: CGFloat = 1
         static let borderPadding: CGFloat = 16
         static let intoButtonHorizontalSpacing: CGFloat = 8
         static let bottomButtonPadding: CGFloat = 16.0
-        static let returnToSenderRowBottomPadding: CGFloat = 24.0
+        static let returnToSenderRowBottomPadding: CGFloat = 32.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WooFoundation
+import Yosemite
 
 struct WooShippingCustomsForm: View {
     @Environment(\.presentationMode) var presentationMode
@@ -104,6 +105,19 @@ struct WooShippingCustomsForm: View {
                                     .font(.subheadline)
                             }
                             .tint(Color.accentColor)
+                            .padding(.bottom, 24)
+
+                            Text("Product Details")
+                                .tertiaryTitleStyle()
+
+                            WooShippingCustomsItem(viewModel: WooShippingCustomsItemViewModel(
+                                description: "Coffee Beans",
+                                hsTariffNumber: "1234",
+                                valuePerUnit: "",
+                                weightPerUnit: "",
+                                originCountry: Country(code: "VN", name: "Vietnam", states: []),
+                                allCountries: [])
+                            )
                         }
                         .padding()
                         .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -59,85 +59,102 @@ struct WooShippingCustomsForm: View {
 
     var body: some View {
         NavigationView {
-        GeometryReader { geometry in
-            ScrollViewReader { proxy in
-                ScrollView {
-                        VStack(alignment: .leading, spacing: Constants.defaultVerticalSpacing) {
-                            HStack {
-                                Text(Localization.contentType)
-                                    .font(.subheadline)
-                                Spacer()
-                            }
-
-                            contentTypeSelectionView
-
-                            HStack {
-                                Text(Localization.restrictionType)
-                                    .font(.subheadline)
-                                Spacer()
-                            }
-
-                            restrictionTypeSelectionView
-
-                            HStack {
-                                Text(Localization.internationalTransactionNumber)
-                                    .font(.subheadline)
-                                Spacer()
-                            }
-
-                            TextField("", text: $viewModel.internationalTransactionNumber)
-                                .padding(Constants.borderPadding)
-                                .roundedBorder(cornerRadius: Constants.borderCornerRadius, lineColor: Color(.separator), lineWidth: Constants.borderWidth)
-
-                            Button {
-                                isShowingITNInfoWebView = true
-                            } label: {
-                                HStack(alignment: .top, spacing: Constants.intoButtonHorizontalSpacing) {
-                                    Image(systemName: "info.circle")
-                                    Text(Localization.infoText)
+            GeometryReader { geometry in
+                VStack {
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: Constants.defaultVerticalSpacing) {
+                                HStack {
+                                    Text(Localization.contentType)
+                                        .font(.subheadline)
+                                    Spacer()
                                 }
-                                .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                                .footnoteStyle()
+
+                                contentTypeSelectionView
+
+                                HStack {
+                                    Text(Localization.restrictionType)
+                                        .font(.subheadline)
+                                    Spacer()
+                                }
+
+                                restrictionTypeSelectionView
+
+                                HStack {
+                                    Text(Localization.internationalTransactionNumber)
+                                        .font(.subheadline)
+                                    Spacer()
+                                }
+
+                                TextField("", text: $viewModel.internationalTransactionNumber)
+                                    .padding(Constants.borderPadding)
+                                    .roundedBorder(cornerRadius: Constants.borderCornerRadius, lineColor: Color(.separator), lineWidth: Constants.borderWidth)
+
+                                Button {
+                                    isShowingITNInfoWebView = true
+                                } label: {
+                                    HStack(alignment: .top, spacing: Constants.intoButtonHorizontalSpacing) {
+                                        Image(systemName: "info.circle")
+                                        Text(Localization.infoText)
+                                    }
+                                    .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                                    .footnoteStyle()
+                                }
+
+                                Toggle(isOn: $viewModel.returnToSenderIfNotDelivered) {
+                                    Text(Localization.returnToSenderMessage)
+                                        .font(.subheadline)
+                                }
+                                .tint(Color.accentColor)
+                                .padding(.bottom, 24)
+
+                                Text("Product Details")
+                                    .tertiaryTitleStyle()
+
+                                WooShippingCustomsItem(viewModel: WooShippingCustomsItemViewModel(
+                                    description: "Coffee Beans",
+                                    hsTariffNumber: "1234",
+                                    valuePerUnit: "",
+                                    weightPerUnit: "",
+                                    originCountry: Country(code: "VN", name: "Vietnam", states: []),
+                                    allCountries: [])
+                                )
                             }
-
-                            Toggle(isOn: $viewModel.returnToSenderIfNotDelivered) {
-                                Text(Localization.returnToSenderMessage)
-                                    .font(.subheadline)
+                            .padding()
+                            .toolbar {
+                                ToolbarItem(placement: .cancellationAction) {
+                                    Button(action: {
+                                        presentationMode.wrappedValue.dismiss()
+                                    }, label: {
+                                        Text(Localization.cancel)
+                                    })
+                                }
                             }
-                            .tint(Color.accentColor)
-                            .padding(.bottom, 24)
+                            .navigationTitle(Localization.customs)
+                            .navigationBarTitleDisplayMode(.inline)
 
-                            Text("Product Details")
-                                .tertiaryTitleStyle()
-
-                            WooShippingCustomsItem(viewModel: WooShippingCustomsItemViewModel(
-                                description: "Coffee Beans",
-                                hsTariffNumber: "1234",
-                                valuePerUnit: "",
-                                weightPerUnit: "",
-                                originCountry: Country(code: "VN", name: "Vietnam", states: []),
-                                allCountries: [])
-                            )
+                            Spacer()
                         }
-                        .padding()
-                        .toolbar {
-                            ToolbarItem(placement: .cancellationAction) {
-                                Button(action: {
-                                    presentationMode.wrappedValue.dismiss()
-                                }, label: {
-                                    Text(Localization.cancel)
-                                })
-                            }
-                        }
-                        .navigationTitle(Localization.customs)
-                        .navigationBarTitleDisplayMode(.inline)
-
-                        Spacer()
+                        .navigationViewStyle(.stack)
+                        .safariSheet(isPresented: $isShowingITNInfoWebView, url: viewModel.itnInfoURL)
                     }
-                    .navigationViewStyle(.stack)
-                    .safariSheet(isPresented: $isShowingITNInfoWebView, url: viewModel.itnInfoURL)
+
+                    Spacer()
+
+                    Divider()
+
+                    Button {
+                        // TODO: Save values
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Text(viewModel.informationIsMissing ? Localization.addMissingInformationButtonTitle : Localization.saveCustomsDetailsButtonTitle)
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(viewModel.informationIsMissing)
+                    .padding(Constants.bottomButtonPadding)
                 }
             }
+
         }
     }
 }
@@ -165,6 +182,12 @@ extension WooShippingCustomsForm {
         static let returnToSenderMessage = NSLocalizedString("wooShipping.customs.returnToSenderMessage",
                                                               value: "Return to sender if package is not able to be delivered",
                                                               comment: "Info label for a toggle to return the package to a sender if necessary toggle")
+        static let addMissingInformationButtonTitle = NSLocalizedString("wooShipping.customs.addMissingInformationButtonTitle",
+                                                              value: "Add Missing Information",
+                                                              comment: "Customs button title when it's disabled and there's still info to add")
+        static let saveCustomsDetailsButtonTitle = NSLocalizedString("wooShipping.customs.saveCustomsDetails",
+                                                              value: "Save Customs Details",
+                                                              comment: "Customs button title when it's enabled and there's no info to add")
     }
 
 }
@@ -176,5 +199,6 @@ extension WooShippingCustomsForm {
         static let borderWidth: CGFloat = 1
         static let borderPadding: CGFloat = 16
         static let intoButtonHorizontalSpacing: CGFloat = 8
+        static let bottomButtonPadding: CGFloat = 16.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -106,11 +106,12 @@ struct WooShippingCustomsForm: View {
                                         .font(.subheadline)
                                 }
                                 .tint(Color.accentColor)
-                                .padding(.bottom, 24)
+                                .padding(.bottom, Constants.returnToSenderRowBottomPadding)
 
                                 Text("Product Details")
                                     .tertiaryTitleStyle()
 
+                                // Dummy data
                                 WooShippingCustomsItem(viewModel: WooShippingCustomsItemViewModel(
                                     title: "Little Nap Brazil 250g",
                                     description: "Coffee Beans",
@@ -201,5 +202,6 @@ extension WooShippingCustomsForm {
         static let borderPadding: CGFloat = 16
         static let intoButtonHorizontalSpacing: CGFloat = 8
         static let bottomButtonPadding: CGFloat = 16.0
+        static let returnToSenderRowBottomPadding: CGFloat = 24.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -4,6 +4,10 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published var internationalTransactionNumber: String
     @Published var returnToSenderIfNotDelivered: Bool
 
+    var informationIsMissing: Bool {
+        false
+    }
+
     let contentType: WooShippingContentType = .merchandise
     let restrictionType: WooShippingRestrictionType = .none
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -49,8 +49,13 @@ struct WooShippingCustomsItem: View {
                         .foregroundColor(.primary)
                         .subheadlineStyle()
                     Spacer()
-                    Image(systemName: "info.circle")
-                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                    Button {
+                        // TODO: Add information
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(Color(.wooCommercePurple(.shade60)))
+
+                    }
                 }
                 .padding(.top, Layout.descriptionTopPadding)
                 TextField("", text: $viewModel.description)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -56,12 +56,14 @@ struct WooShippingCustomsItem: View {
                 TextField("", text: $viewModel.description)
                     .padding(Layout.extraPadding)
                     .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
+                    .padding(.bottom, Layout.collapsibleViewVerticalSpacing)
                 Text(Localization.HSTarriffNumber)
                     .foregroundColor(.primary)
                     .subheadlineStyle()
                 TextField(Localization.HSTarriffNumberPlaceholder, text: $viewModel.hsTariffNumber)
                     .padding(Layout.extraPadding)
                     .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
+
                 Button {
                     isShowingHSTarrifInfoWebView = true
                 } label: {
@@ -71,6 +73,7 @@ struct WooShippingCustomsItem: View {
                     }
                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
                     .footnoteStyle()
+                    .padding(.bottom, Layout.collapsibleViewVerticalSpacing)
                 }
 
                 HStack {
@@ -111,6 +114,7 @@ struct WooShippingCustomsItem: View {
                             .renderedIf(viewModel.weightPerUnit.isEmpty)
                     }
                 }
+                .padding(.bottom, Layout.collapsibleViewVerticalSpacing)
 
                 HStack {
                     Text(Localization.originCountryTitle)
@@ -188,7 +192,7 @@ extension WooShippingCustomsItem {
     enum Layout {
         static let collapsibleViewTopPadding: CGFloat = 4.0
         static let collapsibleViewBottomContentTrailingPadding: CGFloat = -30.0
-        static let collapsibleViewVerticalSpacing: CGFloat = 16
+        static let collapsibleViewVerticalSpacing: CGFloat = 8.0
         static let collapsibleViewBottomLabelVerticalSpacing: CGFloat = 4.0
         static let descriptionTopPadding: CGFloat = 4.0
         static let borderCornerRadius: CGFloat = 8.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -13,9 +13,9 @@ struct WooShippingCustomsItem: View {
                         shouldShowDividers: false,
                         backgroundColor: .clear,
                         label: {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: Layout.collapsibleViewVerticalSpacing) {
                 HStack {
-                    Text("Little Nap Brazil 250g")
+                    Text(viewModel.title)
                         .headlineStyle()
                     Spacer()
                     Image(systemName: "exclamationmark.circle")
@@ -23,49 +23,53 @@ struct WooShippingCustomsItem: View {
                         .renderedIf(viewModel.informationIsMissing)
                 }
 
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Layout.collapsibleViewBottomLabelVerticalSpacing) {
                     HStack {
-                        Text("Coffee beans")
+                        Text(viewModel.description)
                         Spacer()
-                        Text("HS 14-1")
+                        Text(viewModel.hsTariffNumber)
                     }
 
                     HStack {
-                        Text("Japan")
+                        Text(viewModel.originCountry.name)
                         Spacer()
-                        Text("0.3kg")
+                        Text(viewModel.weightPerUnit)
                         Text("•")
-                        Text("$20.00")
+                        Text(viewModel.valuePerUnit)
                     }
                 }.renderedIf(isCollapsed)
                     .foregroundColor(.primary)
                     .subheadlineStyle()
-                    .padding(.trailing, -30)
+                    .padding(.trailing, Layout.collapsibleViewBottomContentTrailingPadding)
             }
-            .padding(.top, 4)
+            .padding(.top, Layout.collapsibleViewTopPadding)
         }, content: {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: Layout.collapsibleViewVerticalSpacing) {
                 Divider()
-
-                Text("Description")
-                    .foregroundColor(.primary)
-                    .subheadlineStyle()
+                HStack {
+                    Text(Localization.descriptionTitle)
+                        .foregroundColor(.primary)
+                        .subheadlineStyle()
+                    Spacer()
+                    Image(systemName: "info.circle")
+                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                }
                     .padding(.top, 4)
                 TextField("", text: $viewModel.description)
-                    .padding(16)
-                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
-                Text("HS tarriff number")
+                    .padding(Layout.extraPadding)
+                    .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
+                Text(Localization.HSTarriffNumber)
                     .foregroundColor(.primary)
                     .subheadlineStyle()
-                TextField("Optional", text: $viewModel.hsTariffNumber)
-                    .padding(16)
-                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+                TextField(Localization.HSTarriffNumberPlaceholder, text: $viewModel.hsTariffNumber)
+                    .padding(Layout.extraPadding)
+                    .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
                 Button {
                     isShowingHSTarrifInfoWebView = true
                 } label: {
-                    HStack(alignment: .top, spacing: 8) {
+                    HStack(alignment: .top, spacing: Layout.hsTarriffNumberMoreInfoVerticalSpacing) {
                         Image(systemName: "info.circle")
-                        Text("More info about HS tarriff")
+                        Text(Localization.HSTarriffNumberMoreInfo)
                     }
                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
                     .footnoteStyle()
@@ -73,44 +77,49 @@ struct WooShippingCustomsItem: View {
 
                 HStack {
                     VStack(alignment: .leading) {
-                        Text("Value per unit")
+                        Text(Localization.valuePerUnitTitle)
                             .foregroundColor(.primary)
                             .subheadlineStyle()
                         TextField("$ 0", text: $viewModel.valuePerUnit)
-                            .padding(16)
-                            .roundedBorder(cornerRadius: 8,
+                            .padding(Layout.extraPadding)
+                            .roundedBorder(cornerRadius: Layout.borderCornerRadius,
                                            lineColor: viewModel.valuePerUnit.isEmpty ? .withColorStudio(name: .red, shade: .shade60) : Color(.separator),
-                                           lineWidth: 1)
-                        Text("Value required")
+                                           lineWidth: Layout.borderLineWidth)
+                        Text(Localization.valueRequiredWarningText)
                             .foregroundColor(.withColorStudio(name: .red, shade: .shade60))
                             .footnoteStyle()
                             .renderedIf(viewModel.valuePerUnit.isEmpty)
                     }
 
                     VStack(alignment: .leading) {
-                        Text("Weight per unit")
+                        Text(Localization.weightPerUnitTitle)
                             .foregroundColor(.primary)
                             .subheadlineStyle()
                         HStack {
                             TextField("0", text: $viewModel.weightPerUnit)
-                                .padding(16)
+                                .padding(Layout.extraPadding)
                             Text("kg")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
-                                .padding(.trailing, 8)
+                                .padding(.trailing, Layout.unitsHorizontalSpacing)
                         }
-                        .roundedBorder(cornerRadius: 8,
+                        .roundedBorder(cornerRadius: Layout.borderCornerRadius,
                                        lineColor: viewModel.weightPerUnit.isEmpty ? .withColorStudio(name: .red, shade: .shade60) : Color(.separator),
-                                       lineWidth: 1)
-                        Text("Value required")
+                                       lineWidth: Layout.borderLineWidth)
+                        Text(Localization.valueRequiredWarningText)
                             .foregroundColor(.withColorStudio(name: .red, shade: .shade60))
                             .footnoteStyle()
                             .renderedIf(viewModel.weightPerUnit.isEmpty)
                     }
                 }
 
-                Text("Origin Country")
-                    .foregroundColor(.primary)
+                HStack {
+                    Text(Localization.originCountryTitle)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Image(systemName: "info.circle")
+                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                }
                     .subheadlineStyle()
 
                 Button {
@@ -125,22 +134,64 @@ struct WooShippingCustomsItem: View {
                     }
                     .padding()
                 }
-                .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+                .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
             }
-            .padding(.leading, 16)
-            .padding(.trailing, 16)
-            .padding(.bottom, 16)
+            .padding(.leading, Layout.extraPadding)
+            .padding(.trailing, Layout.extraPadding)
+            .padding(.bottom, Layout.extraPadding)
         })
-        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+        .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
         .safariSheet(isPresented: $isShowingHSTarrifInfoWebView, url: viewModel.hsTariffURL)
         .sheet(isPresented: $isShowingCountries, content: {
             NavigationStack {
-                SingleSelectionList(title: "Origin Country",
+                SingleSelectionList(title: Localization.originCountryTitle,
                                     items: viewModel.allCountries,
                                     contentKeyPath: \.name,
                                     selected: $viewModel.originCountry)
             }
             .wooNavigationBarStyle()
         })
+    }
+}
+
+extension WooShippingCustomsItem {
+    enum Localization {
+        static let descriptionTitle = NSLocalizedString("wooShipping.customsItems.description",
+                                              value: "Description",
+                                              comment: "Title for the customs items description text field for customs items")
+        static let HSTarriffNumber = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber",
+                                                       value: "HSTarriffNumber",
+                                                       comment: "Title for the HS Tarriff Number text field for customs items")
+        static let HSTarriffNumberPlaceholder = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber.placeholder",
+                                                       value: "Optional",
+                                                       comment: "Placeholder for the HS Tarriff Number text field for customs items")
+        static let HSTarriffNumberMoreInfo = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber.moreInfoText",
+                                                       value: "More info about HS tarriff",
+                                                       comment: "Information text about the HS Tarriff")
+        static let valuePerUnitTitle = NSLocalizedString("wooShipping.customsItems.valuePerUnit",
+                                              value: "Value per unit",
+                                              comment: "Title for the customs items value per unit text field for customs items")
+        static let weightPerUnitTitle = NSLocalizedString("wooShipping.customsItems.weightPerUnit",
+                                              value: "Weight per unit",
+                                              comment: "Title for the customs items weight per unit text field for customs items")
+        static let valueRequiredWarningText = NSLocalizedString("wooShipping.customsItems.valueRequired",
+                                              value: "Value required",
+                                              comment: "Warning text when some required value is missing")
+        static let originCountryTitle = NSLocalizedString("wooShipping.customsItems.originCountry",
+                                              value: "Origin Country",
+                                              comment: "Title for the origin country text field")
+    }
+
+    enum Layout {
+        static let collapsibleViewTopPadding: CGFloat = 4.0
+        static let collapsibleViewBottomContentTrailingPadding: CGFloat = -30.0
+        static let collapsibleViewVerticalSpacing: CGFloat = 8.0
+        static let collapsibleViewBottomLabelVerticalSpacing: CGFloat = 4.0
+        static let descriptionTopPadding: CGFloat = 4.0
+        static let borderCornerRadius: CGFloat = 8.0
+        static let borderLineWidth: CGFloat = 1.0
+        static let extraPadding: CGFloat = 16.0
+        static let hsTarriffNumberMoreInfoVerticalSpacing: CGFloat = 8.0
+        static let unitsHorizontalSpacing: CGFloat = 8.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -81,7 +81,7 @@ struct WooShippingCustomsItem: View {
                     .padding(.bottom, Layout.collapsibleViewVerticalSpacing)
                 }
 
-                HStack {
+                HStack(alignment: .top) {
                     VStack(alignment: .leading) {
                         Text(Localization.valuePerUnitTitle)
                             .foregroundColor(.primary)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -29,7 +29,6 @@ struct WooShippingCustomsItem: View {
                         Spacer()
                         Text(viewModel.hsTariffNumber)
                     }
-
                     HStack {
                         Text(viewModel.originCountry.name)
                         Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+import WooFoundation
+
+struct WooShippingCustomsItem: View {
+    /// Whether the item list is collapsed
+    @State private var isCollapsed: Bool = true
+    @ObservedObject var viewModel: WooShippingCustomsItemViewModel
+    @State private var isShowingHSTarrifInfoWebView = false
+    @State private var isShowingCountries = false
+
+    var body: some View {
+        CollapsibleView(isCollapsed: $isCollapsed,
+                        shouldShowDividers: false,
+                        backgroundColor: .clear,
+                        label: {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Little Nap Brazil 250g")
+                        .headlineStyle()
+                    Spacer()
+                    Image(systemName: "exclamationmark.circle")
+                        .foregroundColor(.withColorStudio(name: .red, shade: .shade60))
+                        .renderedIf(viewModel.informationIsMissing)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Coffee beans")
+                        Spacer()
+                        Text("HS 14-1")
+                    }
+
+                    HStack {
+                        Text("Japan")
+                        Spacer()
+                        Text("0.3kg")
+                        Text("•")
+                        Text("$20.00")
+                    }
+                }.renderedIf(isCollapsed)
+                    .foregroundColor(.primary)
+                    .subheadlineStyle()
+                    .padding(.trailing, -30)
+            }
+            .padding(.top, 4)
+        }, content: {
+            VStack(alignment: .leading, spacing: 8) {
+                Divider()
+
+                Text("Description")
+                    .foregroundColor(.primary)
+                    .subheadlineStyle()
+                    .padding(.top, 4)
+                TextField("", text: $viewModel.description)
+                    .padding(16)
+                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+                Text("HS tarriff number")
+                    .foregroundColor(.primary)
+                    .subheadlineStyle()
+                TextField("Optional", text: $viewModel.hsTariffNumber)
+                    .padding(16)
+                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+                Button {
+                    isShowingHSTarrifInfoWebView = true
+                } label: {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "info.circle")
+                        Text("More info about HS tarriff")
+                    }
+                    .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                    .footnoteStyle()
+                }
+
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text("Value per unit")
+                            .foregroundColor(.primary)
+                            .subheadlineStyle()
+                        TextField("$ 0", text: $viewModel.valuePerUnit)
+                            .padding(16)
+                            .roundedBorder(cornerRadius: 8,
+                                           lineColor: viewModel.valuePerUnit.isEmpty ? .withColorStudio(name: .red, shade: .shade60) : Color(.separator),
+                                           lineWidth: 1)
+                        Text("Value required")
+                            .foregroundColor(.withColorStudio(name: .red, shade: .shade60))
+                            .footnoteStyle()
+                            .renderedIf(viewModel.valuePerUnit.isEmpty)
+                    }
+
+                    VStack(alignment: .leading) {
+                        Text("Weight per unit")
+                            .foregroundColor(.primary)
+                            .subheadlineStyle()
+                        HStack {
+                            TextField("0", text: $viewModel.weightPerUnit)
+                                .padding(16)
+                            Text("kg")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .padding(.trailing, 8)
+                        }
+                        .roundedBorder(cornerRadius: 8,
+                                       lineColor: viewModel.weightPerUnit.isEmpty ? .withColorStudio(name: .red, shade: .shade60) : Color(.separator),
+                                       lineWidth: 1)
+                        Text("Value required")
+                            .foregroundColor(.withColorStudio(name: .red, shade: .shade60))
+                            .footnoteStyle()
+                            .renderedIf(viewModel.weightPerUnit.isEmpty)
+                    }
+                }
+
+                Text("Origin Country")
+                    .foregroundColor(.primary)
+                    .subheadlineStyle()
+
+                Button {
+                    isShowingCountries = true
+
+                } label: {
+                    HStack {
+                        Text(viewModel.originCountry.name)
+                            .bodyStyle()
+                        Spacer()
+                        Image(systemName: "chevron.up.chevron.down")
+                    }
+                    .padding()
+                }
+                .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+            }
+            .padding(.leading, 16)
+            .padding(.trailing, 16)
+            .padding(.bottom, 16)
+        })
+        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 1)
+        .safariSheet(isPresented: $isShowingHSTarrifInfoWebView, url: viewModel.hsTariffURL)
+        .sheet(isPresented: $isShowingCountries, content: {
+            NavigationStack {
+                SingleSelectionList(title: "Origin Country",
+                                    items: viewModel.allCountries,
+                                    contentKeyPath: \.name,
+                                    selected: $viewModel.originCountry)
+            }
+            .wooNavigationBarStyle()
+        })
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -38,7 +38,6 @@ struct WooShippingCustomsItem: View {
                     }
                 }.renderedIf(isCollapsed)
                     .foregroundColor(.primary)
-                    .subheadlineStyle()
                     .padding(.trailing, Layout.collapsibleViewBottomContentTrailingPadding)
             }
             .padding(.top, Layout.collapsibleViewTopPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -185,7 +185,7 @@ extension WooShippingCustomsItem {
     enum Layout {
         static let collapsibleViewTopPadding: CGFloat = 4.0
         static let collapsibleViewBottomContentTrailingPadding: CGFloat = -30.0
-        static let collapsibleViewVerticalSpacing: CGFloat = 8.0
+        static let collapsibleViewVerticalSpacing: CGFloat = 16
         static let collapsibleViewBottomLabelVerticalSpacing: CGFloat = 4.0
         static let descriptionTopPadding: CGFloat = 4.0
         static let borderCornerRadius: CGFloat = 8.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -172,7 +172,7 @@ extension WooShippingCustomsItem {
                                               value: "Description",
                                               comment: "Title for the customs items description text field for customs items")
         static let HSTarriffNumber = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber",
-                                                       value: "HSTarriffNumber",
+                                                       value: "HS tarriff number",
                                                        comment: "Title for the HS Tarriff Number text field for customs items")
         static let HSTarriffNumberPlaceholder = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber.placeholder",
                                                        value: "Optional",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -62,19 +62,19 @@ struct WooShippingCustomsItem: View {
                     .padding(Layout.extraPadding)
                     .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
                     .padding(.bottom, Layout.collapsibleViewVerticalSpacing)
-                Text(Localization.HSTarriffNumber)
+                Text(Localization.HSTariffNumber)
                     .foregroundColor(.primary)
                     .subheadlineStyle()
-                TextField(Localization.HSTarriffNumberPlaceholder, text: $viewModel.hsTariffNumber)
+                TextField(Localization.HSTariffNumberPlaceholder, text: $viewModel.hsTariffNumber)
                     .padding(Layout.extraPadding)
                     .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
 
                 Button {
                     isShowingHSTarrifInfoWebView = true
                 } label: {
-                    HStack(alignment: .top, spacing: Layout.hsTarriffNumberMoreInfoVerticalSpacing) {
+                    HStack(alignment: .top, spacing: Layout.hsTariffNumberMoreInfoVerticalSpacing) {
                         Image(systemName: "info.circle")
-                        Text(Localization.HSTarriffNumberMoreInfo)
+                        Text(Localization.HSTariffNumberMoreInfo)
                     }
                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
                     .footnoteStyle()
@@ -171,15 +171,15 @@ extension WooShippingCustomsItem {
         static let descriptionTitle = NSLocalizedString("wooShipping.customsItems.description",
                                               value: "Description",
                                               comment: "Title for the customs items description text field for customs items")
-        static let HSTarriffNumber = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber",
-                                                       value: "HS tarriff number",
-                                                       comment: "Title for the HS Tarriff Number text field for customs items")
-        static let HSTarriffNumberPlaceholder = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber.placeholder",
+        static let HSTariffNumber = NSLocalizedString("wooShipping.customsItems.hsTariffNumber",
+                                                       value: "HS tariff number",
+                                                       comment: "Title for the HS Tariff Number text field for customs items")
+        static let HSTariffNumberPlaceholder = NSLocalizedString("wooShipping.customsItems.hsTariffNumber.placeholder",
                                                        value: "Optional",
-                                                       comment: "Placeholder for the HS Tarriff Number text field for customs items")
-        static let HSTarriffNumberMoreInfo = NSLocalizedString("wooShipping.customsItems.hsTarriffNumber.moreInfoText",
-                                                       value: "More info about HS tarriff",
-                                                       comment: "Information text about the HS Tarriff")
+                                                       comment: "Placeholder for the HS Tariff Number text field for customs items")
+        static let HSTariffNumberMoreInfo = NSLocalizedString("wooShipping.customsItems.hsTariffNumber.moreInfoText",
+                                                       value: "More info about HS tariff",
+                                                       comment: "Information text about the HS Tariff")
         static let valuePerUnitTitle = NSLocalizedString("wooShipping.customsItems.valuePerUnit",
                                               value: "Value per unit",
                                               comment: "Title for the customs items value per unit text field for customs items")
@@ -203,7 +203,7 @@ extension WooShippingCustomsItem {
         static let borderCornerRadius: CGFloat = 8.0
         static let borderLineWidth: CGFloat = 1.0
         static let extraPadding: CGFloat = 16.0
-        static let hsTarriffNumberMoreInfoVerticalSpacing: CGFloat = 8.0
+        static let hsTariffNumberMoreInfoVerticalSpacing: CGFloat = 8.0
         static let unitsHorizontalSpacing: CGFloat = 8.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -153,7 +153,7 @@ struct WooShippingCustomsItem: View {
             .padding(.trailing, Layout.extraPadding)
             .padding(.bottom, Layout.extraPadding)
         })
-        .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
+        .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: productCardBorderColor(), lineWidth: Layout.borderLineWidth)
         .safariSheet(isPresented: $isShowingHSTarrifInfoWebView, url: viewModel.hsTariffURL)
         .sheet(isPresented: $isShowingCountries, content: {
             NavigationStack {
@@ -164,6 +164,20 @@ struct WooShippingCustomsItem: View {
             }
             .wooNavigationBarStyle()
         })
+    }
+}
+
+extension WooShippingCustomsItem {
+    func productCardBorderColor() -> Color {
+        if isCollapsed {
+            if viewModel.informationIsMissing {
+                return .withColorStudio(name: .red, shade: .shade60)
+            } else {
+                return Color(.separator)
+            }
+        } else {
+            return .withColorStudio(name: .purple, shade: .shade60)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -8,6 +8,8 @@ struct WooShippingCustomsItem: View {
     @State private var isShowingHSTarrifInfoWebView = false
     @State private var isShowingCountries = false
 
+    @Environment(\.shippingWeightUnit) var weightUnit: String
+
     var body: some View {
         CollapsibleView(isCollapsed: $isCollapsed,
                         shouldShowDividers: false,
@@ -104,8 +106,7 @@ struct WooShippingCustomsItem: View {
                         HStack {
                             TextField("0", text: $viewModel.weightPerUnit)
                                 .padding(Layout.extraPadding)
-                            // TODO: Add right unit
-                            Text("kg")
+                            Text(weightUnit)
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                                 .padding(.trailing, Layout.unitsHorizontalSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -54,7 +54,7 @@ struct WooShippingCustomsItem: View {
                     Image(systemName: "info.circle")
                         .foregroundColor(Color(.wooCommercePurple(.shade60)))
                 }
-                    .padding(.top, 4)
+                .padding(.top, Layout.descriptionTopPadding)
                 TextField("", text: $viewModel.description)
                     .padding(Layout.extraPadding)
                     .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
@@ -98,6 +98,7 @@ struct WooShippingCustomsItem: View {
                         HStack {
                             TextField("0", text: $viewModel.weightPerUnit)
                                 .padding(Layout.extraPadding)
+                            // TODO: Add right unit
                             Text("kg")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
@@ -117,14 +118,18 @@ struct WooShippingCustomsItem: View {
                     Text(Localization.originCountryTitle)
                         .foregroundColor(.primary)
                     Spacer()
-                    Image(systemName: "info.circle")
-                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                    Button {
+                        // TODO: Add information
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(Color(.wooCommercePurple(.shade60)))
+
+                    }
                 }
                     .subheadlineStyle()
 
                 Button {
                     isShowingCountries = true
-
                 } label: {
                     HStack {
                         Text(viewModel.originCountry.name)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -1,0 +1,25 @@
+import Yosemite
+import SwiftUI
+
+final class WooShippingCustomsItemViewModel: ObservableObject {
+    @Published var description: String
+    @Published var hsTariffNumber: String
+    @Published var valuePerUnit: String
+    @Published var weightPerUnit: String
+    @Published var originCountry: Country
+
+    var informationIsMissing: Bool = true
+
+    let allCountries: [Country]
+
+    let hsTariffURL: URL? = .init(string: "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29")
+
+    init(description: String, hsTariffNumber: String, valuePerUnit: String, weightPerUnit: String, originCountry: Country, allCountries: [Country]) {
+        self.description = description
+        self.hsTariffNumber = hsTariffNumber
+        self.valuePerUnit = valuePerUnit
+        self.weightPerUnit = weightPerUnit
+        self.originCountry = originCountry
+        self.allCountries = allCountries
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -2,6 +2,7 @@ import Yosemite
 import SwiftUI
 
 final class WooShippingCustomsItemViewModel: ObservableObject {
+    @Published var title: String
     @Published var description: String
     @Published var hsTariffNumber: String
     @Published var valuePerUnit: String
@@ -14,7 +15,8 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     let hsTariffURL: URL? = .init(string: "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29")
 
-    init(description: String, hsTariffNumber: String, valuePerUnit: String, weightPerUnit: String, originCountry: Country, allCountries: [Country]) {
+    init(title: String, description: String, hsTariffNumber: String, valuePerUnit: String, weightPerUnit: String, originCountry: Country, allCountries: [Country]) {
+        self.title = title
         self.description = description
         self.hsTariffNumber = hsTariffNumber
         self.valuePerUnit = valuePerUnit

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -15,7 +15,13 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     let hsTariffURL: URL? = .init(string: "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29")
 
-    init(title: String, description: String, hsTariffNumber: String, valuePerUnit: String, weightPerUnit: String, originCountry: Country, allCountries: [Country]) {
+    init(title: String,
+         description: String,
+         hsTariffNumber: String,
+         valuePerUnit: String,
+         weightPerUnit: String,
+         originCountry: Country,
+         allCountries: [Country]) {
         self.title = title
         self.description = description
         self.hsTariffNumber = hsTariffNumber

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -13,7 +13,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     let allCountries: [Country]
 
-    let hsTariffURL: URL? = .init(string: "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29")
+    let hsTariffURL = WooConstants.URLs.hsTariffURL.asURL()
 
     init(title: String,
          description: String,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1983,6 +1983,8 @@
 		B90C65D129AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */; };
 		B90D21762D14269200ED60ED /* WooShippingCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */; };
 		B90D21782D15B72900ED60ED /* WooShippingCustomsFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90D21772D15B72700ED60ED /* WooShippingCustomsFormViewModel.swift */; };
+		B90D217A2D1B06D000ED60ED /* WooShippingCustomsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90D21792D1B06CE00ED60ED /* WooShippingCustomsItem.swift */; };
+		B90D217C2D1B06F700ED60ED /* WooShippingCustomsItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90D217B2D1B06F600ED60ED /* WooShippingCustomsItemViewModel.swift */; };
 		B90DACC02A30AEF000365897 /* BarcodeScannerItemFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */; };
 		B90DACC22A31BBC800365897 /* BarcodeScannerProductFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */; };
 		B90DD08E2D12FAA400EFC06A /* WooShippingCustomsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */; };
@@ -5104,6 +5106,8 @@
 		B90C65D029AD02CC004CAB9E /* CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingIPPUsersRefresherTests.swift; sourceTree = "<group>"; };
 		B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsForm.swift; sourceTree = "<group>"; };
 		B90D21772D15B72700ED60ED /* WooShippingCustomsFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsFormViewModel.swift; sourceTree = "<group>"; };
+		B90D21792D1B06CE00ED60ED /* WooShippingCustomsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsItem.swift; sourceTree = "<group>"; };
+		B90D217B2D1B06F600ED60ED /* WooShippingCustomsItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsItemViewModel.swift; sourceTree = "<group>"; };
 		B90DACBF2A30AEF000365897 /* BarcodeScannerItemFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerItemFinder.swift; sourceTree = "<group>"; };
 		B90DACC12A31BBC800365897 /* BarcodeScannerProductFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerProductFinderTests.swift; sourceTree = "<group>"; };
 		B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsRow.swift; sourceTree = "<group>"; };
@@ -10873,6 +10877,8 @@
 		B90DD08C2D12FA6600EFC06A /* WooShipping Customs */ = {
 			isa = PBXGroup;
 			children = (
+				B90D217B2D1B06F600ED60ED /* WooShippingCustomsItemViewModel.swift */,
+				B90D21792D1B06CE00ED60ED /* WooShippingCustomsItem.swift */,
 				B90D21772D15B72700ED60ED /* WooShippingCustomsFormViewModel.swift */,
 				B90D21752D14268800ED60ED /* WooShippingCustomsForm.swift */,
 				B90DD08D2D12FA9900EFC06A /* WooShippingCustomsRow.swift */,
@@ -15263,6 +15269,7 @@
 				CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */,
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
+				B90D217C2D1B06F700ED60ED /* WooShippingCustomsItemViewModel.swift in Sources */,
 				EE3B17AF2A9EFE97004D3E0C /* WooPaymentsSetupInstructionsView.swift in Sources */,
 				02FCA5542B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
@@ -16455,6 +16462,7 @@
 				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
 				203163BB2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */,
 				CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */,
+				B90D217A2D1B06D000ED60ED /* WooShippingCustomsItem.swift in Sources */,
 				AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */,
 				203163B72C1C5EDF001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift in Sources */,
 				2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the second part of the Shipping Labels Customs forms: the Product Details and the button to save the Custom Details.  Please note that we don't implement any data binding here.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to orders
2. Tap on a complete order which can render a shipping label
3. Tap on Create Shipping Label
4. Tap on Customs
5. See that the UI for the Product Details and the bottom button are created


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
N/A

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/cd71b92c-ed1b-4df6-ab49-40e6ce32ecc2


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
