### PR TITLE
[Woo POS] [Variable Products] Add parent product to the POSItem enum, and make UI

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -170,6 +170,12 @@ private extension ItemListView {
             } label: {
                 SimpleProductCardView(product: simpleProduct)
             }
+        case .parentProduct(let parentProduct):
+            Button {
+                print("tapped parent product")
+            } label: {
+                ParentProductCardView(parentProduct: parentProduct)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import struct Yosemite.POSParentProduct
 
+/// Displays a card for a parent product in POS.
 struct ParentProductCardView: View {
     private let parentProduct: POSParentProduct
 
@@ -74,7 +75,7 @@ private extension ParentProductCardView {
 
 #if DEBUG
 #Preview {
-    let parentProduct = POSParentProduct(id: UUID(), name: "Parent product 1", productImageSource: nil, productID: 42, type: .variable)
+    let parentProduct = POSParentProduct(id: UUID(), name: "Parent variable product", productImageSource: nil, productID: 42, type: .variable)
     ParentProductCardView(parentProduct: parentProduct)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
@@ -19,6 +19,7 @@ struct ParentProductCardView: View {
                              scale: scale)
             .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
                    height: Constants.productCardSize * scale)
+            .clipped()
 
             VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(parentProduct.name)

--- a/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
@@ -45,7 +45,7 @@ private extension ParentProductCardView {
         switch parentProduct.type {
             case .variable:
                 Text(Localization.variationsAvailable)
-                    .foregroundStyle(Color.posItemSecondaryText)
+                    .foregroundStyle(Color.posSecondaryText)
                     .font(.posBodyRegular)
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
@@ -13,30 +13,20 @@ struct ParentProductCardView: View {
 
     var body: some View {
         HStack(spacing: Constants.cardSpacing) {
-            if let imageSource = parentProduct.productImageSource {
-                ProductImageThumbnail(productImageURL: URL(string: imageSource),
-                                      productImageSize: Constants.productCardSize * scale,
-                                      scale: scale,
-                                      foregroundColor: .clear,
-                                      cachesOriginalImage: true)
-                .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
-                       height: Constants.productCardSize * scale)
-                .clipped()
-            } else {
-                Rectangle()
-                    .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
-                           height: Constants.productCardSize * scale)
-                    .foregroundColor(Color(.secondarySystemFill))
-            }
+            POSItemImageView(imageSource: parentProduct.productImageSource,
+                             imageSize: Constants.productCardSize * scale,
+                             scale: scale)
+            .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
+                   height: Constants.productCardSize * scale)
 
-            DynamicHStack(spacing: Constants.textSpacing) {
-                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
+            VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(parentProduct.name)
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemNameFont)
-                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
+
+                detailView()
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
@@ -44,12 +34,29 @@ struct ParentProductCardView: View {
         }
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
         .background(Color.posSecondaryBackground)
-        .overlay {
-            RoundedRectangle(cornerRadius: Constants.productCardCornerRadius)
-                .stroke(Color.black, lineWidth: Constants.nilOutline)
+        .posItemCardBorderStyles()
+    }
+}
+
+private extension ParentProductCardView {
+    @ViewBuilder
+    func detailView() -> some View {
+        switch parentProduct.type {
+            case .variable:
+                Text(Localization.variationsAvailable)
+                    .foregroundStyle(Color.posItemSecondaryText)
+                    .font(.posBodyRegular)
         }
-        .clipShape(RoundedRectangle(cornerRadius: Constants.productCardCornerRadius))
-        .shadow(color: Color.black.opacity(0.08), radius: 4, y: 2)
+    }
+}
+
+private extension ParentProductCardView {
+    enum Localization {
+        static let variationsAvailable = NSLocalizedString(
+            "pos.parentProductCard.optionsAvailable",
+            value: "Options available",
+            comment: "Text indicating that there are options available for a parent product"
+        )
     }
 }
 
@@ -57,10 +64,6 @@ private extension ParentProductCardView {
     enum Constants {
         static let productCardSize: CGFloat = 112
         static let maximumProductCardSize: CGFloat = Constants.productCardSize * 2
-        static let productCardCornerRadius: CGFloat = 8
-        // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
-        // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
-        static let nilOutline: CGFloat = 0
         static let cardSpacing: CGFloat = 0
         static let textSpacing: CGFloat = 8
         static let horizontalTextPadding: CGFloat = 32

--- a/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import struct Yosemite.POSParentProduct
+
+struct ParentProductCardView: View {
+    private let parentProduct: POSParentProduct
+
+    @ScaledMetric private var scale: CGFloat = 1.0
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    init(parentProduct: POSParentProduct) {
+        self.parentProduct = parentProduct
+    }
+
+    var body: some View {
+        HStack(spacing: Constants.cardSpacing) {
+            if let imageSource = parentProduct.productImageSource {
+                ProductImageThumbnail(productImageURL: URL(string: imageSource),
+                                      productImageSize: Constants.productCardSize * scale,
+                                      scale: scale,
+                                      foregroundColor: .clear,
+                                      cachesOriginalImage: true)
+                .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
+                       height: Constants.productCardSize * scale)
+                .clipped()
+            } else {
+                Rectangle()
+                    .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
+                           height: Constants.productCardSize * scale)
+                    .foregroundColor(Color(.secondarySystemFill))
+            }
+
+            DynamicHStack(spacing: Constants.textSpacing) {
+                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
+                Text(parentProduct.name)
+                    .lineLimit(2)
+                    .foregroundStyle(Color.posPrimaryText)
+                    .multilineTextAlignment(.leading)
+                    .font(Constants.itemNameFont)
+                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
+            }
+            .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
+            .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
+        .background(Color.posSecondaryBackground)
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.productCardCornerRadius)
+                .stroke(Color.black, lineWidth: Constants.nilOutline)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Constants.productCardCornerRadius))
+        .shadow(color: Color.black.opacity(0.08), radius: 4, y: 2)
+    }
+}
+
+private extension ParentProductCardView {
+    enum Constants {
+        static let productCardSize: CGFloat = 112
+        static let maximumProductCardSize: CGFloat = Constants.productCardSize * 2
+        static let productCardCornerRadius: CGFloat = 8
+        // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
+        // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
+        static let nilOutline: CGFloat = 0
+        static let cardSpacing: CGFloat = 0
+        static let textSpacing: CGFloat = 8
+        static let horizontalTextPadding: CGFloat = 32
+        static let verticalTextPadding: CGFloat = 8
+        static let itemNameFont: POSFontStyle = .posBodyEmphasized
+    }
+}
+
+#if DEBUG
+#Preview {
+    let parentProduct = POSParentProduct(id: UUID(), name: "Parent product 1", productImageSource: nil, productID: 42, type: .variable)
+    ParentProductCardView(parentProduct: parentProduct)
+}
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemCardBorderStylesModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemCardBorderStylesModifier.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct POSItemCardBorderStylesModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                RoundedRectangle(cornerRadius: Constants.cardCornerRadius)
+                    .stroke(Color.black, lineWidth: Constants.nilOutline)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: Constants.cardCornerRadius))
+            .shadow(color: Color.black.opacity(0.08), radius: 4, y: 2)
+    }
+}
+
+private extension POSItemCardBorderStylesModifier {
+    enum Constants {
+        static let cardCornerRadius: CGFloat = 8.0
+        // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
+        // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
+        static let nilOutline: CGFloat = 0
+    }
+}
+
+extension View {
+    /// Applies the POS item card border styles to the view.
+    func posItemCardBorderStyles() -> some View {
+        self.modifier(POSItemCardBorderStylesModifier())
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
@@ -13,7 +13,6 @@ struct POSItemImageView: View {
                                   scale: scale,
                                   foregroundColor: .clear,
                                   cachesOriginalImage: true)
-            .clipped()
         } else {
             Rectangle()
                 .foregroundColor(Color(.secondarySystemFill))

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// A view that displays an image in a POS item view.
+struct POSItemImageView: View {
+    let imageSource: String?
+    let imageSize: CGFloat
+    let scale: CGFloat
+
+    var body: some View {
+        if let imageSource = imageSource {
+            ProductImageThumbnail(productImageURL: URL(string: imageSource),
+                                  productImageSize: imageSize,
+                                  scale: scale,
+                                  foregroundColor: .clear,
+                                  cachesOriginalImage: true)
+            .clipped()
+        } else {
+            Rectangle()
+                .foregroundColor(Color(.secondarySystemFill))
+        }
+    }
+}
+
+#Preview("Placeholder") {
+    POSItemImageView(imageSource: nil,
+                     imageSize: 112,
+                     scale: 1)
+}
+
+#Preview("Image") {
+    POSItemImageView(imageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg",
+                     imageSize: 112,
+                     scale: 1)
+}

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
@@ -13,34 +13,21 @@ struct SimpleProductCardView: View {
 
     var body: some View {
         HStack(spacing: Constants.cardSpacing) {
-            if let imageSource = product.productImageSource {
-                ProductImageThumbnail(productImageURL: URL(string: imageSource),
-                                      productImageSize: Constants.productCardSize * scale,
-                                      scale: scale,
-                                      foregroundColor: .clear,
-                                      cachesOriginalImage: true)
-                .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
-                       height: Constants.productCardSize * scale)
-                .clipped()
-            } else {
-                Rectangle()
-                    .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
-                           height: Constants.productCardSize * scale)
-                    .foregroundColor(Color(.secondarySystemFill))
-            }
+            POSItemImageView(imageSource: product.productImageSource,
+                             imageSize: Constants.productCardSize * scale,
+                             scale: scale)
+            .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
+                   height: Constants.productCardSize * scale)
 
-            DynamicHStack(spacing: Constants.textSpacing) {
-                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
+            VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(product.name)
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemNameFont)
-                Spacer()
                 Text(product.formattedPrice)
                     .foregroundStyle(Color.posPrimaryText)
                     .font(Constants.itemPriceFont)
-                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
@@ -48,12 +35,7 @@ struct SimpleProductCardView: View {
         }
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
         .background(Color.posSecondaryBackground)
-        .overlay {
-            RoundedRectangle(cornerRadius: Constants.productCardCornerRadius)
-                .stroke(Color.black, lineWidth: Constants.nilOutline)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: Constants.productCardCornerRadius))
-        .shadow(color: Color.black.opacity(0.08), radius: 4, y: 2)
+        .posItemCardBorderStyles()
     }
 }
 
@@ -61,10 +43,6 @@ private extension SimpleProductCardView {
     enum Constants {
         static let productCardSize: CGFloat = 112
         static let maximumProductCardSize: CGFloat = Constants.productCardSize * 2
-        static let productCardCornerRadius: CGFloat = 8
-        // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
-        // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
-        static let nilOutline: CGFloat = 0
         static let cardSpacing: CGFloat = 0
         static let textSpacing: CGFloat = 8
         static let horizontalTextPadding: CGFloat = 32

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
@@ -18,6 +18,7 @@ struct SimpleProductCardView: View {
                              scale: scale)
             .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
                    height: Constants.productCardSize * scale)
+            .clipped()
 
             DynamicHStack(spacing: Constants.textSpacing) {
                 Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift
@@ -19,15 +19,18 @@ struct SimpleProductCardView: View {
             .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
                    height: Constants.productCardSize * scale)
 
-            VStack(alignment: .leading, spacing: Constants.textSpacing) {
+            DynamicHStack(spacing: Constants.textSpacing) {
+                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
                 Text(product.name)
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemNameFont)
+                Spacer()
                 Text(product.formattedPrice)
                     .foregroundStyle(Color.posPrimaryText)
                     .font(Constants.itemPriceFont)
+                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -87,6 +87,17 @@ extension Color {
         )
     }
 
+    // MARK: - POS Items
+
+    static var posItemSecondaryText: Color {
+        Color(
+            UIColor(
+                light: .withColorStudio(.gray, shade: .shade60),
+                dark: .withColorStudio(.gray, shade: .shade30)
+            )
+        )
+    }
+
     // MARK: - Buttons
 
     static var posPrimaryButtonBackground: Color {

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -87,17 +87,6 @@ extension Color {
         )
     }
 
-    // MARK: - POS Items
-
-    static var posItemSecondaryText: Color {
-        Color(
-            UIColor(
-                light: .withColorStudio(.gray, shade: .shade60),
-                dark: .withColorStudio(.gray, shade: .shade30)
-            )
-        )
-    }
-
     // MARK: - Buttons
 
     static var posPrimaryButtonBackground: Color {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -374,6 +374,7 @@
 		0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0279F0E3252DC9670098D7DE /* ProductVariationLoadUseCase.swift */; };
 		027A2E142513124E00DA6ACB /* Keychain+Entries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027A2E132513124E00DA6ACB /* Keychain+Entries.swift */; };
 		027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027A2E152513356100DA6ACB /* AppleIDCredentialChecker.swift */; };
+		027ADB6E2D1BF5E3009608DB /* ParentProductCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */; };
 		027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BB723FE0CB30040944E /* DefaultProductUIImageLoader.swift */; };
 		027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BBC23FE0DE10040944E /* ProductImageActionHandlerTests.swift */; };
 		027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BBE23FE0F850040944E /* MockMediaStoresManager.swift */; };
@@ -3526,6 +3527,7 @@
 		0279F0E3252DC9670098D7DE /* ProductVariationLoadUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationLoadUseCase.swift; sourceTree = "<group>"; };
 		027A2E132513124E00DA6ACB /* Keychain+Entries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain+Entries.swift"; sourceTree = "<group>"; };
 		027A2E152513356100DA6ACB /* AppleIDCredentialChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIDCredentialChecker.swift; sourceTree = "<group>"; };
+		027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentProductCardView.swift; sourceTree = "<group>"; };
 		027B8BB723FE0CB30040944E /* DefaultProductUIImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductUIImageLoader.swift; sourceTree = "<group>"; };
 		027B8BBC23FE0DE10040944E /* ProductImageActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageActionHandlerTests.swift; sourceTree = "<group>"; };
 		027B8BBE23FE0F850040944E /* MockMediaStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaStoresManager.swift; sourceTree = "<group>"; };
@@ -6989,6 +6991,7 @@
 				68D8FBD02BFEF9C700477C42 /* TotalsView.swift */,
 				68AF3C3A2D01481A006F1ED2 /* POSReceiptEligibilityBanner.swift */,
 				DA1D68C12C36F0980097859A /* PointOfSaleAssets.swift */,
+				027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -14988,6 +14991,7 @@
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,
 				B5DB01B52114AB2D00A4F797 /* WooCrashLoggingStack.swift in Sources */,
 				205B7EBF2C19FBCA00D14A36 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift in Sources */,
+				027ADB6E2D1BF5E3009608DB /* ParentProductCardView.swift in Sources */,
 				26ED9660274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift in Sources */,
 				024DF31E23743045006658FE /* TextList+AztecFormatting.swift in Sources */,
 				CEEF742E2B9A0BAA00B03948 /* SessionsReportCardViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -375,6 +375,8 @@
 		027A2E142513124E00DA6ACB /* Keychain+Entries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027A2E132513124E00DA6ACB /* Keychain+Entries.swift */; };
 		027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027A2E152513356100DA6ACB /* AppleIDCredentialChecker.swift */; };
 		027ADB6E2D1BF5E3009608DB /* ParentProductCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */; };
+		027ADB732D21812D009608DB /* POSItemImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027ADB722D21812D009608DB /* POSItemImageView.swift */; };
+		027ADB752D218A8D009608DB /* POSItemCardBorderStylesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027ADB742D218A8D009608DB /* POSItemCardBorderStylesModifier.swift */; };
 		027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BB723FE0CB30040944E /* DefaultProductUIImageLoader.swift */; };
 		027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BBC23FE0DE10040944E /* ProductImageActionHandlerTests.swift */; };
 		027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BBE23FE0F850040944E /* MockMediaStoresManager.swift */; };
@@ -3528,6 +3530,8 @@
 		027A2E132513124E00DA6ACB /* Keychain+Entries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain+Entries.swift"; sourceTree = "<group>"; };
 		027A2E152513356100DA6ACB /* AppleIDCredentialChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIDCredentialChecker.swift; sourceTree = "<group>"; };
 		027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentProductCardView.swift; sourceTree = "<group>"; };
+		027ADB722D21812D009608DB /* POSItemImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemImageView.swift; sourceTree = "<group>"; };
+		027ADB742D218A8D009608DB /* POSItemCardBorderStylesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemCardBorderStylesModifier.swift; sourceTree = "<group>"; };
 		027B8BB723FE0CB30040944E /* DefaultProductUIImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductUIImageLoader.swift; sourceTree = "<group>"; };
 		027B8BBC23FE0DE10040944E /* ProductImageActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageActionHandlerTests.swift; sourceTree = "<group>"; };
 		027B8BBE23FE0F850040944E /* MockMediaStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaStoresManager.swift; sourceTree = "<group>"; };
@@ -6161,6 +6165,10 @@
 		FEED57F92686544D00E47FD9 /* RoleErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleErrorViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		027ADB6F2D2180FB009608DB /* Product Card Components */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Product Card Components"; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		260837042AA66E4A0004A12B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -6314,6 +6322,8 @@
 				68D3E98C2C7C371B005B6278 /* POSBottomShadowViewModifier.swift */,
 				683AC4AB2CEF019700FF0A5E /* POSSendReceiptView.swift */,
 				20D2CCA22C7E175700051705 /* WavesProgressViewStyle.swift */,
+				027ADB722D21812D009608DB /* POSItemImageView.swift */,
+				027ADB742D218A8D009608DB /* POSItemCardBorderStylesModifier.swift */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -6973,6 +6983,7 @@
 		026826A12BF59DED0036F959 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				027ADB6F2D2180FB009608DB /* Product Card Components */,
 				01620C4C2C5394A400D3EA2F /* Reusable Views */,
 				02E71DB42C118C470036C2FD /* Card Present Payments */,
 				026826B02BF59E170036F959 /* CardReaderConnection */,
@@ -14026,6 +14037,9 @@
 				260837142AA66E4B0004A12B /* PBXTargetDependency */,
 				26F81B212BE433A3009EC58E /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				027ADB6F2D2180FB009608DB /* Product Card Components */,
+			);
 			name = WooCommerce;
 			packageProductDependencies = (
 				263E37E02641AD8300260D3B /* Codegen */,
@@ -15453,6 +15467,7 @@
 				02490D1A284DE664002096EF /* ProductImagesSaver.swift in Sources */,
 				8646A9BA2B46C7CA001F606C /* BlazeAdDestinationSettingView.swift in Sources */,
 				205E794F2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift in Sources */,
+				027ADB752D218A8D009608DB /* POSItemCardBorderStylesModifier.swift in Sources */,
 				0215320B24231D5A003F2BBD /* UIStackView+Subviews.swift in Sources */,
 				02F4F50B237AEB8A00E13A9C /* ProductFormTableViewDataSource.swift in Sources */,
 				2004E2CC2C07795E00D62521 /* CardPresentPaymentError.swift in Sources */,
@@ -16137,6 +16152,7 @@
 				DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */,
 				CE6E110B2C91DA5D00563DD4 /* WooShippingItemRow.swift in Sources */,
 				B946880E29B627EB000646B0 /* SearchableActivityConvertable.swift in Sources */,
+				027ADB732D21812D009608DB /* POSItemImageView.swift in Sources */,
 				EE09DE0B2C2D6E5100A32680 /* SelectPackageImageCoordinator.swift in Sources */,
 				DE621F6A29D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift in Sources */,
 				DE78DE422B2813E4002E58DE /* ThemesCarouselViewModel.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		026CF62C237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF62B237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift */; };
 		026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */; };
 		0271E1662509CF0100633F7A /* AnyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271E1652509CF0100633F7A /* AnyError.swift */; };
+		027ADB6C2D1BF3AD009608DB /* POSParentProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027ADB6B2D1BF3AD009608DB /* POSParentProduct.swift */; };
 		027CC11129F7AAEA00614B6E /* MockGenerativeContentRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027CC11029F7AAEA00614B6E /* MockGenerativeContentRemote.swift */; };
 		0286A1B82A0CBDC40099EF94 /* FeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286A1B72A0CBDC40099EF94 /* FeatureFlagStore.swift */; };
 		0286A1BA2A0CBE1B0099EF94 /* FeatureFlagAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286A1B92A0CBE1B0099EF94 /* FeatureFlagAction.swift */; };
@@ -596,6 +597,7 @@
 		026CF62B237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationAttribute+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationStoreTests.swift; sourceTree = "<group>"; };
 		0271E1652509CF0100633F7A /* AnyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyError.swift; sourceTree = "<group>"; };
+		027ADB6B2D1BF3AD009608DB /* POSParentProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSParentProduct.swift; sourceTree = "<group>"; };
 		027CC11029F7AAEA00614B6E /* MockGenerativeContentRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGenerativeContentRemote.swift; sourceTree = "<group>"; };
 		0286A1B72A0CBDC40099EF94 /* FeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagStore.swift; sourceTree = "<group>"; };
 		0286A1B92A0CBE1B0099EF94 /* FeatureFlagAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagAction.swift; sourceTree = "<group>"; };
@@ -1516,6 +1518,7 @@
 			children = (
 				6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */,
 				68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */,
+				027ADB6B2D1BF3AD009608DB /* POSParentProduct.swift */,
 				68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */,
 			);
 			path = PointOfSale;
@@ -2599,6 +2602,7 @@
 				450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */,
 				B9AECD462851DBED00E78584 /* Order+CurrencyFormattedValues.swift in Sources */,
 				45182D1F27B54D3000B4C05C /* InboxNote+ReadOnlyConvertible.swift in Sources */,
+				027ADB6C2D1BF3AD009608DB /* POSParentProduct.swift in Sources */,
 				022F00C224726090008CD97F /* SiteNotificationCountFileContents.swift in Sources */,
 				247CE7BC2582DC1E00F9D9D1 /* MockCustomer.swift in Sources */,
 				CE0FBB1D2D0C5DE3008B7789 /* WooShippingCarrierPredefinedOptions+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSParentProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSParentProduct.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum POSParentProductType {
+    case variable
+}
+
+public struct POSParentProduct: Equatable, Hashable, Identifiable {
+    public let id: UUID
+    public let name: String
+    public let productImageSource: String?
+    public let productID: Int64
+    public let type: POSParentProductType
+
+    public init(id: UUID, name: String, productImageSource: String?, productID: Int64, type: POSParentProductType) {
+        self.id = id
+        self.name = name
+        self.productImageSource = productImageSource
+        self.productID = productID
+        self.type = type
+    }
+}

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -2,11 +2,14 @@ import struct Networking.PagedItems
 
 public enum POSItem: Equatable, Identifiable, Hashable {
     case simpleProduct(POSSimpleProduct)
+    case parentProduct(POSParentProduct)
 
     public var id: UUID {
         switch self {
         case .simpleProduct(let product):
             return product.id
+        case .parentProduct(let parentProduct):
+            return parentProduct.id
         }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -65,16 +65,27 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     // - Product thumbnail, if any.
     private func mapProductsToPOSItems(products: [Product]) -> [POSItem] {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        return products.map { product in
+        return products.compactMap { product in
             let formattedPrice = currencyFormatter.formatAmount(product.price) ?? "-"
             let thumbnailSource = product.images.first?.src
 
-            return .simpleProduct(POSSimpleProduct(id: UUID(),
-                                                   name: product.name,
-                                                   formattedPrice: formattedPrice,
-                                                   productImageSource: thumbnailSource,
-                                                   productID: product.productID,
-                                                   price: product.price))
+            switch product.productType {
+                case .simple:
+                    return .simpleProduct(POSSimpleProduct(id: UUID(),
+                                                           name: product.name,
+                                                           formattedPrice: formattedPrice,
+                                                           productImageSource: thumbnailSource,
+                                                           productID: product.productID,
+                                                           price: product.price))
+                case .variable:
+                    return .parentProduct(POSParentProduct(id: UUID(),
+                                                           name: product.name,
+                                                           productImageSource: thumbnailSource,
+                                                           productID: product.productID,
+                                                           type: .variable))
+                default:
+                    return nil
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14700
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request adds support for showing the parent product card for a variable product in the POS item selector. The main changes include adding a new `ParentProductCardView`, creating reusable view modifiers for item card styles and a reusable image view to share UI in the simple and parent product card views.

New components and views:

* [`WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift`](diffhunk://#diff-210e84ea8e59459811d01a2b6ef2dd5536513ef37ecded0eaff994597f7d1267R1-R81): Added a new `ParentProductCardView` struct to display parent products in the POS system. This view includes a detailed view for variable products. When supporting other product types with a parent product (e.g. bundle), the detailed view can be configured based on the parent product type.
* [`WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift`](diffhunk://#diff-6622145f20f58fa1cf7d0fc7c922796db46e93cfe364190f42029be226937a6fR1-R34): Introduced a new `POSItemImageView` struct to handle the display of product images within POS item cards. I was wondering if we could just use a placeholder image in `ProductImageThumbnail`, but didn't want to change the pre-existing behavior until we're working on UI/UX polishes.

Refactoring and reusable styles:

* [`WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemCardBorderStylesModifier.swift`](diffhunk://#diff-9911ceecd39f4e08e91981d632212a39da1c1c5b47e9bfeb3f156693140574e2R1-R29): Created a new `POSItemCardBorderStylesModifier` struct to apply consistent border styles to item cards. This modifier is used in both `SimpleProductCardView` and `ParentProductCardView`.
* [`WooCommerce/Classes/POS/Presentation/SimpleProductCardView.swift`](diffhunk://#diff-68c880ea22cd0d896c93b09d412b85170905af695bc79820f03b9ab7c303f693L16-L30): Refactored `SimpleProductCardView` to use the new `POSItemImageView` and `POSItemCardBorderStylesModifier` for improved code reusability and consistency. [[1]](diffhunk://#diff-68c880ea22cd0d896c93b09d412b85170905af695bc79820f03b9ab7c303f693L16-L30) [[2]](diffhunk://#diff-68c880ea22cd0d896c93b09d412b85170905af695bc79820f03b9ab7c303f693L51-L67)

These changes collectively improve the maintainability and visual consistency of the POS product card views.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

🗒️ As the variable products support require WC version 9.6+ which is not publicly released at the time of writing, I'd recommend commenting out [L214 in ProductsRemote](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L214) to include all product types.

- Switch to a store with at least one variable product
- Go to Menu > Point of Sale --> scroll down the list, and make sure the variable products show up in the list without a price and with "Options available" below the product name (no changes expected in the simple product card UI to minimize the risk of this PR)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Compared the product card UI with trunk to ensure there are no UI changes in the simple product cards.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-12-31 at 16 36 45](https://github.com/user-attachments/assets/08d54868-3a92-47b2-8b6f-09a3431f6ac9) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-12-31 at 16 38 02](https://github.com/user-attachments/assets/c43e0879-0315-40c2-9f52-2bfbe1bb79eb)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.