### PR TITLE
After a successful IPP payment, show only print receipt option if email receipt is not supported

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -757,10 +757,6 @@ private extension CollectOrderPaymentUseCase {
                     }
                 },
                                                          noReceiptAction: noReceiptAction)
-            } else if MFMailComposeViewController.canSendMail() {
-                receiptState = .promptToSendEmailReceipt(printReceiptAction: presentBackendReceiptAction,
-                                                         emailReceiptAction: presentBackendReceiptAction,
-                                                         noReceiptAction: noReceiptAction)
             } else {
                 receiptState = .emailSendingNotSupported(printReceiptAction: presentBackendReceiptAction,
                                                          noReceiptAction: noReceiptAction)


### PR DESCRIPTION
Print receipt and email receipt actions for backend receipts are identical and can get confusing. Keep only print receipt action.

<!-- Remember about a good descriptive title. -->

Closes: #14512
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After backend receipts were implemented (>= WooCommerce 8.6), we performed the same action after the user selected "Print Receipt" or "Email Receipt" in a successful payment alert. To avoid confusion, I'm removing the "Email Receipt" option.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:
- WooCommerce version has to be  between 8.6 - 9.4 | or >= 8.6 with `sendReceiptAfterPayment` feature flag disabled
- iOS device has a default mail client

1. Switch to a store eligible for IPP
2. Go to the orders tab
3. Tap + to create an order, add a custom amount or some purchasable products
4. Tap Collect Payment > Card Reader and proceed with the card reader connection and payment with a test card --> a success modal should be shown
5. Notice only the "Print Receipt" option is shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPhone 14 Pro 17.7

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.