### PR TITLE
[Woo POS] [Variable Products] Add variation to POSItem enum with variation card UI

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -172,10 +172,16 @@ private extension ItemListView {
             }
         case .parentProduct(let parentProduct):
             Button {
-                print("tapped parent product")
+                print("Tapped parent product")
             } label: {
                 ParentProductCardView(parentProduct: parentProduct)
             }
+        case .variation(let variation):
+            Button(action: {
+                print("Tapped variation \(variation.name)")
+            }, label: {
+                VariationCardView(variation: variation)
+            })
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/VariationCardView.swift
@@ -59,6 +59,9 @@ private extension VariationCardView {
 }
 
 #Preview("Variation with image") {
-    let variation = POSVariation(id: .init(), name: "500ml, double shot", formattedPrice: "$5.00", productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg")
+    let variation = POSVariation(id: .init(),
+                                 name: "500ml, double shot",
+                                 formattedPrice: "$5.00",
+                                 productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg")
     VariationCardView(variation: variation)
 }

--- a/WooCommerce/Classes/POS/Presentation/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/VariationCardView.swift
@@ -1,0 +1,64 @@
+import struct Yosemite.POSVariation
+import SwiftUI
+
+struct VariationCardView: View {
+    private let variation: POSVariation
+
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    init(variation: POSVariation) {
+        self.variation = variation
+    }
+
+    var body: some View {
+        HStack(spacing: Constants.cardSpacing) {
+            POSItemImageView(imageSource: variation.productImageSource,
+                             imageSize: Constants.productCardSize * scale,
+                             scale: scale)
+            .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
+                   height: Constants.productCardSize * scale)
+            .clipped()
+
+            VStack(alignment: .leading, spacing: Constants.textSpacing) {
+                Text(variation.name)
+                    .lineLimit(2)
+                    .foregroundStyle(Color.posPrimaryText)
+                    .multilineTextAlignment(.leading)
+                    .font(Constants.itemNameFont)
+
+                Text(variation.formattedPrice)
+                    .foregroundStyle(Color.posPrimaryText)
+                    .font(Constants.itemPriceFont)
+            }
+            .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
+            .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
+        .background(Color.posSecondaryBackground)
+        .posItemCardBorderStyles()
+    }
+}
+
+private extension VariationCardView {
+    enum Constants {
+        static let productCardSize: CGFloat = 112
+        static let maximumProductCardSize: CGFloat = Constants.productCardSize * 2
+        static let cardSpacing: CGFloat = 0
+        static let textSpacing: CGFloat = 8
+        static let horizontalTextPadding: CGFloat = 32
+        static let verticalTextPadding: CGFloat = 8
+        static let itemNameFont: POSFontStyle = .posBodyEmphasized
+        static let itemPriceFont: POSFontStyle = .posBodyRegular
+    }
+}
+
+#Preview("Variation without image") {
+    let variation = POSVariation(id: .init(), name: "500ml, double shot", formattedPrice: "$5.00")
+    VariationCardView(variation: variation)
+}
+
+#Preview("Variation with image") {
+    let variation = POSVariation(id: .init(), name: "500ml, double shot", formattedPrice: "$5.00", productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg")
+    VariationCardView(variation: variation)
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -429,6 +429,7 @@
 		029106C22BE34A8600C2248B /* CollapsibleCustomerCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029106C12BE34A8600C2248B /* CollapsibleCustomerCard.swift */; };
 		029106C42BE34AA900C2248B /* CollapsibleCustomerCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029106C32BE34AA900C2248B /* CollapsibleCustomerCardViewModel.swift */; };
 		02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02913E9423A774C500707A0C /* UnitInputFormatter.swift */; };
+		029149782D26658A00F7B3B3 /* VariationCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029149772D26658A00F7B3B3 /* VariationCardView.swift */; };
 		0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0294F8AA25E8A12C005B537A /* WooTabNavigationController.swift */; };
 		02952B5127808B08008E9BA3 /* StoreStatsPeriodViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02952B5027808B08008E9BA3 /* StoreStatsPeriodViewModelTests.swift */; };
 		0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295355A245ADF8100BDC42B /* FilterType+Products.swift */; };
@@ -3585,6 +3586,7 @@
 		029106C12BE34A8600C2248B /* CollapsibleCustomerCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleCustomerCard.swift; sourceTree = "<group>"; };
 		029106C32BE34AA900C2248B /* CollapsibleCustomerCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleCustomerCardViewModel.swift; sourceTree = "<group>"; };
 		02913E9423A774C500707A0C /* UnitInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitInputFormatter.swift; sourceTree = "<group>"; };
+		029149772D26658A00F7B3B3 /* VariationCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariationCardView.swift; sourceTree = "<group>"; };
 		0294F8AA25E8A12C005B537A /* WooTabNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooTabNavigationController.swift; sourceTree = "<group>"; };
 		02952B5027808B08008E9BA3 /* StoreStatsPeriodViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsPeriodViewModelTests.swift; sourceTree = "<group>"; };
 		0295355A245ADF8100BDC42B /* FilterType+Products.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterType+Products.swift"; sourceTree = "<group>"; };
@@ -6165,10 +6167,6 @@
 		FEED57F92686544D00E47FD9 /* RoleErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleErrorViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		027ADB6F2D2180FB009608DB /* Product Card Components */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Product Card Components"; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
-
 /* Begin PBXFrameworksBuildPhase section */
 		260837042AA66E4A0004A12B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -6983,7 +6981,6 @@
 		026826A12BF59DED0036F959 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				027ADB6F2D2180FB009608DB /* Product Card Components */,
 				01620C4C2C5394A400D3EA2F /* Reusable Views */,
 				02E71DB42C118C470036C2FD /* Card Present Payments */,
 				026826B02BF59E170036F959 /* CardReaderConnection */,
@@ -7003,6 +7000,7 @@
 				68AF3C3A2D01481A006F1ED2 /* POSReceiptEligibilityBanner.swift */,
 				DA1D68C12C36F0980097859A /* PointOfSaleAssets.swift */,
 				027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */,
+				029149772D26658A00F7B3B3 /* VariationCardView.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -14037,9 +14035,6 @@
 				260837142AA66E4B0004A12B /* PBXTargetDependency */,
 				26F81B212BE433A3009EC58E /* PBXTargetDependency */,
 			);
-			fileSystemSynchronizedGroups = (
-				027ADB6F2D2180FB009608DB /* Product Card Components */,
-			);
 			name = WooCommerce;
 			packageProductDependencies = (
 				263E37E02641AD8300260D3B /* Codegen */,
@@ -16537,6 +16532,7 @@
 				0313651728ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift in Sources */,
 				571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */,
 				DE7E5E7D2B4BB617002E28D2 /* BlazeTargetLanguagePickerView.swift in Sources */,
+				029149782D26658A00F7B3B3 /* VariationCardView.swift in Sources */,
 				EE09DE082C2C0CA100A32680 /* ProductCreationAIStartingInfoViewModel.swift in Sources */,
 				02B1AA6529A4705A00D54FCB /* TabbedViewController.swift in Sources */,
 				4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		0286A1BC2A0CC4120099EF94 /* FeatureFlagStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286A1BB2A0CC4120099EF94 /* FeatureFlagStoreTests.swift */; };
 		0286A1BE2A0CC4810099EF94 /* MockFeatureFlagRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286A1BD2A0CC4810099EF94 /* MockFeatureFlagRemote.swift */; };
 		028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */; };
+		029149762D2663AB00F7B3B3 /* POSVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029149752D2663AB00F7B3B3 /* POSVariation.swift */; };
 		029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */; };
 		029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */; };
 		029BA557255E0CD4006171FD /* ShippingLabelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA556255E0CD4006171FD /* ShippingLabelStore.swift */; };
@@ -604,6 +605,7 @@
 		0286A1BB2A0CC4120099EF94 /* FeatureFlagStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagStoreTests.swift; sourceTree = "<group>"; };
 		0286A1BD2A0CC4810099EF94 /* MockFeatureFlagRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeatureFlagRemote.swift; sourceTree = "<group>"; };
 		028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsStoreErrorTests.swift; sourceTree = "<group>"; };
+		029149752D2663AB00F7B3B3 /* POSVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSVariation.swift; sourceTree = "<group>"; };
 		029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaRemote.swift; sourceTree = "<group>"; };
 		029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeTests.swift; sourceTree = "<group>"; };
 		029BA556255E0CD4006171FD /* ShippingLabelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStore.swift; sourceTree = "<group>"; };
@@ -1520,6 +1522,7 @@
 				68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */,
 				027ADB6B2D1BF3AD009608DB /* POSParentProduct.swift */,
 				68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */,
+				029149752D2663AB00F7B3B3 /* POSVariation.swift */,
 			);
 			path = PointOfSale;
 			sourceTree = "<group>";
@@ -2523,6 +2526,7 @@
 				74A7689020D45F9300F9D437 /* OrderAction.swift in Sources */,
 				D88E234525AE0EB90023F3B1 /* OrderFeeLine+ReadOnlyConvertible.swift in Sources */,
 				2665034D2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift in Sources */,
+				029149762D2663AB00F7B3B3 /* POSVariation.swift in Sources */,
 				DED91DF02AD6756600CDCC53 /* BlazeStore.swift in Sources */,
 				EE9D030E2B88550F0077CED1 /* FilterOrdersByProduct.swift in Sources */,
 				02FF055323D983F30058E6E7 /* URL+Media.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSVariation.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSVariation.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct POSVariation: Equatable, Hashable, Identifiable {
+    // Identifiable
+    public let id: UUID
+
+    public let name: String
+    public let formattedPrice: String
+    public var productImageSource: String?
+
+    public init(id: UUID, name: String, formattedPrice: String, productImageSource: String? = nil) {
+        self.id = id
+        self.name = name
+        self.formattedPrice = formattedPrice
+        self.productImageSource = productImageSource
+    }
+}

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -3,6 +3,7 @@ import struct Networking.PagedItems
 public enum POSItem: Equatable, Identifiable, Hashable {
     case simpleProduct(POSSimpleProduct)
     case parentProduct(POSParentProduct)
+    case variation(POSVariation)
 
     public var id: UUID {
         switch self {
@@ -10,6 +11,8 @@ public enum POSItem: Equatable, Identifiable, Hashable {
             return product.id
         case .parentProduct(let parentProduct):
             return parentProduct.id
+        case .variation(let variation):
+            return variation.id
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14701 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request introduces a new POS item type to support variations in POS. The key changes include the addition of a new `VariationCardView` SwiftUI view that displays UI for a new `POSVariation` struct. The variation view will be shown in a future PR.

### Product Variations

* **`WooCommerce/Classes/POS/Presentation/ItemListView.swift`**: Added a new case for handling product variations in the `ItemListView` with a corresponding button and temporary print statement. The action will be replaced with `posModel.addToCart(variation)` in a future PR.
* **`WooCommerce/Classes/POS/Presentation/VariationCardView.swift`**: Introduced a new `VariationCardView` component to display product variations. This view includes an image, name, and price of the variation.
* **`Yosemite/Yosemite/PointOfSale/POSVariation.swift`**: Added a new `POSVariation` struct to represent product variations with properties for `id`, `name`, `formattedPrice`, and an optional `productImageSource`.

### Enum Update

* **`Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift`**: Updated the `POSItem` enum to include a new case for `variation`, along with the corresponding `id` property implementation.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Please test the new variation UI in SwiftUI previews, with different orientations, color schemes, and font sizes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested that POS functionality is not affected, no variations should be shown in the item selector.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Light/dark modes:

<img width="999" alt="Screenshot 2025-01-02 at 2 38 34 PM" src="https://github.com/user-attachments/assets/212664e0-ffe4-49ec-b9d1-534f4a7c3a57" />

Different font sizes:

🗒️ The text font size doesn't seem to scale with dynamic type, probably because it's using a custom font.

<img width="990" alt="Screenshot 2025-01-02 at 2 38 01 PM" src="https://github.com/user-attachments/assets/247fae15-42e8-4f92-b9a7-96a0b96591dc" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.