### PR TITLE
Remove `paymentsOnboardingInPointOfSale` feature flag a few weeks after release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -89,8 +89,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productGlobalUniqueIdentifierSupport:
             return true
-        case .paymentsOnboardingInPointOfSale:
-            return true
         case .sendReceiptAfterPayment:
             return true
         case .sendReceiptsForPointOfSale:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -193,10 +193,6 @@ public enum FeatureFlag: Int {
     ///
     case productGlobalUniqueIdentifierSupport
 
-    /// Supports Woo Payments onboarding in POS so that merchants who have not completed onboarding can access POS.
-    ///
-    case paymentsOnboardingInPointOfSale
-
     /// Enables sending receipt after the payment via the API
     case sendReceiptAfterPayment
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
@@ -11,7 +11,6 @@ final class BetaFeaturesConfigurationViewModel: ObservableObject {
     init(appSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          posEligibilityChecker: POSEligibilityCheckerProtocol = POSEligibilityChecker(
-            cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
             siteSettings: ServiceLocator.selectedSiteSettings,
             currencySettings: ServiceLocator.currencySettings,
             featureFlagService: ServiceLocator.featureFlagService

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -24,11 +24,6 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
                 .eraseToAnyPublisher()
         }
 
-        guard featureFlagService.isFeatureFlagEnabled(.paymentsOnboardingInPointOfSale) else {
-            return Publishers.CombineLatest3(isOnboardingComplete, isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled)
-                .map { $0 && $1 && $2 }
-                .eraseToAnyPublisher()
-        }
         return Publishers.CombineLatest(isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled)
             .filter { [weak self] _ in
                 self?.isEligibleFromSiteChecks ?? false
@@ -60,18 +55,6 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
 }
 
 private extension POSEligibilityChecker {
-    var isOnboardingComplete: AnyPublisher<Bool, Never> {
-        return cardPresentPaymentsOnboarding.statePublisher
-            .filter { [weak self] _ in
-                self?.isEligibleFromSiteChecks ?? false
-            }
-            .map { onboardingState in
-                // Woo Payments plugin enabled and user setup complete
-                onboardingState == .completed(plugin: .wcPayOnly) || onboardingState == .completed(plugin: .wcPayPreferred)
-            }
-            .eraseToAnyPublisher()
-    }
-
     var isWooCommerceVersionSupported: AnyPublisher<Bool, Never> {
         Future<Bool, Never> { [weak self] promise in
             guard let self else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -33,14 +33,12 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
     }
 
     private let userInterfaceIdiom: UIUserInterfaceIdiom
-    private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
     private let siteSettings: SelectedSiteSettings
     private let currencySettings: CurrencySettings
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
 
     init(userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
-         cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
          siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          stores: StoresManager = ServiceLocator.stores,
@@ -48,7 +46,6 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
         self.userInterfaceIdiom = userInterfaceIdiom
         self.siteSettings = siteSettings
         self.currencySettings = currencySettings
-        self.cardPresentPaymentsOnboarding = cardPresentPaymentsOnboarding
         self.stores = stores
         self.featureFlagService = featureFlagService
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -159,8 +159,7 @@ final class HubMenuViewModel: ObservableObject {
         self.blazeEligibilityChecker = blazeEligibilityChecker
         self.googleAdsEligibilityChecker = googleAdsEligibilityChecker
         self.cardPresentPaymentsOnboarding = CardPresentPaymentsOnboardingUseCase()
-        self.posEligibilityChecker = POSEligibilityChecker(cardPresentPaymentsOnboarding: cardPresentPaymentsOnboarding,
-                                                           siteSettings: ServiceLocator.selectedSiteSettings,
+        self.posEligibilityChecker = POSEligibilityChecker(siteSettings: ServiceLocator.selectedSiteSettings,
                                                            currencySettings: ServiceLocator.currencySettings,
                                                            featureFlagService: featureFlagService)
         self.analytics = analytics
@@ -284,7 +283,6 @@ private extension HubMenuViewModel {
     }
 
     func setupPOSElement() {
-        cardPresentPaymentsOnboarding.refreshIfNecessary()
         posEligibilityChecker.isEligible.map { isEligibleForPOS in
             if isEligibleForPOS {
                 return PointOfSaleEntryPoint()

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,7 +22,6 @@ final class MockFeatureFlagService: FeatureFlagService {
     var revampedShippingLabelCreation: Bool
     var viewEditCustomFieldsInProductsAndOrders: Bool
     var favoriteProducts: Bool
-    var paymentsOnboardingInPointOfSale: Bool
     var isProductGlobalUniqueIdentifierSupported: Bool
     var isSendReceiptAfterPaymentEnabled: Bool
     var tapToPayEducation: Bool
@@ -49,7 +48,6 @@ final class MockFeatureFlagService: FeatureFlagService {
          revampedShippingLabelCreation: Bool = false,
          viewEditCustomFieldsInProductsAndOrders: Bool = false,
          favoriteProducts: Bool = false,
-         paymentsOnboardingInPointOfSale: Bool = false,
          isProductGlobalUniqueIdentifierSupported: Bool = false,
          isSendReceiptAfterPaymentEnabled: Bool = false,
          tapToPayEducation: Bool = false,
@@ -75,7 +73,6 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.revampedShippingLabelCreation = revampedShippingLabelCreation
         self.viewEditCustomFieldsInProductsAndOrders = viewEditCustomFieldsInProductsAndOrders
         self.favoriteProducts = favoriteProducts
-        self.paymentsOnboardingInPointOfSale = paymentsOnboardingInPointOfSale
         self.isProductGlobalUniqueIdentifierSupported = isProductGlobalUniqueIdentifierSupported
         self.isSendReceiptAfterPaymentEnabled = isSendReceiptAfterPaymentEnabled
         self.tapToPayEducation = tapToPayEducation
@@ -125,8 +122,6 @@ final class MockFeatureFlagService: FeatureFlagService {
             return viewEditCustomFieldsInProductsAndOrders
         case .favoriteProducts:
             return favoriteProducts
-        case .paymentsOnboardingInPointOfSale:
-            return paymentsOnboardingInPointOfSale
         case .productGlobalUniqueIdentifierSupport:
             return isProductGlobalUniqueIdentifierSupported
         case .sendReceiptAfterPayment:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -121,46 +121,9 @@ final class POSEligibilityCheckerTests: XCTestCase {
         }
     }
 
-    func test_is_eligible_when_non_us_site_then_returns_false_with_onboarding_feature_enabled() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true, paymentsOnboardingInPointOfSale: true)
-        [Country.ca, Country.es, Country.gb].forEach { country in
-            // When
-            setupCountry(country: country)
-            accountWhitelistedInBackend(true)
-            let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                                cardPresentPaymentsOnboarding: onboardingUseCase,
-                                                siteSettings: siteSettings,
-                                                currencySettings: Fixtures.usdCurrencySettings,
-                                                stores: stores,
-                                                featureFlagService: featureFlagService)
-            checker.isEligible.assign(to: &$isEligible)
-
-            // Then
-            XCTAssertFalse(isEligible)
-        }
-    }
-
     func test_when_non_usd_currency_then_isEligible_returns_false() {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: .us)
-        accountWhitelistedInBackend(true)
-        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
-                                            siteSettings: siteSettings,
-                                            currencySettings: Fixtures.nonUSDCurrencySettings,
-                                            stores: stores,
-                                            featureFlagService: featureFlagService)
-        checker.isEligible.assign(to: &$isEligible)
-
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
-    func test_when_non_usd_currency_then_isEligible_returns_false_with_onboarding_feature_enabled() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true, paymentsOnboardingInPointOfSale: true)
         setupCountry(country: .us)
         accountWhitelistedInBackend(true)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
@@ -191,49 +154,9 @@ final class POSEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_is_eligible_when_onboarding_state_is_not_completed_wcpay_then_returns_false() throws {
+    func test_is_eligible_when_onboarding_state_is_not_completed_then_returns_true() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: .us)
-        accountWhitelistedInBackend(true)
-        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
-                                            siteSettings: siteSettings,
-                                            currencySettings: Fixtures.usdCurrencySettings,
-                                            stores: stores,
-                                            featureFlagService: featureFlagService)
-        checker.isEligible.assign(to: &$isEligible)
-        XCTAssertTrue(isEligible)
-
-        // When onboarding state is loading
-        onboardingUseCase.state = .loading
-        // Then
-        XCTAssertFalse(isEligible)
-
-        // When onboarding state is stripeOnly
-        onboardingUseCase.state = .completed(plugin: .stripeOnly)
-        // Then
-        XCTAssertFalse(isEligible)
-
-        // When onboarding state is wcPayOnly
-        onboardingUseCase.state = .completed(plugin: .wcPayOnly)
-        // Then
-        XCTAssertTrue(isEligible)
-
-        // When onboarding state is stripePreferred
-        onboardingUseCase.state = .completed(plugin: .stripePreferred)
-        // Then
-        XCTAssertFalse(isEligible)
-
-        // When onboarding state is pluginNotInstalled
-        onboardingUseCase.state = .pluginNotInstalled
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
-    func test_is_eligible_when_onboarding_state_is_not_completed_and_onboarding_feature_enabled_then_returns_true() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true, paymentsOnboardingInPointOfSale: true)
         setupCountry(country: .us)
         accountWhitelistedInBackend(true)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -5,7 +5,6 @@ import Yosemite
 @testable import WooCommerce
 
 final class POSEligibilityCheckerTests: XCTestCase {
-    private var onboardingUseCase: MockCardPresentPaymentsOnboardingUseCase!
     private var stores: MockStoresManager!
     private var storageManager: MockStorageManager!
     private var siteSettings: SelectedSiteSettings!
@@ -15,7 +14,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed(plugin: .wcPayPreferred))
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.updateDefaultStore(storeID: siteID)
         setupWooCommerceVersion()
@@ -27,7 +25,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
         siteSettings = nil
         storageManager = nil
         stores = nil
-        onboardingUseCase = nil
         super.tearDown()
     }
 
@@ -37,7 +34,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
         setupCountry(country: .us)
         accountWhitelistedInBackend(true)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,
                                             currencySettings: Fixtures.usdCurrencySettings,
                                             stores: stores,
@@ -54,7 +50,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
         setupCountry(country: .us)
         accountWhitelistedInBackend(false)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,
                                             currencySettings: Fixtures.usdCurrencySettings,
                                             stores: stores,
@@ -71,7 +66,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
         setupCountry(country: .us)
         accountWhitelistedInBackend(false)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,
                                             currencySettings: Fixtures.usdCurrencySettings,
                                             stores: stores,
@@ -89,7 +83,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
         [UIUserInterfaceIdiom.phone, UIUserInterfaceIdiom.mac, UIUserInterfaceIdiom.tv, UIUserInterfaceIdiom.carPlay]
             .forEach { userInterfaceIdiom in
                 let checker = POSEligibilityChecker(userInterfaceIdiom: userInterfaceIdiom,
-                                                    cardPresentPaymentsOnboarding: onboardingUseCase,
                                                     siteSettings: siteSettings,
                                                     currencySettings: Fixtures.usdCurrencySettings,
                                                     stores: stores,
@@ -109,7 +102,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
             setupCountry(country: country)
             accountWhitelistedInBackend(true)
             let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                                cardPresentPaymentsOnboarding: onboardingUseCase,
                                                 siteSettings: siteSettings,
                                                 currencySettings: Fixtures.usdCurrencySettings,
                                                 stores: stores,
@@ -127,7 +119,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
         setupCountry(country: .us)
         accountWhitelistedInBackend(true)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,
                                             currencySettings: Fixtures.nonUSDCurrencySettings,
                                             stores: stores,
@@ -143,7 +134,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: false)
         setupCountry(country: .us)
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,
                                             currencySettings: Fixtures.usdCurrencySettings,
                                             stores: stores,
@@ -152,26 +142,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
 
         // Then
         XCTAssertFalse(isEligible)
-    }
-
-    func test_is_eligible_when_onboarding_state_is_not_completed_then_returns_true() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: .us)
-        accountWhitelistedInBackend(true)
-        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
-                                            siteSettings: siteSettings,
-                                            currencySettings: Fixtures.usdCurrencySettings,
-                                            stores: stores,
-                                            featureFlagService: featureFlagService)
-        checker.isEligible.assign(to: &$isEligible)
-
-        // When
-        onboardingUseCase.state = .pluginNotInstalled
-
-        // Then
-        XCTAssertTrue(isEligible)
     }
 
     func test_is_eligible_when_WooCommerce_version_is_below_6_6_then_returns_false() throws {
@@ -184,7 +154,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
 
         // When
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,
                                             currencySettings: Fixtures.usdCurrencySettings,
                                             stores: stores,
@@ -206,7 +175,6 @@ final class POSEligibilityCheckerTests: XCTestCase {
 
         // When
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            cardPresentPaymentsOnboarding: onboardingUseCase,
                                             siteSettings: siteSettings,
                                             currencySettings: Fixtures.usdCurrencySettings,
                                             stores: stores,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14343 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The POS payments onboarding feature was released in 21.2 on December 9. Now that it's been a few weeks, it's ready to remove the `paymentsOnboardingInPointOfSale` feature flag and its associated logic from various parts of the codebase.

### Removal of `paymentsOnboardingInPointOfSale` feature flag:

* [`Experiments/Experiments/DefaultFeatureFlagService.swift`](diffhunk://#diff-26c9afc49bb1f1a168517d43d5e36a64ff45adb046469369ef3e4d6800ccc19bL92-L93): Removed the `paymentsOnboardingInPointOfSale` case from the feature flag service.
* [`Experiments/Experiments/FeatureFlag.swift`](diffhunk://#diff-d42bbc633193f198cb514f56f2b0fe8ac65787a3e40a56c44b24069217788929L196-L199): Removed the `paymentsOnboardingInPointOfSale` enum case.

### Updates to eligibility checker logic:

* [`WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift`](diffhunk://#diff-cd6335f0ae63eeef7b8c545c7b9d56035e7455e5cb88b4e83057b94669ffc961L27-L31): Removed checks and logic related to the `paymentsOnboardingInPointOfSale` feature flag. [[1]](diffhunk://#diff-cd6335f0ae63eeef7b8c545c7b9d56035e7455e5cb88b4e83057b94669ffc961L27-L31) [[2]](diffhunk://#diff-cd6335f0ae63eeef7b8c545c7b9d56035e7455e5cb88b4e83057b94669ffc961L63-L74)

### Updates to mock feature flag service:

* [`WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift`](diffhunk://#diff-60e8dd3111fe7ee439972e9acc42d282dd936102d867bfce860894e2ca925a13L25): Removed the `paymentsOnboardingInPointOfSale` property and related logic. [[1]](diffhunk://#diff-60e8dd3111fe7ee439972e9acc42d282dd936102d867bfce860894e2ca925a13L25) [[2]](diffhunk://#diff-60e8dd3111fe7ee439972e9acc42d282dd936102d867bfce860894e2ca925a13L52) [[3]](diffhunk://#diff-60e8dd3111fe7ee439972e9acc42d282dd936102d867bfce860894e2ca925a13L78) [[4]](diffhunk://#diff-60e8dd3111fe7ee439972e9acc42d282dd936102d867bfce860894e2ca925a13L128-L129)

### Updates to unit tests:

* [`WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift`](diffhunk://#diff-d80536f20a5e20807f79c2c26c312c78986904378590e20bc922bbe019077bcaL124-L143): Removed tests related to the `paymentsOnboardingInPointOfSale` feature flag and updated existing tests accordingly. [[1]](diffhunk://#diff-d80536f20a5e20807f79c2c26c312c78986904378590e20bc922bbe019077bcaL124-L143) [[2]](diffhunk://#diff-d80536f20a5e20807f79c2c26c312c78986904378590e20bc922bbe019077bcaL161-L177) [[3]](diffhunk://#diff-d80536f20a5e20807f79c2c26c312c78986904378590e20bc922bbe019077bcaL194-R157) [[4]](diffhunk://#diff-d80536f20a5e20807f79c2c26c312c78986904378590e20bc922bbe019077bcaL206-L245)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Optional - feel free to do a confidence test on the payments onboarding by making sure POS is eligible for a store with incomplete payments onboarding state.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [x] @jaclync smoke tests POS before merging

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.