### PR TITLE
Package selection enhancements UI - part 1

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
@@ -129,14 +129,14 @@ struct WooAddCustomPackageView: View {
                         }
                         else {
                             Spacer()
-                            Button(WooShippingAddPackageView.Localization.addPackage) {
+                            Button(selectionButtonText) {
                                 Task { @MainActor in
                                     isAddingPackage = true
                                     await addPackageButtonTapped()
                                     isAddingPackage = false
                                 }
                             }
-                            .disabled(!viewModel.validateCustomPackageInputFields())
+                            .disabled(selectionButtonDisabled)
                             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isAddingPackage))
                             .padding(.bottom)
                         }
@@ -163,6 +163,17 @@ struct WooAddCustomPackageView: View {
                 .disabled(isSavingPackage)
             }
         }
+    }
+
+    private var selectionButtonDisabled: Bool {
+        !viewModel.validateCustomPackageInputFields()
+    }
+
+    private var selectionButtonText: String {
+        if selectionButtonDisabled {
+            return WooShippingAddPackageView.Localization.addPackageDetails
+        }
+        return WooShippingAddPackageView.Localization.addPackage
     }
 
     private func unitInputView(for unitType: WooShippingPackageUnitType, unit: String) -> some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -136,13 +136,24 @@ struct WooCarrierPackagesSelectionView: View {
             }
             Spacer()
             Divider()
-            Button(WooShippingAddPackageView.Localization.addPackage) {
+            Button(selectionButtonText) {
                 addPackageButtonTapped()
             }
-            .disabled(viewModel.selectedCarriersPackageId == nil)
+            .disabled(selectionButtonDisabled)
             .buttonStyle(PrimaryButtonStyle())
             .padding()
         }
+    }
+
+    private var selectionButtonDisabled: Bool {
+        viewModel.selectedCarriersPackageId == nil
+    }
+
+    private var selectionButtonText: String {
+        if selectionButtonDisabled {
+            return WooShippingAddPackageView.Localization.selectPackage
+        }
+        return WooShippingAddPackageView.Localization.addPackage
     }
 
     private func addPackageButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -147,13 +147,24 @@ struct WooSavedPackagesSelectionView: View {
                 Divider()
             }
             Spacer()
-            Button(WooShippingAddPackageView.Localization.addPackage) {
+            Button(selectionButtonText) {
                 addPackageButtonTapped()
             }
-            .disabled(viewModel.selectedSavedPackageId == nil || !viewModel.hasSavedPackages)
+            .disabled(selectionButtonDisabled)
             .buttonStyle(PrimaryButtonStyle())
             .padding()
         }
+    }
+
+    private var selectionButtonDisabled: Bool {
+        viewModel.selectedSavedPackageId == nil || !viewModel.hasSavedPackages
+    }
+
+    private var selectionButtonText: String {
+        if selectionButtonDisabled {
+            return WooShippingAddPackageView.Localization.selectPackage
+        }
+        return WooShippingAddPackageView.Localization.addPackage
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -138,5 +138,11 @@ extension WooShippingAddPackageView {
         static let saved = NSLocalizedString("wooShipping.createLabel.addPackage.saved",
                                              value: "Saved",
                                              comment: "Info label for saved package option")
+        static let selectPackage = NSLocalizedString("wooShipping.createLabel.addPackage.selectPackage",
+                                                     value: "Select Package",
+                                                     comment: "Title for the Add Package screen Select Package button")
+        static let addPackageDetails = NSLocalizedString("wooShipping.createLabel.addPackage.addPackageDetails",
+                                                         value: "Add Package Details",
+                                                         comment: "Title for the Add Package screen Add Package Details button")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13786
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updated package selection/addition button texts in disabled state to:
- "Add Package Details" when adding a custom package
- "Select a Package" when adding a carrier or saved package

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7.  Tap "Select a Package."
10. Switch to "Custom" tab
11. Check that the button on the bottom is disabled and has text "Add Package Details"
12. Enter the data above the button and check that the state of the button changes to enabled state and text to "Add Package"
13. Switch to Carrier tab
14. Check that the button on the bottom is disabled and has text "Select a Package"
15. Select one of the packages
16. Check that the state of the button changes to enabled state and text to "Add Package"
17. Switch to Saved tab
18. Check that the button on the bottom is disabled and has text "Select a Package"
19. Select one of the packages
20. Check that the state of the button changes to enabled state and text to "Add Package"

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 09 44 08](https://github.com/user-attachments/assets/f31ca109-7217-470c-8dbe-c2b1765a2c68)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 09 39 14](https://github.com/user-attachments/assets/d54d6d6e-7515-4ffc-9339-4f3ea5457817)       |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 09 44 18](https://github.com/user-attachments/assets/0b7a680d-3326-43f9-aad0-e29dcc5a81ff)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 09 39 29](https://github.com/user-attachments/assets/61b3007c-91db-4e85-a3ca-f430341425df) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 09 44 23](https://github.com/user-attachments/assets/3471cf76-7c67-41a0-a790-31df1fecbae1)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 09 39 38](https://github.com/user-attachments/assets/8b20a53e-7a48-4c1d-acc2-faae71d5b596) |

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
