### PR TITLE
Order Creation: Don't show 'Recalculate' button if order sync is not required

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [**] Store Picker: Sites can now be hidden from the list for a more focused experience for agencies. [https://github.com/woocommerce/woocommerce-ios/pull/14780]
 - [*] Fetching plugins info in the app (e.g. payments onboarding) is more resilient to unexpected types in unrelated fields in the system status response. This used to result in a decoding error. [https://github.com/woocommerce/woocommerce-ios/pull/14781]
+- [*] Fixed an issue on iPad where creating an order with a custom amount type failed after selecting and deselecting a product. [https://github.com/woocommerce/woocommerce-ios/pull/14789]
 
 21.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1550,6 +1550,13 @@ private extension EditableOrderViewModel {
         syncRequired = false
     }
 
+    func isSyncRequired(products: [Product], variations: [ProductVariation]) -> Bool {
+        let addedItemsToSync = productInputAdditionsToSync(products: products, variations: variations)
+        let removedItemsToSync = productInputDeletionsToSync(products: products, variations: variations)
+
+        return (addedItemsToSync + removedItemsToSync).isNotEmpty
+    }
+
     /// Adds a selected product (from the product list) to the order.
     ///
     func changeSelectionStateForProduct(_ product: Product, to isSelected: Bool) {
@@ -2012,7 +2019,7 @@ private extension EditableOrderViewModel {
         case .immediate:
             syncOrderItems(products: selectedProducts, variations: selectedProductVariations)
         case .onRecalculateButtonTap:
-            syncRequired = true
+            syncRequired = isSyncRequired(products: selectedProducts, variations: selectedProductVariations)
         case .onSelectorButtonTap:
             return
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -337,6 +337,60 @@ final class EditableOrderViewModelTests: XCTestCase {
         }
     }
 
+    func test_doneButtonType_when_custom_amount_using_onRecalculateButtonTap_sync_approach() throws {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               featureFlagService: MockFeatureFlagService(sideBySideViewForOrderForm: true))
+        viewModel.toggleProductSelectorVisibility()
+
+        viewModel.selectionSyncApproach = .onRecalculateButtonTap
+
+        // When
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.name = "Test"
+        addCustomAmountViewModel.doneButtonPressed()
+
+        // Then
+        switch viewModel.doneButtonType {
+        case .create:
+            // Success – we just don't care about the `loading` parameter
+            break
+        default:
+            XCTFail("Unexpected doneButtonType")
+        }
+    }
+
+    func test_doneButtonType_when_toggled_product_selection_and_custom_amount_using_onRecalculateButtonTap_sync_approach() throws {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               featureFlagService: MockFeatureFlagService(sideBySideViewForOrderForm: true))
+        viewModel.toggleProductSelectorVisibility()
+
+        viewModel.selectionSyncApproach = .onRecalculateButtonTap
+        let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
+
+        // When we add custom amount
+        let addCustomAmountViewModel = viewModel.addCustomAmountViewModel(with: .fixedAmount)
+        addCustomAmountViewModel.name = "Test"
+        addCustomAmountViewModel.doneButtonPressed()
+        // and toggle product selection
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID, selected: true)
+        productSelectorViewModel.changeSelectionStateForProduct(with: product.productID, selected: false)
+
+        // Then
+        switch viewModel.doneButtonType {
+        case .create:
+            // Success – we just don't care about the `loading` parameter
+            break
+        default:
+            XCTFail("Unexpected doneButtonType")
+        }
+    }
+
     func test_view_model_is_updated_when_product_is_added_to_order_using_buttonTap_sync_approach_then_changes_to_immediate() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14514
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When creating an order on iPad, if the merchant enters a custom amount  and then selects & deselects any product in the product selector, there's no way to create an order.

It happens because selecting and deselecting a product selection sets the `syncRequired` to true which results in 'Recalculate' button being shown. Tapping the button has no effect since `syncOrderItems` method returns early due to no items available for sync.

## Solution

Set `syncRequired` to `true` only if there are items to sync. Added `isSyncRequired` method that borrows logic from `syncOrderItems` to determine the synchronization requirement. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to the orders tab on iPad
2. Tap +
3. Tap Add Custom Amount and enter a custom amount
4. In the product selector, select a product
5. Confirm that 'Recalculate' button is shown
6. In the product selector, deselect this product
7. Confirm that 'Collect Payment' is shown

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- I first confirmed the issue and made a fix using `EditableOrderViewModelTests` unit tests which are quite extensive. 
- I also tested various scenarios with more complicated products to confirm that `isSyncRequired` works as expected. The change should be safe since the logic is used in `syncOrderItems` already.
- Confirmed that the fix only affects `onRecalculateButtonTap` sync approach is only used for `sideBySide`  presentation style.
- Reviewed a task that introduced this https://github.com/woocommerce/woocommerce-ios/pull/12136. I think this is a corner case that wasn't thought through. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://github.com/user-attachments/assets/d9573fad-d6dd-4652-a615-0e66c0f46b7f

### After

https://github.com/user-attachments/assets/7a40e73a-8a44-46fd-8e01-39413a93a4d8

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.