### PR TITLE
Rename `PointOfSaleProductService` to `PointOfSaleItemService` with basic unit tests on variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -97,10 +97,10 @@ final class HubMenuViewModel: ObservableObject {
     private(set) lazy var posItemProvider: PointOfSaleItemServiceProtocol = {
         let currencySettings = ServiceLocator.currencySettings
 
-        return PointOfSaleProductService(siteID: siteID,
-                                         currencySettings: currencySettings,
-                                         credentials: credentials,
-                                         isVariableProductsFeatureEnabled: featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale))
+        return PointOfSaleItemService(siteID: siteID,
+                                      currencySettings: currencySettings,
+                                      credentials: credentials,
+                                      isVariableProductsFeatureEnabled: featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale))
     }()
 
     private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 		6801E41A2D1002CE00F9DF46 /* POSReceiptServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6801E4192D1002CC00F9DF46 /* POSReceiptServiceTests.swift */; };
 		6801E41C2D1007D200F9DF46 /* MockPOSReceiptsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6801E41B2D1007D000F9DF46 /* MockPOSReceiptsRemote.swift */; };
 		681D952B28E0F62B00C4039E /* CustomerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681D952A28E0F62B00C4039E /* CustomerAction.swift */; };
-		687F83722C0EBF8900460AB3 /* POSProductProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687F83712C0EBF8900460AB3 /* POSProductProviderTests.swift */; };
+		687F83722C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */; };
 		6889089F28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6889089E28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift */; };
 		6898F3742C0842150039F10A /* PointOfSaleItemServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */; };
 		689D11D52891B9A400F6A83F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 689D11D42891B9A400F6A83F /* WooFoundation.framework */; };
@@ -272,7 +272,7 @@
 		68BD37B528DB2E9800C2A517 /* CustomerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD37B428DB2E9800C2A517 /* CustomerStore.swift */; };
 		68BD37B928DB323D00C2A517 /* CustomerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD37B828DB323D00C2A517 /* CustomerStoreTests.swift */; };
 		68EA25342C08734900C49AE2 /* POSSimpleProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */; };
-		68EA25382C0876DF00C49AE2 /* PointOfSaleProductService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */; };
+		68EA25382C0876DF00C49AE2 /* PointOfSaleItemService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
 		741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34812195EA71005F5BD9 /* CommentStore.swift */; };
 		741F34842195F752005F5BD9 /* CommentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34832195F752005F5BD9 /* CommentStoreTests.swift */; };
@@ -797,7 +797,7 @@
 		6801E4192D1002CC00F9DF46 /* POSReceiptServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSReceiptServiceTests.swift; sourceTree = "<group>"; };
 		6801E41B2D1007D000F9DF46 /* MockPOSReceiptsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSReceiptsRemote.swift; sourceTree = "<group>"; };
 		681D952A28E0F62B00C4039E /* CustomerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerAction.swift; sourceTree = "<group>"; };
-		687F83712C0EBF8900460AB3 /* POSProductProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductProviderTests.swift; sourceTree = "<group>"; };
+		687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemServiceTests.swift; sourceTree = "<group>"; };
 		6889089E28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Customer+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemServiceProtocol.swift; sourceTree = "<group>"; };
 		689D11D42891B9A400F6A83F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -805,7 +805,7 @@
 		68BD37B428DB2E9800C2A517 /* CustomerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerStore.swift; sourceTree = "<group>"; };
 		68BD37B828DB323D00C2A517 /* CustomerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerStoreTests.swift; sourceTree = "<group>"; };
 		68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSimpleProduct.swift; sourceTree = "<group>"; };
-		68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleProductService.swift; sourceTree = "<group>"; };
+		68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemService.swift; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
 		741F34812195EA71005F5BD9 /* CommentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentStore.swift; sourceTree = "<group>"; };
 		741F34832195F752005F5BD9 /* CommentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentStoreTests.swift; sourceTree = "<group>"; };
@@ -1510,7 +1510,7 @@
 		687F83702C0EBF3E00460AB3 /* PointOfSale */ = {
 			isa = PBXGroup;
 			children = (
-				687F83712C0EBF8900460AB3 /* POSProductProviderTests.swift */,
+				687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */,
 			);
 			path = PointOfSale;
 			sourceTree = "<group>";
@@ -1521,7 +1521,7 @@
 				6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */,
 				68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */,
 				027ADB6B2D1BF3AD009608DB /* POSParentProduct.swift */,
-				68EA25372C0876DF00C49AE2 /* PointOfSaleProductService.swift */,
+				68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */,
 				029149752D2663AB00F7B3B3 /* POSVariation.swift */,
 			);
 			path = PointOfSale;
@@ -2537,7 +2537,7 @@
 				DE2E8EA72953F85C002E4B14 /* WordPressSiteStore.swift in Sources */,
 				74858DB421C02B5A00754F3E /* OrderNote+ReadOnlyType.swift in Sources */,
 				0248B3652459018100A271A4 /* ResultsController+FilterProducts.swift in Sources */,
-				68EA25382C0876DF00C49AE2 /* PointOfSaleProductService.swift in Sources */,
+				68EA25382C0876DF00C49AE2 /* PointOfSaleItemService.swift in Sources */,
 				02E262C2238CF74D00B79588 /* StorageShippingSettingsService.swift in Sources */,
 				FE28F6EE268440B1004465C7 /* UserAction.swift in Sources */,
 				DE34050828BC706B00CF0D97 /* DeauthenticatedStore.swift in Sources */,
@@ -2707,7 +2707,7 @@
 				312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */,
 				453954DC2C91F79B00A3E64A /* MetaDataStoreTests.swift in Sources */,
 				EEB4E2CF29B04D7900371C3C /* StoreOnboardingTasksStoreTests.swift in Sources */,
-				687F83722C0EBF8900460AB3 /* POSProductProviderTests.swift in Sources */,
+				687F83722C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift in Sources */,
 				03EB99922907EBB300F06A39 /* JustInTimeMessageStoreTests.swift in Sources */,
 				026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */,
 				7492FAE1217FB87100ED2C69 /* SettingStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -14,7 +14,7 @@ public enum PointOfSaleProductServiceError: Error {
 
 /// Product provider for the Point of Sale feature
 ///
-public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
+public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     private var siteID: Int64
     private let currencyFormatter: CurrencyFormatter
     private let productsRemote: ProductsRemote
@@ -112,7 +112,7 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
     }
 }
 
-private extension PointOfSaleProductService {
+private extension PointOfSaleItemService {
     func filterProducts(products: [Product], using criteria: [(Product) -> Bool]) -> [Product] {
         return products.filter { product in
             criteria.allSatisfy { $0(product) }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -3,7 +3,7 @@ import WooFoundation
 @testable import Networking
 @testable import Yosemite
 
-final class PointOfSaleProductServiceTests: XCTestCase {
+final class PointOfSaleItemServiceTests: XCTestCase {
     private var currencySettings: CurrencySettings!
     private var itemProvider: PointOfSaleItemServiceProtocol!
     private var network: MockNetwork!
@@ -13,7 +13,7 @@ final class PointOfSaleProductServiceTests: XCTestCase {
         super.setUp()
         network = MockNetwork()
         currencySettings = CurrencySettings()
-        itemProvider = PointOfSaleProductService(siteID: siteID,
+        itemProvider = PointOfSaleItemService(siteID: siteID,
                                                  currencySettings: currencySettings,
                                                  network: network,
                                                  isVariableProductsFeatureEnabled: false)
@@ -111,7 +111,7 @@ final class PointOfSaleProductServiceTests: XCTestCase {
 
     func test_providePointOfSaleItems_sets_types_parameters_to_simple_only() async throws {
         // Given
-        let itemProvider = PointOfSaleProductService(siteID: siteID,
+        let itemProvider = PointOfSaleItemService(siteID: siteID,
                                                      currencySettings: currencySettings,
                                                      network: network,
                                                      isVariableProductsFeatureEnabled: false)
@@ -125,7 +125,7 @@ final class PointOfSaleProductServiceTests: XCTestCase {
 
     func test_providePointOfSaleItems_sets_types_parameters_correctly_when_variable_products_feature_is_enabled() async throws {
         // Given
-        let itemProvider = PointOfSaleProductService(siteID: siteID,
+        let itemProvider = PointOfSaleItemService(siteID: siteID,
                                                      currencySettings: currencySettings,
                                                      network: network,
                                                      isVariableProductsFeatureEnabled: true)
@@ -135,5 +135,68 @@ final class PointOfSaleProductServiceTests: XCTestCase {
 
         // Then
         XCTAssertEqual(network.queryParametersDictionary?["include_types"] as? String, "simple,variable")
+    }
+
+    func test_providePointOfSaleVariationItems_returns_variations_when_load_succeeds() async throws {
+        // Given
+        let itemProvider = PointOfSaleItemService(siteID: siteID,
+                                                  currencySettings: currencySettings,
+                                                  network: network,
+                                                  isVariableProductsFeatureEnabled: true)
+        let parentProductID: Int64 = 123
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products/\(parentProductID)/variations", filename: "product-variations-load-all")
+        let pagedVariations = try await itemProvider.providePointOfSaleVariationItems(
+            for: .init(
+                id: .init(),
+                name: "Tea",
+                productImageSource: nil,
+                productID: parentProductID,
+                type: .variable
+            ),
+            pageNumber: 1
+        )
+
+        // Then
+        let variations = pagedVariations.items
+
+        XCTAssertFalse(variations.isEmpty)
+        let firstVariation = try XCTUnwrap(variations.first)
+        guard case let .variation(firstVariation) = firstVariation else {
+            return XCTFail("Variation is expected.")
+        }
+        XCTAssertEqual(firstVariation.name, "Variation 1275")
+        XCTAssertEqual(firstVariation.formattedPrice, "$12.00")
+    }
+
+    func test_providePointOfSaleVariationItems_throws_error_when_variations_load_fails() async throws {
+        // Given
+        let itemProvider = PointOfSaleItemService(siteID: siteID,
+                                            currencySettings: currencySettings,
+                                            network: network,
+                                            isVariableProductsFeatureEnabled: true)
+        let parentProductID: Int64 = 123
+        let expectedError = PointOfSaleProductServiceError.requestFailed
+
+        // When
+        network.simulateError(requestUrlSuffix: "products/\(parentProductID)/variations", error: expectedError)
+
+        // Then
+        do {
+            _ = try await itemProvider.providePointOfSaleVariationItems(
+                for: .init(
+                    id: .init(),
+                    name: "Tea",
+                    productImageSource: nil,
+                    productID: parentProductID,
+                    type: .variable
+                ),
+                pageNumber: 1
+            )
+            XCTFail("An error is expected.")
+        } catch {
+            XCTAssertEqual(error as? PointOfSaleProductServiceError, expectedError)
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14702 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As we're adding variation items fetching to `PointOfSaleItemServiceProtocol`, it starts to look odd with the name `PointOfSaleProductService` that seems to be product-specific. This PR simply renames `PointOfSaleProductService` to `PointOfSaleItemService` across different files and references. Two test cases were also added for `providePointOfSaleVariationItems` function that didn't fit in https://github.com/woocommerce/woocommerce-ios/pull/14786 that introduced it.

### Renaming and Refactoring:

* [`WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift`](diffhunk://#diff-a7353a3c9b54e18ce66e192000f034059a624c6824a359575150dc1788697d04L100-R100): Updated the instantiation of the `PointOfSaleItemService` to reflect the new name.

* [`Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift`](diffhunk://#diff-4ff6f858a82d655da0ffbd0c0620178056e0a60bd6a43fea67a3aafcf46219c9L17-R17): Renamed the class `PointOfSaleProductService` to `PointOfSaleItemService` and updated internal references accordingly. [[1]](diffhunk://#diff-4ff6f858a82d655da0ffbd0c0620178056e0a60bd6a43fea67a3aafcf46219c9L17-R17) [[2]](diffhunk://#diff-4ff6f858a82d655da0ffbd0c0620178056e0a60bd6a43fea67a3aafcf46219c9L115-R115)

* [`Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift`](diffhunk://#diff-1055f7d4db4a4d30e8faa6fb56af2b43d4d99d9df12a9ae48a9e60e4fa9d7dcaL6-R6): Updated the test class name and references from `PointOfSaleProductServiceTests` to `PointOfSaleItemServiceTests`, and added new test cases for variations. [[1]](diffhunk://#diff-1055f7d4db4a4d30e8faa6fb56af2b43d4d99d9df12a9ae48a9e60e4fa9d7dcaL6-R6) [[2]](diffhunk://#diff-1055f7d4db4a4d30e8faa6fb56af2b43d4d99d9df12a9ae48a9e60e4fa9d7dcaL16-R16) [[3]](diffhunk://#diff-1055f7d4db4a4d30e8faa6fb56af2b43d4d99d9df12a9ae48a9e60e4fa9d7dcaL114-R114) [[4]](diffhunk://#diff-1055f7d4db4a4d30e8faa6fb56af2b43d4d99d9df12a9ae48a9e60e4fa9d7dcaL128-R128) [[5]](diffhunk://#diff-1055f7d4db4a4d30e8faa6fb56af2b43d4d99d9df12a9ae48a9e60e4fa9d7dcaR139-R201)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

A confidence test to ensure the products & variations are loaded properly in the item selector would be helpful.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [x] @jaclync performs a confidence test above before merging

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.