### PR TITLE
[Woo POS] [Cash & Receipts] Handle navigation when order completed via cash 

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
@@ -42,4 +42,7 @@ protocol CardPresentPaymentFacade {
 
     /// Cancels any in-progress payment.
     func cancelPayment()
+
+    /// Cancels any in-progress payment, returning when complete
+    func cancelPayment() async throws
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -104,7 +104,7 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
     func disconnectReader() async {
         readerConnectionStatusSubject.send(.disconnecting)
 
-        cancelPayment()
+        try? await cancelPayment()
 
         connectionControllerManager.knownReaderProvider.forgetCardReader()
 
@@ -161,6 +161,18 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
     func cancelPayment() {
         paymentTask?.cancel()
     }
+
+    @MainActor
+    func cancelPayment() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            var nillableContinuation: CheckedContinuation<Void, any Error>? = continuation
+            let action = CardPresentPaymentAction.cancelPayment { result in
+                nillableContinuation?.resume(with: result)
+                nillableContinuation = nil
+            }
+            stores.dispatch(action)
+        }
+    }
 }
 
 private extension CardPresentPaymentService {
@@ -213,4 +225,5 @@ enum CardPresentPaymentServiceError: Error {
     case invalidAmount
     case unknownPaymentError(underlyingError: Error)
     case incompleteAddressConnectionError
+    case couldNotCancelPayment
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -104,7 +104,11 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
     func disconnectReader() async {
         readerConnectionStatusSubject.send(.disconnecting)
 
-        try? await cancelPayment()
+        do {
+            try await cancelPayment()
+        } catch {
+            DDLogError("Attempting to cancel the payment has failed \(error)")
+        }
 
         connectionControllerManager.knownReaderProvider.forgetCardReader()
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -207,6 +207,7 @@ extension PointOfSaleAggregateModel {
 
     func cancelCashPayment() async throws {
         isCashPaymentInProgress = false
+        paymentState = .card(.idle)
         await startPaymentWhenCardReaderConnected()
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -201,24 +201,19 @@ extension PointOfSaleAggregateModel {
 
     // Prevents card payments from the moment the merchant decides we start collecting cash
     // Once we get the callback from the card service, we switch to cash collection state
-    func startCashPayment() {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            try? await cardPresentPaymentService.cancelPayment()
-            paymentState = .cash(.collectingCash)
-        }
+    @MainActor
+    func startCashPayment() async {
+        try? await cardPresentPaymentService.cancelPayment()
+        paymentState = .cash(.collectingCash)
     }
 
-    func cancelCashPayment() {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-
-            if case .connected = cardReaderConnectionStatus {
-                try? await cardPresentPaymentService.cancelPayment()
-                await collectPayment()
-            } else {
-                paymentState = .card(.idle)
-            }
+    @MainActor
+    func cancelCashPayment() async {
+        if case .connected = cardReaderConnectionStatus {
+            try? await cardPresentPaymentService.cancelPayment()
+            await collectPayment()
+        } else {
+            paymentState = .card(.idle)
         }
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -199,13 +199,14 @@ extension PointOfSaleAggregateModel {
         }
     }
 
+    // Prevents card payments from the moment the merchant decides we start collecting cash
+    // Once we get the callback from the card service, we switch to cash collection state
     func startCashPayment() {
-        // Uncomment the lines below to prevent card payments from as soon as the button to open cash payment entry is tapped.
-//        Task { @MainActor [weak self] in
-//            guard let self else { return }
-//            try? await cardPresentPaymentService.cancelPayment()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await cardPresentPaymentService.cancelPayment()
             paymentState = .cash(.collectingCash)
-//        }
+        }
     }
 
     func cancelCashPayment() {
@@ -240,9 +241,6 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func collectCashPayment() async throws {
-        // Currently, we allow card payments right up until the `Mark order complete` button is tapped.
-        // Delete the following row if we decide to cancel at the outset of cash payments.
-        try? await cardPresentPaymentService.cancelPayment()
         try await orderController.collectCashPayment()
         cashPaymentSuccess()
     }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -210,7 +210,6 @@ extension PointOfSaleAggregateModel {
     @MainActor
     func cancelCashPayment() async {
         if case .connected = cardReaderConnectionStatus {
-            try? await cardPresentPaymentService.cancelPayment()
             await collectPayment()
         } else {
             paymentState = .card(.idle)

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -203,13 +203,14 @@ extension PointOfSaleAggregateModel {
         paymentState = .cash(.collectingCash)
     }
 
-    func cashPaymentSuccess() {
+    private func cashPaymentSuccess() {
         paymentState = .cash(.paymentSuccess)
     }
 
     @MainActor
     func collectCashPayment() async throws {
         try await orderController.collectCashPayment()
+        cashPaymentSuccess()
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -201,11 +201,7 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func collectCashPayment() async throws {
-        do {
-            try await orderController.collectCashPayment()
-        } catch {
-            debugPrint(error)
-        }
+        try await orderController.collectCashPayment()
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -203,6 +203,10 @@ extension PointOfSaleAggregateModel {
         paymentState = .cash(.collectingCash)
     }
 
+    func cashPaymentSuccess() {
+        paymentState = .cash(.paymentSuccess)
+    }
+
     @MainActor
     func collectCashPayment() async throws {
         try await orderController.collectCashPayment()

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -199,6 +199,10 @@ extension PointOfSaleAggregateModel {
         }
     }
 
+    func startCashPayment() {
+        paymentState = .cash(.collectingCash)
+    }
+
     @MainActor
     func collectCashPayment() async throws {
         try await orderController.collectCashPayment()

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -61,7 +61,6 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
 
-    private var isCashPaymentInProgress: Bool = false
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
 
@@ -201,19 +200,15 @@ extension PointOfSaleAggregateModel {
     }
 
     func startCashPayment() {
-        isCashPaymentInProgress = true
         paymentState = .cash(.collectingCash)
     }
 
-    func cancelCashPayment() async throws {
-        isCashPaymentInProgress = false
+    func cancelCashPayment() {
         paymentState = .card(.idle)
-        await startPaymentWhenCardReaderConnected()
     }
 
     private func cashPaymentSuccess() {
         paymentState = .cash(.paymentSuccess)
-        isCashPaymentInProgress = false
     }
 
     @MainActor
@@ -309,17 +304,10 @@ private extension PointOfSaleAggregateModel {
             .assign(to: &$cardPresentPaymentInlineMessage)
 
         cardPresentPaymentService.paymentEventPublisher
-            .compactMap { [weak self] paymentEvent -> PointOfSalePaymentState? in
-                guard let self else { return nil }
-
-                let newPaymentState = PointOfSalePaymentState(from: paymentEvent,
-                                                              using: presentationStyleDeterminerDependencies)
-
-                if self.isCashPaymentInProgress, case .card = newPaymentState {
-                    cardPresentPaymentService.cancelPayment()
-                    return .cash(.collectingCash)
-                }
-                return newPaymentState
+            .compactMap { [weak self] paymentEvent in
+                guard let self else { return .none }
+                return PointOfSalePaymentState(from: paymentEvent,
+                                               using: presentationStyleDeterminerDependencies)
             }
             .assign(to: &$paymentState)
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -61,6 +61,7 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
 
+    private var isCashPaymentInProgress: Bool = false
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
 
@@ -129,6 +130,7 @@ extension PointOfSaleAggregateModel {
     }
 
     func startNewCart() {
+        isCashPaymentInProgress = false
         removeAllItemsFromCart()
         orderController.clearOrder()
         setStateForEditing()
@@ -200,10 +202,12 @@ extension PointOfSaleAggregateModel {
     }
 
     func startCashPayment() {
+        isCashPaymentInProgress = true
         paymentState = .cash(.collectingCash)
     }
 
     func cancelCashPayment() {
+        isCashPaymentInProgress = false
         paymentState = .card(.idle)
     }
 
@@ -304,10 +308,17 @@ private extension PointOfSaleAggregateModel {
             .assign(to: &$cardPresentPaymentInlineMessage)
 
         cardPresentPaymentService.paymentEventPublisher
-            .compactMap { [weak self] paymentEvent in
-                guard let self else { return .none }
-                return PointOfSalePaymentState(from: paymentEvent,
-                                               using: presentationStyleDeterminerDependencies)
+            .compactMap { [weak self] paymentEvent -> PointOfSalePaymentState? in
+                guard let self else { return nil }
+
+                let newPaymentState = PointOfSalePaymentState(from: paymentEvent,
+                                                              using: presentationStyleDeterminerDependencies)
+
+                if self.isCashPaymentInProgress, case .card = newPaymentState {
+                    cardPresentPaymentService.cancelPayment()
+                    return .cash(.paymentSuccess)
+                }
+                return newPaymentState
             }
             .assign(to: &$paymentState)
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -61,6 +61,7 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
 
+    private var isCashPaymentInProgress: Bool = false
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
 
@@ -200,15 +201,18 @@ extension PointOfSaleAggregateModel {
     }
 
     func startCashPayment() {
+        isCashPaymentInProgress = true
         paymentState = .cash(.collectingCash)
     }
 
-    func cancelCashPayment() {
-        paymentState = .card(.idle)
+    func cancelCashPayment() async throws {
+        isCashPaymentInProgress = false
+        await startPaymentWhenCardReaderConnected()
     }
 
     private func cashPaymentSuccess() {
         paymentState = .cash(.paymentSuccess)
+        isCashPaymentInProgress = false
     }
 
     @MainActor
@@ -304,10 +308,17 @@ private extension PointOfSaleAggregateModel {
             .assign(to: &$cardPresentPaymentInlineMessage)
 
         cardPresentPaymentService.paymentEventPublisher
-            .compactMap { [weak self] paymentEvent in
-                guard let self else { return .none }
-                return PointOfSalePaymentState(from: paymentEvent,
-                                               using: presentationStyleDeterminerDependencies)
+            .compactMap { [weak self] paymentEvent -> PointOfSalePaymentState? in
+                guard let self else { return nil }
+
+                let newPaymentState = PointOfSalePaymentState(from: paymentEvent,
+                                                              using: presentationStyleDeterminerDependencies)
+
+                if self.isCashPaymentInProgress, case .card = newPaymentState {
+                    cardPresentPaymentService.cancelPayment()
+                    return .cash(.collectingCash)
+                }
+                return newPaymentState
             }
             .assign(to: &$paymentState)
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -212,20 +212,7 @@ extension PointOfSaleAggregateModel {
     func cancelCashPayment() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            // Because we don't know the previous card payment state, we have to cancel then collect again.
-            // If the reader's not connected, we don't want to call collect because it'll start a connection attempt.
-            // This is bad.
-            // To improve this, if we keep allowing card payments while cash payment is showing, we should improve the
-            // paymentState representation to allow two payment states to be known. It would need to be a struct with something like:
-            /*
 
-             struct PointOfSalePaymentState {
-                 let activePaymentMethod: PointOfSaleActivePaymentMethod //(enum for just `.card`, `.cash` without associated type)
-                 let cardPaymentState: PointOfSaleCardPaymentState
-                 let cashPaymentState: PointOfSaleCashPaymentState
-             }
-
-             */
             if case .connected = cardReaderConnectionStatus {
                 try? await cardPresentPaymentService.cancelPayment()
                 await collectPayment()

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -70,7 +70,7 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderController: PointOfSaleOrderControllerProtocol,
          analytics: Analytics = ServiceLocator.analytics,
-         paymentState: PointOfSalePaymentState = .idle) {
+         paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.itemsController = itemsController
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderController = orderController
@@ -136,7 +136,7 @@ extension PointOfSaleAggregateModel {
 
     private func setStateForEditing() {
         orderStage = .building
-        paymentState = .idle
+        paymentState = .card(.idle)
         cardPresentPaymentInlineMessage = nil
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -163,9 +163,9 @@ extension PointOfSaleAggregateModel {
 
     /// Starts a payment immediately if a reader is connected.
     /// Otherwise, schedules a payment to start the next time a reader connects.
-    /// Note that any schedlued payments are cancelled by `cancelReaderPreparation`
+    /// Note that any scheduled payments are cancelled by `cancelReaderPreparation`
     /// e.g. when the TotalsView goes offscreen.
-    func startPaymentWhenCardReaderConnected() async {
+    private func startPaymentWhenCardReaderConnected() async {
         guard case .connected = cardReaderConnectionStatus else {
             return startPaymentOnCardReaderConnection = $cardReaderConnectionStatus
                 .filter { status in
@@ -179,15 +179,15 @@ extension PointOfSaleAggregateModel {
                 .removeDuplicates()
                 .sink { _ in
                     Task { @MainActor [weak self] in
-                        await self?.collectPayment()
+                        await self?.collectCardPayment()
                     }
                 }
         }
-        await collectPayment()
+        await collectCardPayment()
     }
 
     @MainActor
-    func collectPayment() async {
+    private func collectCardPayment() async {
         guard let order = orderController.order else {
             return
             // Should this throw?
@@ -210,7 +210,7 @@ extension PointOfSaleAggregateModel {
     @MainActor
     func cancelCashPayment() async {
         if case .connected = cardReaderConnectionStatus {
-            await collectPayment()
+            await collectCardPayment()
         } else {
             paymentState = .card(.idle)
         }
@@ -240,7 +240,7 @@ extension PointOfSaleAggregateModel {
         Task { [weak self] in
             guard let self else { return }
             try await cardPresentPaymentService.cancelPayment()
-            await collectPayment()
+            await collectCardPayment()
         }
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -203,6 +203,10 @@ extension PointOfSaleAggregateModel {
         paymentState = .cash(.collectingCash)
     }
 
+    func cancelCashPayment() {
+        paymentState = .card(.idle)
+    }
+
     private func cashPaymentSuccess() {
         paymentState = .cash(.paymentSuccess)
     }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -61,7 +61,6 @@ class PointOfSaleAggregateModel: ObservableObject, PointOfSaleAggregateModelProt
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
 
-    private var isCashPaymentInProgress: Bool = false
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
 
@@ -130,7 +129,6 @@ extension PointOfSaleAggregateModel {
     }
 
     func startNewCart() {
-        isCashPaymentInProgress = false
         removeAllItemsFromCart()
         orderController.clearOrder()
         setStateForEditing()
@@ -202,13 +200,38 @@ extension PointOfSaleAggregateModel {
     }
 
     func startCashPayment() {
-        isCashPaymentInProgress = true
-        paymentState = .cash(.collectingCash)
+        // Uncomment the lines below to prevent card payments from as soon as the button to open cash payment entry is tapped.
+//        Task { @MainActor [weak self] in
+//            guard let self else { return }
+//            try? await cardPresentPaymentService.cancelPayment()
+            paymentState = .cash(.collectingCash)
+//        }
     }
 
     func cancelCashPayment() {
-        isCashPaymentInProgress = false
-        paymentState = .card(.idle)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            // Because we don't know the previous card payment state, we have to cancel then collect again.
+            // If the reader's not connected, we don't want to call collect because it'll start a connection attempt.
+            // This is bad.
+            // To improve this, if we keep allowing card payments while cash payment is showing, we should improve the
+            // paymentState representation to allow two payment states to be known. It would need to be a struct with something like:
+            /*
+
+             struct PointOfSalePaymentState {
+                 let activePaymentMethod: PointOfSaleActivePaymentMethod //(enum for just `.card`, `.cash` without associated type)
+                 let cardPaymentState: PointOfSaleCardPaymentState
+                 let cashPaymentState: PointOfSaleCashPaymentState
+             }
+
+             */
+            if case .connected = cardReaderConnectionStatus {
+                try? await cardPresentPaymentService.cancelPayment()
+                await collectPayment()
+            } else {
+                paymentState = .card(.idle)
+            }
+        }
     }
 
     private func cashPaymentSuccess() {
@@ -217,6 +240,9 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func collectCashPayment() async throws {
+        // Currently, we allow card payments right up until the `Mark order complete` button is tapped.
+        // Delete the following row if we decide to cancel at the outset of cash payments.
+        try? await cardPresentPaymentService.cancelPayment()
         try await orderController.collectCashPayment()
         cashPaymentSuccess()
     }
@@ -232,9 +258,10 @@ extension PointOfSaleAggregateModel {
     }
 
     func cancelThenCollectPayment() {
-        cardPresentPaymentService.cancelPayment()
         Task { [weak self] in
-            await self?.collectPayment()
+            guard let self else { return }
+            try await cardPresentPaymentService.cancelPayment()
+            await collectPayment()
         }
     }
 
@@ -314,10 +341,6 @@ private extension PointOfSaleAggregateModel {
                 let newPaymentState = PointOfSalePaymentState(from: paymentEvent,
                                                               using: presentationStyleDeterminerDependencies)
 
-                if self.isCashPaymentInProgress, case .card = newPaymentState {
-                    cardPresentPaymentService.cancelPayment()
-                    return .cash(.paymentSuccess)
-                }
                 return newPaymentState
             }
             .assign(to: &$paymentState)

--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-enum PointOfSalePaymentState {
+enum PointOfSalePaymentState: Equatable {
+    case card(PointOfSaleCardPaymentState)
+    case cash(PointOfSaleCashPaymentState)
+}
+
+enum PointOfSaleCardPaymentState: Equatable {
     case idle
     case acceptingCard
     case validatingOrder
@@ -11,35 +16,40 @@ enum PointOfSalePaymentState {
     case cardPaymentSuccessful
 }
 
+enum PointOfSaleCashPaymentState: Equatable {
+    case collectingCash
+    case paymentSuccess
+}
+
 extension PointOfSalePaymentState {
     init?(from cardPaymentEvent: CardPresentPaymentEvent,
           using paymentEventPresentationStyleDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies) {
         switch cardPaymentEvent {
         case .idle:
-            self = .idle
+            self = .card(.idle)
         case .show(.validatingOrder):
-            self = .validatingOrder
+            self = .card(.validatingOrder)
         case .show(.preparingForPayment):
-            self = .preparingReader
+            self = .card(.preparingReader)
         case .show(.tapSwipeOrInsertCard):
-            self = .acceptingCard
+            self = .card(.acceptingCard)
         case .show(.processing),
                 .show(.displayReaderMessage):
-            self = .processingPayment
+            self = .card(.processingPayment)
         case .show(.paymentError):
             if case let .show(eventDetails) = cardPaymentEvent,
                case let .message(messageType) = PointOfSaleCardPresentPaymentEventPresentationStyle(
                 for: eventDetails,
                 dependencies: paymentEventPresentationStyleDependencies),
                case .validatingOrderError = messageType {
-                self = .validatingOrderError
+                self = .card(.validatingOrderError)
             } else {
-                self = .paymentError
+                self = .card(.paymentError)
             }
         case .show(.paymentCaptureError):
-            self = .paymentError
+            self = .card(.paymentError)
         case .show(.paymentSuccess):
-            self = .cardPaymentSuccessful
+            self = .card(.cardPaymentSuccessful)
         default:
             return nil
         }
@@ -47,16 +57,18 @@ extension PointOfSalePaymentState {
 
     var shownFullScreen: Bool {
         switch self {
-        case .processingPayment,
-                .paymentError,
-                .cardPaymentSuccessful:
+        case .card(.processingPayment),
+                .card(.paymentError),
+                .card(.cardPaymentSuccessful):
             return true
-        case .idle,
-                .validatingOrder,
-                .validatingOrderError,
-                .preparingReader,
-                .acceptingCard:
+        case .card(.idle),
+                .card(.validatingOrder),
+                .card(.validatingOrderError),
+                .card(.preparingReader),
+                .card(.acceptingCard):
             return false
+        case .cash:
+            return true
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -43,7 +43,7 @@ struct POSFloatingControlView: View {
             }
             .background(backgroundColor)
             .cornerRadius(Constants.cornerRadius)
-            .disabled(posModel.paymentState == .processingPayment)
+            .disabled(posModel.paymentState == .card(.processingPayment))
 
             CardReaderConnectionStatusView()
                 .foregroundStyle(fontColor)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct PointOfSaleCollectCashView: View {
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject private var posModel: PointOfSaleAggregateModel
     @FocusState private var isTextFieldFocused: Bool
@@ -32,7 +31,7 @@ struct PointOfSaleCollectCashView: View {
         VStack(alignment: .center, spacing: 20) {
             HStack {
                 Button(action: {
-                    dismiss()
+                    posModel.addMoreToCart()
                 }, label: {
                     VStack {
                         HStack {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -12,6 +12,8 @@ struct PointOfSaleCollectCashView: View {
 
     let orderTotal: String
 
+    let onCashPaymentComplete: (Result<Void, Error>) -> Void
+
     private var formattedOrderTotal: String {
         String.localizedStringWithFormat(Localization.backNavigationSubtitle, orderTotal)
     }
@@ -71,11 +73,10 @@ struct PointOfSaleCollectCashView: View {
                     isLoading = true
                     do {
                         try await markComplete()
-                        // TODO:
-                        // Redirect to success view on completion
-                        // https://github.com/woocommerce/woocommerce-ios/issues/14602
+                        onCashPaymentComplete(.success(()))
+                        dismiss()
                     } catch {
-                        debugPrint(error)
+                        onCashPaymentComplete(.failure((error)))
                     }
                     isLoading = false
                 }
@@ -111,11 +112,7 @@ struct PointOfSaleCollectCashView: View {
     }
 
     private func markComplete() async throws {
-        do {
-            try await posModel.collectCashPayment()
-        } catch {
-            debugPrint(error)
-        }
+        try await posModel.collectCashPayment()
     }
 }
 
@@ -162,7 +159,7 @@ private extension PointOfSaleCollectCashView {
         itemsController: PointOfSalePreviewItemsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController())
-    PointOfSaleCollectCashView(orderTotal: "$1.23")
+    PointOfSaleCollectCashView(orderTotal: "$1.23", onCashPaymentComplete: { _ in })
         .environmentObject(posModel)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -148,7 +148,7 @@ private extension PointOfSaleCollectCashView {
             comment: "Button to mark a cash payment as completed"
         )
         static let failedToCollectCashPayment = NSLocalizedString(
-            "pointOfSale.cashview.failedToCollectCashPayment",
+            "pointOfSale.cashview.failedToCollectCashPayment.draft",
             value: "Error trying to process payment. Try again.",
             comment: "Error message when the system fails to collect a cash payment."
         )

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -31,7 +31,9 @@ struct PointOfSaleCollectCashView: View {
         VStack(alignment: .center, spacing: 20) {
             HStack {
                 Button(action: {
-                    posModel.cancelCashPayment()
+                    Task { @MainActor in
+                        await posModel.cancelCashPayment()
+                    }
                 }, label: {
                     VStack {
                         HStack {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCollectCashView: View {
 
     let orderTotal: String
 
-    let onCashPaymentComplete: (Result<Void, Error>) -> Void
+    let onCashPaymentSuccess: () -> Void
 
     private var formattedOrderTotal: String {
         String.localizedStringWithFormat(Localization.backNavigationSubtitle, orderTotal)
@@ -73,10 +73,10 @@ struct PointOfSaleCollectCashView: View {
                     isLoading = true
                     do {
                         try await markComplete()
-                        onCashPaymentComplete(.success(()))
+                        onCashPaymentSuccess()
                         dismiss()
                     } catch {
-                        onCashPaymentComplete(.failure((error)))
+                        errorMessage = Localization.failedToCollectCashPayment
                     }
                     isLoading = false
                 }
@@ -150,6 +150,12 @@ private extension PointOfSaleCollectCashView {
             value: "Mark payment as complete",
             comment: "Button to mark a cash payment as completed"
         )
+        static let failedToCollectCashPayment = NSLocalizedString(
+            "pointOfSale.cashview.failedToCollectCashPayment",
+            value: "Error trying to process payment. Try again.",
+            comment: "Error message when the system fails to collect a cash payment."
+        )
+        
     }
 }
 
@@ -159,7 +165,7 @@ private extension PointOfSaleCollectCashView {
         itemsController: PointOfSalePreviewItemsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController())
-    PointOfSaleCollectCashView(orderTotal: "$1.23", onCashPaymentComplete: { _ in })
+    PointOfSaleCollectCashView(orderTotal: "$1.23", onCashPaymentSuccess: { })
         .environmentObject(posModel)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -70,7 +70,6 @@ struct PointOfSaleCollectCashView: View {
                     isLoading = true
                     do {
                         try await markComplete()
-                        posModel.cashPaymentSuccess()
                     } catch {
                         errorMessage = Localization.failedToCollectCashPayment
                     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -31,7 +31,7 @@ struct PointOfSaleCollectCashView: View {
         VStack(alignment: .center, spacing: 20) {
             HStack {
                 Button(action: {
-                    posModel.addMoreToCart()
+                    posModel.cancelCashPayment()
                 }, label: {
                     VStack {
                         HStack {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -31,7 +31,9 @@ struct PointOfSaleCollectCashView: View {
         VStack(alignment: .center, spacing: 20) {
             HStack {
                 Button(action: {
-                    posModel.cancelCashPayment()
+                    Task { @MainActor in
+                        try await posModel.cancelCashPayment()
+                    }
                 }, label: {
                     VStack {
                         HStack {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -31,9 +31,7 @@ struct PointOfSaleCollectCashView: View {
         VStack(alignment: .center, spacing: 20) {
             HStack {
                 Button(action: {
-                    Task { @MainActor in
-                        try await posModel.cancelCashPayment()
-                    }
+                    posModel.cancelCashPayment()
                 }, label: {
                     VStack {
                         HStack {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -12,8 +12,6 @@ struct PointOfSaleCollectCashView: View {
 
     let orderTotal: String
 
-    let onCashPaymentSuccess: () -> Void
-
     private var formattedOrderTotal: String {
         String.localizedStringWithFormat(Localization.backNavigationSubtitle, orderTotal)
     }
@@ -73,8 +71,7 @@ struct PointOfSaleCollectCashView: View {
                     isLoading = true
                     do {
                         try await markComplete()
-                        onCashPaymentSuccess()
-                        dismiss()
+                        posModel.cashPaymentSuccess()
                     } catch {
                         errorMessage = Localization.failedToCollectCashPayment
                     }
@@ -164,7 +161,7 @@ private extension PointOfSaleCollectCashView {
         itemsController: PointOfSalePreviewItemsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController())
-    PointOfSaleCollectCashView(orderTotal: "$1.23", onCashPaymentSuccess: { })
+    PointOfSaleCollectCashView(orderTotal: "$1.23")
         .environmentObject(posModel)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -155,7 +155,6 @@ private extension PointOfSaleCollectCashView {
             value: "Error trying to process payment. Try again.",
             comment: "Error message when the system fails to collect a cash payment."
         )
-        
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -41,7 +41,7 @@ struct PointOfSaleDashboardView: View {
         .environment(\.floatingControlAreaSize,
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))
-        .environment(\.posBackgroundAppearance, posModel.paymentState != .processingPayment ? .primary : .secondary)
+        .environment(\.posBackgroundAppearance, posModel.paymentState != .card(.processingPayment) ? .primary : .secondary)
         .animation(.easeInOut, value: posModel.itemsViewState.containerState == .loading)
         .background(Color.posPrimaryBackground)
         .navigationBarBackButtonHidden(true)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -26,9 +26,6 @@ struct TotalsView: View {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.colorScheme) var colorScheme
 
-    @State private var shouldShowCollectCashPayment: Bool = false
-    @State private var shouldShowPaymentSuccessView: Bool = false
-
     var body: some View {
         HStack {
             switch posModel.orderState {
@@ -39,7 +36,7 @@ struct TotalsView: View {
 
                     VStack(alignment: .center, spacing: Constants.verticalSpacing) {
                         if isShowingCardReaderStatus {
-                            cardReaderView
+                            paymentView
                                 .font(.title)
                                 .padding([.leading, .trailing],
                                          dynamicTypeSize.isAccessibilitySize ? nil :
@@ -62,7 +59,7 @@ struct TotalsView: View {
                                 .layoutPriority(2)
                         }
                         Button(action: {
-                            shouldShowCollectCashPayment = true
+                            posModel.startCashPayment()
                         }, label: {
                             Text(Localization.cashPaymentButtonTitle)
                                 .font(POSFontStyle.posBodyEmphasized)
@@ -89,23 +86,6 @@ struct TotalsView: View {
             isShowingTotalsFields = shouldShowTotalsFields
         }
         .onChange(of: shouldShowTotalsFields, perform: hideTotalsFieldsWithDelay)
-        .fullScreenCover(isPresented: $shouldShowPaymentSuccessView) {
-            if case .loaded(let total) = posModel.orderState {
-                let viewModel = PointOfSaleCardPresentPaymentSuccessMessageViewModel(formattedOrderTotal: total.orderTotal)
-                PointOfSaleCardPresentPaymentInLineMessage(messageType: .paymentSuccess(viewModel: viewModel))
-                    .matchedGeometryEffect(id: Constants.matchedGeometryCashId,
-                                           in: totalsFieldAnimation)
-            }
-        }
-        .fullScreenCover(isPresented: $shouldShowCollectCashPayment) {
-            if case .loaded(let total) = posModel.orderState {
-                PointOfSaleCollectCashView(orderTotal: total.orderTotal, onCashPaymentSuccess: {
-                    shouldShowPaymentSuccessView = true
-                })
-                .matchedGeometryEffect(id: Constants.matchedGeometryCashId,
-                                       in: totalsFieldAnimation)
-            }
-        }
         .geometryGroupIfSupported()
     }
 
@@ -234,23 +214,31 @@ private extension TotalsView {
 
 private extension TotalsView {
 
-    @ViewBuilder private var cardReaderView: some View {
-        switch posModel.cardReaderConnectionStatus {
-        case .connected, .disconnecting, .cancellingConnection:
-            if let inlinePaymentMessage = posModel.cardPresentPaymentInlineMessage {
-                HStack(alignment: .center) {
-                    Spacer()
-                    PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
-                    Spacer()
+    @ViewBuilder private var paymentView: some View {
+        switch posModel.paymentState {
+        case .card(let cardPaymentState):
+            switch posModel.cardReaderConnectionStatus {
+            case .connected, .disconnecting, .cancellingConnection:
+                if let inlinePaymentMessage = posModel.cardPresentPaymentInlineMessage {
+                    HStack(alignment: .center) {
+                        Spacer()
+                        PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
+                        Spacer()
+                    }
+                } else {
+                    EmptyView()
                 }
-            } else {
-                EmptyView()
+            case .disconnected:
+                PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
+                    posModel.connectCardReader()
+                }
             }
-        case .disconnected:
-            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
-                posModel.connectCardReader()
+        case .cash(let cashPaymentState):
+            if case .loaded(let total) = posModel.orderState {
+                PointOfSaleCollectCashView(orderTotal: total.orderTotal, onCashPaymentSuccess: { })
             }
         }
+
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -59,7 +59,9 @@ struct TotalsView: View {
                                 .layoutPriority(2)
                         }
                         Button(action: {
-                            posModel.startCashPayment()
+                            Task { @MainActor in
+                                await posModel.startCashPayment()
+                            }
                         }, label: {
                             Text(Localization.cashPaymentButtonTitle)
                                 .font(POSFontStyle.posBodyEmphasized)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -20,7 +20,7 @@ struct TotalsView: View {
     private var shouldShowCollectCashPaymentButton: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.acceptCashForPointOfSale) &&
         posModel.orderState != .syncing &&
-        (posModel.paymentState == .idle || posModel.paymentState == .acceptingCard)
+        (posModel.paymentState == .card(.idle) || posModel.paymentState == .card(.acceptingCard))
     }
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -111,9 +111,9 @@ struct TotalsView: View {
 
     private var backgroundColor: Color {
         switch posModel.paymentState {
-        case .cardPaymentSuccessful:
+        case .card(.cardPaymentSuccessful):
             .posSecondaryBackground
-        case .processingPayment:
+        case .card(.processingPayment):
             colorScheme == .light ? Color(.wooCommercePurple(.shade70)) : Color(.wooCommercePurple(.shade10))
         default:
             .clear
@@ -221,7 +221,7 @@ private extension TotalsView {
     /// Hide totals fields with animation after a delay when starting to processing a payment
     /// - Parameter isShowing
     private func hideTotalsFieldsWithDelay(_ isShowing: Bool) {
-        guard !isShowing && posModel.paymentState == .processingPayment else {
+        guard !isShowing && posModel.paymentState == .card(.processingPayment) else {
             self.isShowingTotalsFields = isShowing
             return
         }
@@ -303,16 +303,21 @@ private extension TotalsView {
         }
 
         switch posModel.paymentState {
-        case .validatingOrderError:
-            return .outlined
-        case .paymentError:
-            return .topAligned
-        case .idle,
-                .acceptingCard,
-                .validatingOrder,
-                .preparingReader,
-                .processingPayment,
-                .cardPaymentSuccessful:
+        case .card(let cardPaymentState):
+            switch cardPaymentState {
+            case .validatingOrderError:
+                return .outlined
+            case .paymentError:
+                return .topAligned
+            case .idle,
+                    .acceptingCard,
+                    .validatingOrder,
+                    .preparingReader,
+                    .processingPayment,
+                    .cardPaymentSuccessful:
+                break
+            }
+        case .cash:
             break
         }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -234,11 +234,21 @@ private extension TotalsView {
                 }
             }
         case .cash(let cashPaymentState):
-            if case .loaded(let total) = posModel.orderState {
-                PointOfSaleCollectCashView(orderTotal: total.orderTotal, onCashPaymentSuccess: { })
+            switch cashPaymentState {
+            case .collectingCash:
+                if case .loaded(let total) = posModel.orderState {
+                    PointOfSaleCollectCashView(orderTotal: total.orderTotal)
+                }
+            case .paymentSuccess:
+                if case .loaded(let total) = posModel.orderState {
+                    HStack(alignment: .center) {
+                        Spacer()
+                        PointOfSaleCardPresentPaymentInLineMessage(messageType: .paymentSuccess(viewModel: .init(formattedOrderTotal: total.orderTotal)))
+                        Spacer()
+                    }
+                }
             }
         }
-
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -27,6 +27,7 @@ struct TotalsView: View {
     @Environment(\.colorScheme) var colorScheme
 
     @State private var shouldShowCollectCashPayment: Bool = false
+    @State private var shouldShowPaymentSuccessView: Bool = false
 
     var body: some View {
         HStack {
@@ -88,11 +89,27 @@ struct TotalsView: View {
             isShowingTotalsFields = shouldShowTotalsFields
         }
         .onChange(of: shouldShowTotalsFields, perform: hideTotalsFieldsWithDelay)
-        .fullScreenCover(isPresented: $shouldShowCollectCashPayment) {
+        .fullScreenCover(isPresented: $shouldShowPaymentSuccessView) {
             if case .loaded(let total) = posModel.orderState {
-                PointOfSaleCollectCashView(orderTotal: total.orderTotal)
+                let viewModel = PointOfSaleCardPresentPaymentSuccessMessageViewModel(formattedOrderTotal: total.orderTotal)
+                PointOfSaleCardPresentPaymentInLineMessage(messageType: .paymentSuccess(viewModel: viewModel))
                     .matchedGeometryEffect(id: Constants.matchedGeometryCashId,
                                            in: totalsFieldAnimation)
+            }
+        }
+        .fullScreenCover(isPresented: $shouldShowCollectCashPayment) {
+            if case .loaded(let total) = posModel.orderState {
+                PointOfSaleCollectCashView(orderTotal: total.orderTotal, onCashPaymentComplete: { cashPaymentResult in
+                    switch cashPaymentResult {
+                    case .success:
+                        shouldShowPaymentSuccessView = true
+                    case .failure:
+                        // TODO: Present error
+                        shouldShowCollectCashPayment = false
+                    }
+                })
+                .matchedGeometryEffect(id: Constants.matchedGeometryCashId,
+                                       in: totalsFieldAnimation)
             }
         }
         .geometryGroupIfSupported()

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -99,14 +99,8 @@ struct TotalsView: View {
         }
         .fullScreenCover(isPresented: $shouldShowCollectCashPayment) {
             if case .loaded(let total) = posModel.orderState {
-                PointOfSaleCollectCashView(orderTotal: total.orderTotal, onCashPaymentComplete: { cashPaymentResult in
-                    switch cashPaymentResult {
-                    case .success:
-                        shouldShowPaymentSuccessView = true
-                    case .failure:
-                        // TODO: Present error
-                        shouldShowCollectCashPayment = false
-                    }
+                PointOfSaleCollectCashView(orderTotal: total.orderTotal, onCashPaymentSuccess: {
+                    shouldShowPaymentSuccessView = true
                 })
                 .matchedGeometryEffect(id: Constants.matchedGeometryCashId,
                                        in: totalsFieldAnimation)

--- a/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
@@ -26,14 +26,19 @@ final class CartViewHelper {
 private extension PointOfSalePaymentState {
     var allowsCartEditing: Bool {
         switch self {
-        case .processingPayment,
-                .paymentError,
-                .cardPaymentSuccessful,
-                .validatingOrder,
-                .preparingReader:
+        case .card(let cardPaymentState):
+            switch cardPaymentState {
+            case .processingPayment,
+                    .paymentError,
+                    .cardPaymentSuccessful,
+                    .validatingOrder,
+                    .preparingReader:
+                return false
+            case .idle, .validatingOrderError, .acceptingCard:
+                return true
+            }
+        case .cash:
             return false
-        case .idle, .validatingOrderError, .acceptingCard:
-            return true
         }
     }
 }

--- a/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
@@ -3,15 +3,20 @@ import Foundation
 final class TotalsViewHelper {
     func shouldShowTotalsFields(for paymentState: PointOfSalePaymentState) -> Bool {
         switch paymentState {
-        case .idle,
-                .acceptingCard,
-                .validatingOrder,
-                .validatingOrderError,
-                .preparingReader:
-            return true
-        case .processingPayment,
-                .paymentError,
-                .cardPaymentSuccessful:
+        case .card(let cardPaymentState):
+            switch cardPaymentState {
+            case .idle,
+                    .acceptingCard,
+                    .validatingOrder,
+                    .validatingOrderError,
+                    .preparingReader:
+                return true
+            case .processingPayment,
+                    .paymentError,
+                    .cardPaymentSuccessful:
+                return false
+            }
+        case .cash:
             return false
         }
     }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -33,7 +33,7 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
                                                                                                                itemStates: [:])),
          orderStage: PointOfSaleOrderStage = .building,
          orderState: PointOfSaleOrderState = .idle,
-         paymentState: PointOfSalePaymentState = .idle) {
+         paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.cardReaderConnectionStatus = cardReaderConnectionStatus
         self.itemsViewState = itemsViewState
         self.orderStage = orderStage

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -306,13 +306,13 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == .cash(.collectingCash))
         }
 
-        @Test func cancelCashPayment_resets_payment_state_to_idle() {
+        @Test func cancelCashPayment_resets_payment_state_to_idle() async throws {
             // Given
             sut.startCashPayment()
             #expect(sut.paymentState == .cash(.collectingCash))
 
             // When
-            sut.cancelCashPayment()
+            try await sut.cancelCashPayment()
 
             // Then
             #expect(sut.paymentState == .card(.idle))
@@ -329,7 +329,7 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == .cash(.collectingCash))
 
             // When
-            sut.cancelCashPayment()
+            try await sut.cancelCashPayment()
 
             // Then
             #expect(sut.orderStage == .finalizing)

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -306,13 +306,13 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == .cash(.collectingCash))
         }
 
-        @Test func cancelCashPayment_resets_payment_state_to_idle() async throws {
+        @Test func cancelCashPayment_resets_payment_state_to_idle() {
             // Given
             sut.startCashPayment()
             #expect(sut.paymentState == .cash(.collectingCash))
 
             // When
-            try await sut.cancelCashPayment()
+            sut.cancelCashPayment()
 
             // Then
             #expect(sut.paymentState == .card(.idle))
@@ -329,7 +329,7 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == .cash(.collectingCash))
 
             // When
-            try await sut.cancelCashPayment()
+            sut.cancelCashPayment()
 
             // Then
             #expect(sut.orderStage == .finalizing)

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -298,6 +298,22 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentInlineMessage == nil)
         }
 
+        @Test func startCashPayment_sets_payment_state_to_collectingCash() {
+            // When
+            sut.startCashPayment()
+
+            // Then
+            #expect(sut.paymentState == .cash(.collectingCash))
+        }
+
+        @Test func cashPaymentSuccess_sets_payment_state_to_paymentSuccess() {
+            // When
+            sut.cashPaymentSuccess()
+
+            // Then
+            #expect(sut.paymentState == .cash(.paymentSuccess))
+        }
+
         @Test func cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async throws {
             // Given order totals:
             // Note that orderTotal is used, but the Order values are given for test robustness.

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -306,6 +306,35 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == .cash(.collectingCash))
         }
 
+        @Test func cancelCashPayment_resets_payment_state_to_idle() {
+            // Given
+            sut.startCashPayment()
+            #expect(sut.paymentState == .cash(.collectingCash))
+
+            // When
+            sut.cancelCashPayment()
+
+            // Then
+            #expect(sut.paymentState == .card(.idle))
+        }
+
+        @Test func cancelCashPayment_maintains_order_stage_as_finalizing() async throws {
+            // Given
+            #expect(sut.orderStage == .building)
+
+            await sut.checkOut()
+            #expect(sut.orderStage == .finalizing)
+
+            sut.startCashPayment()
+            #expect(sut.paymentState == .cash(.collectingCash))
+
+            // When
+            sut.cancelCashPayment()
+
+            // Then
+            #expect(sut.orderStage == .finalizing)
+        }
+
         @Test func cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async throws {
             // Given order totals:
             // Note that orderTotal is used, but the Order values are given for test robustness.

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -298,21 +298,30 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentInlineMessage == nil)
         }
 
-        @Test func startCashPayment_sets_payment_state_to_collectingCash() {
+        @Test func startCashPayment_calls_for_ongoing_card_payment_cancellation() async {
             // When
-            sut.startCashPayment()
+            await sut.startCashPayment()
+
+            // Then
+            #expect(cardPresentPaymentService.cancelPaymentCalled == true)
+            #expect(sut.paymentState == .cash(.collectingCash))
+        }
+
+        @Test func startCashPayment_sets_payment_state_to_collectingCash() async {
+            // When
+            await sut.startCashPayment()
 
             // Then
             #expect(sut.paymentState == .cash(.collectingCash))
         }
 
-        @Test func cancelCashPayment_resets_payment_state_to_idle() {
+        @Test func cancelCashPayment_resets_payment_state_to_idle() async {
             // Given
-            sut.startCashPayment()
+            await sut.startCashPayment()
             #expect(sut.paymentState == .cash(.collectingCash))
 
             // When
-            sut.cancelCashPayment()
+            await sut.cancelCashPayment()
 
             // Then
             #expect(sut.paymentState == .card(.idle))
@@ -325,11 +334,11 @@ struct PointOfSaleAggregateModelTests {
             await sut.checkOut()
             #expect(sut.orderStage == .finalizing)
 
-            sut.startCashPayment()
+            await sut.startCashPayment()
             #expect(sut.paymentState == .cash(.collectingCash))
 
             // When
-            sut.cancelCashPayment()
+            await sut.cancelCashPayment()
 
             // Then
             #expect(sut.orderStage == .finalizing)

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -229,7 +229,7 @@ struct PointOfSaleAggregateModelTests {
                 orderController: orderController)
         }
 
-        @Test func init_sets_paymentState_to_idle() async throws {
+        @Test func init_sets_card_paymentState_to_idle() async throws {
             // Given that we don't specify a payment state
             // When we init
             let sut = PointOfSaleAggregateModel(
@@ -238,22 +238,22 @@ struct PointOfSaleAggregateModelTests {
                 orderController: orderController)
 
             // Then
-            #expect(sut.paymentState == .idle)
+            #expect(sut.paymentState == .card(.idle))
         }
 
-        @Test func startNewCart_sets_payment_state_to_idle() async throws {
+        @Test func startNewCart_sets_card_payment_state_to_idle() async throws {
             // Given
             let sut = PointOfSaleAggregateModel(
                 itemsController: itemsController,
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                paymentState: .cardPaymentSuccessful)
+                paymentState: .card(.cardPaymentSuccessful))
 
             // When
             sut.startNewCart()
 
             // Then
-            #expect(sut.paymentState == .idle)
+            #expect(sut.paymentState == .card(.idle))
         }
 
         @Test func startNewCart_sets_payment_message_to_nil() async throws {
@@ -268,19 +268,19 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentInlineMessage == nil)
         }
 
-        @Test func addMoreToCart_sets_payment_state_to_idle() async throws {
+        @Test func addMoreToCart_sets_card_payment_state_to_idle() async throws {
             // Given
             let sut = PointOfSaleAggregateModel(
                 itemsController: itemsController,
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                paymentState: .cardPaymentSuccessful)
+                paymentState: .card(.cardPaymentSuccessful))
 
             // When
             sut.addMoreToCart()
 
             // Then
-            #expect(sut.paymentState == .idle)
+            #expect(sut.paymentState == .card(.idle))
         }
 
         @Test func addMoreToCart_sets_payment_message_to_nil() async throws {

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -306,14 +306,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == .cash(.collectingCash))
         }
 
-        @Test func cashPaymentSuccess_sets_payment_state_to_paymentSuccess() {
-            // When
-            sut.cashPaymentSuccess()
-
-            // Then
-            #expect(sut.paymentState == .cash(.paymentSuccess))
-        }
-
         @Test func cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async throws {
             // Given order totals:
             // Note that orderTotal is used, but the Order values are given for test robustness.

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewHelperTests.swift
@@ -5,15 +5,15 @@ import Testing
 struct CartViewHelperTests {
     let sut = CartViewHelper()
 
-    @Test func shouldPreventCartEditing_when_paymentState_idle_and_order_is_syncing() async throws {
+    @Test func shouldPreventCartEditing_when_card_paymentState_idle_and_order_is_syncing() async throws {
         // Given
 
         // When, Then
         #expect(sut.shouldPreventCartEditing(orderState: .syncing,
-                                             paymentState: .idle) == true)
+                                             paymentState: .card(.idle)) == true)
     }
 
-    @Test func shouldPreventCartEditing_when_paymentState_cardPaymentSuccessful() async throws {
+    @Test func shouldPreventCartEditing_when_card_paymentState_cardPaymentSuccessful() async throws {
         // Given
         let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
             cartTotal: "$10.00",
@@ -22,10 +22,10 @@ struct CartViewHelperTests {
 
         // When, Then
         #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
-                                             paymentState: .cardPaymentSuccessful) == true)
+                                             paymentState: .card(.cardPaymentSuccessful)) == true)
     }
 
-    @Test func shouldPreventCartEditing_when_paymentState_processingPayment() async throws {
+    @Test func shouldPreventCartEditing_when_card_paymentState_processingPayment() async throws {
         // Given
         let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
             cartTotal: "$10.00",
@@ -34,10 +34,10 @@ struct CartViewHelperTests {
 
         // When, Then
         #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
-                                             paymentState: .processingPayment) == true)
+                                             paymentState: .card(.processingPayment)) == true)
     }
 
-    @Test func shouldPreventCartEditing_false_when_paymentState_acceptingCard() async throws {
+    @Test func shouldPreventCartEditing_false_when_card_paymentState_acceptingCard() async throws {
         // Given
         let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
             cartTotal: "$10.00",
@@ -46,10 +46,10 @@ struct CartViewHelperTests {
 
         // When, Then
         #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
-                                             paymentState: .acceptingCard) == false)
+                                             paymentState: .card(.acceptingCard)) == false)
     }
 
-    @Test func shouldPreventCartEditing_false_when_paymentState_validatingOrderError() async throws {
+    @Test func shouldPreventCartEditing_false_when_card_paymentState_validatingOrderError() async throws {
         // Given
         let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
             cartTotal: "$10.00",
@@ -58,7 +58,7 @@ struct CartViewHelperTests {
 
         // When, Then
         #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
-                                             paymentState: .validatingOrderError) == false)
+                                             paymentState: .card(.validatingOrderError)) == false)
     }
 
     @Test(arguments: zip([0, 1, 2, 3], [nil, "1 item", "2 items", "3 items"]))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14602

## Description
This PR addresses POS navigation when we attempt to collect a cash payment for an order:
- Upon success, the success view is presented, and we can proceed to send a receipt or start a new order.
- Upon failure, an error message is presented, and we remain in the cash collection view.

Currently we're using the `PointOfSaleCardPresentPaymentSuccessMessageView` for both card payments and cash payments success scenarios, and the different `PointOfSaleCardPresentPaymentMessageType` cases are tied to the card payment state. 

I've approached this without touching the card payment state or the card service but by introducing a property to react alongside the card payment messages and leaving the completion handling to the app side, as the POS does nothing regarding cash. Happy to iterate as needed, as another option could be to use some sort of `PaymentResult` state to track both card or cash state as needed.

## Testing
- Enable the `.acceptCashForPointOfSale` flag
- Add items to the cart > checkout > tap "Cash payment"
- Add any value to the textfield, or none, tap on "Mark order as completed"
- Observe that the success view is presented, and we can either send a receipt or start a new order
- Repeat the process by throwing an error on:
```
    private func markComplete() async throws {
        try await posModel.collectCashPayment()
    }
```
- Observe that the error message is presented, and disappears once we start typing any value in the text field

### Error:

https://github.com/user-attachments/assets/02c8f446-e8a4-43a4-8901-35c8194d7a04

### Success:

https://github.com/user-attachments/assets/4edb7cf4-d921-4b6e-9306-38f4ed85aaa3


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
