### PR TITLE
HACK Week: Update Yosemite to support persisting order filter history

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		DE50296728C7114800551736 /* JetpackConnectionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */; };
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
 		DE87F4042D2BC93100869522 /* OrderFilterHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE87F4032D2BC92600869522 /* OrderFilterHistory.swift */; };
+		DE87F4062D2BD49700869522 /* AppSettingsStoreTests+OrderFilterHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE87F4052D2BD49700869522 /* AppSettingsStoreTests+OrderFilterHistory.swift */; };
 		DEA493922B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */; };
 		DEA493942B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */; };
 		DEA493962B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */; };
@@ -1022,6 +1023,7 @@
 		DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionStoreTests.swift; sourceTree = "<group>"; };
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
 		DE87F4032D2BC92600869522 /* OrderFilterHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderFilterHistory.swift; sourceTree = "<group>"; };
+		DE87F4052D2BD49700869522 /* AppSettingsStoreTests+OrderFilterHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettingsStoreTests+OrderFilterHistory.swift"; sourceTree = "<group>"; };
 		DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetDevice+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetLanguage+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetTopic+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1777,6 +1779,7 @@
 				0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */,
 				312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */,
 				455A931C2747C19300259C7F /* AppSettingsStoreTests+OrdersSettings.swift */,
+				DE87F4052D2BD49700869522 /* AppSettingsStoreTests+OrderFilterHistory.swift */,
 				458C6DE725ACC554009B300D /* AppSettingsStoreTests+ProductsSettings.swift */,
 				B5BC736720D1AA8F00B5B6FA /* AccountStoreTests.swift */,
 				D88303E825E459DC00C877F9 /* CardPresentPaymentStoreTests.swift */,
@@ -2707,6 +2710,7 @@
 				027CC11129F7AAEA00614B6E /* MockGenerativeContentRemote.swift in Sources */,
 				02DF98092A136BFB0009E2EA /* MockSitePluginsRemote.swift in Sources */,
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,
+				DE87F4062D2BD49700869522 /* AppSettingsStoreTests+OrderFilterHistory.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockAcountStore.swift in Sources */,
 				312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */,
 				453954DC2C91F79B00A3E64A /* MetaDataStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -478,6 +478,7 @@
 		DE423F3A2D0AD08600116F1B /* ReadOnlyConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE423F392D0AD07C00116F1B /* ReadOnlyConvertibleTests.swift */; };
 		DE50296728C7114800551736 /* JetpackConnectionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */; };
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
+		DE87F4042D2BC93100869522 /* OrderFilterHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE87F4032D2BC92600869522 /* OrderFilterHistory.swift */; };
 		DEA493922B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */; };
 		DEA493942B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */; };
 		DEA493962B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */; };
@@ -1020,6 +1021,7 @@
 		DE423F392D0AD07C00116F1B /* ReadOnlyConvertibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyConvertibleTests.swift; sourceTree = "<group>"; };
 		DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionStoreTests.swift; sourceTree = "<group>"; };
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
+		DE87F4032D2BC92600869522 /* OrderFilterHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderFilterHistory.swift; sourceTree = "<group>"; };
 		DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetDevice+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetLanguage+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetTopic+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1380,6 +1382,7 @@
 			children = (
 				4591A6AF274BB23000F51DCD /* OrderDateRangeFilter.swift */,
 				4591A6B3274BB29000F51DCD /* StoredOrderSettings.swift */,
+				DE87F4032D2BC92600869522 /* OrderFilterHistory.swift */,
 				EE9D030D2B88550F0077CED1 /* FilterOrdersByProduct.swift */,
 				86BB4C952B89FCF30096E92D /* CustomerFilter.swift */,
 				016EFCAD2C4155650016BDAA /* OrderItem+BasePrice.swift */,
@@ -2500,6 +2503,7 @@
 				CC24A4F129ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift in Sources */,
 				03101F0129DD7D9D00769CF3 /* CardReaderType+ReadOnlyConvertible.swift in Sources */,
 				CE4FD4502350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift in Sources */,
+				DE87F4042D2BC93100869522 /* OrderFilterHistory.swift in Sources */,
 				02FF055123D983F30058E6E7 /* MediaAssetExporter.swift in Sources */,
 				073AF84427DB10270074EDF0 /* CardPresentPaymentGatewayExtension.swift in Sources */,
 				B9AECD3C2850F3C600E78584 /* OrderCardPresentPaymentEligibilityStore.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -57,14 +57,14 @@ public enum AppSettingsAction: Action {
     case upsertOrderFilterHistory(filter: StoredOrderSettings.Setting,
                                   onCompletion: (Error?) -> Void)
 
-    /// Retrieves all persisted order filters
+    /// Retrieves all persisted order filters for a given site
     case loadOrderFilterHistory(siteID: Int64, onCompletion: (Result<[StoredOrderSettings.Setting], Error>) -> Void)
 
     /// Removes a filter from the persisted history
     case removeFromOrderFilterHistory(filter: StoredOrderSettings.Setting,
                                       onCompletion: (Error?) -> Void)
 
-    /// Clears all the order filter history
+    /// Clears all the order filter history for a given site
     case resetOrderFilterHistory(siteID: Int64, onCompletion: (Error?) -> Void)
 
     // MARK: - Products Settings

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -53,14 +53,14 @@ public enum AppSettingsAction: Action {
 
     // MARK: - Order filter history
 
-    /// Insert or update the order filter history
+    /// Inserts or updates the order filter history
     case upsertOrderFilterHistory(filter: StoredOrderSettings.Setting,
                                   onCompletion: (Error?) -> Void)
 
     /// Retrieves all persisted order filters
     case loadOrderFilterHistory(siteID: Int64, onCompletion: (Result<[StoredOrderSettings.Setting], Error>) -> Void)
 
-    /// Remove a filter from the persisted history
+    /// Removes a filter from the persisted history
     case removeFromOrderFilterHistory(filter: StoredOrderSettings.Setting,
                                       onCompletion: (Error?) -> Void)
 

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -51,6 +51,22 @@ public enum AppSettingsAction: Action {
     ///
     case resetOrdersSettings
 
+    // MARK: - Order filter history
+
+    /// Insert or update the order filter history
+    case upsertOrderFilterHistory(filter: StoredOrderSettings.Setting,
+                                  onCompletion: (Error?) -> Void)
+
+    /// Retrieves all persisted order filters
+    case loadOrderFilterHistory(siteID: Int64, onCompletion: (Result<[StoredOrderSettings.Setting], Error>) -> Void)
+
+    /// Remove a filter from the persisted history
+    case removeFromOrderFilterHistory(filter: StoredOrderSettings.Setting,
+                                      onCompletion: (Error?) -> Void)
+
+    /// Clears all the order filter history
+    case resetOrderFilterHistory(siteID: Int64, onCompletion: (Error?) -> Void)
+
     // MARK: - Products Settings
 
     /// Loads the products settings

--- a/Yosemite/Yosemite/Model/Orders/OrderFilterHistory.swift
+++ b/Yosemite/Yosemite/Model/Orders/OrderFilterHistory.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Models a pair of `siteID` and list of order settings
+/// These entities will be serialized to a plist file using `AppSettingsStore`
+///
+public struct OrderFilterHistory: Codable, Equatable {
+    /// SiteID: settings
+    public let history: [Int64: [StoredOrderSettings.Setting]]
+
+    public init(history: [Int64: [StoredOrderSettings.Setting]]) {
+        self.history = history
+    }
+}

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -749,7 +749,7 @@ private extension AppSettingsStore {
         }
     }
 
-    /// Retrieves all persisted order filters
+    /// Retrieves all persisted order filters for a given site
     func loadOrderFilterHistory(siteID: Int64,
                                 onCompletion: @escaping (Result<[StoredOrderSettings.Setting], Error>) -> Void) {
         guard let allHistory: OrderFilterHistory = try? fileStorage.data(for: orderFilterHistoryURL),
@@ -786,7 +786,7 @@ private extension AppSettingsStore {
         }
     }
 
-    /// Clears all the order filter history for a given site ID
+    /// Clears all the order filter history for a given site
     func resetOrderFilterHistory(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         var existingHistory: [Int64: [StoredOrderSettings.Setting]] = [:]
         if let storedHistory: OrderFilterHistory = try? fileStorage.data(for: orderFilterHistoryURL) {

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -119,13 +119,13 @@ public class AppSettingsStore: Store {
         case .resetOrdersSettings:
             resetOrdersSettings()
         case let .upsertOrderFilterHistory(filter, onCompletion):
-            break // TODO
+            upsertOrderFilterHistory(filter: filter, onCompletion: onCompletion)
         case let .loadOrderFilterHistory(siteID, onCompletion):
-            break // TODO
+            loadOrderFilterHistory(siteID: siteID, onCompletion: onCompletion)
         case let .removeFromOrderFilterHistory(filter, onCompletion):
-            break // TODO
+            removeFromOrderFilterHistory(filter: filter, onCompletion: onCompletion)
         case let .resetOrderFilterHistory(siteID, onCompletion):
-            break // TODO
+            resetOrderFilterHistory(siteID: siteID, onCompletion: onCompletion)
         case .loadProductsSettings(let siteID, let onCompletion):
             loadProductsSettings(siteID: siteID, onCompletion: onCompletion)
         case .upsertProductsSettings(let siteID,
@@ -713,6 +713,32 @@ private extension AppSettingsStore {
         } catch {
             DDLogError("⛔️ Deleting the orders settings files failed. Error: \(error)")
         }
+    }
+}
+
+// MARK: - Order filter history
+private extension AppSettingsStore {
+    /// Inserts or update the order filter history
+    func upsertOrderFilterHistory(filter: StoredOrderSettings.Setting,
+                                  onCompletion: @escaping (Error?) -> Void) {
+        // TODO
+    }
+
+    /// Retrieves all persisted order filters
+    func loadOrderFilterHistory(siteID: Int64,
+                                onCompletion: @escaping (Result<[StoredOrderSettings.Setting], Error>) -> Void) {
+        // TODO
+    }
+
+    /// Removes a filter from the persisted history
+    func removeFromOrderFilterHistory(filter: StoredOrderSettings.Setting,
+                                      onCompletion: @escaping (Error?) -> Void) {
+        // TODO
+    }
+
+    /// Clears all the order filter history
+    func resetOrderFilterHistory(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
+        // TODO
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -118,6 +118,14 @@ public class AppSettingsStore: Store {
                                  onCompletion: onCompletion)
         case .resetOrdersSettings:
             resetOrdersSettings()
+        case let .upsertOrderFilterHistory(filter, onCompletion):
+            break // TODO
+        case let .loadOrderFilterHistory(siteID, onCompletion):
+            break // TODO
+        case let .removeFromOrderFilterHistory(filter, onCompletion):
+            break // TODO
+        case let .resetOrderFilterHistory(siteID, onCompletion):
+            break // TODO
         case .loadProductsSettings(let siteID, let onCompletion):
             loadProductsSettings(siteID: siteID, onCompletion: onCompletion)
         case .upsertProductsSettings(let siteID,

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -752,7 +752,14 @@ private extension AppSettingsStore {
     /// Retrieves all persisted order filters
     func loadOrderFilterHistory(siteID: Int64,
                                 onCompletion: @escaping (Result<[StoredOrderSettings.Setting], Error>) -> Void) {
-        // TODO
+        guard let allHistory: OrderFilterHistory = try? fileStorage.data(for: orderFilterHistoryURL),
+                let siteHistory = allHistory.history[siteID] else {
+            let error = AppSettingsStoreErrors.noOrderFilterHistory
+            onCompletion(.failure(error))
+            return
+        }
+
+        onCompletion(.success(siteHistory))
     }
 
     /// Removes a filter from the persisted history
@@ -1157,6 +1164,7 @@ enum AppSettingsStoreErrors: Error {
     case writePListToFileStorage
     case noOrdersSettings
     case noProductsSettings
+    case noOrderFilterHistory
     case writeOrdersSettings
     case writeProductsSettings
     case noEligibilityErrorInfo

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -786,12 +786,21 @@ private extension AppSettingsStore {
         }
     }
 
-    /// Clears all the order filter history
+    /// Clears all the order filter history for a given site ID
     func resetOrderFilterHistory(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
+        var existingHistory: [Int64: [StoredOrderSettings.Setting]] = [:]
+        if let storedHistory: OrderFilterHistory = try? fileStorage.data(for: orderFilterHistoryURL) {
+            existingHistory = storedHistory.history
+        }
+
+        existingHistory[siteID]?.removeAll()
+
+        let newStoredHistory = OrderFilterHistory(history: existingHistory)
         do {
-            try fileStorage.deleteFile(at: orderFilterHistoryURL)
+            try fileStorage.write(newStoredHistory, to: orderFilterHistoryURL)
+            onCompletion(nil)
         } catch {
-            DDLogError("⛔️ Deleting the orders settings files failed. Error: \(error)")
+            onCompletion(AppSettingsStoreErrors.writeOrderFilterHistory)
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -745,7 +745,7 @@ private extension AppSettingsStore {
             try fileStorage.write(newStoredHistory, to: orderFilterHistoryURL)
             onCompletion(nil)
         } catch {
-            onCompletion(AppSettingsStoreErrors.writeOrdersSettings)
+            onCompletion(AppSettingsStoreErrors.writeOrderFilterHistory)
         }
     }
 
@@ -765,12 +765,34 @@ private extension AppSettingsStore {
     /// Removes a filter from the persisted history
     func removeFromOrderFilterHistory(filter: StoredOrderSettings.Setting,
                                       onCompletion: @escaping (Error?) -> Void) {
-        // TODO
+        var existingHistory: [Int64: [StoredOrderSettings.Setting]] = [:]
+        if let storedHistory: OrderFilterHistory = try? fileStorage.data(for: orderFilterHistoryURL) {
+            existingHistory = storedHistory.history
+        }
+
+        guard let siteHistory = existingHistory[filter.siteID] else {
+            onCompletion(nil)
+            return
+        }
+
+        existingHistory[filter.siteID] = siteHistory.filter { $0 != filter }
+
+        let newStoredHistory = OrderFilterHistory(history: existingHistory)
+        do {
+            try fileStorage.write(newStoredHistory, to: orderFilterHistoryURL)
+            onCompletion(nil)
+        } catch {
+            onCompletion(AppSettingsStoreErrors.writeOrderFilterHistory)
+        }
     }
 
     /// Clears all the order filter history
     func resetOrderFilterHistory(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        // TODO
+        do {
+            try fileStorage.deleteFile(at: orderFilterHistoryURL)
+        } catch {
+            DDLogError("⛔️ Deleting the orders settings files failed. Error: \(error)")
+        }
     }
 }
 
@@ -1166,6 +1188,7 @@ enum AppSettingsStoreErrors: Error {
     case noProductsSettings
     case noOrderFilterHistory
     case writeOrdersSettings
+    case writeOrderFilterHistory
     case writeProductsSettings
     case noEligibilityErrorInfo
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -53,6 +53,12 @@ public class AppSettingsStore: Store {
         return documents!.appendingPathComponent(Constants.ordersSettings)
     }()
 
+    /// URL to the plist file containing the persisted order filter history
+    private lazy var orderFilterHistoryURL: URL = {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        return documents!.appendingPathComponent(Constants.orderFilterHistory)
+    }()
+
     /// URL to the plist file that we use to determine the settings applied in Products
     ///
     private lazy var productsSettingsURL: URL = {
@@ -721,7 +727,26 @@ private extension AppSettingsStore {
     /// Inserts or update the order filter history
     func upsertOrderFilterHistory(filter: StoredOrderSettings.Setting,
                                   onCompletion: @escaping (Error?) -> Void) {
-        // TODO
+        var existingHistory: [Int64: [StoredOrderSettings.Setting]] = [:]
+        if let storedHistory: OrderFilterHistory = try? fileStorage.data(for: orderFilterHistoryURL) {
+            existingHistory = storedHistory.history
+        }
+
+        var siteHistory = existingHistory[filter.siteID] ?? []
+        if siteHistory.contains(filter) {
+            siteHistory = [filter] + siteHistory.filter { $0 != filter } // move the filter to the top
+        } else {
+            siteHistory.append(filter)
+        }
+        existingHistory[filter.siteID] = siteHistory
+
+        let newStoredHistory = OrderFilterHistory(history: existingHistory)
+        do {
+            try fileStorage.write(newStoredHistory, to: orderFilterHistoryURL)
+            onCompletion(nil)
+        } catch {
+            onCompletion(AppSettingsStoreErrors.writeOrdersSettings)
+        }
     }
 
     /// Retrieves all persisted order filters
@@ -1150,4 +1175,5 @@ private enum Constants {
     static let generalStoreSettingsFileName = "general-store-settings.plist"
     static let ordersSettings = "orders-settings.plist"
     static let productsSettings = "products-settings.plist"
+    static let orderFilterHistory = "order-filter-history.plist"
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
@@ -1,0 +1,82 @@
+import Testing
+@testable import Yosemite
+@testable import Storage
+
+struct AppSettingsStoreTests_OrderFilterHistory {
+
+    /// Mock Dispatcher!
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Mock File Storage: Load data in memory
+    ///
+    private var fileStorage: MockInMemoryStorage!
+
+    /// Mock General Settings Storage: Load data in memory
+    ///
+    private var generalAppSettings: GeneralAppSettingsStorage!
+
+    init() {
+        dispatcher = Dispatcher()
+        storageManager = MockStorageManager()
+        fileStorage = MockInMemoryStorage()
+        generalAppSettings = GeneralAppSettingsStorage(fileStorage: fileStorage)
+    }
+
+    @MainActor
+    @Test func loadOrderFilterHistory_returns_correct_results_after_upserting() async throws {
+        // Given
+        let siteID: Int64 = 123
+        let filter = createMockFilter(siteID: siteID)
+        let subject = AppSettingsStore(dispatcher: dispatcher!,
+                                       storageManager: storageManager!,
+                                       fileStorage: fileStorage!,
+                                       generalAppSettings: generalAppSettings!)
+
+        // Confidence check
+        await #expect(throws: AppSettingsStoreErrors.noOrderFilterHistory) {
+            _ = try await withCheckedThrowingContinuation { continuation in
+                subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID) { result in
+                    continuation.resume(with: result)
+                })
+            }
+        }
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            subject.onAction(AppSettingsAction.upsertOrderFilterHistory(filter: filter, onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+        try #require(error == nil)
+
+        // Then
+        let resultAfterWritingAction: [StoredOrderSettings.Setting] = try await withCheckedThrowingContinuation { continuation in
+            subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID) { result in
+                continuation.resume(with: result)
+            })
+        }
+        #expect(resultAfterWritingAction == [filter])
+    }
+
+}
+
+private extension AppSettingsStoreTests_OrderFilterHistory {
+    func createMockFilter(siteID: Int64) -> StoredOrderSettings.Setting {
+        let orderStatuses: [OrderStatusEnum] = [.pending, .completed]
+        let startDate = Date().yearStart
+        let endDate = Date().yearEnd
+        let dateRange = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
+        let productFilter = FilterOrdersByProduct(id: 1, name: "Sample product")
+        let customerFilter = CustomerFilter(customer: Customer.fake().copy(customerID: 1))
+        return StoredOrderSettings.Setting(siteID: siteID,
+                                           orderStatusesFilter: orderStatuses,
+                                           dateRangeFilter: dateRange,
+                                           productFilter: productFilter,
+                                           customerFilter: customerFilter)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
@@ -30,8 +30,12 @@ struct AppSettingsStoreTests_OrderFilterHistory {
     @MainActor
     @Test func loadOrderFilterHistory_returns_correct_results_after_upserting() async throws {
         // Given
-        let siteID: Int64 = 123
-        let filter = createMockFilter(siteID: siteID)
+        let siteID1: Int64 = 123
+        let filter1 = createMockFilter(siteID: siteID1)
+
+        let siteID2: Int64 = 34
+        let filter2 = createMockFilter(siteID: siteID2)
+
         let subject = AppSettingsStore(dispatcher: dispatcher!,
                                        storageManager: storageManager!,
                                        fileStorage: fileStorage!,
@@ -40,34 +44,111 @@ struct AppSettingsStoreTests_OrderFilterHistory {
         // Confidence check
         await #expect(throws: AppSettingsStoreErrors.noOrderFilterHistory) {
             _ = try await withCheckedThrowingContinuation { continuation in
-                subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID) { result in
+                subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID1) { result in
                     continuation.resume(with: result)
                 })
             }
         }
 
+        // When inserting two filters for two sites
+        try await insertMockFilter(filter: filter1, using: subject)
+        try await insertMockFilter(filter: filter2, using: subject)
+
+        // Then
+        let resultAfterWritingAction = try await withCheckedThrowingContinuation { continuation in
+            subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID1) { result in
+                continuation.resume(with: result)
+            })
+        }
+        #expect(resultAfterWritingAction == [filter1])
+    }
+
+    @MainActor
+    @Test func loadOrderFilterHistory_returns_correct_results_after_removing_filter() async throws {
+        // Given
+        let siteID1: Int64 = 123
+        let filter1 = createMockFilter(siteID: siteID1, orderStatuses: [.pending])
+        let filter2 = createMockFilter(siteID: siteID1, orderStatuses: [.completed])
+
+        let subject = AppSettingsStore(dispatcher: dispatcher!,
+                                       storageManager: storageManager!,
+                                       fileStorage: fileStorage!,
+                                       generalAppSettings: generalAppSettings!)
+
+        try await insertMockFilter(filter: filter1, using: subject)
+        try await insertMockFilter(filter: filter2, using: subject)
+
+        // Confidence check
+        let initialResult = try await withCheckedThrowingContinuation { continuation in
+            subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID1) { result in
+                continuation.resume(with: result)
+            })
+        }
+        #expect(initialResult == [filter1, filter2])
+
         // When
         let error = await withCheckedContinuation { continuation in
-            subject.onAction(AppSettingsAction.upsertOrderFilterHistory(filter: filter, onCompletion: { error in
+            subject.onAction(AppSettingsAction.removeFromOrderFilterHistory(filter: filter1, onCompletion: { error in
                 continuation.resume(returning: error)
             }))
         }
         try #require(error == nil)
 
         // Then
-        let resultAfterWritingAction: [StoredOrderSettings.Setting] = try await withCheckedThrowingContinuation { continuation in
-            subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID) { result in
+        let resultAfterRemoval = try await withCheckedThrowingContinuation { continuation in
+            subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID1) { result in
                 continuation.resume(with: result)
             })
         }
-        #expect(resultAfterWritingAction == [filter])
+        #expect(resultAfterRemoval == [filter2])
     }
 
+    @MainActor
+    @Test func resetOrderFilterHistory_clears_all_persisted_history() async throws {
+        // Given
+        let siteID1: Int64 = 123
+        let filter1 = createMockFilter(siteID: siteID1)
+
+        let siteID2: Int64 = 34
+        let filter2 = createMockFilter(siteID: siteID2)
+
+        let subject = AppSettingsStore(dispatcher: dispatcher!,
+                                       storageManager: storageManager!,
+                                       fileStorage: fileStorage!,
+                                       generalAppSettings: generalAppSettings!)
+
+        try await insertMockFilter(filter: filter1, using: subject)
+        try await insertMockFilter(filter: filter2, using: subject)
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            subject.onAction(AppSettingsAction.resetOrderFilterHistory(siteID: siteID1, onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+        try #require(error == nil)
+
+        // Then
+        let site1Filters = try await withCheckedThrowingContinuation { continuation in
+            subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID1) { result in
+                continuation.resume(with: result)
+            })
+        }
+        #expect(site1Filters == [])
+
+        let site2Filters = try await withCheckedThrowingContinuation { continuation in
+            subject.onAction(AppSettingsAction.loadOrderFilterHistory(siteID: siteID2) { result in
+                continuation.resume(with: result)
+            })
+        }
+        #expect(site2Filters == [filter2])
+    }
 }
 
 private extension AppSettingsStoreTests_OrderFilterHistory {
-    func createMockFilter(siteID: Int64) -> StoredOrderSettings.Setting {
-        let orderStatuses: [OrderStatusEnum] = [.pending, .completed]
+    func createMockFilter(siteID: Int64,
+                          orderStatuses: [OrderStatusEnum] = [.pending, .completed]) -> StoredOrderSettings.Setting {
+        let orderStatuses = orderStatuses
         let startDate = Date().yearStart
         let endDate = Date().yearEnd
         let dateRange = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
@@ -78,5 +159,14 @@ private extension AppSettingsStoreTests_OrderFilterHistory {
                                            dateRangeFilter: dateRange,
                                            productFilter: productFilter,
                                            customerFilter: customerFilter)
+    }
+
+    func insertMockFilter(filter: StoredOrderSettings.Setting, using store: AppSettingsStore) async throws {
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(AppSettingsAction.upsertOrderFilterHistory(filter: filter, onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+        try #require(error == nil)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14791 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There's a feature request to re-apply filters used in the past for the order and product lists.

This PR updates `AppSettingsStore` and `AppSettingsAction` to support loading/persisting/removing order filter history and let users manage filters they used for the order list.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
The new actions haven't been integrated yet, so just CI passing should be sufficient.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Unit tests were added for loading, removing, and resetting filters.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.