### PR TITLE
Package selection enhancements UI - part 2

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -140,10 +140,10 @@ struct WooCarrierPackagesSelectionView: View {
                 addPackageButtonTapped()
             }
             .disabled(selectionButtonDisabled)
-            .if(viewModel.previousSelectedSelectedCarriersPackageAreSame) {
+            .if(viewModel.previousSelectedAndSelectedCarriersPackageAreSame) {
                 $0.buttonStyle(SecondaryButtonStyle())
             }
-            .if(!viewModel.previousSelectedSelectedCarriersPackageAreSame) {
+            .if(!viewModel.previousSelectedAndSelectedCarriersPackageAreSame) {
                 $0.buttonStyle(PrimaryButtonStyle())
             }
             .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -140,7 +140,12 @@ struct WooCarrierPackagesSelectionView: View {
                 addPackageButtonTapped()
             }
             .disabled(selectionButtonDisabled)
-            .buttonStyle(PrimaryButtonStyle())
+            .if(viewModel.previousSelectedSelectedCarriersPackageAreSame) {
+                $0.buttonStyle(SecondaryButtonStyle())
+            }
+            .if(!viewModel.previousSelectedSelectedCarriersPackageAreSame) {
+                $0.buttonStyle(PrimaryButtonStyle())
+            }
             .padding()
         }
     }
@@ -152,6 +157,12 @@ struct WooCarrierPackagesSelectionView: View {
     private var selectionButtonText: String {
         if selectionButtonDisabled {
             return WooShippingAddPackageView.Localization.selectPackage
+        }
+        if let previousSelectedPackage = viewModel.previousSelectedPackage {
+            if previousSelectedPackage.id == viewModel.selectedCarriersPackageId {
+                return WooShippingAddPackageView.Localization.done
+            }
+            return WooShippingAddPackageView.Localization.useSelectedPackage
         }
         return WooShippingAddPackageView.Localization.addPackage
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -151,7 +151,12 @@ struct WooSavedPackagesSelectionView: View {
                 addPackageButtonTapped()
             }
             .disabled(selectionButtonDisabled)
-            .buttonStyle(PrimaryButtonStyle())
+            .if(viewModel.previousSelectedSelectedSavedPackageAreSame) {
+                $0.buttonStyle(SecondaryButtonStyle())
+            }
+            .if(!viewModel.previousSelectedSelectedSavedPackageAreSame) {
+                $0.buttonStyle(PrimaryButtonStyle())
+            }
             .padding()
         }
     }
@@ -163,6 +168,12 @@ struct WooSavedPackagesSelectionView: View {
     private var selectionButtonText: String {
         if selectionButtonDisabled {
             return WooShippingAddPackageView.Localization.selectPackage
+        }
+        if let previousSelectedPackage = viewModel.previousSelectedPackage {
+            if previousSelectedPackage.id == viewModel.selectedSavedPackageId {
+                return WooShippingAddPackageView.Localization.done
+            }
+            return WooShippingAddPackageView.Localization.useSelectedPackage
         }
         return WooShippingAddPackageView.Localization.addPackage
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -151,10 +151,10 @@ struct WooSavedPackagesSelectionView: View {
                 addPackageButtonTapped()
             }
             .disabled(selectionButtonDisabled)
-            .if(viewModel.previousSelectedSelectedSavedPackageAreSame) {
+            .if(viewModel.previousSelectedAndSelectedSavedPackageAreSame) {
                 $0.buttonStyle(SecondaryButtonStyle())
             }
-            .if(!viewModel.previousSelectedSelectedSavedPackageAreSame) {
+            .if(!viewModel.previousSelectedAndSelectedSavedPackageAreSame) {
                 $0.buttonStyle(PrimaryButtonStyle())
             }
             .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -62,7 +62,7 @@ struct WooShippingAddPackageView: View {
                     })
                 }
             }
-            .navigationTitle(Localization.addPackage)
+            .navigationTitle(packagesViewModel.previousSelectedPackage != nil ? Localization.editPackage :  Localization.addPackage)
             .navigationBarTitleDisplayMode(.inline)
         }
         .navigationViewStyle(.stack)
@@ -144,5 +144,14 @@ extension WooShippingAddPackageView {
         static let addPackageDetails = NSLocalizedString("wooShipping.createLabel.addPackage.addPackageDetails",
                                                          value: "Add Package Details",
                                                          comment: "Title for the Add Package screen Add Package Details button")
+        static let editPackage = NSLocalizedString("wooShipping.createLabel.editPackage.title",
+                                                   value: "Edit Package",
+                                                   comment: "Title for the Edit Package screen")
+        static let done = NSLocalizedString("wooShipping.createLabel.editPackage.done",
+                                            value: "Done",
+                                            comment: "Title for the Edit Package screen Done button")
+        static let useSelectedPackage = NSLocalizedString("wooShipping.createLabel.editPackage.useSelectedPackage",
+                                                          value: "Use Selected Package",
+                                                          comment: "Title for the Edit Package screen Use Selected Package button")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -65,7 +65,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         return nil
     }
 
-    var previousSelectedSelectedSavedPackageAreSame: Bool {
+    var previousSelectedAndSelectedSavedPackageAreSame: Bool {
         guard let previousSelectedPackage else {
             return false
         }
@@ -100,7 +100,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 
         return nil
     }
-    var previousSelectedSelectedCarriersPackageAreSame: Bool {
+    var previousSelectedAndSelectedCarriersPackageAreSame: Bool {
         guard let previousSelectedPackage else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -40,7 +40,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     @Published private(set) var isLoadingPackages: Bool = false
 
     /// Holds the previously selected package data, which can be transformed e.g. to select the correct tabs in the view.
-    private let previousSelectedPackage: WooShippingPackageDataRepresentable?
+    let previousSelectedPackage: WooShippingPackageDataRepresentable?
 
     // MARK: - saved
 
@@ -63,6 +63,13 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         }
 
         return nil
+    }
+
+    var previousSelectedSelectedSavedPackageAreSame: Bool {
+        guard let previousSelectedPackage else {
+            return false
+        }
+        return previousSelectedPackage.id == selectedSavedPackageId
     }
 
     // MARK: - carrier
@@ -92,6 +99,12 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         }
 
         return nil
+    }
+    var previousSelectedSelectedCarriersPackageAreSame: Bool {
+        guard let previousSelectedPackage else {
+            return false
+        }
+        return previousSelectedPackage.id == selectedCarriersPackageId
     }
 
     // MARK: - Storage


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13786
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Use different button style if package was already selected
- Changed title to "Edit Package" if we are editing the package
- Updated button texts depending on the state (editing, adding, same package etc.)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7.  Tap "Select a Package."
8.  Switch to Carrier or Saved tab
9. Select one of the packages and tap "Add Package" button
10. Tap Edit package button
11. Change which package is selected and observe that the button text and style is proper

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-06 at 15 04 56](https://github.com/user-attachments/assets/e173517d-18e9-45a4-ad64-04126bb4014c)

Selected the same carrier package

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 53 45](https://github.com/user-attachments/assets/5da26e8c-fa96-44a0-a13a-88cceb51c2d6)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 49 17](https://github.com/user-attachments/assets/36d5c430-ecf0-4cb9-85b5-936174d2df20) |

Selected different carrier package

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 53 48](https://github.com/user-attachments/assets/967a3735-c012-48ba-819e-42031773ece5)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 49 21](https://github.com/user-attachments/assets/aa713df0-364e-47fc-9153-fcfe548cf4ed) |

Selected different saved package

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 53 41](https://github.com/user-attachments/assets/88e7be7d-8979-49cb-acee-fbace3a350e3)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 49 06](https://github.com/user-attachments/assets/0aa8a6eb-2f63-4a63-a631-d48a21d83943) |

Selected same saved package

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 53 37](https://github.com/user-attachments/assets/1f2b3b16-987d-464d-a6e9-cb949030a6b0)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 49 00](https://github.com/user-attachments/assets/5e60d56e-9ddf-4736-842a-b7d53ba99f87) |

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
