### PR TITLE
Update AutomatticAbout library to last version

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
           "branch": null,
-          "revision": "31045d654bcc1f2b56c85dd658f160fad5b50a29",
-          "version": "1.1.4"
+          "revision": "606384a7492faa1139d489080dd961b0b57f9fd9",
+          "version": "1.1.5"
         }
       },
       {
@@ -84,7 +84,7 @@
       },
       {
         "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": null,
           "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -18696,7 +18696,7 @@
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.1.5;
 			};
 		};
 		202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */ = {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: woocommerce/woomobile-private#389
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR updates the AutomatticAbout library to the last [version](https://github.com/Automattic/AutomatticAbout-Swift/releases/tag/1.1.5) that includes the update Woo logo.

## Steps to reproduce
1. Open the app.
2. Open the Settings.
3. Tap on WooCommerce row.

## Testing information
- Confirm the new logo is shown in the Automattic Family section.

Tested using iPhone 16 Pro simulator, iOS 18.1.

## Screenshots
| Light | Dark |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 48 23](https://github.com/user-attachments/assets/863e5585-9f5f-4c5e-a337-5c6f2084b7f6) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 14 48 29](https://github.com/user-attachments/assets/d2352758-354a-4c65-b4c9-68b2f7fc2470) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.