### PR TITLE
Performance improvement of unit tests: Optimization of waitUntil

### DIFF
--- a/TestKit/Package.resolved
+++ b/TestKit/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "package": "Difference",
+        "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
+        "state": {
+          "branch": "master",
+          "revision": "7eb73c5d28c87dd6c4bac805aa28f757648aa92c",
+          "version": null
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
+          "version": "13.7.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/TestKit/Package.swift
+++ b/TestKit/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Difference", url: "https://github.com/krzysztofzablocki/Difference.git", .branch("master")),
-        .package(url:  "https://github.com/Quick/Nimble.git", from: "13.0.0")
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
     ],
     targets: [
         .target(

--- a/TestKit/Package.swift
+++ b/TestKit/Package.swift
@@ -11,12 +11,13 @@ let package = Package(
             targets: ["TestKit"]),
     ],
     dependencies: [
-        .package(name: "Difference", url: "https://github.com/krzysztofzablocki/Difference.git", .branch("master"))
+        .package(name: "Difference", url: "https://github.com/krzysztofzablocki/Difference.git", .branch("master")),
+        .package(url:  "https://github.com/Quick/Nimble.git", from: "13.0.0")
     ],
     targets: [
         .target(
             name: "TestKit",
-            dependencies: ["Difference"]),
+            dependencies: ["Difference", "Nimble"]),
         .testTarget(
             name: "TestKitTests",
             dependencies: ["TestKit"]),

--- a/TestKit/Sources/TestKit/XCTestCase+Wait.swift
+++ b/TestKit/Sources/TestKit/XCTestCase+Wait.swift
@@ -37,11 +37,37 @@ extension XCTestCase {
     /// }
     /// ```
     ///
-    public func waitUntil(file: StaticString = #file,
+    @available(*, noasync, message: "Use await until(expression:) instead!")
+    public func waitUntil(fileID: String = #fileID,
+                          file: FileString = #filePath,
                           line: UInt = #line,
+                          column: UInt = #column,
                           timeout: TimeInterval = 5.0,
-                          condition: @escaping (() -> Bool)) {
-        expect(condition()).toEventually(beTrue(), timeout: .seconds(Int(timeout)))
+                          _ expression: @escaping () throws -> Bool) {
+        _ = expect(fileID: fileID, file: file, line: line, column: column, expression)
+            .toEventually(beTrue(), timeout: .seconds(Int(timeout)))
+    }
+
+    /// Waits until `condition` returns `true` in async conext.
+    ///
+    /// Example usage:
+    ///
+    /// ```
+    /// var valueThatIsUpdatedAsynchronously: Int = 0
+    ///
+    /// await until {
+    ///     valueThatIsUpdatedAsynchronously > 5
+    /// }
+    /// ```
+    ///
+    public func until(fileID: String = #fileID,
+                      file: FileString = #filePath,
+                      line: UInt = #line,
+                      column: UInt = #column,
+                      timeout: TimeInterval = 5.0,
+                      _ expression: @escaping () throws -> Bool) async {
+        _ = await expect(fileID: fileID, file: file, line: line, column: column, expression)
+            .toEventually(beTrue(), timeout: .seconds(Int(timeout)))
     }
 
     /// Waits until a value is provided by a promise (block) and returns that value.

--- a/TestKit/Sources/TestKit/XCTestCase+Wait.swift
+++ b/TestKit/Sources/TestKit/XCTestCase+Wait.swift
@@ -1,5 +1,6 @@
 
 import XCTest
+import Nimble
 
 extension XCTestCase {
     /// Creates an XCTestExpectation and waits for `block` to call `fulfill()`.
@@ -24,7 +25,7 @@ extension XCTestCase {
         wait(for: [exp], timeout: timeout)
     }
 
-    /// Creates an `XCTestExpectation` and waits until `condition` returns `true`.
+    /// Waits until `condition` returns `true`.
     ///
     /// Example usage:
     ///
@@ -40,19 +41,7 @@ extension XCTestCase {
                           line: UInt = #line,
                           timeout: TimeInterval = 5.0,
                           condition: @escaping (() -> Bool)) {
-        let predicate = NSPredicate { _, _ -> Bool in
-            return condition()
-        }
-
-        let exp = expectation(for: predicate, evaluatedWith: nil)
-
-        let result = XCTWaiter.wait(for: [exp], timeout: timeout)
-        switch result {
-        case .timedOut:
-            XCTFail("Timed out waiting for condition to return `true`.", file: file, line: line)
-        default:
-            break
-        }
+        expect(condition()).toEventually(beTrue(), timeout: .seconds(Int(timeout)))
     }
 
     /// Waits until a value is provided by a promise (block) and returns that value.

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,6 +29,24 @@
         }
       },
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+          "version": "2.2.2"
+        }
+      },
+      {
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
@@ -53,6 +71,15 @@
           "branch": null,
           "revision": "c0ed5f5de62475e286a3b7c676cec99fa34533ce",
           "version": "1.1.1"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
+          "version": "13.7.1"
         }
       },
       {

--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -58,15 +58,18 @@ final class TooltipPresenter {
     }
 
     private var previousDeviceOrientation: UIDeviceOrientation?
+    private var animation: TooltipAnimation.Type
 
     init(containerView: UIView,
          tooltip: Tooltip,
          target: Target,
+         animation: TooltipAnimation.Type = UIView.self,
          primaryTooltipAction: (() -> Void)? = nil,
          secondaryTooltipAction: (() -> Void)? = nil
     ) {
         self.containerView = containerView
         self.tooltip = tooltip
+        self.animation = animation
         self.primaryTooltipAction = primaryTooltipAction
         self.secondaryTooltipAction = secondaryTooltipAction
         self.target = target
@@ -99,7 +102,7 @@ final class TooltipPresenter {
     }
 
     func dismissTooltip() {
-        UIView.animate(
+        animation.animate(
             withDuration: Constants.tooltipAnimationDuration,
             delay: 0,
             options: .curveEaseOut
@@ -125,20 +128,20 @@ final class TooltipPresenter {
     }
 
     private func animateTooltipIn() {
-        UIView.animate(
+        animation.animate(
             withDuration: Constants.tooltipAnimationDuration,
             delay: 0,
-            options: .curveEaseOut
-        ) {
-            guard let tooltipTopConstraint = self.tooltipTopConstraint else {
-                return
-            }
+            options: .curveEaseOut,
+            animations: {
+                guard let tooltipTopConstraint = self.tooltipTopConstraint else {
+                    return
+                }
 
-            self.tooltip.alpha = 1
-            tooltipTopConstraint.constant -= Constants.tooltipTopConstraintAnimationOffset
+                self.tooltip.alpha = 1
+                tooltipTopConstraint.constant -= Constants.tooltipTopConstraintAnimationOffset
 
-            self.containerView.layoutIfNeeded()
-        }
+                self.containerView.layoutIfNeeded()
+            }, completion: nil)
     }
 
     private func configureDismissal() {
@@ -202,7 +205,7 @@ final class TooltipPresenter {
     }
 
     @objc private func resetTooltipAndShow() {
-        UIView.animate(
+        animation.animate(
             withDuration: Constants.tooltipAnimationDuration,
             delay: 0,
             options: .curveEaseOut
@@ -273,3 +276,16 @@ final class TooltipPresenter {
         }
     }
 }
+
+// MARK: - TooltipAnimation
+
+/// Enable dependency injection for animation
+protocol TooltipAnimation: AnyObject {
+    static func animate(withDuration duration: TimeInterval,
+                        delay: TimeInterval,
+                        options: UIView.AnimationOptions,
+                        animations: @escaping () -> Void,
+                        completion: ((Bool) -> Void)?)
+}
+
+extension UIView: TooltipAnimation {}

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -415,9 +415,9 @@ final class AppCoordinatorTests: XCTestCase {
         // Then
         XCTAssertEqual(window.rootViewController, loginNavigationController)
         waitUntil {
-            loginNavigationController.viewControllers.count == 2
+            loginNavigationController.viewControllers.count == 2 &&
+            loginNavigationController.presentedViewController == nil
         }
-        XCTAssertNil(loginNavigationController.presentedViewController)
     }
 
     func test_appCoordinator_start_resets_default_store_and_proceeds_to_login_when_isAuthenticated_and_needsDefaultStore_are_false() {

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -409,7 +409,8 @@ final class AuthenticationManagerTests: XCTestCase {
 
         // Then
         waitUntil {
-            navigationController.viewControllers.isNotEmpty
+            navigationController.viewControllers.isNotEmpty &&
+            navigationController.topViewController != nil
         }
         let topController = navigationController.topViewController
         XCTAssertTrue(topController is ULAccountMismatchViewController)

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackConnectionWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackConnectionWebViewModelTests.swift
@@ -27,7 +27,7 @@ final class JetpackConnectionWebViewModelTests: XCTestCase {
         let adminPolicy = await viewModel.decidePolicy(for: adminURL)
         let finalUrl = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
         let completionPolicy = await viewModel.decidePolicy(for: finalUrl)
-        waitUntil {
+        await until {
             completionTriggered == true
         }
 
@@ -52,7 +52,7 @@ final class JetpackConnectionWebViewModelTests: XCTestCase {
         let authorizePolicy = await viewModel.decidePolicy(for: authorizeURL)
         let finalUrl = try XCTUnwrap(URL(string: "https://wordpress.com/jetpack/connect/plans"))
         let completionPolicy = await viewModel.decidePolicy(for: finalUrl)
-        waitUntil {
+        await until {
             completionTriggered == true
         }
 
@@ -175,7 +175,7 @@ final class JetpackConnectionWebViewModelTests: XCTestCase {
         // When
         let finalUrl = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
         _ = await viewModel.decidePolicy(for: finalUrl)
-        waitUntil {
+        await until {
             completionTriggered == true
         }
 
@@ -205,7 +205,7 @@ final class JetpackConnectionWebViewModelTests: XCTestCase {
         // When
         let finalUrl = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
         _ = await viewModel.decidePolicy(for: finalUrl)
-        waitUntil {
+        await until {
             completionTriggered == true
         }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
@@ -153,7 +153,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         viewModel.password = "simple password"
 
         // Then
-        waitUntil {
+        await until {
             self.viewModel.passwordErrorMessage == nil
         }
     }
@@ -168,7 +168,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         viewModel.email = "real@woocommerce.com"
 
         // Then
-        waitUntil {
+        await until {
             self.viewModel.emailErrorMessage == nil
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
@@ -431,7 +431,7 @@ final class BlazeConfirmPaymentViewModelTests: XCTestCase {
         viewModel.addPaymentWebViewModel?.didAddNewPaymentMethod()
 
         // Then
-        waitUntil {
+        await until {
             didTriggerFetchPaymentInfo == true
         }
     }
@@ -455,7 +455,7 @@ final class BlazeConfirmPaymentViewModelTests: XCTestCase {
         viewModel.paymentMethodsViewModel?.didSelectPaymentMethod(withID: "payment-method-1")
 
         // Then
-        waitUntil {
+        await until {
             viewModel.showAddPaymentSheet == false
         }
     }
@@ -487,7 +487,7 @@ final class BlazeConfirmPaymentViewModelTests: XCTestCase {
         viewModel.paymentMethodsViewModel?.didSelectPaymentMethod(withID: "new-payment-method")
 
         // Then
-        waitUntil {
+        await until {
             didTriggerFetchPaymentInfo == true
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
@@ -63,7 +63,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         insertCampaigns([fakeBlazeCampaign])
 
         // Then
-        waitUntil {
+        await until {
             self.pushNotesManager.requestedLocalNotifications.isNotEmpty
         }
 
@@ -110,7 +110,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         insertCampaigns([fakeBlazeCampaign1, fakeBlazeCampaign2, fakeBlazeCampaign3])
 
         // Then
-        waitUntil {
+        await until {
             self.pushNotesManager.requestedLocalNotifications.isNotEmpty
         }
 
@@ -144,7 +144,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         // When
         insertCampaigns([fakeBlazeCampaign1])
 
-        waitUntil {
+        await until {
             self.pushNotesManager.requestedLocalNotifications.count == 1
         }
 
@@ -180,7 +180,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         insertCampaigns([fakeBlazeCampaign1, fakeBlazeCampaign2])
 
         // Then
-        waitUntil {
+        await until {
             self.pushNotesManager.requestedLocalNotifications.isNotEmpty
         }
 
@@ -297,7 +297,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         // When
         await sut.scheduleNoCampaignReminder()
 
-        waitUntil {
+        await until {
             self.pushNotesManager.canceledLocalNotificationScenarios.isNotEmpty
         }
 
@@ -321,7 +321,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         await sut.scheduleAbandonedCreationReminder()
 
         // Then
-        waitUntil {
+        await until {
             self.pushNotesManager.requestedLocalNotifications.isNotEmpty
         }
 
@@ -367,7 +367,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         // When
         await sut.scheduleAbandonedCreationReminder()
 
-        waitUntil {
+        await until {
             self.pushNotesManager.requestedLocalNotifications.count == 1
         }
 
@@ -420,7 +420,7 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
         pushNotesManager.sendLocalNotificationResponse(response)
 
         // Then
-        waitUntil {
+        await until {
             self.defaults[.blazeAbandonedCampaignCreationReminderOpened] == true
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -692,7 +692,7 @@ final class DashboardViewModelTests: XCTestCase {
         await viewModel.onViewAppear()
 
         // Then
-        waitUntil {
+        await until {
             scheduler.scheduleNoCampaignReminderCalled == true
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/ThemeSettingViewModelTests.swift
@@ -70,7 +70,7 @@ final class ThemeSettingViewModelTests: XCTestCase {
                                   stores: stores,
                                   themeInstaller: themeInstaller)
         // Then
-        waitUntil {
+        await until {
             themeInstaller.installPendingThemeCalled == true
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Feature Highlight/TooltipPresenterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Feature Highlight/TooltipPresenterTests.swift
@@ -9,20 +9,23 @@ final class TooltipPresenterTests: XCTestCase {
         let containerView = UIView()
         let toolTip = Tooltip()
 
-        waitForExpectation { exp in
-            let sut = TooltipPresenter(containerView: containerView,
-                                       tooltip: toolTip,
-                                       target: .point(tooltipTargetPoint),
-                                       primaryTooltipAction: {
-                // Then
-                exp.fulfill()
-            })
+        var primaryTooltipActionCalled = false
+        let sut = TooltipPresenter(containerView: containerView,
+                                   tooltip: toolTip,
+                                   target: .point(tooltipTargetPoint),
+                                   animation: TooltipAnimationMock.self,
+                                   primaryTooltipAction: {
+            // Then
+            primaryTooltipActionCalled = true
+        })
 
-            sut.showTooltip()
+        sut.showTooltip()
 
-            // When
-            sut.dismissTooltip()
-        }
+        // When
+        sut.dismissTooltip()
+
+        // Then
+        XCTAssertTrue(primaryTooltipActionCalled)
     }
 
     // MARK: `removeTooltip`
@@ -32,28 +35,39 @@ final class TooltipPresenterTests: XCTestCase {
         let containerView = UIView()
         let toolTip = Tooltip()
 
-        waitForExpectation { exp in
-            exp.isInverted = true
+        var primaryTooltipActionCalled = false
+        let sut = TooltipPresenter(containerView: containerView,
+                                   tooltip: toolTip,
+                                   target: .point(tooltipTargetPoint),
+                                   animation: TooltipAnimationMock.self,
+                                   primaryTooltipAction: {
+            // Then
+            primaryTooltipActionCalled = true
+        })
 
-            let sut = TooltipPresenter(containerView: containerView,
-                                       tooltip: toolTip,
-                                       target: .point(tooltipTargetPoint),
-                                       primaryTooltipAction: {
-                // Then
-                // `primaryTooltipAction` should not be fired
-                exp.fulfill()
-            })
+        sut.showTooltip()
 
-            sut.showTooltip()
+        // When
+        sut.removeTooltip()
 
-            // When
-            sut.removeTooltip()
-        }
+        // Then
+        XCTAssertFalse(primaryTooltipActionCalled)
     }
 }
 
 private extension TooltipPresenterTests {
     func tooltipTargetPoint() -> CGPoint {
         .zero
+    }
+}
+
+private class TooltipAnimationMock: TooltipAnimation {
+    static func animate(withDuration duration: TimeInterval,
+                        delay: TimeInterval,
+                        options: UIView.AnimationOptions,
+                        animations: @escaping () -> Void,
+                        completion: ((Bool) -> Void)?) {
+        animations()
+        completion?(true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -34,7 +34,7 @@ final class HubMenuViewModelTests: XCTestCase {
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores,
                                          blazeEligibilityChecker: blazeEligibilityChecker)
-        waitUntil(timeout: 2) {
+        waitUntil {
             // The first check is triggered by `updateMenuItemEligibility`
             blazeEligibilityChecker.siteEligibilityCheckCount == 1
         }
@@ -43,7 +43,7 @@ final class HubMenuViewModelTests: XCTestCase {
         viewModel.viewDidAppear()
 
         // Then
-        waitUntil(timeout: 2) {
+        waitUntil {
             blazeEligibilityChecker.siteEligibilityCheckCount == 2
         }
 
@@ -52,7 +52,7 @@ final class HubMenuViewModelTests: XCTestCase {
         viewModel.viewDidAppear()
 
         // Then
-        waitUntil(timeout: 2) {
+        waitUntil {
             blazeEligibilityChecker.siteEligibilityCheckCount == 3
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -225,13 +225,11 @@ final class MainTabBarControllerTests: XCTestCase {
         }
         completion(.success(ProductReviewFromNoteParcelFactory().parcel(metaSiteID: 606)))
 
-        // Assert
-        waitUntil {
-            hubMenuNavigationController.viewControllers.count != 0
-        }
         // HubMenuViewController should be pushed, and be the MainTabBarController visible index
-        assertThat(hubMenuNavigationController.topViewController, isAnInstanceOf: HubMenuViewController.self)
-        XCTAssertEqual(tabBarController.selectedIndex, WooTab.hubMenu.visibleIndex())
+        waitUntil {
+            hubMenuNavigationController.topViewController is HubMenuViewController &&
+            tabBarController.selectedIndex == WooTab.hubMenu.visibleIndex()
+        }
     }
 
     func test_when_receiving_product_image_upload_error_a_notice_is_enqueued() throws {
@@ -357,8 +355,10 @@ final class MainTabBarControllerTests: XCTestCase {
         }
 
         // Then
-        let productNavigationController = try XCTUnwrap(productsNavigationController.presentedViewController as? UINavigationController)
-        assertThat(productNavigationController.topViewController, isAnInstanceOf: ProductLoaderViewController.self)
+        waitUntil {
+            let productNavigationController = productsNavigationController.presentedViewController as? UINavigationController
+            return productNavigationController?.topViewController is ProductLoaderViewController
+        }
     }
 
     // MARK: - Analytics
@@ -494,8 +494,11 @@ final class MainTabBarControllerTests: XCTestCase {
         let tabContainerController = try XCTUnwrap(tabBarController.selectedViewController as? TabContainerController)
         let ordersSplitViewWrapper = try XCTUnwrap(tabContainerController.wrappedController as? OrdersSplitViewWrapperController)
         let splitViewController = try XCTUnwrap(ordersSplitViewWrapper.children.first as? UISplitViewController)
-        let secondaryViewController = try XCTUnwrap((splitViewController.viewController(for: .secondary) as? UINavigationController)?.topViewController)
-        assertThat(secondaryViewController, isAnInstanceOf: OrderLoaderViewController.self)
+
+        waitUntil {
+            let secondaryViewController = (splitViewController.viewController(for: .secondary) as? UINavigationController)?.topViewController
+            return secondaryViewController is OrderLoaderViewController
+        }
 
         // Resets the tab bar controller mock at the end of the test.
         TestingAppDelegate.mockTabBarController = nil
@@ -537,8 +540,10 @@ final class MainTabBarControllerTests: XCTestCase {
         let tabContainerController = try XCTUnwrap(tabBarController.selectedViewController as? TabContainerController)
         let ordersSplitViewWrapper = try XCTUnwrap(tabContainerController.wrappedController as? OrdersSplitViewWrapperController)
         let splitViewController = try XCTUnwrap(ordersSplitViewWrapper.children.first as? UISplitViewController)
-        let secondaryViewController = try XCTUnwrap((splitViewController.viewController(for: .secondary) as? UINavigationController)?.topViewController)
-        assertThat(secondaryViewController, isAnInstanceOf: OrderLoaderViewController.self)
+        waitUntil {
+            let secondaryViewController = (splitViewController.viewController(for: .secondary) as? UINavigationController)?.topViewController
+            return secondaryViewController is OrderLoaderViewController
+        }
 
         // Resets the tab bar controller mock at the end of the test.
         TestingAppDelegate.mockTabBarController = nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -267,15 +267,9 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
-        let topBanner = await waitForAsync { promise in
-            viewModel.$topBanner.sink { topBanner in
-                promise(topBanner)
-            }
-            .store(in: &self.subscriptions)
-        }
 
         // Then
-        XCTAssert(topBanner == .none)
+        XCTAssert(viewModel.topBanner == .none)
     }
 
     func test_storing_error_shows_error_banner() async {
@@ -284,17 +278,10 @@ final class OrderListViewModelTests: XCTestCase {
         let viewModel = OrderListViewModel(siteID: siteID, filters: nil)
 
         // When
-        viewModel.dataLoadingError = expectedError
         viewModel.activate()
-        let topBanner = await waitForAsync { promise in
-            viewModel.$topBanner.sink { topBanner in
-                promise(topBanner)
-            }
-            .store(in: &self.subscriptions)
-        }
+        viewModel.dataLoadingError = expectedError
 
-        // Then
-        XCTAssert(topBanner == .error(expectedError))
+        XCTAssert(viewModel.topBanner == .error(expectedError))
     }
 
     // MARK: - Filters Applied

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -476,7 +476,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         // When
         // Regeneration attempt
         await viewModel.generateShareMessage()
-        waitUntil {
+        await until {
             viewModel.generationInProgress == false
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewController+ProductImageUploaderTests.swift
@@ -79,23 +79,42 @@ final class ProductFormViewController_ProductImageUploaderTests: XCTestCase {
                                                     productImageActionHandler: actionHandler,
                                                     presentationStyle: .navigationStack,
                                                     productImageUploader: productImageUploader)
-        let rootNavigationController = UINavigationController(rootViewController: .init())
+        let rootNavigationController = MockNavigationController(rootViewController: .init())
         window.rootViewController = rootNavigationController
 
         // When
         rootNavigationController.pushViewController(productForm, animated: false)
-
-        waitUntil {
-            rootNavigationController.viewControllers.count == 2
-        }
-
+        // And
         rootNavigationController.popViewController(animated: false)
-
-        waitUntil {
-            rootNavigationController.viewControllers.count == 1
-        }
 
         // Then
         XCTAssertTrue(productImageUploader.startEmittingErrorsWasCalled)
+    }
+}
+
+// MARK: - MockNavigationController
+/// Popping with UINavigationController doesn't work reliably in unit tests and doesn't always result in viewWillDisappear being called.
+/// Created a mock to simulate the behavior of UINavigationController.
+///
+private class MockNavigationController: UINavigationController {
+    private var pushedViewControllers: [UIViewController] = []
+    private var isBeingDismissedToReturn: Bool = false
+
+    override var isBeingDismissed: Bool {
+        isBeingDismissedToReturn
+    }
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        super.pushViewController(viewController, animated: true)
+        isBeingDismissedToReturn = false
+        pushedViewControllers.append(viewController)
+    }
+
+    @discardableResult
+    override func popViewController(animated: Bool) -> UIViewController? {
+        let viewController = pushedViewControllers.popLast()
+        isBeingDismissedToReturn = true
+        viewController?.viewWillDisappear(animated)
+        return super.popViewController(animated: animated)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/WordPressMediaLibraryImagePickerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/WordPressMediaLibraryImagePickerCoordinatorTests.swift
@@ -158,6 +158,11 @@ final class WordPressMediaLibraryImagePickerCoordinatorTests: XCTestCase {
                 self.sourceViewController.presentedViewController != nil
             }
             let mediaPicker = try XCTUnwrap(self.sourceViewController.presentedViewController as? WordPressMediaLibraryPickerViewController)
+
+            self.waitUntil {
+                return mediaPicker.presentationController?.delegate != nil
+            }
+
             mediaPicker.presentationController?.delegate?.presentationControllerDidDismiss?(.init(presentedViewController: .init(), presenting: nil))
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Themes/ThemesCarouselViewModelTests.swift
@@ -103,7 +103,7 @@ final class ThemesCarouselViewModelTests: XCTestCase {
         viewModel.updateCurrentTheme(id: theme1.id)
 
         // Then
-        waitUntil {
+        await until {
             viewModel.state == .content(themes: [theme2])
         }
     }
@@ -132,7 +132,7 @@ final class ThemesCarouselViewModelTests: XCTestCase {
         viewModel.updateCurrentTheme(id: theme1.id)
 
         // Then
-        waitUntil {
+        await until {
             viewModel.state == .error
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
Part of: #11228
Context: pdfdoF-64g-p2#comment-7238

I picked one-reviewer per team for awareness.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

WooCommerce-iOS has multiple slow unit tests. [See Buildkite for slowest tests within the last 7 days](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios/tests?branch=trunk&filter=duration&period=7days). 

Unit tests run duration is around 7min 45sec with an average test execution duration of 85ms. Ideally, we should aim for 10ms average test duration.

There are multiple reasons why (some) unit tests are slow. Some of which are understandable and could only be deleted or moved away while others could be improved.

Examples:
- Test target includes performance tests (e.g `testViewModelGenerationTimeWithFromBigSetOfCategories`) which is slow by design
- CoreData-related tests, such as `MigrationTests`
- ViewController tests, such as `MainTabBarControllerTests` which an under-the-hood rely on UIKit
- Asynchronous tests that inefficiently wait for expectations
- Asynchronous tests that wait for something not to happen (`isInverted = true`) which requires the test to wait up until `timeout` to verify
- ....

This PR is likely the first of at least a couple of PRs. In my investigation, I try to go through the slowest tests and find common issues. I'm looking for a few key improvements that could apply to many tests. 

## Solution

The following changes improve unit test target speed from around 7:45min to 4:30min

### Improve `waitUntil`  to use a more efficient mechanism

Many of the slowest tests are relying on `waitUntil` defined in `TestKit` that waits for the condition to be true up until the timeout. 

It uses [expectation(for: predicate)](https://developer.apple.com/documentation/xctest/xctestcase/1500569-expectationforpredicate) which is convenience method for [XCTNSPredicateExpectation](https://developer.apple.com/documentation/xctest/xctnspredicateexpectation). 

As explained [in Gio's blog post](https://mokacoding.com/blog/xctnspredicateexpectation-slow/):
> XCTNSPredicateExpectation requires a timeout of at least 1.1 seconds or it will fail regardless of whether the behavior under test occurred. To avoid slowing down your tests, use [Nimble](https://github.com/Quick/Nimble)'s toEventually instead.
>
> Do yourself, your team, and your CI a favor and rewrite all your tests using XCTNSPredicateExpectation with Nimble's toEventually.

I tested replacing the `expectation(for: predicate)` with Nible's `expect(condition:).toEventually(beTrue))` and the performance improved substantially:
- Improved `waitUntil`
- Added `await until` to be used in async contexts
- Updated async test usage where necessary

Although this is an extra dependency, it only affects a test target and produces a great performance improvement:

🐢  **[Trunk](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios/runs/2a27fc16-c859-85f6-80ee-448043898acd)**

<img width="700" alt="image" src="https://github.com/user-attachments/assets/c23513a8-516a-418a-96ae-b497ffa36917" />

🐈  **[This Branch](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios/runs/29351208-5782-816f-b032-7d840a350a4d)**

<img width="700" alt="image" src="https://github.com/user-attachments/assets/65cd2df4-cbf6-4b3d-917e-0acfa5e89d30" />

### Turn asynchronous tests into synchronous ones

Along the way, I noticed some slow async tests that could be turned into synchronous ones and run in a few ms instead of a couple of seconds:

- `OrderListViewModelTests  test_banner_should_not_be_shown_when_there_is_no_error` was one of the slower tests due to a few `await` calls. However, the same logic can be tested without them. 
- `TooltipPresenterTests` would run slow because `UIView.animate` was used within tested methods. I injected a mock animation method to make the test synchronous.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

CI should succeed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There's a danger of introducing extra flakiness. However, after finalizing changes I ran a test suite on my MacBook and on CI dozens of times.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.