### PR TITLE
[Woo POS] [Variable Products] Support adding variation to cart

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -91,14 +91,20 @@ private extension ChildItemList {
                                                             POSVariation(
                                                                 id: .init(),
                                                                 name: "Cinamon chestnut latte",
-                                                                formattedPrice: "$5.75"
+                                                                formattedPrice: "$5.75",
+                                                                price: "5.75",
+                                                                productID: 134,
+                                                                variationID: 256
                                                             )
                                                         ),
                                                         .variation(
                                                             POSVariation(
                                                                 id: .init(),
                                                                 name: "Choco latte",
-                                                                formattedPrice: "$6.5"
+                                                                formattedPrice: "$6.5",
+                                                                price: "6.5",
+                                                                productID: 134,
+                                                                variationID: 256
                                                             )
                                                         )
                                                     ])]))

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -32,7 +32,7 @@ private struct ItemListRow: View {
             }
         case let .variation(variation):
             Button(action: {
-                print("Tapped variation \(variation.name)")
+                posModel.addToCart(variation)
             }, label: {
                 VariationCardView(variation: variation)
             })

--- a/WooCommerce/Classes/POS/Presentation/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/VariationCardView.swift
@@ -54,7 +54,12 @@ private extension VariationCardView {
 }
 
 #Preview("Variation without image") {
-    let variation = POSVariation(id: .init(), name: "500ml, double shot", formattedPrice: "$5.00")
+    let variation = POSVariation(id: .init(),
+                                 name: "500ml, double shot",
+                                 formattedPrice: "$5.00",
+                                 price: "5.00",
+                                 productID: 134,
+                                 variationID: 256)
     VariationCardView(variation: variation)
 }
 
@@ -62,6 +67,9 @@ private extension VariationCardView {
     let variation = POSVariation(id: .init(),
                                  name: "500ml, double shot",
                                  formattedPrice: "$5.00",
-                                 productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg")
+                                 price: "5.00",
+                                 productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg",
+                                 productID: 134,
+                                 variationID: 256)
     VariationCardView(variation: variation)
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -110,8 +110,18 @@ private var mockItems: [POSItem] {
 
 private var mockVariationItems: [POSItem] {
     [
-        .variation(.init(id: UUID(), name: "Variation 1", formattedPrice: "$1.00", productImageSource: nil)),
-        .variation(.init(id: UUID(), name: "Variation 2", formattedPrice: "$2.00", productImageSource: nil)),
+        .variation(.init(id: UUID(),
+                         name: "Variation 1",
+                         formattedPrice: "$1.00",
+                         price: "1.00",
+                         productID: 134,
+                         variationID: 256)),
+        .variation(.init(id: UUID(),
+                         name: "Variation 2",
+                         formattedPrice: "$2.00",
+                         price: "2.00",
+                         productID: 134,
+                         variationID: 256)),
     ]
 }
 

--- a/Yosemite/Yosemite/PointOfSale/POSVariation.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSVariation.swift
@@ -1,17 +1,36 @@
 import Foundation
 
-public struct POSVariation: Equatable, Hashable, Identifiable {
-    // Identifiable
+public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Hashable, Identifiable {
+    // Identifiable & POSOrderableItem
     public let id: UUID
 
+    // POSOrderableItem
     public let name: String
     public let formattedPrice: String
     public var productImageSource: String?
 
-    public init(id: UUID, name: String, formattedPrice: String, productImageSource: String? = nil) {
+    // OrderSyncProductVariationTypeProtocol
+    public let productID: Int64
+    public let productVariationID: Int64
+    public let price: String
+
+    public init(id: UUID, name: String, formattedPrice: String, price: String, productImageSource: String? = nil, productID: Int64, variationID: Int64) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
+        self.price = price
         self.productImageSource = productImageSource
+        self.productID = productID
+        self.productVariationID = variationID
+    }
+}
+
+extension POSVariation: POSOrderableItem {
+    public func toOrderSyncProductInput(quantity: Decimal) -> OrderSyncProductInput {
+        OrderSyncProductInput(product: .variation(self), quantity: quantity)
+    }
+
+    public func matches(orderItem: OrderItem) -> Bool {
+        productID == orderItem.productID && productVariationID == orderItem.variationID
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleProductService.swift
@@ -76,7 +76,10 @@ public final class PointOfSaleProductService: PointOfSaleItemServiceProtocol {
                                      // TODO-14702: variation name with ProductVariationFormatter
                                      name: "Variation \(variation.productVariationID)",
                                      formattedPrice: currencyFormatter.formatAmount(variation.price) ?? "-",
-                                     productImageSource: variation.image?.src))
+                                     price: variation.price,
+                                     productImageSource: variation.image?.src,
+                                     productID: variation.productID,
+                                     variationID: variation.productVariationID))
             }),
             // TODO-14696: pagination support for variations lists
             hasMorePages: false

--- a/Yosemite/Yosemite/Stores/Order/OrderSyncProductInput.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderSyncProductInput.swift
@@ -18,6 +18,23 @@ public extension OrderSyncProductTypeProtocol where Self: Equatable {
     }
 }
 
+public protocol OrderSyncProductVariationTypeProtocol: Hashable {
+    var price: String { get }
+    var productVariationID: Int64 { get }
+    var productID: Int64 { get }
+
+    func isEqual(to: any OrderSyncProductVariationTypeProtocol) -> Bool
+}
+
+extension ProductVariation: OrderSyncProductVariationTypeProtocol {}
+
+public extension OrderSyncProductVariationTypeProtocol where Self: Equatable {
+    func isEqual(to other: any OrderSyncProductVariationTypeProtocol) -> Bool {
+        guard let other = other as? Self else { return false }
+        return self == other
+    }
+}
+
 /// Product input for an `OrderSynchronizer` type.
 ///
 public struct OrderSyncProductInput {
@@ -39,7 +56,7 @@ public struct OrderSyncProductInput {
     ///
     public enum ProductType: Hashable {
         case product(any OrderSyncProductTypeProtocol)
-        case variation(ProductVariation)
+        case variation(any OrderSyncProductVariationTypeProtocol)
 
         public func hash(into hasher: inout Hasher) {
             switch self {
@@ -57,7 +74,7 @@ public struct OrderSyncProductInput {
             case (.product(let lhsProduct), .product(let rhsProduct)):
                 return lhsProduct.isEqual(to: rhsProduct)
             case (.variation(let lhsVariation), .variation(let rhsVariation)):
-                return lhsVariation == rhsVariation
+                return lhsVariation.isEqual(to: rhsVariation)
             default:
                 return false
             }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -168,6 +168,11 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         }
         XCTAssertEqual(firstVariation.name, "Variation 1275")
         XCTAssertEqual(firstVariation.formattedPrice, "$12.00")
+        XCTAssertEqual(firstVariation.price, "12")
+        XCTAssertEqual(firstVariation.productImageSource,
+                       "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1")
+        XCTAssertEqual(firstVariation.productID, parentProductID)
+        XCTAssertEqual(firstVariation.productVariationID, 1275)
     }
 
     func test_providePointOfSaleVariationItems_throws_error_when_variations_load_fails() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14697 

Please review https://github.com/woocommerce/woocommerce-ios/pull/14793 first.

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request adds support for adding a variation to the cart in POS.

Enhancements to `POSVariation`:

* [`Yosemite/Yosemite/PointOfSale/POSVariation.swift`](diffhunk://#diff-bf9d9e67e2f89978ff4b350e7d9a27004e035e9d66aa732d9913f2e16ce24bceL3-R34): Added new properties `price`, `productID`, and `variationID` to the `POSVariation` struct and updated the initializer accordingly. Implemented the `OrderSyncProductVariationTypeProtocol` and `POSOrderableItem` protocols.

Updates to POS item handling:

* [`WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift`](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bL94-R107): Updated instances of `POSVariation` to include the new properties `price`, `productID`, and `variationID`.
* [`WooCommerce/Classes/POS/Presentation/VariationCardView.swift`](diffhunk://#diff-caf6d6fdeb31ae1d035078ff5dbaab37d2ae7aae3379c059a885988b7f60c00fL57-R73): Modified the `VariationCardView` previews to include the new properties `price`, `productID`, and `variationID`.
* [`WooCommerce/Classes/POS/Utils/PreviewHelpers.swift`](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dL113-R124): Updated mock variation items to include the new properties `price`, `productID`, and `variationID`.

Protocol and type updates:

* [`Yosemite/Yosemite/Stores/Order/OrderSyncProductInput.swift`](diffhunk://#diff-e70a055982a31442eb876283f74120f28cc8fcf2e64737f11287d2706363c344R21-R37): Introduced the `OrderSyncProductVariationTypeProtocol` and updated the `OrderSyncProductInput` struct to use this protocol for variations. [[1]](diffhunk://#diff-e70a055982a31442eb876283f74120f28cc8fcf2e64737f11287d2706363c344R21-R37) [[2]](diffhunk://#diff-e70a055982a31442eb876283f74120f28cc8fcf2e64737f11287d2706363c344L42-R59) [[3]](diffhunk://#diff-e70a055982a31442eb876283f74120f28cc8fcf2e64737f11287d2706363c344L60-R77)

Testing updates:

* [`Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift`](diffhunk://#diff-1055f7d4db4a4d30e8faa6fb56af2b43d4d99d9df12a9ae48a9e60e4fa9d7dcaR171-R175): Added assertions to test the new properties `price`, `productID`, and `variationID` in `POSVariation`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

🗒️ As the variable products support requires WC version 9.6+ which is not publicly released at the time of writing, I'd recommend commenting out [L214 in ProductsRemote](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L214) to include all product types.

- Switch to a store eligible for POS and has at least one variable product
- Go to Menu > Point of Sale mode
- Tap on a variable product --> variations should be loaded shortly
- Tap on a variation --> the variation should be added to cart
- Add more items to cart if you like
- Continue to check out and pay for the order --> payment should succeed
- Exit POS and go to the orders tab, then tap on the order from POS --> the order should include the correct variation/product(s) as in the cart in POS

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1e279481-d650-4267-9c2c-7b7825a3fa0e

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.