### PR TITLE
[Woo POS] [Variable Products] Show variation name based on variation and variable product attributes

### DIFF
--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -120,6 +120,14 @@ extension ProductAttribute: Comparable {
     }
 }
 
+extension ProductAttribute: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(siteID)
+        hasher.combine(name)
+        hasher.combine(attributeID)
+    }
+}
+
 // MARK: - Decoding Errors
 //
 enum ProductAttributeDecodingError: Error {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -2,7 +2,6 @@ import Foundation
 import Combine
 import enum Yosemite.POSItem
 import protocol Yosemite.PointOfSaleItemServiceProtocol
-import enum Yosemite.PointOfSaleProductServiceError
 import struct Yosemite.POSParentProduct
 import class Yosemite.Store
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -77,7 +77,7 @@ private extension ChildItemList {
         name: "Variable latte",
         productImageSource: nil,
         productID: 1,
-        type: .variable
+        type: .variable(allAttributes: [])
     )
     let parentItem = POSItem.parentProduct(parentProduct)
     let itemsController = PointOfSalePreviewItemsController()

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -77,7 +77,7 @@ private extension ChildItemList {
         name: "Variable latte",
         productImageSource: nil,
         productID: 1,
-        type: .variable(allAttributes: [])
+        type: .variable(.init())
     )
     let parentItem = POSItem.parentProduct(parentProduct)
     let itemsController = PointOfSalePreviewItemsController()

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -62,7 +62,7 @@ private struct ItemListRow: View {
                                 name: "Variable mocha",
                                 productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg",
                                 productID: 16,
-                                type: .variable(allAttributes: [])
+                                type: .variable(.init())
                             )
                         )
                     ]

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -62,7 +62,7 @@ private struct ItemListRow: View {
                                 name: "Variable mocha",
                                 productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg",
                                 productID: 16,
-                                type: .variable
+                                type: .variable(allAttributes: [])
                             )
                         )
                     ]

--- a/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
@@ -76,7 +76,13 @@ private extension ParentProductCardView {
 
 #if DEBUG
 #Preview {
-    let parentProduct = POSParentProduct(id: UUID(), name: "Parent variable product", productImageSource: nil, productID: 42, type: .variable)
+    let parentProduct = POSParentProduct(
+        id: UUID(),
+        name: "Parent variable product",
+        productImageSource: nil,
+        productID: 42,
+        type: .variable(allAttributes: [])
+    )
     ParentProductCardView(parentProduct: parentProduct)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift
@@ -81,7 +81,7 @@ private extension ParentProductCardView {
         name: "Parent variable product",
         productImageSource: nil,
         productID: 42,
-        type: .variable(allAttributes: [])
+        type: .variable(.init())
     )
     ParentProductCardView(parentProduct: parentProduct)
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -101,7 +101,7 @@ private var mockItems: [POSItem] {
                 name: "Variable product 1",
                 productImageSource: nil,
                 productID: 5,
-                type: .variable
+                type: .variable(allAttributes: [])
             )
         ),
         .simpleProduct(POSSimpleProduct(id: UUID(), name: "Product 4", formattedPrice: "$4.00", productID: 4, price: "4.00"))

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -101,7 +101,7 @@ private var mockItems: [POSItem] {
                 name: "Variable product 1",
                 productImageSource: nil,
                 productID: 5,
-                type: .variable(allAttributes: [])
+                type: .variable(.init())
             )
         ),
         .simpleProduct(POSSimpleProduct(id: UUID(), name: "Product 4", formattedPrice: "$4.00", productID: 4, price: "4.00"))

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -2,48 +2,6 @@ import Foundation
 import Yosemite
 import WooFoundation
 
-// MARK: - View Model for a Variation Attribute
-//
-struct VariationAttributeViewModel: Equatable {
-
-    /// Attribute name
-    ///
-    let name: String
-
-    /// Attribute value
-    ///
-    let value: String?
-
-    /// Returns the attribute value, or "Any \(name)" if the attribute value is nil or empty
-    ///
-    var nameOrValue: String {
-        guard let value = value, value.isNotEmpty else {
-            return String(format: Localization.anyAttributeFormat, name)
-        }
-        return value
-    }
-
-    init(name: String, value: String? = nil) {
-        self.name = name
-        self.value = value
-    }
-
-    init(orderItemAttribute: OrderItemAttribute) {
-        self.init(name: orderItemAttribute.name, value: orderItemAttribute.value)
-    }
-
-    init(productVariationAttribute: ProductVariationAttribute) {
-        self.init(name: productVariationAttribute.name, value: productVariationAttribute.option)
-    }
-}
-
-extension VariationAttributeViewModel {
-    enum Localization {
-        static let anyAttributeFormat =
-            NSLocalizedString("Any %1$@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
-    }
-}
-
 
 // MARK: - View Model for a product details cell
 //

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2178,7 +2178,6 @@
 		CCE73D2529EDAB5C0064E797 /* SubscriptionPeriod+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE73D2429EDAB5C0064E797 /* SubscriptionPeriod+UI.swift */; };
 		CCE785C829C1E8280003977F /* BundledProductsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */; };
 		CCE785CA29C1F9170003977F /* ProductBundleItemStockStatus+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */; };
-		CCEC256A27B581E800EF9FA3 /* ProductVariationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */; };
 		CCF27B35280EF69700B755E1 /* orders_3337_add_product.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */; };
 		CCF27B3A280EF98F00B755E1 /* orders_3337.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B39280EF98F00B755E1 /* orders_3337.json */; };
 		CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */; };
@@ -5314,7 +5313,6 @@
 		CCE73D2429EDAB5C0064E797 /* SubscriptionPeriod+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SubscriptionPeriod+UI.swift"; sourceTree = "<group>"; };
 		CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewModelTests.swift; sourceTree = "<group>"; };
 		CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItemStockStatus+UI.swift"; sourceTree = "<group>"; };
-		CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatter.swift; sourceTree = "<group>"; };
 		CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337_add_product.json; sourceTree = "<group>"; };
 		CCF27B39280EF98F00B755E1 /* orders_3337.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337.json; sourceTree = "<group>"; };
 		CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollList.swift; sourceTree = "<group>"; };
@@ -12080,7 +12078,6 @@
 				D817585C22BB5E6900289CFE /* Order Details */,
 				0371C36C2876E91500277E2C /* Feature Announcement Cards */,
 				D843D5D82248EE90001BFA55 /* ManualTrackingViewModel.swift */,
-				CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */,
 				CECC758B23D2227000486676 /* ProductDetailsCellViewModel.swift */,
 				D843D5D622485B19001BFA55 /* ShippingProvidersViewModel.swift */,
 				D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */,
@@ -15818,7 +15815,6 @@
 				02E8B17C23E2C78A00A43403 /* ProductImageStatus.swift in Sources */,
 				03F5CB832A0C3A1A0026877A /* AnimatedPlaceholder.swift in Sources */,
 				0259D5FF2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift in Sources */,
-				CCEC256A27B581E800EF9FA3 /* ProductVariationFormatter.swift in Sources */,
 				02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */,
 				7E7C5F8F2719BA7300315B61 /* ProductCategoryCellViewModel.swift in Sources */,
 				DE8AA0B32BBE55E40084D2CC /* DashboardViewHostingController.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		02C254FA2563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254F92563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift */; };
 		02C254FE2563C6E500A04423 /* ShippingLabelSettings+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254FD2563C6E500A04423 /* ShippingLabelSettings+ReadOnlyConvertible.swift */; };
 		02C255022563C76A00A04423 /* ShippingLabel+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C255012563C76A00A04423 /* ShippingLabel+ReadOnlyConvertible.swift */; };
+		02CC7C2C2D2CE5CB00907B83 /* ProductVariationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CC7C2B2D2CE5CB00907B83 /* ProductVariationFormatter.swift */; };
+		02CC7C2E2D2CE5F600907B83 /* VariationAttributeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CC7C2D2D2CE5F600907B83 /* VariationAttributeViewModel.swift */; };
 		02DAE7F8291A9F11009342B7 /* DomainStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DAE7F7291A9F11009342B7 /* DomainStoreTests.swift */; };
 		02DAE7FA291A9F36009342B7 /* MockDomainRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DAE7F9291A9F36009342B7 /* MockDomainRemote.swift */; };
 		02DF98092A136BFB0009E2EA /* MockSitePluginsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DF98082A136BFB0009E2EA /* MockSitePluginsRemote.swift */; };
@@ -618,6 +620,8 @@
 		02C254F92563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelRefund+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		02C254FD2563C6E500A04423 /* ShippingLabelSettings+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelSettings+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		02C255012563C76A00A04423 /* ShippingLabel+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabel+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		02CC7C2B2D2CE5CB00907B83 /* ProductVariationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatter.swift; sourceTree = "<group>"; };
+		02CC7C2D2D2CE5F600907B83 /* VariationAttributeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariationAttributeViewModel.swift; sourceTree = "<group>"; };
 		02DAE7F7291A9F11009342B7 /* DomainStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainStoreTests.swift; sourceTree = "<group>"; };
 		02DAE7F9291A9F36009342B7 /* MockDomainRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDomainRemote.swift; sourceTree = "<group>"; };
 		02DF98082A136BFB0009E2EA /* MockSitePluginsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSitePluginsRemote.swift; sourceTree = "<group>"; };
@@ -2065,6 +2069,8 @@
 			isa = PBXGroup;
 			children = (
 				B9C0C1072A3C666A00DF84EA /* ProductVariationStorageManager.swift */,
+				02CC7C2B2D2CE5CB00907B83 /* ProductVariationFormatter.swift */,
+				02CC7C2D2D2CE5F600907B83 /* VariationAttributeViewModel.swift */,
 			);
 			path = ProductVariations;
 			sourceTree = "<group>";
@@ -2383,6 +2389,7 @@
 				CE0FBB252D0C65EB008B7789 /* WooShippingCustomPackage+ReadOnlyConvertible.swift in Sources */,
 				CE3B7AD72225ECA90050FE4B /* OrderStatusStore.swift in Sources */,
 				B5631ECD2114DF8C008D3535 /* EntityListener.swift in Sources */,
+				02CC7C2E2D2CE5F600907B83 /* VariationAttributeViewModel.swift in Sources */,
 				D80F758A223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift in Sources */,
 				B9AECD442851D95600E78584 /* TotalRefundedCalculationUseCase.swift in Sources */,
 				86DAA7982CD9E31E002AE55E /* MockPaymentActionHandler.swift in Sources */,
@@ -2600,6 +2607,7 @@
 				0232372922F7DA6E00715FAB /* StatsTimeRangeV4.swift in Sources */,
 				247CE85C25832A5000F9D9D1 /* MockProductVariationActionHandler.swift in Sources */,
 				CEC7D5992CDE360E00111B79 /* WooShippingStore.swift in Sources */,
+				02CC7C2C2D2CE5CB00907B83 /* ProductVariationFormatter.swift in Sources */,
 				B5F2AE9720EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift in Sources */,
 				247CE7C02582DC7200F9D9D1 /* ProductImage+Mocks.swift in Sources */,
 				7492FADF217FB11D00ED2C69 /* SettingAction.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSParentProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSParentProduct.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public enum POSParentProductType {
-    case variable
+public enum POSParentProductType: Equatable, Hashable {
+    case variable(allAttributes: [ProductAttribute])
 }
 
 public struct POSParentProduct: Equatable, Hashable, Identifiable {

--- a/Yosemite/Yosemite/PointOfSale/POSParentProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSParentProduct.swift
@@ -1,7 +1,22 @@
 import Foundation
 
 public enum POSParentProductType: Equatable, Hashable {
-    case variable(allAttributes: [ProductAttribute])
+    case variable(POSVariableParentProduct)
+}
+
+public struct POSVariableParentProduct: Equatable, Hashable {
+    let allAttributes: [ProductAttribute]
+
+    init(allAttributes: [ProductAttribute]) {
+        self.allAttributes = allAttributes
+    }
+
+#if DEBUG
+    /// Initializer for SwiftUI previews.
+    public init() {
+        allAttributes = []
+    }
+#endif
 }
 
 public struct POSParentProduct: Equatable, Hashable, Identifiable {

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -7,8 +7,9 @@ import class Networking.AlamofireNetwork
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 
-public enum PointOfSaleProductServiceError: Error {
+public enum PointOfSaleItemServiceError: Error, Equatable {
     case requestFailed
+    case invalidParentProduct(POSParentProduct)
     case unknown
 }
 
@@ -65,16 +66,25 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     }
 
     public func providePointOfSaleVariationItems(for parentProduct: POSParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem> {
+        guard case let .variable(allAttributes) = parentProduct.type else {
+            assertionFailure(
+                "Unexpected parent product when loading variations: \(parentProduct)"
+            )
+            throw PointOfSaleItemServiceError.invalidParentProduct(parentProduct)
+        }
         let variations = try await variationRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProduct.productID,
                                           pageNumber: pageNumber)
         return .init(
             items: variations.compactMap({ variation in
-                POSItem
+                let variationName = ProductVariationFormatter().generateName(
+                    for: variation,
+                    from: allAttributes
+                )
+                return POSItem
                     .variation(.init(id: UUID(),
-                                     // TODO-14702: variation name with ProductVariationFormatter
-                                     name: "Variation \(variation.productVariationID)",
+                                     name: variationName,
                                      formattedPrice: currencyFormatter.formatAmount(variation.price) ?? "-",
                                      productImageSource: variation.image?.src))
             }),
@@ -104,7 +114,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                                                            name: product.name,
                                                            productImageSource: thumbnailSource,
                                                            productID: product.productID,
-                                                           type: .variable))
+                                                           type: .variable(allAttributes: product.attributesForVariations)))
                 default:
                     return nil
             }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -66,7 +66,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     }
 
     public func providePointOfSaleVariationItems(for parentProduct: POSParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem> {
-        guard case let .variable(allAttributes) = parentProduct.type else {
+        guard case let .variable(variableProduct) = parentProduct.type else {
             assertionFailure(
                 "Unexpected parent product when loading variations: \(parentProduct)"
             )
@@ -80,7 +80,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             items: variations.compactMap({ variation in
                 let variationName = ProductVariationFormatter().generateName(
                     for: variation,
-                    from: allAttributes
+                    from: variableProduct.allAttributes
                 )
                 return POSItem
                     .variation(.init(id: UUID(),
@@ -114,7 +114,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                                                            name: product.name,
                                                            productImageSource: thumbnailSource,
                                                            productID: product.productID,
-                                                           type: .variable(allAttributes: product.attributesForVariations)))
+                                                           type: .variable(.init(allAttributes: product.attributesForVariations))))
                 default:
                     return nil
             }

--- a/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
@@ -1,16 +1,16 @@
 import Foundation
-import Yosemite
 
 /// Helper to format product variation details, such as variation name or attributes.
 ///
-struct ProductVariationFormatter {
+public struct ProductVariationFormatter {
+    public init() {}
 
     /// Generates a name for the product variation, given a list of the parent product attributes, e.g. "Blue - Any Size"
     /// - Parameters:
     ///   - variation: The product variation whose name is being generated
     ///   - allAttributes: A list of attributes from the parent `Product`
     ///
-    func generateName(for variation: ProductVariation, from allAttributes: [ProductAttribute]) -> String {
+    public func generateName(for variation: ProductVariation, from allAttributes: [ProductAttribute]) -> String {
         let variationAttributes = generateAttributes(for: variation, from: allAttributes)
         return variationAttributes.map { $0.nameOrValue }.joined(separator: " - ")
     }
@@ -20,7 +20,7 @@ struct ProductVariationFormatter {
     ///   - variation: The product variation whose attributes are being generated
     ///   - allAttributes: A list of attributes from the parent `Product`
     ///
-    func generateAttributes(for variation: ProductVariation, from allAttributes: [ProductAttribute]) -> [VariationAttributeViewModel] {
+    public func generateAttributes(for variation: ProductVariation, from allAttributes: [ProductAttribute]) -> [VariationAttributeViewModel] {
         return allAttributes
             .sorted(by: { (lhs, rhs) -> Bool in
                 lhs.position < rhs.position

--- a/Yosemite/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// MARK: - View Model for a Variation Attribute
-//
+/// View Model for a Variation Attribute.
 public struct VariationAttributeViewModel: Equatable {
 
     /// Attribute name

--- a/Yosemite/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// MARK: - View Model for a Variation Attribute
+//
+public struct VariationAttributeViewModel: Equatable {
+
+    /// Attribute name
+    ///
+    public let name: String
+
+    /// Attribute value
+    ///
+    public let value: String?
+
+    /// Returns the attribute value, or "Any \(name)" if the attribute value is nil or empty
+    ///
+    public var nameOrValue: String {
+        guard let value = value, !value.isEmpty else {
+            return String(format: Localization.anyAttributeFormat, name)
+        }
+        return value
+    }
+
+    public init(name: String, value: String? = nil) {
+        self.name = name
+        self.value = value
+    }
+
+    public init(orderItemAttribute: OrderItemAttribute) {
+        self.init(name: orderItemAttribute.name, value: orderItemAttribute.value)
+    }
+
+    init(productVariationAttribute: ProductVariationAttribute) {
+        self.init(name: productVariationAttribute.name, value: productVariationAttribute.option)
+    }
+}
+
+extension VariationAttributeViewModel {
+    enum Localization {
+        static let anyAttributeFormat =
+            NSLocalizedString("Any %1$@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
+    }
+}

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -181,6 +181,15 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                             visible: true,
                             variation: true,
                             options: ["99%", "87%"]
+                        ),
+                        .init(
+                            siteID: siteID,
+                            attributeID: 0,
+                            name: "Size",
+                            position: 4,
+                            visible: true,
+                            variation: true,
+                            options: ["6 piece"]
                         )
                     ]
                 )
@@ -196,7 +205,10 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         guard case let .variation(firstVariation) = firstVariation else {
             return XCTFail("Variation is expected.")
         }
-        XCTAssertEqual(firstVariation.name, "marble - nuts - 99%")
+        XCTAssertEqual(
+            firstVariation.name,
+            "marble - nuts - 99% - \(String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Size"))"
+        )
         XCTAssertEqual(firstVariation.formattedPrice, "$12.00")
     }
 

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -27,7 +27,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
 
     func test_PointOfSaleItemServiceProtocol_when_fails_request_with_requestFailed_then_throws_error() async throws {
         // Given
-        let expectedError = PointOfSaleProductServiceError.requestFailed
+        let expectedError = PointOfSaleItemServiceError.requestFailed
         network.simulateError(requestUrlSuffix: "products", error: expectedError)
 
         // When
@@ -36,7 +36,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
             XCTFail("Expected an error, but got success.")
         } catch {
             // Then
-            XCTAssertEqual(error as? PointOfSaleProductServiceError, expectedError)
+            XCTAssertEqual(error as? PointOfSaleItemServiceError, expectedError)
         }
     }
 
@@ -153,7 +153,37 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                 name: "Tea",
                 productImageSource: nil,
                 productID: parentProductID,
-                type: .variable
+                type: .variable(
+                    allAttributes: [
+                        .init(
+                            siteID: siteID,
+                            attributeID: 0,
+                            name: "Shape",
+                            position: 1,
+                            visible: true,
+                            variation: true,
+                            options: ["Marble", "Heart"]
+                        ),
+                        .init(
+                            siteID: siteID,
+                            attributeID: 0,
+                            name: "Flavor",
+                            position: 2,
+                            visible: true,
+                            variation: true,
+                            options: ["fruity", "nuts"]
+                        ),
+                        .init(
+                            siteID: siteID,
+                            attributeID: 0,
+                            name: "Darkness",
+                            position: 3,
+                            visible: true,
+                            variation: true,
+                            options: ["99%", "87%"]
+                        )
+                    ]
+                )
             ),
             pageNumber: 1
         )
@@ -166,7 +196,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         guard case let .variation(firstVariation) = firstVariation else {
             return XCTFail("Variation is expected.")
         }
-        XCTAssertEqual(firstVariation.name, "Variation 1275")
+        XCTAssertEqual(firstVariation.name, "marble - nuts - 99%")
         XCTAssertEqual(firstVariation.formattedPrice, "$12.00")
     }
 
@@ -177,7 +207,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                                             network: network,
                                             isVariableProductsFeatureEnabled: true)
         let parentProductID: Int64 = 123
-        let expectedError = PointOfSaleProductServiceError.requestFailed
+        let expectedError = PointOfSaleItemServiceError.requestFailed
 
         // When
         network.simulateError(requestUrlSuffix: "products/\(parentProductID)/variations", error: expectedError)
@@ -190,13 +220,13 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                     name: "Tea",
                     productImageSource: nil,
                     productID: parentProductID,
-                    type: .variable
+                    type: .variable(allAttributes: [])
                 ),
                 pageNumber: 1
             )
             XCTFail("An error is expected.")
         } catch {
-            XCTAssertEqual(error as? PointOfSaleProductServiceError, expectedError)
+            XCTAssertEqual(error as? PointOfSaleItemServiceError, expectedError)
         }
     }
 }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -154,7 +154,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                 productImageSource: nil,
                 productID: parentProductID,
                 type: .variable(
-                    allAttributes: [
+                    .init(allAttributes: [
                         .init(
                             siteID: siteID,
                             attributeID: 0,
@@ -192,7 +192,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                             options: ["6 piece"]
                         )
                     ]
-                )
+                ))
             ),
             pageNumber: 1
         )
@@ -232,7 +232,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                     name: "Tea",
                     productImageSource: nil,
                     productID: parentProductID,
-                    type: .variable(allAttributes: [])
+                    type: .variable(.init(allAttributes: []))
                 ),
                 pageNumber: 1
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14702 

Please review https://github.com/woocommerce/woocommerce-ios/pull/14793 first.

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The PR adds support to show the name for variations in the POS item selector the same way as in the products tab. The key changes involve updating the `POSParentProductType` to include attributes from a variable product, moving and modifying the `ProductVariationFormatter` and `VariationAttributeViewModel` classes, and generating variation name in the `PointOfSaleItemService`.

### Changes to Product Variations and Attributes Handling:

* `POSParentProductType` now includes attributes, which allows for generating the name of product variations to show attributes in the expected order including "any" attributes. (`Yosemite/Yosemite/PointOfSale/POSParentProduct.swift`)
* Added error handling for invalid parent products in `PointOfSaleItemService`. (`Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift`) [[1]](diffhunk://#diff-4ff6f858a82d655da0ffbd0c0620178056e0a60bd6a43fea67a3aafcf46219c9L10-R12) [[2]](diffhunk://#diff-4ff6f858a82d655da0ffbd0c0620178056e0a60bd6a43fea67a3aafcf46219c9R69-R87)
* Updated the `providePointOfSaleVariationItems` method to use `ProductVariationFormatter` for generating variation names. (`Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift`)

### Code Refactoring and File Management:

* Moved `ProductVariationFormatter` from WooCommerce to Yosemite and made it public. (`Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift`) [[1]](diffhunk://#diff-8099cd3d8a6875f41d3fd5f0d1d6048d07b8fcf4528342bf758ded9a76d44bb9L2-R13) [[2]](diffhunk://#diff-8099cd3d8a6875f41d3fd5f0d1d6048d07b8fcf4528342bf758ded9a76d44bb9L23-R23)
* Added `VariationAttributeViewModel` to Yosemite project files to support variation attribute handling. (`Yosemite/Yosemite.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-d1524c2acad9880f1765f03843824d6925cebf6464010e52ecee833c9926ac12R84-R85) [[2]](diffhunk://#diff-d1524c2acad9880f1765f03843824d6925cebf6464010e52ecee833c9926ac12R623-R624)

### Miscellaneous Changes:

* Implemented `Hashable` for `ProductAttribute` to support hashing. (`Networking/Networking/Model/Product/ProductAttribute.swift`)
* Removed unused import statements and cleaned up code. (`WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift`)
* Updated various mock data and preview methods to include attributes. Empty value is used as previews use a different items service from `PointOfSaleItemService` that generates the variation name based on attributes. (`WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift`, `WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift`, `WooCommerce/Classes/POS/Presentation/ParentProductCardView.swift`, `WooCommerce/Classes/POS/Utils/PreviewHelpers.swift`) [[1]](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bL80-R80) [[2]](diffhunk://#diff-4dabea090e9975b33e741405197fdc574e0876ec76ece41f80b312e6766f217dL65-R65) [[3]](diffhunk://#diff-210e84ea8e59459811d01a2b6ef2dd5536513ef37ecded0eaff994597f7d1267L79-R85) [[4]](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dL104-R104)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

🗒️ As the variable products support requires WC version 9.6+ which is not publicly released at the time of writing, I'd recommend commenting out [L214 in ProductsRemote](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L214) to include all product types.

- Switch to a store eligible for POS and has at least one variable product
- Go to Menu > Point of Sale mode
- Tap on a variable product --> variations should be loaded shortly. each variation card should show the correct name with the attributes in the right order and include any attributes
- Check a few other variable products and verify that the variation name is displayed correctly

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/95255f2f-2535-46db-a81b-0e5c3b1e1340



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.