### PR TITLE
[Shipping Labels] Update origin addresses endpoint

### DIFF
--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -298,7 +298,7 @@ private extension WooShippingRemote {
         static let purchase = "label/purchase"
         static let status = "label/status"
         static let print = "label/print"
-        static let originAddresses = "origin-addresses"
+        static let originAddresses = "address/origins"
     }
 
     enum ParameterKey {

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -387,7 +387,7 @@ final class WooShippingRemoteTests: XCTestCase {
     func test_loadOriginAddresses_parses_success_response() throws {
         // Given
         let remote = WooShippingRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "origin-addresses", filename: "wooshipping-get-origin-addresses-success")
+        network.simulateResponse(requestUrlSuffix: "address/origins", filename: "wooshipping-get-origin-addresses-success")
 
         // When
         let result: Result<[WooShippingOriginAddress], Error> = waitFor { promise in
@@ -417,7 +417,7 @@ final class WooShippingRemoteTests: XCTestCase {
     func test_loadOriginAddresses_returns_error_on_failure() throws {
         // Given
         let remote = WooShippingRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "origin-addresses", filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "address/origins", filename: "generic_error")
 
         // When
         let result: Result<[WooShippingOriginAddress], Error> = waitFor { promise in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to: #13779
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Update origin addresses endpoint (p1736243308265609-slack-C02KUCFCSFP)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Check test coverage and make sure CI passes

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
