### PR TITLE
[Woo POS] [Cash & Receipts] Validate cash amount

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -57,7 +57,7 @@ struct PointOfSaleCollectCashView: View {
             if let changeDue = changeDueMessage {
                 Text(changeDue)
                     .font(.posBodyRegular)
-                    .foregroundColor(.green)
+                    .foregroundColor(.posTextSuccess)
             }
 
             if let errorMessage = errorMessage {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import class WooFoundation.CurrencyFormatter
 
 struct PointOfSaleCollectCashView: View {
     @Environment(\.colorScheme) var colorScheme
@@ -9,6 +10,8 @@ struct PointOfSaleCollectCashView: View {
     @State private var isLoading: Bool = false
     @State private var errorMessage: String?
 
+    private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+
     let orderTotal: String
 
     private var formattedOrderTotal: String {
@@ -16,10 +19,26 @@ struct PointOfSaleCollectCashView: View {
     }
 
     private func validateAmount() -> Bool {
-        // TODO:
-        // Validate amount entered vs order total
-        // https://github.com/woocommerce/woocommerce-ios/issues/14749
-        return true
+        guard let orderDecimal = parseCurrency(orderTotal),
+              let inputDecimal = parseCurrency(textFieldAmountInput) else {
+            errorMessage = "Invalid amount. Please try again."
+            return false
+        }
+        switch inputDecimal.compare(orderDecimal) {
+            case .orderedAscending:
+                // inputDecimal < orderDecimal
+                errorMessage = "Not enough cash to cover the order."
+                return false
+            case .orderedDescending:
+                // inputDecimal > orderDecimal
+                let changeDue = inputDecimal.subtracting(orderDecimal)
+                errorMessage = "Change due: \(formatAsCurrency(changeDue))"
+                return true
+            case .orderedSame:
+                // inputDecimal == orderDecimal
+                errorMessage = nil
+                return true
+            }
     }
 
     @StateObject private var textFieldViewModel = FormattableAmountTextFieldViewModel(size: .extraLarge,
@@ -109,6 +128,16 @@ struct PointOfSaleCollectCashView: View {
 
     private func markComplete() async throws {
         try await posModel.collectCashPayment()
+    }
+}
+
+private extension PointOfSaleCollectCashView {
+    func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
+        currencyFormatter.convertToDecimal(amountString, locale: .current)
+    }
+
+    private func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
+        currencyFormatter.formatAmount(amount) ?? "$0.00"
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -1,17 +1,80 @@
 import SwiftUI
 import class WooFoundation.CurrencyFormatter
 
+final class CollectCashViewHelper {
+    private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+
+    func updatechangeDueMessage(orderTotal: String,
+                                textFieldAmountInput: String) -> String? {
+        guard let orderDecimal = parseCurrency(orderTotal),
+              let inputDecimal = parseCurrency(textFieldAmountInput) else {
+            return nil
+        }
+        if inputDecimal.compare(orderDecimal) == .orderedDescending {
+            let changeDue = inputDecimal.subtracting(orderDecimal)
+            return  String.localizedStringWithFormat(Localization.changeDueMessage, formatAsCurrency(changeDue))
+        } else {
+            return nil
+        }
+    }
+
+    func validateAmountOnSubmit(orderTotal: String,
+                                textFieldAmountInput: String,
+                                onError: (String) -> Void) -> Bool {
+        guard let orderDecimal = parseCurrency(orderTotal),
+              let inputDecimal = parseCurrency(textFieldAmountInput) else {
+            onError(Localization.failedToCollectCashPayment)
+            return false
+        }
+
+        if inputDecimal.compare(orderDecimal) == .orderedAscending {
+            onError(Localization.cashPaymentAmountNotEnough)
+            return false
+        }
+        return true
+    }
+
+    func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
+        currencyFormatter.convertToDecimal(amountString, locale: .current)
+    }
+
+    func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
+        currencyFormatter.formatAmount(amount) ?? "$0.00"
+    }
+}
+
+private extension CollectCashViewHelper {
+    enum Localization {
+        static let changeDueMessage = NSLocalizedString(
+            "collectcashviewhelper.changedue",
+            value: "Change due: %1$@",
+            comment: "Change due when the cash amount entered exceeds the order total." +
+            "Reads as 'Change due: $1.23'"
+        )
+        static let failedToCollectCashPayment = NSLocalizedString(
+            "collectcashviewhelper.failedtocollectcashpayment.errormessage",
+            value: "Error trying to process payment. Try again.",
+            comment: "Error message when the system fails to collect a cash payment."
+        )
+        static let cashPaymentAmountNotEnough = NSLocalizedString(
+            "collectcashviewhelper.cashpaymentamountnotenough.errormessage",
+            value: "Amount must be more or equal to total.",
+            comment: "Error message when the cash amount entered is less than the order total."
+        )
+    }
+}
+
 struct PointOfSaleCollectCashView: View {
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject private var posModel: PointOfSaleAggregateModel
     @FocusState private var isTextFieldFocused: Bool
 
+    private let viewHelper = CollectCashViewHelper()
+
     @State private var textFieldAmountInput: String = ""
     @State private var isLoading: Bool = false
     @State private var errorMessage: String?
     @State private var changeDueMessage: String?
-
-    private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
 
     let orderTotal: String
 
@@ -119,41 +182,26 @@ struct PointOfSaleCollectCashView: View {
 
 private extension PointOfSaleCollectCashView {
     func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
-        currencyFormatter.convertToDecimal(amountString, locale: .current)
+        viewHelper.parseCurrency(amountString)
     }
 
     private func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
-        currencyFormatter.formatAmount(amount) ?? "$0.00"
+        viewHelper.formatAsCurrency(amount)
     }
 
     private func updateChangeDueMessage() {
-        guard let orderDecimal = parseCurrency(orderTotal),
-              let inputDecimal = parseCurrency(textFieldAmountInput) else {
-            changeDueMessage = nil
-            return
-        }
-
-        if inputDecimal.compare(orderDecimal) == .orderedDescending {
-            let changeDue = inputDecimal.subtracting(orderDecimal)
-            changeDueMessage = String.localizedStringWithFormat(Localization.changeDueMessage, formatAsCurrency(changeDue))
-        } else {
-            changeDueMessage = nil
-        }
+        changeDueMessage = viewHelper.updatechangeDueMessage(
+            orderTotal: orderTotal,
+            textFieldAmountInput: textFieldAmountInput)
     }
 
     private func validateAmountOnSubmit() -> Bool {
-            guard let orderDecimal = parseCurrency(orderTotal),
-                  let inputDecimal = parseCurrency(textFieldAmountInput) else {
-                errorMessage = Localization.failedToCollectCashPayment
-                return false
-            }
-
-            if inputDecimal.compare(orderDecimal) == .orderedAscending {
-                errorMessage = Localization.cashPaymentAmountNotEnough
-                return false
-            }
-            errorMessage = nil
-            return true
+        viewHelper.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: textFieldAmountInput,
+            onError: { error in
+                errorMessage = error
+            })
         }
 }
 
@@ -195,17 +243,6 @@ private extension PointOfSaleCollectCashView {
             "pointOfSale.cashview.failedtocollectcashpayment.errormessage",
             value: "Error trying to process payment. Try again.",
             comment: "Error message when the system fails to collect a cash payment."
-        )
-        static let cashPaymentAmountNotEnough = NSLocalizedString(
-            "pointOfSale.cashview.cashpaymentamountnotenough.errormessage",
-            value: "Amount must be more or equal to total.",
-            comment: "Error message when the cash amount entered is less than the order total."
-        )
-        static let changeDueMessage = NSLocalizedString(
-            "pointOfSale.cashview.changedue",
-            value: "Change due: %1$@",
-            comment: "Change due when the cash amount entered exceeds the order total." +
-            "Reads as 'Change due: $1.23'"
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -9,6 +9,7 @@ struct PointOfSaleCollectCashView: View {
     @State private var textFieldAmountInput: String = ""
     @State private var isLoading: Bool = false
     @State private var errorMessage: String?
+    @State private var changeDueMessage: String?
 
     private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
 
@@ -16,29 +17,6 @@ struct PointOfSaleCollectCashView: View {
 
     private var formattedOrderTotal: String {
         String.localizedStringWithFormat(Localization.backNavigationSubtitle, orderTotal)
-    }
-
-    private func validateAmount() -> Bool {
-        guard let orderDecimal = parseCurrency(orderTotal),
-              let inputDecimal = parseCurrency(textFieldAmountInput) else {
-            errorMessage = "Invalid amount. Please try again."
-            return false
-        }
-        switch inputDecimal.compare(orderDecimal) {
-            case .orderedAscending:
-                // inputDecimal < orderDecimal
-                errorMessage = "Not enough cash to cover the order."
-                return false
-            case .orderedDescending:
-                // inputDecimal > orderDecimal
-                let changeDue = inputDecimal.subtracting(orderDecimal)
-                errorMessage = "Change due: \(formatAsCurrency(changeDue))"
-                return true
-            case .orderedSame:
-                // inputDecimal == orderDecimal
-                errorMessage = nil
-                return true
-            }
     }
 
     @StateObject private var textFieldViewModel = FormattableAmountTextFieldViewModel(size: .extraLarge,
@@ -73,7 +51,14 @@ struct PointOfSaleCollectCashView: View {
             FormattableAmountTextField(viewModel: textFieldViewModel, style: .pos)
                 .onChange(of: textFieldViewModel.amount) { newValue in
                     textFieldAmountInput = newValue
+                    updateChangeDueMessage()
                 }
+
+            if let changeDue = changeDueMessage {
+                Text(changeDue)
+                    .font(.posBodyRegular)
+                    .foregroundColor(.green)
+            }
 
             if let errorMessage = errorMessage {
                 Text(errorMessage)
@@ -83,7 +68,7 @@ struct PointOfSaleCollectCashView: View {
 
             Button(action: {
                 Task { @MainActor in
-                    guard validateAmount() else {
+                    guard validateAmountOnSubmit() else {
                         return
                     }
                     isLoading = true
@@ -121,6 +106,7 @@ struct PointOfSaleCollectCashView: View {
         .background(backgroundColor)
         .padding()
         .animation(.easeInOut, value: errorMessage)
+        .animation(.easeInOut, value: changeDueMessage)
         .onChange(of: textFieldAmountInput) { _ in
             errorMessage = nil
         }
@@ -139,6 +125,36 @@ private extension PointOfSaleCollectCashView {
     private func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
         currencyFormatter.formatAmount(amount) ?? "$0.00"
     }
+
+    private func updateChangeDueMessage() {
+        guard let orderDecimal = parseCurrency(orderTotal),
+              let inputDecimal = parseCurrency(textFieldAmountInput) else {
+            changeDueMessage = nil
+            return
+        }
+
+        if inputDecimal.compare(orderDecimal) == .orderedDescending {
+            let changeDue = inputDecimal.subtracting(orderDecimal)
+            changeDueMessage = "Change due: \(formatAsCurrency(changeDue))"
+        } else {
+            changeDueMessage = nil
+        }
+    }
+
+    private func validateAmountOnSubmit() -> Bool {
+            guard let orderDecimal = parseCurrency(orderTotal),
+                  let inputDecimal = parseCurrency(textFieldAmountInput) else {
+                errorMessage = "Invalid amount. Please try again."
+                return false
+            }
+
+            if inputDecimal.compare(orderDecimal) == .orderedAscending {
+                errorMessage = "Amount must be more or equal to total"
+                return false
+            }
+            errorMessage = nil
+            return true
+        }
 }
 
 private extension PointOfSaleCollectCashView {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -135,7 +135,7 @@ private extension PointOfSaleCollectCashView {
 
         if inputDecimal.compare(orderDecimal) == .orderedDescending {
             let changeDue = inputDecimal.subtracting(orderDecimal)
-            changeDueMessage = "Change due: \(formatAsCurrency(changeDue))"
+            changeDueMessage = String.localizedStringWithFormat(Localization.changeDueMessage, formatAsCurrency(changeDue))
         } else {
             changeDueMessage = nil
         }
@@ -144,12 +144,12 @@ private extension PointOfSaleCollectCashView {
     private func validateAmountOnSubmit() -> Bool {
             guard let orderDecimal = parseCurrency(orderTotal),
                   let inputDecimal = parseCurrency(textFieldAmountInput) else {
-                errorMessage = "Invalid amount. Please try again."
+                errorMessage = Localization.failedToCollectCashPayment
                 return false
             }
 
             if inputDecimal.compare(orderDecimal) == .orderedAscending {
-                errorMessage = "Amount must be more or equal to total"
+                errorMessage = Localization.cashPaymentAmountNotEnough
                 return false
             }
             errorMessage = nil
@@ -192,9 +192,20 @@ private extension PointOfSaleCollectCashView {
             comment: "Button to mark a cash payment as completed"
         )
         static let failedToCollectCashPayment = NSLocalizedString(
-            "pointOfSale.cashview.failedToCollectCashPayment.draft",
+            "pointOfSale.cashview.failedtocollectcashpayment.errormessage",
             value: "Error trying to process payment. Try again.",
             comment: "Error message when the system fails to collect a cash payment."
+        )
+        static let cashPaymentAmountNotEnough = NSLocalizedString(
+            "pointOfSale.cashview.cashpaymentamountnotenough.errormessage",
+            value: "Amount must be more or equal to total.",
+            comment: "Error message when the cash amount entered is less than the order total."
+        )
+        static let changeDueMessage = NSLocalizedString(
+            "pointOfSale.cashview.changedue",
+            value: "Change due: %1$@",
+            comment: "Change due when the cash amount entered exceeds the order total." +
+            "Reads as 'Change due: $1.23'"
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -1,68 +1,4 @@
 import SwiftUI
-import class WooFoundation.CurrencyFormatter
-
-final class CollectCashViewHelper {
-    private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-
-    func updatechangeDueMessage(orderTotal: String,
-                                textFieldAmountInput: String) -> String? {
-        guard let orderDecimal = parseCurrency(orderTotal),
-              let inputDecimal = parseCurrency(textFieldAmountInput) else {
-            return nil
-        }
-        if inputDecimal.compare(orderDecimal) == .orderedDescending {
-            let changeDue = inputDecimal.subtracting(orderDecimal)
-            return  String.localizedStringWithFormat(Localization.changeDueMessage, formatAsCurrency(changeDue))
-        } else {
-            return nil
-        }
-    }
-
-    func validateAmountOnSubmit(orderTotal: String,
-                                textFieldAmountInput: String,
-                                onError: (String) -> Void) -> Bool {
-        guard let orderDecimal = parseCurrency(orderTotal),
-              let inputDecimal = parseCurrency(textFieldAmountInput) else {
-            onError(Localization.failedToCollectCashPayment)
-            return false
-        }
-
-        if inputDecimal.compare(orderDecimal) == .orderedAscending {
-            onError(Localization.cashPaymentAmountNotEnough)
-            return false
-        }
-        return true
-    }
-
-    func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
-        currencyFormatter.convertToDecimal(amountString, locale: .current)
-    }
-
-    func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
-        currencyFormatter.formatAmount(amount) ?? "$0.00"
-    }
-}
-
-private extension CollectCashViewHelper {
-    enum Localization {
-        static let changeDueMessage = NSLocalizedString(
-            "collectcashviewhelper.changedue",
-            value: "Change due: %1$@",
-            comment: "Change due when the cash amount entered exceeds the order total." +
-            "Reads as 'Change due: $1.23'"
-        )
-        static let failedToCollectCashPayment = NSLocalizedString(
-            "collectcashviewhelper.failedtocollectcashpayment.errormessage",
-            value: "Error trying to process payment. Try again.",
-            comment: "Error message when the system fails to collect a cash payment."
-        )
-        static let cashPaymentAmountNotEnough = NSLocalizedString(
-            "collectcashviewhelper.cashpaymentamountnotenough.errormessage",
-            value: "Amount must be more or equal to total.",
-            comment: "Error message when the cash amount entered is less than the order total."
-        )
-    }
-}
 
 struct PointOfSaleCollectCashView: View {
     @Environment(\.colorScheme) var colorScheme
@@ -181,14 +117,6 @@ struct PointOfSaleCollectCashView: View {
 }
 
 private extension PointOfSaleCollectCashView {
-    func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
-        viewHelper.parseCurrency(amountString)
-    }
-
-    private func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
-        viewHelper.formatAsCurrency(amount)
-    }
-
     private func updateChangeDueMessage() {
         changeDueMessage = viewHelper.updatechangeDueMessage(
             orderTotal: orderTotal,

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -87,6 +87,15 @@ extension Color {
         )
     }
 
+    static var posTextSuccess: Color {
+        Color(
+            UIColor(
+                light: UIColor(red: 10.0/255.0, green: 148.0/255.0, blue: 0.0/255.0, alpha: 1.0),
+                dark: UIColor(red: 10.0/255.0, green: 148.0/255.0, blue: 0.0/255.0, alpha: 1.0)
+            )
+        )
+    }
+
     // MARK: - Buttons
 
     static var posPrimaryButtonBackground: Color {

--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -1,0 +1,65 @@
+import Foundation
+import class WooFoundation.CurrencyFormatter
+
+final class CollectCashViewHelper {
+    private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+
+    func updatechangeDueMessage(orderTotal: String,
+                                textFieldAmountInput: String) -> String? {
+        guard let orderDecimal = parseCurrency(orderTotal),
+              let inputDecimal = parseCurrency(textFieldAmountInput) else {
+            return nil
+        }
+        if inputDecimal.compare(orderDecimal) == .orderedDescending {
+            let changeDue = inputDecimal.subtracting(orderDecimal)
+            return  String.localizedStringWithFormat(Localization.changeDueMessage, formatAsCurrency(changeDue))
+        } else {
+            return nil
+        }
+    }
+
+    func validateAmountOnSubmit(orderTotal: String,
+                                textFieldAmountInput: String,
+                                onError: (String) -> Void) -> Bool {
+        guard let orderDecimal = parseCurrency(orderTotal),
+              let inputDecimal = parseCurrency(textFieldAmountInput) else {
+            onError(Localization.failedToCollectCashPayment)
+            return false
+        }
+
+        if inputDecimal.compare(orderDecimal) == .orderedAscending {
+            onError(Localization.cashPaymentAmountNotEnough)
+            return false
+        }
+        return true
+    }
+
+    func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
+        currencyFormatter.convertToDecimal(amountString, locale: .current)
+    }
+
+    func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
+        currencyFormatter.formatAmount(amount) ?? "$0.00"
+    }
+}
+
+private extension CollectCashViewHelper {
+    enum Localization {
+        static let changeDueMessage = NSLocalizedString(
+            "collectcashviewhelper.changedue",
+            value: "Change due: %1$@",
+            comment: "Change due when the cash amount entered exceeds the order total." +
+            "Reads as 'Change due: $1.23'"
+        )
+        static let failedToCollectCashPayment = NSLocalizedString(
+            "collectcashviewhelper.failedtocollectcashpayment.errormessage",
+            value: "Error trying to process payment. Try again.",
+            comment: "Error message when the system fails to collect a cash payment."
+        )
+        static let cashPaymentAmountNotEnough = NSLocalizedString(
+            "collectcashviewhelper.cashpaymentamountnotenough.errormessage",
+            value: "Amount must be more or equal to total.",
+            comment: "Error message when the cash amount entered is less than the order total."
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -34,11 +34,11 @@ final class CollectCashViewHelper {
         return true
     }
 
-    func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
+    private func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
         currencyFormatter.convertToDecimal(amountString, locale: .current)
     }
 
-    func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
+    private func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
         currencyFormatter.formatAmount(amount) ?? "$0.00"
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1575,6 +1575,7 @@
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
 		6888A2CA2A66C42C0026F5C0 /* FullFeatureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */; };
 		6891C3642D364AFE00B5B48C /* CollectCashViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6891C3632D364AFB00B5B48C /* CollectCashViewHelper.swift */; };
+		6891C3662D364C1A00B5B48C /* CollectCashViewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6891C3652D364C1A00B5B48C /* CollectCashViewHelperTests.swift */; };
 		68A345642D029E12002EE324 /* PaymentButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A345632D029E09002EE324 /* PaymentButtons.swift */; };
 		68A38DF52B293B030090C263 /* MockProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A38DF42B293B030090C263 /* MockProductListViewModel.swift */; };
 		68A5221B2BA1804900A6A584 /* PluginDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */; };
@@ -4672,6 +4673,7 @@
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
 		6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListViewModel.swift; sourceTree = "<group>"; };
 		6891C3632D364AFB00B5B48C /* CollectCashViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectCashViewHelper.swift; sourceTree = "<group>"; };
+		6891C3652D364C1A00B5B48C /* CollectCashViewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectCashViewHelperTests.swift; sourceTree = "<group>"; };
 		68A345632D029E09002EE324 /* PaymentButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtons.swift; sourceTree = "<group>"; };
 		68A38DF42B293B030090C263 /* MockProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductListViewModel.swift; sourceTree = "<group>"; };
 		68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailsViewModelTests.swift; sourceTree = "<group>"; };
@@ -12720,6 +12722,7 @@
 			children = (
 				683763192C2E6F5900AD51D0 /* CartViewHelperTests.swift */,
 				02B191532CCF377E00CF38C9 /* PointOfSaleCardPresentPaymentOnboardingViewModelTests.swift */,
+				6891C3652D364C1A00B5B48C /* CollectCashViewHelperTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -17254,6 +17257,7 @@
 				DA81B4362C8F2BB8000F3466 /* MarkOrderAsReadUseCase.swift in Sources */,
 				02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */,
 				B9B6DEF1283F8EB100901FB7 /* SitePluginsURLTests.swift in Sources */,
+				6891C3662D364C1A00B5B48C /* CollectCashViewHelperTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
 				AEB6903729770B1D00872FE0 /* ProductListViewModelTests.swift in Sources */,
 				03B9E52B2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1574,6 +1574,7 @@
 		6885E2CC2C32B14B004C8D70 /* TotalsViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */; };
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
 		6888A2CA2A66C42C0026F5C0 /* FullFeatureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */; };
+		6891C3642D364AFE00B5B48C /* CollectCashViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6891C3632D364AFB00B5B48C /* CollectCashViewHelper.swift */; };
 		68A345642D029E12002EE324 /* PaymentButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A345632D029E09002EE324 /* PaymentButtons.swift */; };
 		68A38DF52B293B030090C263 /* MockProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A38DF42B293B030090C263 /* MockProductListViewModel.swift */; };
 		68A5221B2BA1804900A6A584 /* PluginDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */; };
@@ -4670,6 +4671,7 @@
 		6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewHelper.swift; sourceTree = "<group>"; };
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
 		6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListViewModel.swift; sourceTree = "<group>"; };
+		6891C3632D364AFB00B5B48C /* CollectCashViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectCashViewHelper.swift; sourceTree = "<group>"; };
 		68A345632D029E09002EE324 /* PaymentButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtons.swift; sourceTree = "<group>"; };
 		68A38DF42B293B030090C263 /* MockProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductListViewModel.swift; sourceTree = "<group>"; };
 		68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailsViewModelTests.swift; sourceTree = "<group>"; };
@@ -6961,6 +6963,7 @@
 		026826912BF59D7A0036F959 /* ViewHelpers */ = {
 			isa = PBXGroup;
 			children = (
+				6891C3632D364AFB00B5B48C /* CollectCashViewHelper.swift */,
 				6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */,
 				6837631B2C2E847D00AD51D0 /* CartViewHelper.swift */,
 			);
@@ -15376,6 +15379,7 @@
 				B5F355EF21CD500200A7077A /* SearchViewController.swift in Sources */,
 				773077EC251E943700178696 /* ProductDownloadFileViewModel.swift in Sources */,
 				0273708024C0094500167204 /* ProductListMultiSelectorDataSource.swift in Sources */,
+				6891C3642D364AFE00B5B48C /* CollectCashViewHelper.swift in Sources */,
 				DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */,
 				DED9740B2AD7D09E00122EB4 /* BlazeCampaignListView.swift in Sources */,
 				E1ED16E4266E10A10037B8DB /* ApplicationLogViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import WooCommerce
+
+struct CollectCashViewHelperTests {
+    let sut = CollectCashViewHelper()
+
+    @Test func updatechangeDueMessage_when_invalid_orderDecimal_then_returns_nil() {
+        // Given
+        let invalidOrderTotal = "not a value"
+        let validAmountInput = "20.00"
+
+        // When
+        let result = sut.updatechangeDueMessage(
+            orderTotal: invalidOrderTotal,
+            textFieldAmountInput: validAmountInput)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func updatechangeDueMessage_when_invalid_textFieldAmountInput_then_returns_nil() {
+        // Given
+        let invalidOrderTotal = "20.00"
+        let validAmountInput = "not a value"
+
+        // When
+        let result = sut.updatechangeDueMessage(
+            orderTotal: invalidOrderTotal,
+            textFieldAmountInput: validAmountInput)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func updatechangeDueMessage_when_input_is_below_total_then_returns_nil() {
+        // Given
+        let orderTotal = "20.00"
+        let textFieldAmountInput = "10.00"
+
+        // When
+        let result = sut.updatechangeDueMessage(
+            orderTotal: orderTotal,
+            textFieldAmountInput: textFieldAmountInput)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func updatechangeDueMessage_when_input_is_above_total_then_returns_change_due_formatted_message() {
+        // Given
+        let orderTotal = "10.00"
+        let textFieldAmountInput = "20.00"
+        let expectedMessage = "Change due: $10.00"
+
+        // When
+        let result = sut.updatechangeDueMessage(
+            orderTotal: orderTotal,
+            textFieldAmountInput: textFieldAmountInput)
+
+        // Then
+        #expect(result == expectedMessage)
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
@@ -60,4 +60,83 @@ struct CollectCashViewHelperTests {
         // Then
         #expect(result == expectedMessage)
     }
+
+    @Test func validateAmountOnSubmit_when_invalid_orderDecimal_then_returns_false_with_expected_error_message() {
+        // Given
+        let invalidOrderTotal = "not a value"
+        let validAmountInput = "20.00"
+        let expectedErrorMessage = "Error trying to process payment. Try again."
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: invalidOrderTotal,
+            textFieldAmountInput: validAmountInput,
+            onError: { error in
+                capturedErrorMessage = error
+            })
+
+        // Then
+        #expect(result == false)
+        #expect(capturedErrorMessage == expectedErrorMessage)
+    }
+
+    @Test func validateAmountOnSubmit_when_invalid_input_then_returns_false_with_expected_error_message() {
+        // Given
+        let validOrderTotal = "20.00"
+        let invalidAmountInput = "not a value"
+        let expectedErrorMessage = "Error trying to process payment. Try again."
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: validOrderTotal,
+            textFieldAmountInput: invalidAmountInput,
+            onError: { error in
+                capturedErrorMessage = error
+            })
+
+        // Then
+        #expect(result == false)
+        #expect(capturedErrorMessage == expectedErrorMessage)
+    }
+
+    @Test func validateAmountOnSubmit_when_inputDecimal_is_less_than_orderTotal_then_returns_false_with_expected_error_message() {
+        // Given
+        let orderTotal = "20.00"
+        let inputAmount = "10.00"
+        let expectedErrorMessage = "Amount must be more or equal to total."
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount
+        ) { error in
+            capturedErrorMessage = error
+        }
+
+        // Then
+        #expect(result == false)
+        #expect(capturedErrorMessage == expectedErrorMessage)
+    }
+
+    @Test func validateAmountOnSubmit_when_inputDecimal_is_greater_than_or_equal_to_orderTotal_then_returns_true() {
+        // Given
+        let orderTotal = "20.00"
+        let inputAmount = "20.00"
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount
+        ) { error in
+            capturedErrorMessage = error
+        }
+
+        // Then
+        #expect(result == true)
+        #expect(capturedErrorMessage == nil)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14749 

## Description
This PR adds validation to the cash amount entered by a merchant during the cash collection flow.
- If the amount is not enough, does not show any message until we press the "collect" button, at which point an error message (red) will appear
- If the amount is exact, we can collect normally
- If the amount exceeds the order total, a "change due" (green) message will be shown each time we change the input.


https://github.com/user-attachments/assets/348d2b57-bd86-4589-8991-9b5e20c14633


## Testing
- Enable `.acceptCashForPointOfSale` feature flag
- In POS, add items to the cart, then tap on "Cash Payment"
- Enter an amount less, equal, and exceeding the order total. Observe that responds as in the description
- Using `.` or `,` for decimals should behave the same.
- Upon completion, the order appears in the app under the Orders tab.

You will see some additional space at the bottom of the success view, as well as the floating button to connect the reader. This is unrelated to this PR and will be addressed in the parent PR (#14602) or in a follow-up

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
