### PR TITLE
HACK Week: Add entry point for the filter history screen

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -101,6 +101,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .hideSitesInStorePicker:
             return true
+        case .filterHistoryOnOrderAndProductLists:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -215,4 +215,8 @@ public enum FeatureFlag: Int {
     /// Supports hiding sites from the store picker
     ///
     case hideSitesInStorePicker
+
+    /// Supports managing filer history on order and product lists
+    ///
+    case filterHistoryOnOrderAndProductLists
 }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -105,6 +105,7 @@ final class FilterListViewController<ViewModel: FilterListViewModel>: UIViewCont
     }()
 
     private var clearAllBarButtonItem: UIBarButtonItem?
+    private var historyBarButtonItem: UIBarButtonItem?
 
     private var selectedFilterTypeSubscription: AnyCancellable?
     private var selectedFilterValueSubscription: AnyCancellable?
@@ -185,6 +186,10 @@ final class FilterListViewController<ViewModel: FilterListViewModel>: UIViewCont
         listSelector.reloadData()
         onClearAction()
     }
+
+    @objc private func showFilterHistory() {
+        // TODO-14791: show history view
+    }
 }
 
 // MARK: - View Configuration
@@ -199,6 +204,15 @@ private extension FilterListViewController {
 
         let clearAllButtonTitle = NSLocalizedString("Clear all", comment: "Button title for clearing all filters for the list.")
         clearAllBarButtonItem = UIBarButtonItem(title: clearAllButtonTitle, style: .plain, target: self, action: #selector(clearAllButtonTapped))
+
+        if viewModel.shouldShowHistory {
+            historyBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "clock"), style: .plain, target: self, action: #selector(showFilterHistory))
+            historyBarButtonItem?.accessibilityHint = NSLocalizedString(
+                "filterListViewController.historyBarButtonItem.accessibilityHint",
+                value: "Filter history",
+                comment: "Accessibility hint for the filter history button on the filter list screen"
+            )
+        }
     }
 
     func configureMainView() {
@@ -350,7 +364,14 @@ private extension FilterListViewController {
     }
 
     func updateClearAllActionVisibility(numberOfActiveFilters: Int) {
-        listSelector.navigationItem.rightBarButtonItem = numberOfActiveFilters > 0 ? clearAllBarButtonItem: nil
+        let buttonItems: [UIBarButtonItem] = {
+            var contents = [historyBarButtonItem].compactMap { $0 }
+            if numberOfActiveFilters > 0, let clearAllBarButtonItem {
+                contents.append(clearAllBarButtonItem)
+            }
+            return contents
+        }()
+        listSelector.navigationItem.rightBarButtonItems = buttonItems
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -22,6 +22,9 @@ protocol FilterListViewModel {
     /// The final value returned to the caller of `FilterListViewController`.
     var criteria: Criteria { get }
 
+    /// Whether to display the entry point to the filter history
+    var shouldShowHistory: Bool { get }
+
     // Navigation & Actions
 
     /// Resets the filter criteria.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -57,11 +57,12 @@ final class FilterOrderListViewModel: FilterListViewModel {
 
     let filterTypeViewModels: [FilterTypeViewModel]
 
+    let shouldShowHistory: Bool
+
     private let orderStatusFilterViewModel: FilterTypeViewModel
     private let dateRangeFilterViewModel: FilterTypeViewModel
     private let productFilterViewModel: FilterTypeViewModel
     private let customerFilterViewModel: FilterTypeViewModel
-    private let featureFlagService: FeatureFlagService
 
     /// - Parameters:
     ///   - filters: the filters to be applied initially.
@@ -77,7 +78,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
         productFilterViewModel = OrderListFilter.product(siteID: siteID).createViewModel(filters: filters, allowedStatuses: allowedStatuses)
         customerFilterViewModel = OrderListFilter.customer(siteID: siteID).createViewModel(filters: filters, allowedStatuses: allowedStatuses)
 
-        self.featureFlagService = featureFlagService
+        shouldShowHistory = featureFlagService.isFeatureFlagEnabled(.filterHistoryOnOrderAndProductLists)
         filterTypeViewModels = [orderStatusFilterViewModel, dateRangeFilterViewModel, customerFilterViewModel, productFilterViewModel]
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -52,6 +52,8 @@ final class FilterProductListViewModel: FilterListViewModel {
 
     let filterTypeViewModels: [FilterTypeViewModel]
 
+    let shouldShowHistory: Bool
+
     private let stockStatusFilterViewModel: FilterTypeViewModel
     private let productStatusFilterViewModel: FilterTypeViewModel
     private let productTypeFilterViewModel: FilterTypeViewModel
@@ -73,6 +75,7 @@ final class FilterProductListViewModel: FilterListViewModel {
         self.productTypeFilterViewModel = ProductListFilter.productType(siteID: siteID).createViewModel(filters: filters)
         self.productCategoryFilterViewModel = ProductListFilter.productCategory(siteID: siteID).createViewModel(filters: filters)
         self.productFavoriteFilterViewModel = ProductListFilter.favoriteProducts.createViewModel(filters: filters)
+        self.shouldShowHistory = false
 
         if featureFlagService.isFeatureFlagEnabled(.favoriteProducts) {
             self.filterTypeViewModels = [


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14791 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new feature flag for the filter history screen and entry point from the filter screen. The entry point is currently enabled for the order filter only, given that the feature flag is enabled.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Ensure that `filterHistoryOnOrderAndProductLists` feature flag is enabled and build the app.
- Log in to a test store with existing orders if needed.
- Switch to the Orders tab and select Filters
- Confirm that there's a clock button on the top right of the Filters screen.
- Confirm that the same button is not available in the Products > Filters screen.
- Turn off the feature flag and rebuild the app.
- Confirm that the button is not available in the order filters screen.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro and confirmed that the entry point is available only on the order filter screen when the feature flag is enabled.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/9439697e-5345-4266-88c2-e63a0d5073a8" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
