### PR TITLE
[Shipping labels] Fetch origin addresses and select default origin address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddress+Woo.swift
@@ -23,15 +23,6 @@ extension WooShippingOriginAddress {
         return output.joined(separator: "\n")
     }
 
-    /// Returns the Postal Address, formated and ready for display.
-    ///
-    var formattedPostalAddress: String? {
-        return postalAddress.formatted(as: .mailingAddress)?.replacingOccurrences(of: "\n", with: ", ")
-    }
-}
-
-private extension WooShippingOriginAddress {
-
     /// Returns the first and last name combined (if there are, effectively, two names).
     /// If only one name is present, that name is returned.
     var fullName: String? {
@@ -46,6 +37,15 @@ private extension WooShippingOriginAddress {
             return nil
         }
     }
+
+    /// Returns the Postal Address, formatted and ready for display.
+    ///
+    var formattedPostalAddress: String? {
+        return postalAddress.formatted(as: .mailingAddress)?.replacingOccurrences(of: "\n", with: ", ")
+    }
+}
+
+private extension WooShippingOriginAddress {
 
     /// Returns the two Address Lines combined (if there are, effectively, two lines).
     /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -98,7 +98,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// If the purchase button should be enabled.
     var isPurchaseButtonEnabled: Bool {
-        selectedRate != nil && shippingLabel == nil
+        // Don't allow purchasing if a label is already purchased
+        shippingLabel == nil
+        // or if any required fields are missing
+        && selectedOriginAddress != nil && destinationAddress != nil && selectedPackage != nil && selectedRate != nil
     }
 
     /// If the label purchase is in progress.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -10,7 +10,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let order: Order
     private let itemsDataSource: WooShippingItemsDataSource
     private var originAddresses: [WooShippingOriginAddress] = []
-    private let originSiteAddress: ShippingLabelAddress?
     private let destinationAddress: ShippingLabelAddress?
     private let stores: StoresManager
     private var subscriptions: Set<AnyCancellable> = []
@@ -54,12 +53,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     @Published private var selectedRate: WooShippingSelectedRate?
 
     /// Address to ship from (store address).
-    private var selectedOriginAddress: WooShippingOriginAddress?
+    @Published private var selectedOriginAddress: WooShippingOriginAddress?
 
     /// Address to ship from (store address), formatted for display.
-    var originAddress: String {
-        selectedOriginAddress?.formattedPostalAddress ?? ""
-    }
+    @Published private(set) var originAddress: String = ""
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     private(set) lazy var destinationAddressLines: [String] = {
@@ -118,7 +115,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Initialize the view model without an existing shipping label.
     init(order: Order,
-         originAddress: SiteAddress? = nil,
+         selectedOriginAddress: WooShippingOriginAddress? = nil,
          selectedPackage: WooShippingPackageDataRepresentable? = nil,
          selectedRate: WooShippingSelectedRate? = nil,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
@@ -133,27 +130,15 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.items = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase
-        let accountSettings = Self.getStoredAccountSettings()
-        let company = ServiceLocator.stores.sessionManager.defaultSite?.name
-        let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount
-        self.originSiteAddress = Self.getDefaultOriginAddress(accountSettings: accountSettings,
-                                                              company: company,
-                                                              siteAddress: originAddress ?? SiteAddress(),
-                                                              account: defaultAccount,
-                                                              userDefaults: userDefaults)
         self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
+        self.selectedOriginAddress = selectedOriginAddress
         self.selectedPackage = selectedPackage
         self.selectedRate = selectedRate
         self.stores = stores
         self.debounceDuration = debounceDuration
-        shippingService = WooShippingServiceViewModel(order: order,
-                                                      originAddress: originSiteAddress,
-                                                      destinationAddress: destinationAddress,
-                                                      stores: stores) { [weak self] selectedRate in
-            self?.selectedRate = selectedRate
-        }
 
+        observeSelectedOriginAddress()
         observeSelectedPackage()
         observeForLabelRates()
         loadStoreOptions()
@@ -173,7 +158,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.items = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
-        self.originSiteAddress = shippingLabel.originAddress
+        self.originAddress = shippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
         self.destinationAddress = shippingLabel.destinationAddress
         self.onLabelPurchase = nil
         self.stores = stores
@@ -187,7 +172,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Purchases a shipping label with the provided label details and settings.
     func purchaseLabel() {
-        guard isPurchaseButtonEnabled, !isPurchasingLabel, let originSiteAddress, let destinationAddress, let selectedPackage, let selectedRate else {
+        guard isPurchaseButtonEnabled, !isPurchasingLabel, let selectedOriginAddress, let destinationAddress, let selectedPackage, let selectedRate else {
             return
         }
         isPurchasingLabel = true
@@ -199,7 +184,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                          productIDs: itemsDataSource.items.map(\.productOrVariationID))
         let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,
                                                              orderID: order.orderID,
-                                                             originAddress: originSiteAddress,
+                                                             originAddress: selectedOriginAddress.toShippingLabelAddress(),
                                                              destinationAddress: destinationAddress,
                                                              package: packagePurchase) { [weak self] result in
             guard let self else { return }
@@ -277,6 +262,22 @@ private extension WooShippingCreateLabelsViewModel {
                 return (itemsWeight + (Double(selectedPackage.weight) ?? 0)).description
             }
             .assign(to: &$shipmentWeight)
+    }
+
+    /// Observes the selected origin address and updates the displayed origin address and shipping service.
+    func observeSelectedOriginAddress() {
+        $selectedOriginAddress
+            .sink { [weak self] selectedOriginAddress in
+                guard let self else { return }
+                originAddress = selectedOriginAddress?.formattedPostalAddress ?? ""
+                shippingService = WooShippingServiceViewModel(order: order,
+                                                              originAddress: selectedOriginAddress?.toShippingLabelAddress(),
+                                                              destinationAddress: destinationAddress,
+                                                              stores: stores) { [weak self] selectedRate in
+                    self?.selectedRate = selectedRate
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     /// Observes the selected package and shipment weight and requests the available shipping rates.
@@ -399,5 +400,23 @@ private extension WooShippingCreateLabelsViewModel {
                                                               value: "Adult Signature Required",
                                                               comment: "Label for row showing the additional cost to require an adult signature " +
                                                               "on the shipping label creation screen")
+    }
+}
+
+private extension WooShippingOriginAddress {
+    /// Converts the origin address to a `ShippingLabelAddress`.
+    ///
+    /// This prepares the address for use in e.g. fetching available shipping rates or purchasing the label.
+    ///
+    func toShippingLabelAddress() -> ShippingLabelAddress {
+        ShippingLabelAddress(company: company,
+                             name: fullName ?? "",
+                             phone: phone,
+                             country: country,
+                             state: state,
+                             address1: address1,
+                             address2: address2,
+                             city: city,
+                             postcode: postcode)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -9,6 +9,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
     private let order: Order
     private let itemsDataSource: WooShippingItemsDataSource
+    private var originAddresses: [WooShippingOriginAddress] = []
     private let originSiteAddress: ShippingLabelAddress?
     private let destinationAddress: ShippingLabelAddress?
     private let stores: StoresManager
@@ -52,10 +53,13 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Selected shipping rate when creating a shipping label.
     @Published private var selectedRate: WooShippingSelectedRate?
 
+    /// Address to ship from (store address).
+    private var selectedOriginAddress: WooShippingOriginAddress?
+
     /// Address to ship from (store address), formatted for display.
-    private(set) lazy var originAddress: String = {
-        originSiteAddress?.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
-    }()
+    var originAddress: String {
+        selectedOriginAddress?.formattedPostalAddress ?? ""
+    }
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     private(set) lazy var destinationAddressLines: [String] = {
@@ -154,6 +158,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         observeForLabelRates()
         loadStoreOptions()
         loadPackages()
+        loadOriginAddresses()
     }
 
     /// Initialize the view model from an existing shipping label.
@@ -237,6 +242,22 @@ private extension WooShippingCreateLabelsViewModel {
         let action = WooShippingAction.loadPackages(siteID: order.siteID) { result in
             if case .failure(let error) = result {
                 DDLogError("⛔️ Error loading packages for Woo Shipping labels: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    /// Syncs origin addresses to use for shipping label from remote.
+    ///
+    func loadOriginAddresses() {
+        let action = WooShippingAction.loadOriginAddresses(siteID: order.siteID) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let addresses):
+                originAddresses = addresses
+                selectedOriginAddress = addresses.first(where: \.defaultAddress)
+            case .failure(let error):
+                DDLogError("⛔️ Error loading origin addresses for Woo Shipping labels: \(error)")
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -35,16 +35,32 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingRates.count, 1)
     }
 
-    func test_site_address_converted_to_formatted_originAddress() {
+    func test_default_origin_address_fetched_and_converted_to_formatted_originAddress() {
         // Given
-        let siteSettings = mapLoadGeneralSiteSettingsResponse()
-        let siteAddress = SiteAddress(siteSettings: siteSettings)
+        let originAddresses = [WooShippingOriginAddress.fake(),
+                               WooShippingOriginAddress.fake().copy(address1: "123 Main Street",
+                                                                    city: "San Francisco",
+                                                                    state: "CA",
+                                                                    postcode: "12345",
+                                                                    country: "US",
+                                                                    defaultAddress: true)]
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success(originAddresses))
+            case .loadPackages:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
 
         // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), originAddress: siteAddress)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), stores: stores)
 
         // Then
-        XCTAssertEqual("60 29th Street #343, Auburn NY 13021, US", viewModel.originAddress)
+        XCTAssertEqual("123 Main Street, San Francisco CA 12345, US", viewModel.originAddress)
     }
 
     func test_order_shipping_address_converted_to_formatted_desinationAddressLines() {
@@ -82,7 +98,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             switch action {
             case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
                 completion(.success(ShippingLabel.fake()))
-            case .loadPackages:
+            case .loadPackages, .loadOriginAddresses:
                 break
             default:
                 XCTFail("Unexpected action: \(action)")
@@ -113,7 +129,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             switch action {
             case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
                 completion(.success(ShippingLabel.fake()))
-            case .loadPackages:
+            case .loadPackages, .loadOriginAddresses:
                 break
             default:
                 XCTFail("Unexpected action: \(action)")
@@ -202,21 +218,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let expectedShippingLabel = ShippingLabel.fake().copy(carrierID: "usps", trackingNumber: "1234567890")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            switch action {
-            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
-                completion(.success(expectedShippingLabel))
-            case .loadPackages:
-                break
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
                                                          originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
                                                          selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate(),
                                                          stores: stores)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
+                completion(.success(expectedShippingLabel))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
 
         // When
         viewModel.purchaseLabel()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -153,9 +153,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertTrue(markOrderComplete)
     }
 
-    func test_canPurchaseLabel_true_when_shipping_rate_is_selected() throws {
+    func test_isPurchaseButtonEnabled_true_when_required_fields_are_set() throws {
         // Given
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                         selectedOriginAddress: WooShippingOriginAddress.fake(),
                                                          selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate())
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -108,7 +108,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // When
         let markOrderComplete: Bool = waitFor { promise in
             let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
-                                                             originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
+                                                             selectedOriginAddress: WooShippingOriginAddress.fake(),
                                                              selectedPackage: self.samplePackageData(),
                                                              selectedRate: self.sampleSelectedRate(),
                                                              stores: stores) { complete in
@@ -139,7 +139,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // When
         let markOrderComplete: Bool = waitFor { promise in
             let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
-                                                             originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
+                                                             selectedOriginAddress: WooShippingOriginAddress.fake(),
                                                              selectedPackage: self.samplePackageData(),
                                                              selectedRate: self.sampleSelectedRate(),
                                                              stores: stores) { complete in
@@ -156,7 +156,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_canPurchaseLabel_true_when_shipping_rate_is_selected() throws {
         // Given
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
-                                                         originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
                                                          selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate())
 
@@ -219,7 +218,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let expectedShippingLabel = ShippingLabel.fake().copy(carrierID: "usps", trackingNumber: "1234567890")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
-                                                         originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
+                                                         selectedOriginAddress: WooShippingOriginAddress.fake(),
                                                          selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate(),
                                                          stores: stores)
@@ -246,7 +245,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         var isPurchasingLabelDuringPurchase = false
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
-                                                         originAddress: SiteAddress(siteSettings: mapLoadGeneralSiteSettingsResponse()),
+                                                         selectedOriginAddress: WooShippingOriginAddress.fake(),
                                                          selectedPackage: samplePackageData(),
                                                          selectedRate: sampleSelectedRate(),
                                                          stores: stores)
@@ -301,7 +300,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let expectedWeight = 2.5
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
-                                                         originAddress: SiteAddress(siteSettings: self.mapLoadGeneralSiteSettingsResponse()),
+                                                         selectedOriginAddress: WooShippingOriginAddress.fake(),
                                                          selectedPackage: samplePackageData(),
                                                          stores: stores,
                                                          itemsDataSource: MockItemsDataSource(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
⚠️ Depends on #14810 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the origin address used for the revamped Woo Shipping label flow. Previously we were using the store address as the origin address; now, we are fetching the origin addresses from the Woo Shipping extension and selecting the default origin address. (Future PRs will add support for selecting/editing origin addresses.)

### How

* Adds a new property `originAddresses` to track the list of available origin addresses.
* Adds a new property `selectedOriginAddress` to track the selected origin address from the list of available origin addresses.
* Observes `selectedOriginAddress`. When a new origin address is selected, we update the displayed address (`originAddress`, used in the "Shipment details" bottom sheet) and the shipping service (used to fetch shipping rates, which depend on the origin).
* When the view model initializes, we fetch the origin addresses from remote.
* We still need to pass addresses as `ShippingLabelAddress` in various contexts (e.g. to get shipping rates or purchase the label). To support that, this also adds an extension to convert a `WooShippingOriginAddress` to a `ShippingLabelAddress`.

If we're initializing the view model for an already purchased shipping label, we use the origin address (a `ShippingLabelAddress`) directly to set `originAddress`, formatted for display. This skips fetching origin addresses and setting the `selectedOriginAddress` because viewing a purchased shipping label doesn't require editing/updating its origin address or other actions that depend on that property.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Select a store with a version of Woo Shipping supporting the new origin addresses endpoint (p1736243308265609-slack-C02KUCFCSFP).
2. Create or open an order with at least one physical product and the `processing` order status.
3. Tap "Create Shipping Label."
4. Open the Shipment details bottom sheet.
5. Confirm the "Ship from" section shows your store's default origin address for Woo Shipping.

You can also update the default origin address in the Woo Shipping settings on the web and confirm that the updated address is shown if you repeat the steps above.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before ("Ship from" is store address)|After ("Ship form" is default origin address)
-|-
![Simulator Screenshot - iPhone 16 Pro - 2025-01-07 at 18 18 03](https://github.com/user-attachments/assets/bc7f30a4-3330-40f6-a512-9c4786f94a08)|![Simulator Screenshot - iPhone 16 Pro - 2025-01-07 at 18 21 19](https://github.com/user-attachments/assets/905a8af4-76e6-473a-ac57-eadb501bb900)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.