### PR TITLE
[Woo POS] Reuse a scrollable item list in parent and chid item list views

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -7,7 +7,6 @@ struct ChildItemList: View {
     private let parentProduct: POSParentProduct
     @EnvironmentObject private var posModel: PointOfSaleAggregateModel
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
 
     private var state: ItemListState {
         posModel.itemsViewState.itemsStack
@@ -34,17 +33,7 @@ struct ChildItemList: View {
                 Spacer()
             }
             .padding(.horizontal, Constants.itemListPadding)
-            ScrollView {
-                VStack {
-                    ItemList(state: state)
-                        .background(Color.posPrimaryBackground)
-                        .toolbar(.hidden, for: .navigationBar)
-                        .transition(.opacity)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.bottom, floatingControlAreaSize.height)
-                .padding(.horizontal, Constants.itemListPadding)
-            }
+            ScrollableItemList(state: state, headerView: {})
         }
         .task {
             guard state.items.isEmpty else {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ScrollableItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ScrollableItemList.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Scrollable list of items in POS, with an optional given view above the item list.
+struct ScrollableItemList<HeaderView: View>: View {
+    private let state: ItemListState
+    private let headerView: HeaderView
+
+    @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
+
+    init(
+        state: ItemListState,
+        @ViewBuilder headerView: () -> HeaderView
+    ) {
+        self.state = state
+        self.headerView = headerView()
+
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack {
+                ItemList(state: state)
+                    .background(Color.posPrimaryBackground)
+                    .toolbar(.hidden, for: .navigationBar)
+                    .transition(.opacity)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, floatingControlAreaSize.height)
+            .padding(.horizontal, Constants.itemListPadding)
+        }
+    }
+}
+
+private enum Constants {
+    static let itemListPadding: CGFloat = 16
+}
+
+#Preview {
+    ScrollableItemList(state: .loading([]), headerView: { EmptyView() })
+}

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ScrollableItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ScrollableItemList.swift
@@ -7,13 +7,10 @@ struct ScrollableItemList<HeaderView: View>: View {
 
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
 
-    init(
-        state: ItemListState,
-        @ViewBuilder headerView: () -> HeaderView
-    ) {
+    init(state: ItemListState,
+         @ViewBuilder headerView: () -> HeaderView) {
         self.state = state
         self.headerView = headerView()
-
     }
 
     var body: some View {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -134,16 +134,12 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        ScrollView {
-            VStack {
-                if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
-                    bannerCardView
-                }
-                ItemList(state: itemListState)
+        ScrollableItemList(state: itemListState,
+                           headerView: {
+            if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
+                bannerCardView
             }
-            .frame(maxWidth: .infinity)
-            .padding(.bottom, floatingControlAreaSize.height)
-            .padding(.horizontal, Constants.itemListPadding)
+        })
             .background(GeometryReader { proxy in
                 Color.clear
                     .onChange(of: proxy.frame(in: .global).maxY) { maxY in
@@ -159,7 +155,6 @@ private extension ItemListView {
                         lastScrollPosition = maxY
                     }
             })
-        }
     }
 
     @ViewBuilder
@@ -243,7 +238,6 @@ private extension ItemListView {
         static let infoIconPadding: CGFloat = 16
         static let bannerInfoIconSize: CGFloat = 44
         static let iconPadding: CGFloat = 26
-        static let itemListPadding: CGFloat = 16
         static let bannerCardPadding: CGFloat = 16
         static let viewHeight: CGFloat = UIScreen.main.bounds.height
         static let scrollThresholdMultiplier: CGFloat = 1.7

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */; };
 		0269A63C2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269A63B2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift */; };
 		026A23FF2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */; };
+		026A4FEE2D2E4F10002C42C2 /* ScrollableItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026A4FED2D2E4F10002C42C2 /* ScrollableItemList.swift */; };
 		026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */; };
 		026CAF7E2AC2B76C002D23BB /* ConfigurableBundleProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CAF7D2AC2B76C002D23BB /* ConfigurableBundleProductViewModel.swift */; };
 		026CAF802AC2B7FF002D23BB /* ConfigurableBundleProductView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CAF7F2AC2B7FF002D23BB /* ConfigurableBundleProductView.swift */; };
@@ -3508,6 +3509,7 @@
 		0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecTextViewAttachmentHandler.swift; sourceTree = "<group>"; };
 		0269A63B2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingStepListView.swift; sourceTree = "<group>"; };
 		026A23FE2A3173F100EFE4BD /* MockBlazeEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBlazeEligibilityChecker.swift; sourceTree = "<group>"; };
+		026A4FED2D2E4F10002C42C2 /* ScrollableItemList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableItemList.swift; sourceTree = "<group>"; };
 		026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignment.swift; sourceTree = "<group>"; };
 		026CAF7D2AC2B76C002D23BB /* ConfigurableBundleProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleProductViewModel.swift; sourceTree = "<group>"; };
 		026CAF7F2AC2B7FF002D23BB /* ConfigurableBundleProductView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleProductView.swift; sourceTree = "<group>"; };
@@ -7293,6 +7295,7 @@
 			children = (
 				0291497A2D2682FF00F7B3B3 /* ItemList.swift */,
 				0291497C2D26CB2500F7B3B3 /* ChildItemList.swift */,
+				026A4FED2D2E4F10002C42C2 /* ScrollableItemList.swift */,
 			);
 			path = "Item Selector";
 			sourceTree = "<group>";
@@ -15285,6 +15288,7 @@
 				205B7EB92C19FAF700D14A36 /* PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift in Sources */,
 				31C21FA426D9949000916E2E /* SeveralReadersFoundViewController.swift in Sources */,
 				205B7ED12C19FD8500D14A36 /* PointOfSaleCardPresentPaymentErrorMessageViewModel.swift in Sources */,
+				026A4FEE2D2E4F10002C42C2 /* ScrollableItemList.swift in Sources */,
 				CECEFA6D2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift in Sources */,
 				013D2FB62CFF54BB00845D75 /* TapToPayEducationStepsFactory.swift in Sources */,
 				02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14702 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR aims to address the feedback in https://github.com/woocommerce/woocommerce-ios/pull/14786#discussion_r1905850656 to create a reusable scrollable view that can be used in both the parent and child item list views.

It introduces the `ScrollableItemList` component to simplify the codebase. The main changes include refactoring existing item list views to use the new component.

Introducing the `ScrollableItemList` component:
* [`WooCommerce/Classes/POS/Presentation/Item Selector/ScrollableItemList.swift`](diffhunk://#diff-fe2455ed116b33d2d16a47468da7e9ed75d42657f7ad0b01e38b22a933ca488bR1-R37): Added the new `ScrollableItemList` component, which encapsulates the item list presentation logic, including the background color, toolbar settings, and padding.

Refactoring item list views:
* [`WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift`](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bL37-R36): Replaced the `ScrollView` containing the `ItemList` with the new `ScrollableItemList` component.
* [`WooCommerce/Classes/POS/Presentation/ItemListView.swift`](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L137-R142): Updated the `listView` method to use the `ScrollableItemList` component instead of a `ScrollView`. Removed redundant `itemListPadding` constant. [[1]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L137-R142) [[2]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L246)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

🗒️ As the variable products support requires WC version 9.6+ which is not publicly released at the time of writing, I'd recommend commenting out [L214 in ProductsRemote](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L214) to include all product types.

- Switch to a store eligible for POS and has at least one variable product
- Go to Menu > Point of Sale mode --> products should be shown as before after the loading state
- Tap on a variable product --> variations should be shown as before after the loading state
- Feel free to add some product(s) and variation(s) to cart and proceed with the payment flow to ensure the checkout flow remains the same

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/db6a4986-0524-4ee8-a3cc-98cf63bb1428



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.