### PR TITLE
Allow the keyboard to be dismissed after editing package weight

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingSelectedPackageView.swift
@@ -38,6 +38,8 @@ struct WooShippingSelectedPackageView: View {
         }
     }
 
+    @FocusState var isTotalWeightInputActive: Bool
+
     private var shipmentWeight: some View {
         VStack(alignment: .leading) {
             Text(Localization.totalWeight)
@@ -46,6 +48,18 @@ struct WooShippingSelectedPackageView: View {
                 TextField("", text: $totalWeight)
                     .keyboardType(.decimalPad)
                     .bodyStyle()
+                    .focused($isTotalWeightInputActive)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            Button {
+                                isTotalWeightInputActive = false
+                            } label: {
+                                Text(Localization.done)
+                                    .bold()
+                            }
+                        }
+                    }
                 Text(weightUnit)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -70,6 +84,9 @@ private extension WooShippingSelectedPackageView {
         static let totalWeight = NSLocalizedString("wooShipping.createLabels.package.totalWeight",
                                                     value: "Total shipment weight (with package)",
                                                     comment: "Label for the total shipment weight input field in the shipping label creation screen.")
+        static let done = NSLocalizedString("wooShipping.createLabels.package.done",
+                                            value: "Done",
+                                            comment: "Button for dismissing the keyboard")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14801
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Added **Done** button to toolbar as part of the keyboard to be able to dismiss keyboard when editing package weight

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Install and set up the Woo Shipping extension on your store.
2. Build and run the app with the revampedShippingLabelCreation feature flag enabled.
3. Create an order with the processing status and at least one physical product.
4. In your WooCommerce product settings on the web, change the weight and dimension units and save your changes.
5. On the Orders tab in the app, open the order you created.
6. In the order details, select "Create Shipping Label."
7.  Tap "Select a Package."
10. Switch to Carrier or Saved tab and select one of the packages
11. Tap "Add package"
12. Tap field with label "Total shipment weight (with package)" to edit the weight
13. Check that the keyboard has a toolbar with "Done" button and that tapping on that button dismisses the keyboard

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-08 at 14 17 45](https://github.com/user-attachments/assets/ac33c99b-66eb-42eb-a197-209d94353104)

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-08 at 14 07 55](https://github.com/user-attachments/assets/55391f76-dbf0-4bf7-860c-0a8582917f36)

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-08 at 14 10 00](https://github.com/user-attachments/assets/4af264c6-34f9-4354-bef1-72e1e4039347)      | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-08 at 14 08 27](https://github.com/user-attachments/assets/4fbbf1fc-0b8f-42bc-89a8-7be12614495f)       |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
