### PR TITLE
[Shipping labels] Display origin address selection sheet from "Ship from" address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -5,6 +5,9 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
     let addresses: [WooShippingOriginAddress]
     @Published private(set) var selectedAddressID: String?
 
+    /// Closure (set externally) called when an address is selected.
+    var onSelect: ((WooShippingOriginAddress) -> Void)?
+
     init(addresses: [WooShippingOriginAddress],
          selectedAddressID: String? = nil) {
         self.addresses = addresses
@@ -22,6 +25,7 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
             return
         }
         selectedAddressID = address.id
+        onSelect?(address)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -34,6 +34,9 @@ struct WooShippingCreateLabelsView: View {
     /// Whether the shipment details bottom sheet is expanded.
     @State private var isShipmentDetailsExpanded = false
 
+    /// Whether the origin address list sheet is presented.
+    @State private var isOriginAddressListPresented = false
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -111,10 +114,20 @@ struct WooShippingCreateLabelsView: View {
                             HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
                                 Text(Localization.BottomSheet.shipFrom)
                                     .trackSize(size: $shipmentDetailsShipFromSize)
-                                Text(viewModel.originAddress)
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Button {
+                                    isOriginAddressListPresented = true
+                                } label: {
+                                    HStack {
+                                        Text(viewModel.originAddress)
+                                            .lineLimit(1)
+                                            .truncationMode(.tail)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                        Image(systemName: "ellipsis")
+                                            .frame(width: Layout.ellipsisWidth)
+                                            .bold()
+                                    }
+                                }
+                                .buttonStyle(TextButtonStyle())
                             }
                             .padding(Layout.bottomSheetPadding)
                             Divider()
@@ -157,6 +170,11 @@ struct WooShippingCreateLabelsView: View {
                     .padding([.bottom, .horizontal], Layout.bottomSheetPadding)
                 }
                 .ignoresSafeArea(edges: .horizontal)
+                .sheet(isPresented: $isOriginAddressListPresented) {
+                    WooShippingOriginAddressListView(viewModel: viewModel.originAddresses)
+                        .presentationDetents([.medium, .large])
+                        .presentationDragIndicator(.visible)
+                }
             }
             .shippingWeightUnit(viewModel.weightUnit)
             .shippingDimensionsUnit(viewModel.dimensionsUnit)
@@ -271,6 +289,7 @@ private extension WooShippingCreateLabelsView {
         static let iconSize: CGFloat = 32
         static let rowHeight: CGFloat = 32
         static let chevronSize: CGFloat = 30
+        static let ellipsisWidth: CGFloat = 22
         static let bottomSheetSpacing: CGFloat = 16
         static let bottomSheetPadding: CGFloat = 16
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -245,7 +245,11 @@ private extension WooShippingCreateLabelsViewModel {
             switch result {
             case .success(let addresses):
                 selectedOriginAddress = addresses.first(where: \.defaultAddress)
-                originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses, selectedAddressID: selectedOriginAddress?.id)
+                originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
+                                                                        selectedAddressID: selectedOriginAddress?.id)
+                originAddresses.onSelect = { [weak self] selectedAddress in
+                    self?.selectedOriginAddress = selectedAddress
+                }
             case .failure(let error):
                 DDLogError("⛔️ Error loading origin addresses for Woo Shipping labels: \(error)")
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -9,7 +9,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
     private let order: Order
     private let itemsDataSource: WooShippingItemsDataSource
-    private var originAddresses: [WooShippingOriginAddress] = []
     private let destinationAddress: ShippingLabelAddress?
     private let stores: StoresManager
     private var subscriptions: Set<AnyCancellable> = []
@@ -51,6 +50,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Selected shipping rate when creating a shipping label.
     @Published private var selectedRate: WooShippingSelectedRate?
+
+    /// View model for a list of origin addresses to ship from.
+    private(set) var originAddresses = WooShippingOriginAddressListViewModel(addresses: [])
 
     /// Address to ship from (store address).
     @Published private var selectedOriginAddress: WooShippingOriginAddress?
@@ -242,8 +244,8 @@ private extension WooShippingCreateLabelsViewModel {
             guard let self else { return }
             switch result {
             case .success(let addresses):
-                originAddresses = addresses
                 selectedOriginAddress = addresses.first(where: \.defaultAddress)
+                originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses, selectedAddressID: selectedOriginAddress?.id)
             case .failure(let error):
                 DDLogError("⛔️ Error loading origin addresses for Woo Shipping labels: \(error)")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -35,6 +35,24 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingRates.count, 1)
     }
 
+    func test_origin_addresses_fetched_and_converted_to_originAddresses_view_model() {
+        // Given
+        let originAddress = WooShippingOriginAddress.fake().copy(id: "default", defaultAddress: true)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            if case let .loadOriginAddresses(_, completion) = action {
+                completion(.success([originAddress]))
+            }
+        }
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), stores: stores)
+
+        // Then
+        XCTAssertEqual(viewModel.originAddresses.addresses.count, 1)
+        XCTAssertEqual(viewModel.originAddresses.selectedAddressID, originAddress.id)
+    }
+
     func test_default_origin_address_fetched_and_converted_to_formatted_originAddress() {
         // Given
         let originAddresses = [WooShippingOriginAddress.fake(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
@@ -56,4 +56,22 @@ final class WooShippingOriginAddressListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedAddressID, addressToSelect.id)
     }
 
+    func test_select_calls_onSelect_closure() {
+        // Given
+        let addressToSelect = WooShippingOriginAddress.fake().copy(id: "1")
+        let addresses = [addressToSelect, WooShippingOriginAddress.fake().copy(id: "2")]
+        let viewModel = WooShippingOriginAddressListViewModel(addresses: addresses, selectedAddressID: nil)
+
+        // When
+        let selectedAddress = waitFor { promise in
+            viewModel.onSelect = { address in
+                promise(address)
+            }
+            viewModel.select(addressToSelect)
+        }
+
+        // Then
+        XCTAssertEqual(selectedAddress, addressToSelect)
+    }
+
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the Woo Shipping label flow, we can now tap the "Ship from" address (in the Shipment details bottom sheet) to open a bottom sheet with the list of origin addresses. Tapping an address will select it as the origin address for the shipping label.

Note: The UI to edit an origin address will be added in a future PR.

### How

* The origin address list view model `WooShippingOriginAddressListViewModel` now has an `onSelect` closure property, which is called when a new address is selected in the list.
* In the shipping label view, the "Ship from" address now has an ellipsis and the entire field is tappable to open the origin addresses list in a bottom sheet.
* The main view model `WooShippingCreateLabelsViewModel` now has a property for the origin address list view model.
   * This view model is set by default with an empty list of origin addresses. We are discussing what to display as an empty/error state if the origin addresses can't be loaded from remote.
   * After origin addresses are fetched from remote, we set the view model with the list of addresses and pre-select the default address. (There will always be at least one origin address saved remotely; the default origin address can't be deleted.)
   * When a new address is selected in the origin address list, we set that as the selected origin address to use in the shipping label.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Select a store with a version of Woo Shipping supporting the new origin addresses endpoint (p1736243308265609-slack-C02KUCFCSFP).
2. Create or open an order with at least one physical product and the processing order status.
3. Tap "Create Shipping Label."
4. Open the Shipment details bottom sheet.
5. Tap the "Ship from" address and confirm a bottom sheet opens with your store's origin addresses.
6. Confirm you can drag the sheet to make it larger, and scroll the sheet if needed to view all the addresses.
7. Select a different origin address.
8. Dismiss the bottom sheet and confirm the "Ship from" address displays your selection.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/5e3bdc45-7d93-436c-a459-2976dc6cab27



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.