### PR TITLE
[UI Tests] - Use latest ScreenObject version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,70 +23,70 @@ steps:
   #################
   # Create Prototype Build
   #################
-  # - label: ":hammer_and_wrench: Prototype Build"
-  #   command: .buildkite/commands/prototype-build.sh
-  #   plugins: [$CI_TOOLKIT]
-  #   if: build.pull_request.id != null
-  #   notify:
-  #     - github_commit_status:
-  #         context: Prototype Build
+  - label: ":hammer_and_wrench: Prototype Build"
+    command: .buildkite/commands/prototype-build.sh
+    plugins: [$CI_TOOLKIT]
+    if: build.pull_request.id != null
+    notify:
+      - github_commit_status:
+          context: Prototype Build
 
   #################
   # Run Unit Tests
   #################
-  # - label: ":microscope: Unit Tests"
-  #   command: .buildkite/commands/run-unit-tests.sh
-  #   depends_on: build
-  #   plugins: [$CI_TOOLKIT]
-  #   artifact_paths:
-  #     - fastlane/test_output/*
-  #   notify:
-  #     - github_commit_status:
-  #         context: Unit Tests
+  - label: ":microscope: Unit Tests"
+    command: .buildkite/commands/run-unit-tests.sh
+    depends_on: build
+    plugins: [$CI_TOOLKIT]
+    artifact_paths:
+      - fastlane/test_output/*
+    notify:
+      - github_commit_status:
+          context: Unit Tests
 
   #################
   # Linters
   #################
-  # - group: Linters
-  #   steps:
-  #     - label: ":radioactive_sign: Danger - PR Check"
-  #       command: danger
-  #       key: danger
-  #       if: build.pull_request.id != null
-  #       retry:
-  #         manual:
-  #           permit_on_passed: true
-  #       agents:
-  #         queue: linter
-  #       notify:
-  #         - github_commit_status:
-  #             context: Danger - PR Check
+  - group: Linters
+    steps:
+      - label: ":radioactive_sign: Danger - PR Check"
+        command: danger
+        key: danger
+        if: build.pull_request.id != null
+        retry:
+          manual:
+            permit_on_passed: true
+        agents:
+          queue: linter
+        notify:
+          - github_commit_status:
+              context: Danger - PR Check
 
-  #     - label: ":swift: SwiftLint"
-  #       command: swiftlint
-  #       notify:
-  #         - github_commit_status:
-  #             context: SwiftLint
-  #       agents:
-  #         queue: linter
+      - label: ":swift: SwiftLint"
+        command: swiftlint
+        notify:
+          - github_commit_status:
+              context: SwiftLint
+        agents:
+          queue: linter
 
-  #     - label: 🧹 Lint Translations
-  #       command: gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot
-  #       plugins:
-  #         - docker#v3.8.0:
-  #             image: public.ecr.aws/automattic/glotpress-validator:1.0.0
-  #       agents:
-  #         queue: default
-  #       notify:
-  #         - github_commit_status:
-  #             context: Lint Translations
+      - label: 🧹 Lint Translations
+        command: gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot
+        plugins:
+          - docker#v3.8.0:
+              image: public.ecr.aws/automattic/glotpress-validator:1.0.0
+        agents:
+          queue: default
+        notify:
+          - github_commit_status:
+              context: Lint Translations
 
-  #     - label: ":sleuth_or_spy: Lint Localized Strings Format"
-  #       command: .buildkite/commands/lint-localized-strings-format.sh
-  #       plugins: [$CI_TOOLKIT]
-  #       notify:
-  #         - github_commit_status:
-  #             context: Lint Localized Strings Format
+      - label: ":sleuth_or_spy: Lint Localized Strings Format"
+        command: .buildkite/commands/lint-localized-strings-format.sh
+        plugins: [$CI_TOOLKIT]
+        notify:
+          - github_commit_status:
+              context: Lint Localized Strings Format
 
   #################
   # UI Tests
@@ -95,8 +95,7 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 16'
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    # if: build.branch == 'trunk' || build.branch =~ /^release\//
-    if: build.branch == 'jostnes/update-screenobject-and-timeouts'
+    if: build.branch == 'trunk' || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*
@@ -108,8 +107,7 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad (10th generation)"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    # if: build.branch == 'trunk' || build.branch =~ /^release\//
-    if: build.branch == 'jostnes/update-screenobject-and-timeouts'
+    if: build.branch == 'trunk' || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,70 +23,70 @@ steps:
   #################
   # Create Prototype Build
   #################
-  - label: ":hammer_and_wrench: Prototype Build"
-    command: .buildkite/commands/prototype-build.sh
-    plugins: [$CI_TOOLKIT]
-    if: build.pull_request.id != null
-    notify:
-      - github_commit_status:
-          context: Prototype Build
+  # - label: ":hammer_and_wrench: Prototype Build"
+  #   command: .buildkite/commands/prototype-build.sh
+  #   plugins: [$CI_TOOLKIT]
+  #   if: build.pull_request.id != null
+  #   notify:
+  #     - github_commit_status:
+  #         context: Prototype Build
 
   #################
   # Run Unit Tests
   #################
-  - label: ":microscope: Unit Tests"
-    command: .buildkite/commands/run-unit-tests.sh
-    depends_on: build
-    plugins: [$CI_TOOLKIT]
-    artifact_paths:
-      - fastlane/test_output/*
-    notify:
-      - github_commit_status:
-          context: Unit Tests
+  # - label: ":microscope: Unit Tests"
+  #   command: .buildkite/commands/run-unit-tests.sh
+  #   depends_on: build
+  #   plugins: [$CI_TOOLKIT]
+  #   artifact_paths:
+  #     - fastlane/test_output/*
+  #   notify:
+  #     - github_commit_status:
+  #         context: Unit Tests
 
   #################
   # Linters
   #################
-  - group: Linters
-    steps:
-      - label: ":radioactive_sign: Danger - PR Check"
-        command: danger
-        key: danger
-        if: build.pull_request.id != null
-        retry:
-          manual:
-            permit_on_passed: true
-        agents:
-          queue: linter
-        notify:
-          - github_commit_status:
-              context: Danger - PR Check
+  # - group: Linters
+  #   steps:
+  #     - label: ":radioactive_sign: Danger - PR Check"
+  #       command: danger
+  #       key: danger
+  #       if: build.pull_request.id != null
+  #       retry:
+  #         manual:
+  #           permit_on_passed: true
+  #       agents:
+  #         queue: linter
+  #       notify:
+  #         - github_commit_status:
+  #             context: Danger - PR Check
 
-      - label: ":swift: SwiftLint"
-        command: swiftlint
-        notify:
-          - github_commit_status:
-              context: SwiftLint
-        agents:
-          queue: linter
+  #     - label: ":swift: SwiftLint"
+  #       command: swiftlint
+  #       notify:
+  #         - github_commit_status:
+  #             context: SwiftLint
+  #       agents:
+  #         queue: linter
 
-      - label: 🧹 Lint Translations
-        command: gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot
-        plugins:
-          - docker#v3.8.0:
-              image: public.ecr.aws/automattic/glotpress-validator:1.0.0
-        agents:
-          queue: default
-        notify:
-          - github_commit_status:
-              context: Lint Translations
+  #     - label: 🧹 Lint Translations
+  #       command: gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot
+  #       plugins:
+  #         - docker#v3.8.0:
+  #             image: public.ecr.aws/automattic/glotpress-validator:1.0.0
+  #       agents:
+  #         queue: default
+  #       notify:
+  #         - github_commit_status:
+  #             context: Lint Translations
 
-      - label: ":sleuth_or_spy: Lint Localized Strings Format"
-        command: .buildkite/commands/lint-localized-strings-format.sh
-        plugins: [$CI_TOOLKIT]
-        notify:
-          - github_commit_status:
-              context: Lint Localized Strings Format
+  #     - label: ":sleuth_or_spy: Lint Localized Strings Format"
+  #       command: .buildkite/commands/lint-localized-strings-format.sh
+  #       plugins: [$CI_TOOLKIT]
+  #       notify:
+  #         - github_commit_status:
+  #             context: Lint Localized Strings Format
 
   #################
   # UI Tests
@@ -95,7 +95,8 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 16'
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == 'trunk' || build.branch =~ /^release\//
+    # if: build.branch == 'trunk' || build.branch =~ /^release\//
+    if: build.branch == 'jostnes/update-screenobject-and-timeouts'
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*
@@ -107,7 +108,8 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad (10th generation)"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == 'trunk' || build.branch =~ /^release\//
+    # if: build.branch == 'trunk' || build.branch =~ /^release\//
+    if: build.branch == 'jostnes/update-screenobject-and-timeouts'
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
-          "version": "0.2.3"
+          "revision": "7aa2f067f24c8083ba3cfede002ea79e5bf43903",
+          "version": "0.2.4"
         }
       },
       {

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
@@ -10,8 +10,7 @@ public final class MyStoreScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.staticTexts["Your WooCommerce Store"] }],
-            app: app,
-            waitTimeout: 35
+            app: app
         )
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
@@ -31,8 +31,7 @@ public final class TabNavComponent: ScreenObject {
                 ordersTabButtonGetter,
                 productsTabButtonGetter
             ],
-            app: app,
-            waitTimeout: 35
+            app: app
         )
     }
 


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After the change made in https://github.com/woocommerce/woocommerce-ios/pull/14767, the tests no longer fail with the following error `WooCommerceUITests-Runner (2458) encountered an error (The test runner failed to initialize for UI testing. (Underlying Error: Timed out waiting for AX loaded notification))`. 

Now, _most_ errors are related to timeouts or elements not being ready. This PR updates the UI tests to use the latest version of ScreenObject that has an increased default timeout value of 45 seconds (previously 20 seconds) and removes the custom timeout previously added to some screens.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
N/A - UI tests were failing intermittently in CI

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I ran the whole UI test suite 5x in CI and did not see failures related to timeouts (see: [testing builds](https://buildkite.com/automattic/woocommerce-ios/builds?branch=jostnes%2Fupdate-screenobject-and-timeouts)). However, there was some test flakiness during testing, but it seems that the failures were resolved on the second retry. We can revisit this value and reduce the duration if necessary the next time XCode or Mac Agent is updated.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.