### PR TITLE
HACK Week: Support filter history in product list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Filters/FilterHistoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterHistoryView.swift
@@ -129,6 +129,7 @@ private extension FilterHistoryView {
                                       selected: selectedFilter == filter,
                                       displayMode: .compact,
                                       alignment: .trailing)
+                    .listRowInsets(EdgeInsets())
                     .onTapGesture {
                         selectedFilter = filter
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -83,7 +83,7 @@ final class FilterProductListViewModel: FilterListViewModel {
         self.productTypeFilterViewModel = ProductListFilter.productType(siteID: siteID).createViewModel(filters: filters)
         self.productCategoryFilterViewModel = ProductListFilter.productCategory(siteID: siteID).createViewModel(filters: filters)
         self.productFavoriteFilterViewModel = ProductListFilter.favoriteProducts.createViewModel(filters: filters)
-        self.shouldShowHistory = false
+        self.shouldShowHistory = featureFlagService.isFeatureFlagEnabled(.filterHistoryOnOrderAndProductLists)
         self.stores = stores
         self.siteID = siteID
 

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -65,6 +65,8 @@ final class FilterProductListViewModel: FilterListViewModel {
     private let productCategoryFilterViewModel: FilterTypeViewModel
     private let productFavoriteFilterViewModel: FilterTypeViewModel
 
+    private let siteID: Int64
+    private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
 
     /// - Parameters:
@@ -73,6 +75,7 @@ final class FilterProductListViewModel: FilterListViewModel {
     ///   - featureFlagService: Feature flag service
     init(filters: Filters,
          siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.featureFlagService = featureFlagService
         self.stockStatusFilterViewModel = ProductListFilter.stockStatus.createViewModel(filters: filters)
@@ -81,6 +84,8 @@ final class FilterProductListViewModel: FilterListViewModel {
         self.productCategoryFilterViewModel = ProductListFilter.productCategory(siteID: siteID).createViewModel(filters: filters)
         self.productFavoriteFilterViewModel = ProductListFilter.favoriteProducts.createViewModel(filters: filters)
         self.shouldShowHistory = false
+        self.stores = stores
+        self.siteID = siteID
 
         if featureFlagService.isFeatureFlagEnabled(.favoriteProducts) {
             self.filterTypeViewModels = [
@@ -118,23 +123,72 @@ final class FilterProductListViewModel: FilterListViewModel {
     }
 
     func applyPastFilter(_ filter: Filters) {
-        fatalError("Filter history is not yet implemented for product list")
+        stockStatusFilterViewModel.selectedValue = filter.stockStatus
+        productStatusFilterViewModel.selectedValue = filter.productStatus
+        productTypeFilterViewModel.selectedValue = filter.promotableProductType
+        productCategoryFilterViewModel.selectedValue = filter.productCategory
+        productFavoriteFilterViewModel.selectedValue = filter.favoriteProduct
     }
 
+    @MainActor
     func retrieveFilterHistory() async throws -> [Filters] {
-        fatalError("Filter history is not yet implemented for product list")
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(AppSettingsAction.loadProductFilterHistory(siteID: siteID, onCompletion: { result in
+                switch result {
+                case .success(let history):
+                    let filters = history.map { settings in
+                        let promotableProductType = settings.productTypeFilter.map { PromotableProductType(productType: $0, isAvailable: true, promoteUrl: nil) }
+                        return FilterProductListViewModel.Filters(stockStatus: settings.stockStatusFilter,
+                                                                  productStatus: settings.productStatusFilter,
+                                                                  promotableProductType: promotableProductType,
+                                                                  productCategory: settings.productCategoryFilter,
+                                                                  favoriteProduct: settings.favoriteProduct ? FavoriteProductsFilter() : nil,
+                                                                  numberOfActiveFilters: settings.numberOfActiveFilters())
+                    }
+                    continuation.resume(returning: filters)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }))
+        }
     }
 
-    func saveSelectedFilterToHistory(_ filter: Criteria) {
-        fatalError("Filter history is not yet implemented for product list")
+    func saveSelectedFilterToHistory(_ filter: Filters) {
+        let productSettings = StoredProductSettings.Setting(siteID: siteID,
+                                                            sort: nil, // This will be ignored in product filter anyway
+                                                            stockStatusFilter: filter.stockStatus,
+                                                            productStatusFilter: filter.productStatus,
+                                                            productTypeFilter: filter.promotableProductType?.productType,
+                                                            productCategoryFilter: filter.productCategory,
+                                                            favoriteProduct: filter.favoriteProduct?.isActive ?? false)
+        stores.dispatch(AppSettingsAction.upsertProductFilterHistory(filter: productSettings, onCompletion: { error in
+            if let error {
+                DDLogError("⛔️ Error saving product filter to history: \(error)")
+            }
+        }))
     }
 
-    func removeFilterFromHistory(_ filter: Criteria) {
-        fatalError("Filter history is not yet implemented for product list")
+    func removeFilterFromHistory(_ filter: Filters) {
+        let productSettings = StoredProductSettings.Setting(siteID: siteID,
+                                                            sort: nil, // This will be ignored in product filter anyway
+                                                            stockStatusFilter: filter.stockStatus,
+                                                            productStatusFilter: filter.productStatus,
+                                                            productTypeFilter: filter.promotableProductType?.productType,
+                                                            productCategoryFilter: filter.productCategory,
+                                                            favoriteProduct: filter.favoriteProduct?.isActive ?? false)
+        stores.dispatch(AppSettingsAction.removeFromProductFilterHistory(filter: productSettings, onCompletion: { error in
+            if let error {
+                DDLogError("⛔️ Error removing product filter from history: \(error)")
+            }
+        }))
     }
 
     func clearAllFilterHistory() {
-        fatalError("Filter history is not yet implemented for product list")
+        stores.dispatch(AppSettingsAction.resetProductFilterHistory(siteID: siteID, onCompletion: { error in
+            if let error {
+                DDLogError("⛔️ Error resetting product filter history: \(error)")
+            }
+        }))
     }
 
     func clearAll() {

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -41,8 +41,13 @@ final class FilterProductListViewModel: FilterListViewModel {
             self.numberOfActiveFilters = numberOfActiveFilters
         }
 
+        /// Generated string to be displayed in the filter history.
         var readableString: String {
-            let elements: [String?] = [stockStatus?.rawValue, productStatus?.rawValue, promotableProductType?.productType.rawValue, productCategory?.slug]
+            let elements: [String?] = [stockStatus?.description,
+                                       productStatus?.description,
+                                       promotableProductType?.productType.description,
+                                       productCategory?.description,
+                                       favoriteProduct?.description]
             return elements.compactMap { $0 }.joined(separator: ", ")
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -91,4 +91,116 @@ final class FilterProductListViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.filterTypeViewModels.contains(where: { $0.title == FilterProductListViewModel.ProductListFilter.Localization.favoriteProduct } ))
     }
+
+    func test_applyPastFilter_updates_the_filters_correctly() {
+        // Given
+        let filters = createMockFilters(stockStatus: .inStock)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0)
+
+        // When
+        let newFilter = createMockFilters(stockStatus: .onBackOrder)
+        viewModel.applyPastFilter(newFilter)
+
+        // Then
+        XCTAssertEqual(viewModel.criteria.stockStatus, .onBackOrder)
+    }
+
+    @MainActor
+    func test_retrieveFilterHistory_returns_correct_results() async throws {
+        // Given
+        let siteID: Int64 = 123
+        let expectedFilters = createMockFilters(stockStatus: .outOfStock)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadProductFilterHistory(_, onCompletion):
+                onCompletion(.success([StoredProductSettings.Setting(siteID: siteID,
+                                                                     sort: nil,
+                                                                     stockStatusFilter: expectedFilters.stockStatus,
+                                                                     productStatusFilter: expectedFilters.productStatus,
+                                                                     productTypeFilter: expectedFilters.promotableProductType?.productType,
+                                                                     productCategoryFilter: expectedFilters.productCategory,
+                                                                     favoriteProduct: expectedFilters.favoriteProduct?.isActive ?? false)]))
+            default:
+                break
+            }
+        }
+
+        let viewModel = FilterProductListViewModel(filters: createMockFilters(), siteID: siteID, stores: stores)
+
+        // When
+        let retrievedFilters = try await viewModel.retrieveFilterHistory()
+        
+        // Then
+        XCTAssertEqual(retrievedFilters, [expectedFilters])
+    }
+
+    func test_saveSelectedFilterToHistory_sends_correct_settings_to_storage() {
+        // Given
+        let siteID: Int64 = 123
+        let filters = createMockFilters()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var savedSettings: StoredProductSettings.Setting?
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .upsertProductFilterHistory(settings, onCompletion):
+                savedSettings = settings
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: siteID, stores: stores)
+
+        // When
+        viewModel.saveSelectedFilterToHistory(filters)
+
+        // Then
+        XCTAssertEqual(savedSettings?.stockStatusFilter, filters.stockStatus)
+        XCTAssertEqual(savedSettings?.productTypeFilter, filters.promotableProductType?.productType)
+        XCTAssertEqual(savedSettings?.productStatusFilter, filters.productStatus)
+        XCTAssertEqual(savedSettings?.productCategoryFilter, filters.productCategory)
+        XCTAssertEqual(savedSettings?.favoriteProduct, filters.favoriteProduct?.isActive ?? false)
+    }
+
+    func test_removeFilterFromHistory_removes_the_correct_settings_in_storage() {
+        // Given
+        let siteID: Int64 = 123
+        let filters = createMockFilters()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var removedSettings: StoredProductSettings.Setting?
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .removeFromProductFilterHistory(settings, onCompletion):
+                removedSettings = settings
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: siteID, stores: stores)
+
+        // When
+        viewModel.removeFilterFromHistory(filters)
+
+        // Then
+        XCTAssertEqual(removedSettings?.stockStatusFilter, filters.stockStatus)
+        XCTAssertEqual(removedSettings?.productTypeFilter, filters.promotableProductType?.productType)
+        XCTAssertEqual(removedSettings?.productStatusFilter, filters.productStatus)
+        XCTAssertEqual(removedSettings?.productCategoryFilter, filters.productCategory)
+        XCTAssertEqual(removedSettings?.favoriteProduct, filters.favoriteProduct?.isActive ?? false)
+    }
+}
+
+private extension FilterProductListViewModelTests {
+    func createMockFilters(stockStatus: ProductStockStatus? = .inStock) -> FilterProductListViewModel.Filters {
+        FilterProductListViewModel.Filters(stockStatus: stockStatus,
+                                           productStatus: .draft,
+                                           promotableProductType: PromotableProductType(productType: .grouped,
+                                                                                        isAvailable: true,
+                                                                                        promoteUrl: nil),
+                                           productCategory: filterProductCategory,
+                                           favoriteProduct: FavoriteProductsFilter(),
+                                           numberOfActiveFilters: 5)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -130,7 +130,7 @@ final class FilterProductListViewModelTests: XCTestCase {
 
         // When
         let retrievedFilters = try await viewModel.retrieveFilterHistory()
-        
+
         // Then
         XCTAssertEqual(retrievedFilters, [expectedFilters])
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14791 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables saving, applying, removing and resetting filter history in the product list.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Ensure that `filterHistoryOnOrderAndProductLists` feature flag is enabled and run the app.
- Log in to a store with existing products.
- Navigate to the Products tab > Filters > select the Clock button on the top right.
- Confirm that the filter history is empty by default.
- Navigate back to the Filters screen, select some filters and apply it.
- Navigate back to the Filter history screen and confirm that the last filter is displayed in the history.
- Go back to the Filters screen and apply new filters.
- Go to the Filter history screen and confirm that the latest filters are displayed at the top of the history. 
- Swipe left on one of the filters and tap Delete. Confirm that the filter is no longer displayed on the Filter History screen
- Apply a past filter and confirm that the Filters screen are updated with the details of the filter.
- Tap Show Products and confirm that the order list are updated correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 in light mode, dark mode and different text sizes and confirmed that all look good and work as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/dce0052c-eb5d-4dca-8018-5729ac30c4c0



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
