### PR TITLE
[Shipping labels] Add basic UI for editing an origin address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -39,12 +39,16 @@ struct WooShippingEditAddressView: View {
                     .font(.subheadline)
                     .bold()
                 }
-                AddressTextField(field: .country, text: $country, focused: $focusedField)
-                    .padding(.top, Constants.extraPadding)
+                AddressSelection(field: .country, selected: country) {
+                    // TODO: Handle country selection
+                }
+                .padding(.top, Constants.extraPadding)
                 AddressTextField(field: .address, text: $address, focused: $focusedField)
                 AddressTextField(field: .city, text: $city, focused: $focusedField)
                 AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
-                    AddressTextField(field: .state, text: $state, focused: $focusedField)
+                    AddressSelection(field: .state, selected: state) {
+                        // TODO: Handle state selection
+                    }
                     AddressTextField(field: .postalCode, text: $postalCode, focused: $focusedField)
                 }
                 .padding(.bottom, Constants.extraPadding)
@@ -91,8 +95,48 @@ struct WooShippingEditAddressView: View {
                     .focused($focused, equals: field)
                     .padding()
                     .roundedBorder(cornerRadius: Constants.cornerRadius,
-                                   lineColor: focused == field ? Color(.accent) : Color(.separator),
-                                   lineWidth: focused == field ? 2 : 1)
+                                   lineColor: focused == field ? Color(.accent) : Constants.defaultBorderColor,
+                                   lineWidth: focused == field ? 2 : Constants.defaultBorderWidth)
+            }
+        }
+    }
+
+    private struct AddressSelection: View {
+        /// Which address field to display.
+        let field: AddressField
+
+        /// The text to display for the selection.
+        let selected: String
+
+        /// The action to perform when the button is tapped.
+        var action: () -> Void
+
+        var body: some View {
+            VStack(spacing: Constants.innerSpacing) {
+                HStack {
+                    Text(field.title)
+                    if field.required {
+                        Text("*")
+                    }
+                    Spacer()
+                }
+                .font(.subheadline)
+                .foregroundStyle(Color(.text))
+                Button {
+                    action()
+                } label: {
+                    HStack {
+                        Text(selected)
+                            .bodyStyle()
+                        Spacer()
+                        Image(systemName: "chevron.up.chevron.down")
+                            .foregroundStyle(Color(.accent))
+                    }
+                    .padding()
+                    .roundedBorder(cornerRadius: Constants.cornerRadius,
+                                   lineColor: Constants.defaultBorderColor,
+                                   lineWidth: Constants.defaultBorderWidth)
+                }
             }
         }
     }
@@ -141,6 +185,8 @@ private extension WooShippingEditAddressView {
         static let innerSpacing: CGFloat = 8
         static let extraPadding: CGFloat = 24
         static let cornerRadius: CGFloat = 8
+        static let defaultBorderColor: Color = Color(.separator)
+        static let defaultBorderWidth: CGFloat = 1
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -2,36 +2,19 @@ import SwiftUI
 
 /// View for editing an address in the Woo Shipping label creation flow.
 struct WooShippingEditAddressView: View {
-    @State private var name: String
-    @State private var company: String
-    @State private var country: String
-    @State private var address: String
-    @State private var city: String
-    @State private var state: String
-    @State private var postalCode: String
+    @State var name: String
+    @State var company: String
+    @State var country: String
+    @State var address: String
+    @State var city: String
+    @State var state: String
+    @State var postalCode: String
 
-    /// Whether to show the company text field.
-    @State private var showCompanyField: Bool
+    /// Whether to show the company field by default.
+    @State var showCompanyField: Bool
 
     /// Tracks the focused address field.
     @FocusState private var focusedField: AddressField?
-
-    init(name: String,
-         company: String,
-         country: String,
-         address: String,
-         city: String,
-         state: String,
-         postalCode: String) {
-        _name = State(initialValue: name)
-        _company = State(initialValue: company)
-        _country = State(initialValue: country)
-        _address = State(initialValue: address)
-        _city = State(initialValue: city)
-        _state = State(initialValue: state)
-        _postalCode = State(initialValue: postalCode)
-        _showCompanyField = State(initialValue: !company.isEmpty)
-    }
 
     var body: some View {
         ScrollView {
@@ -167,7 +150,8 @@ private extension WooShippingEditAddressView {
                                address: "15 ALGONKIN ST",
                                city: "TICONDEROGA",
                                state: "NY",
-                               postalCode: "12883-1487")
+                               postalCode: "12883-1487",
+                               showCompanyField: false)
 }
 
 #Preview("With Company") {
@@ -177,5 +161,6 @@ private extension WooShippingEditAddressView {
                                address: "15 ALGONKIN ST",
                                city: "TICONDEROGA",
                                state: "NY",
-                               postalCode: "12883-1487")
+                               postalCode: "12883-1487",
+                               showCompanyField: true)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -19,6 +19,8 @@ struct WooShippingEditAddressView: View {
     /// Tracks the focused address field.
     @FocusState private var focusedField: AddressField?
 
+    @Environment(\.dismiss) private var dismiss
+
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.verticalSpacing) {
@@ -54,6 +56,13 @@ struct WooShippingEditAddressView: View {
                     .tint(Color(.accent))
             }
             .padding()
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        dismiss()
+                    }
+                }
+            }
         }
     }
 
@@ -176,6 +185,9 @@ private extension WooShippingEditAddressView {
         static let defaultAddress = NSLocalizedString("wooShipping.createLabels.editAddress.defaultAddress",
                                                     value: "Save as default origin address",
                                                     comment: "Label for the default address toggle in the Woo Shipping label creation flow")
+        static let cancel = NSLocalizedString("wooShipping.createLabels.editAddress.cancel",
+                                            value: "Cancel",
+                                            comment: "Button to cancel editing an address in the Woo Shipping label creation flow")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -33,9 +33,9 @@ struct WooShippingEditAddressView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.verticalSpacing) {
-                LabelAndTextField(title: Localization.name, text: $name)
+                AddressTextField(field: .name, text: $name)
                 if showCompanyField {
-                    LabelAndTextField(title: Localization.company, text: $company, required: false)
+                    AddressTextField(field: .company, text: $company)
                 } else {
                     Button {
                         showCompanyField = true
@@ -46,39 +46,60 @@ struct WooShippingEditAddressView: View {
                     .font(.subheadline)
                     .bold()
                 }
-                LabelAndTextField(title: Localization.country, text: $country)
+                AddressTextField(field: .country, text: $country)
                     .padding(.top, Constants.extraPadding)
-                LabelAndTextField(title: Localization.address, text: $address)
-                LabelAndTextField(title: Localization.city, text: $city)
+                AddressTextField(field: .address, text: $address)
+                AddressTextField(field: .city, text: $city)
                 AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
-                    LabelAndTextField(title: Localization.state, text: $state)
-                    LabelAndTextField(title: Localization.postalCode, text: $postalCode)
+                    AddressTextField(field: .state, text: $state)
+                    AddressTextField(field: .postalCode, text: $postalCode)
                 }
             }
             .padding()
         }
     }
 
-    private struct LabelAndTextField: View {
-        let title: String
+    private struct AddressTextField: View {
+        let field: AddressField
         @Binding var text: String
-        var required: Bool = true
 
         var body: some View {
             VStack(spacing: Constants.innerSpacing) {
                 HStack {
-                    Text(title)
-                    if required {
+                    Text(field.title)
+                    if field.required {
                         Text("*")
                     }
                     Spacer()
                 }
                 .font(.subheadline)
                 .foregroundStyle(Color(.text))
-                TextField(title, text: $text, prompt: Text(required ? "" : Localization.optional))
+                TextField(field.title, text: $text, prompt: Text(field.required ? "" : Localization.optional))
                     .padding()
                     .roundedBorder(cornerRadius: Constants.cornerRadius, lineColor: Constants.borderColor, lineWidth: Constants.borderWidth)
             }
+        }
+    }
+}
+
+private extension WooShippingEditAddressView {
+    enum AddressField {
+        case name, company, country, address, city, state, postalCode
+
+        var title: String {
+            switch self {
+            case .name: return Localization.name
+            case .company: return Localization.company
+            case .country: return Localization.country
+            case .address: return Localization.address
+            case .city: return Localization.city
+            case .state: return Localization.state
+            case .postalCode: return Localization.postalCode
+            }
+        }
+
+        var required: Bool {
+            self != .company
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -74,12 +74,7 @@ struct WooShippingEditAddressView: View {
         @Binding var text: String
 
         /// The focused state of the field.
-        var focused: FocusState<AddressField?>.Binding
-
-        /// Whether the field is focused.
-        private var isFocused: Bool {
-            focused.wrappedValue == field
-        }
+        @FocusState.Binding var focused: AddressField?
 
         var body: some View {
             VStack(spacing: Constants.innerSpacing) {
@@ -93,11 +88,11 @@ struct WooShippingEditAddressView: View {
                 .font(.subheadline)
                 .foregroundStyle(Color(.text))
                 TextField(field.title, text: $text, prompt: Text(field.required ? "" : Localization.optional))
-                    .focused(focused, equals: field)
+                    .focused($focused, equals: field)
                     .padding()
                     .roundedBorder(cornerRadius: Constants.cornerRadius,
-                                   lineColor: isFocused ? Color(.accent) : Color(.separator),
-                                   lineWidth: isFocused ? 2 : 1)
+                                   lineColor: focused == field ? Color(.accent) : Color(.separator),
+                                   lineWidth: focused == field ? 2 : 1)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -82,7 +82,7 @@ struct WooShippingEditAddressView: View {
 
         var body: some View {
             VStack(spacing: Constants.innerSpacing) {
-                HStack {
+                HStack(spacing: Constants.requiredLabelSpacing) {
                     Text(field.title)
                     if field.required {
                         Text("*")
@@ -113,7 +113,7 @@ struct WooShippingEditAddressView: View {
 
         var body: some View {
             VStack(spacing: Constants.innerSpacing) {
-                HStack {
+                HStack(spacing: Constants.requiredLabelSpacing) {
                     Text(field.title)
                     if field.required {
                         Text("*")
@@ -187,6 +187,7 @@ private extension WooShippingEditAddressView {
         static let cornerRadius: CGFloat = 8
         static let defaultBorderColor: Color = Color(.separator)
         static let defaultBorderWidth: CGFloat = 1
+        static let requiredLabelSpacing: CGFloat = 4
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -13,6 +13,9 @@ struct WooShippingEditAddressView: View {
     /// Whether to show the company text field.
     @State private var showCompanyField: Bool
 
+    /// Tracks the focused address field.
+    @FocusState private var focusedField: AddressField?
+
     init(name: String,
          company: String,
          country: String,
@@ -33,9 +36,9 @@ struct WooShippingEditAddressView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.verticalSpacing) {
-                AddressTextField(field: .name, text: $name)
+                AddressTextField(field: .name, text: $name, focused: $focusedField)
                 if showCompanyField {
-                    AddressTextField(field: .company, text: $company)
+                    AddressTextField(field: .company, text: $company, focused: $focusedField)
                 } else {
                     Button {
                         showCompanyField = true
@@ -46,13 +49,13 @@ struct WooShippingEditAddressView: View {
                     .font(.subheadline)
                     .bold()
                 }
-                AddressTextField(field: .country, text: $country)
+                AddressTextField(field: .country, text: $country, focused: $focusedField)
                     .padding(.top, Constants.extraPadding)
-                AddressTextField(field: .address, text: $address)
-                AddressTextField(field: .city, text: $city)
+                AddressTextField(field: .address, text: $address, focused: $focusedField)
+                AddressTextField(field: .city, text: $city, focused: $focusedField)
                 AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
-                    AddressTextField(field: .state, text: $state)
-                    AddressTextField(field: .postalCode, text: $postalCode)
+                    AddressTextField(field: .state, text: $state, focused: $focusedField)
+                    AddressTextField(field: .postalCode, text: $postalCode, focused: $focusedField)
                 }
             }
             .padding()
@@ -60,8 +63,19 @@ struct WooShippingEditAddressView: View {
     }
 
     private struct AddressTextField: View {
+        /// Which address field to display.
         let field: AddressField
+
+        /// The text to display in the text field.
         @Binding var text: String
+
+        /// The focused state of the field.
+        var focused: FocusState<AddressField?>.Binding
+
+        /// Whether the field is focused.
+        private var isFocused: Bool {
+            focused.wrappedValue == field
+        }
 
         var body: some View {
             VStack(spacing: Constants.innerSpacing) {
@@ -75,8 +89,11 @@ struct WooShippingEditAddressView: View {
                 .font(.subheadline)
                 .foregroundStyle(Color(.text))
                 TextField(field.title, text: $text, prompt: Text(field.required ? "" : Localization.optional))
+                    .focused(focused, equals: field)
                     .padding()
-                    .roundedBorder(cornerRadius: Constants.cornerRadius, lineColor: Constants.borderColor, lineWidth: Constants.borderWidth)
+                    .roundedBorder(cornerRadius: Constants.cornerRadius,
+                                   lineColor: isFocused ? Color(.accent) : Color(.separator),
+                                   lineWidth: isFocused ? 2 : 1)
             }
         }
     }
@@ -110,8 +127,6 @@ private extension WooShippingEditAddressView {
         static let innerSpacing: CGFloat = 8
         static let extraPadding: CGFloat = 24
         static let cornerRadius: CGFloat = 8
-        static let borderWidth: CGFloat = 1
-        static let borderColor: Color = Color(.separator)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -27,7 +27,9 @@ struct WooShippingEditAddressView: View {
                     AddressTextField(field: .company, text: $company, focused: $focusedField)
                 } else {
                     Button {
-                        showCompanyField = true
+                        withAnimation {
+                            showCompanyField = true
+                        }
                     } label: {
                         Text(Localization.addCompany)
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -11,6 +11,7 @@ struct WooShippingEditAddressView: View {
     @State var postalCode: String
     @State var email: String
     @State var phone: String
+    @State var saveAsDefault: Bool
 
     /// Whether to show the company field by default.
     @State var showCompanyField: Bool
@@ -45,6 +46,10 @@ struct WooShippingEditAddressView: View {
                 .padding(.bottom, Constants.extraPadding)
                 AddressTextField(field: .email, text: $email, focused: $focusedField)
                 AddressTextField(field: .phone, text: $phone, focused: $focusedField)
+                    .padding(.bottom, Constants.extraPadding)
+                Toggle(Localization.defaultAddress, isOn: $saveAsDefault)
+                    .font(.subheadline)
+                    .tint(Color(.accent))
             }
             .padding()
         }
@@ -166,6 +171,9 @@ private extension WooShippingEditAddressView {
         static let optional = NSLocalizedString("wooShipping.createLabels.editAddress.optional",
                                                     value: "Optional",
                                                     comment: "Text indicating that a field is optional")
+        static let defaultAddress = NSLocalizedString("wooShipping.createLabels.editAddress.defaultAddress",
+                                                    value: "Save as default origin address",
+                                                    comment: "Label for the default address toggle in the Woo Shipping label creation flow")
     }
 }
 
@@ -179,6 +187,7 @@ private extension WooShippingEditAddressView {
                                postalCode: "12883-1487",
                                email: "",
                                phone: "",
+                               saveAsDefault: true,
                                showCompanyField: false)
 }
 
@@ -192,5 +201,6 @@ private extension WooShippingEditAddressView {
                                postalCode: "12883-1487",
                                email: "",
                                phone: "",
+                               saveAsDefault: false,
                                showCompanyField: true)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// View for editing an address in the Woo Shipping label creation flow.
+struct WooShippingEditAddressView: View {
+    @State private var name: String
+    @State private var company: String
+    @State private var country: String
+    @State private var address: String
+    @State private var city: String
+    @State private var state: String
+    @State private var postalCode: String
+
+    /// Whether to show the company text field.
+    @State private var showCompanyField: Bool
+
+    init(name: String,
+         company: String,
+         country: String,
+         address: String,
+         city: String,
+         state: String,
+         postalCode: String) {
+        _name = State(initialValue: name)
+        _company = State(initialValue: company)
+        _country = State(initialValue: country)
+        _address = State(initialValue: address)
+        _city = State(initialValue: city)
+        _state = State(initialValue: state)
+        _postalCode = State(initialValue: postalCode)
+        _showCompanyField = State(initialValue: !company.isEmpty)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Constants.verticalSpacing) {
+                LabelAndTextField(title: Localization.name, text: $name)
+                if showCompanyField {
+                    LabelAndTextField(title: Localization.company, text: $company, required: false)
+                } else {
+                    Button {
+                        showCompanyField = true
+                    } label: {
+                        Text(Localization.addCompany)
+                    }
+                    .buttonStyle(PlusButtonStyle())
+                    .font(.subheadline)
+                    .bold()
+                }
+                LabelAndTextField(title: Localization.country, text: $country)
+                    .padding(.top, Constants.extraPadding)
+                LabelAndTextField(title: Localization.address, text: $address)
+                LabelAndTextField(title: Localization.city, text: $city)
+                AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
+                    LabelAndTextField(title: Localization.state, text: $state)
+                    LabelAndTextField(title: Localization.postalCode, text: $postalCode)
+                }
+            }
+            .padding()
+        }
+    }
+
+    private struct LabelAndTextField: View {
+        let title: String
+        @Binding var text: String
+        var required: Bool = true
+
+        var body: some View {
+            VStack(spacing: Constants.innerSpacing) {
+                HStack {
+                    Text(title)
+                    if required {
+                        Text("*")
+                    }
+                    Spacer()
+                }
+                .font(.subheadline)
+                .foregroundStyle(Color(.text))
+                TextField(title, text: $text, prompt: Text(required ? "" : Localization.optional))
+                    .padding()
+                    .roundedBorder(cornerRadius: Constants.cornerRadius, lineColor: Constants.borderColor, lineWidth: Constants.borderWidth)
+            }
+        }
+    }
+}
+
+private extension WooShippingEditAddressView {
+    enum Constants {
+        static let verticalSpacing: CGFloat = 16
+        static let innerSpacing: CGFloat = 8
+        static let extraPadding: CGFloat = 24
+        static let cornerRadius: CGFloat = 8
+        static let borderWidth: CGFloat = 1
+        static let borderColor: Color = Color(.separator)
+    }
+
+    enum Localization {
+        static let name = NSLocalizedString("wooShipping.createLabels.editAddress.name",
+                                            value: "Name",
+                                            comment: "Label for the name field when editing an address in the Woo Shipping label creation flow")
+        static let company = NSLocalizedString("wooShipping.createLabels.editAddress.company",
+                                                  value: "Company",
+                                                    comment: "Label for the company field when editing an address in the Woo Shipping label creation flow")
+        static let addCompany = NSLocalizedString("wooShipping.createLabels.editAddress.addCompany",
+                                                    value: "Add company",
+                                                    comment: "Button to add a company field when editing an address in the Woo Shipping label creation flow")
+        static let country = NSLocalizedString("wooShipping.createLabels.editAddress.country",
+                                                    value: "Country",
+                                                    comment: "Label for the country field when editing an address in the Woo Shipping label creation flow")
+        static let address = NSLocalizedString("wooShipping.createLabels.editAddress.address",
+                                                    value: "Address",
+                                                    comment: "Label for the address field when editing an address in the Woo Shipping label creation flow")
+        static let city = NSLocalizedString("wooShipping.createLabels.editAddress.city",
+                                                    value: "City",
+                                                    comment: "Label for the city field when editing an address in the Woo Shipping label creation flow")
+        static let state = NSLocalizedString("wooShipping.createLabels.editAddress.state",
+                                                    value: "State",
+                                                    comment: "Label for the state field when editing an address in the Woo Shipping label creation flow")
+        static let postalCode = NSLocalizedString("wooShipping.createLabels.editAddress.postalCode",
+                                                    value: "Postal code",
+                                                    comment: "Label for the postal code field when editing an address in the Woo Shipping label creation flow")
+        static let optional = NSLocalizedString("wooShipping.createLabels.editAddress.optional",
+                                                    value: "Optional",
+                                                    comment: "Text indicating that a field is optional")
+    }
+}
+
+#Preview("Without Company") {
+    WooShippingEditAddressView(name: "HEADQUARTERS",
+                               company: "",
+                               country: "UNITED STATES",
+                               address: "15 ALGONKIN ST",
+                               city: "TICONDEROGA",
+                               state: "NY",
+                               postalCode: "12883-1487")
+}
+
+#Preview("With Company") {
+    WooShippingEditAddressView(name: "HEADQUARTERS",
+                               company: "COMPANY",
+                               country: "UNITED STATES",
+                               address: "15 ALGONKIN ST",
+                               city: "TICONDEROGA",
+                               state: "NY",
+                               postalCode: "12883-1487")
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -9,6 +9,8 @@ struct WooShippingEditAddressView: View {
     @State var city: String
     @State var state: String
     @State var postalCode: String
+    @State var email: String
+    @State var phone: String
 
     /// Whether to show the company field by default.
     @State var showCompanyField: Bool
@@ -40,6 +42,9 @@ struct WooShippingEditAddressView: View {
                     AddressTextField(field: .state, text: $state, focused: $focusedField)
                     AddressTextField(field: .postalCode, text: $postalCode, focused: $focusedField)
                 }
+                .padding(.bottom, Constants.extraPadding)
+                AddressTextField(field: .email, text: $email, focused: $focusedField)
+                AddressTextField(field: .phone, text: $phone, focused: $focusedField)
             }
             .padding()
         }
@@ -84,7 +89,15 @@ struct WooShippingEditAddressView: View {
 
 private extension WooShippingEditAddressView {
     enum AddressField {
-        case name, company, country, address, city, state, postalCode
+        case name
+        case company
+        case country
+        case address
+        case city
+        case state
+        case postalCode
+        case email
+        case phone
 
         var title: String {
             switch self {
@@ -95,11 +108,18 @@ private extension WooShippingEditAddressView {
             case .city: return Localization.city
             case .state: return Localization.state
             case .postalCode: return Localization.postalCode
+            case .email: return Localization.email
+            case .phone: return Localization.phone
             }
         }
 
         var required: Bool {
-            self != .company
+            switch self {
+            case .name, .country, .address, .city, .state, .postalCode, .email, .phone:
+                return true
+            case .company:
+                return false
+            }
         }
     }
 }
@@ -137,6 +157,12 @@ private extension WooShippingEditAddressView {
         static let postalCode = NSLocalizedString("wooShipping.createLabels.editAddress.postalCode",
                                                     value: "Postal code",
                                                     comment: "Label for the postal code field when editing an address in the Woo Shipping label creation flow")
+        static let email = NSLocalizedString("wooShipping.createLabels.editAddress.email",
+                                                    value: "Email Address",
+                                                    comment: "Label for the email field when editing an address in the Woo Shipping label creation flow")
+        static let phone = NSLocalizedString("wooShipping.createLabels.editAddress.phone",
+                                                    value: "Phone",
+                                                    comment: "Label for the phone field when editing an address in the Woo Shipping label creation flow")
         static let optional = NSLocalizedString("wooShipping.createLabels.editAddress.optional",
                                                     value: "Optional",
                                                     comment: "Text indicating that a field is optional")
@@ -151,6 +177,8 @@ private extension WooShippingEditAddressView {
                                city: "TICONDEROGA",
                                state: "NY",
                                postalCode: "12883-1487",
+                               email: "",
+                               phone: "",
                                showCompanyField: false)
 }
 
@@ -162,5 +190,7 @@ private extension WooShippingEditAddressView {
                                city: "TICONDEROGA",
                                state: "NY",
                                postalCode: "12883-1487",
+                               email: "",
+                               phone: "",
                                showCompanyField: true)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
@@ -27,7 +27,7 @@ struct WooShippingOriginAddressListView: View {
                     }
                     Spacer()
                     PencilEditButton {
-                        // TODO: Edit origin address
+                        viewModel.addressToEdit = address
                     }
                     .buttonStyle(TextButtonStyle())
                 }
@@ -38,13 +38,32 @@ struct WooShippingOriginAddressListView: View {
                 .roundedBorder(cornerRadius: Constants.cornerRadius,
                                lineColor: Color(viewModel.isSelected(address) ? .wooCommercePurple(.shade60) : .separator),
                                lineWidth: viewModel.isSelected(address) ? 2 : 0.5)
-                    .onTapGesture {
-                        viewModel.select(address)
-                    }
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: Constants.verticalSpacing, trailing: 0))
+                .onTapGesture {
+                    viewModel.select(address)
+                }
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: Constants.verticalSpacing, trailing: 0))
             }
             .listStyle(.plain)
+            .sheet(item: $viewModel.addressToEdit) { address in
+                // TODO: Handle edits to the address fields
+                // TODO: Confirm what to display for `address` field
+                NavigationStack {
+                    WooShippingEditAddressView(name: address.fullName ?? "",
+                                               company: address.company,
+                                               country: address.country,
+                                               address: address.address1,
+                                               city: address.city,
+                                               state: address.state,
+                                               postalCode: address.postcode,
+                                               email: address.email,
+                                               phone: address.phone,
+                                               saveAsDefault: address.defaultAddress,
+                                               showCompanyField: address.company.isNotEmpty)
+                    .navigationTitle(Localization.editOrigin)
+                    .navigationBarTitleDisplayMode(.inline)
+                }
+            }
         }
         .padding()
     }
@@ -66,6 +85,9 @@ private extension WooShippingOriginAddressListView {
         static let defaultAddress = NSLocalizedString("wooShipping.originAddresses.defaultAddress",
                                                       value: "(default)",
                                                       comment: "Indicates that the address is the default origin address  on the shipping label creation screen")
+        static let editOrigin = NSLocalizedString("wooShipping.originAddresses.editOrigin",
+                                                    value: "Edit Origin",
+                                                    comment: "Title for the edit origin address screen in the shipping label creation flow")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -5,6 +5,10 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
     let addresses: [WooShippingOriginAddress]
     @Published private(set) var selectedAddressID: String?
 
+    /// Origin address to edit.
+    /// Setting this property will navigate to the address edit screen.
+    @Published var addressToEdit: WooShippingOriginAddress?
+
     /// Closure (set externally) called when an address is selected.
     var onSelect: ((WooShippingOriginAddress) -> Void)?
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2333,6 +2333,7 @@
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
 		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
 		CE7FE6942D1324BD000F9475 /* WooShippingOriginAddressListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7FE6932D1324BD000F9475 /* WooShippingOriginAddressListView.swift */; };
+		CE852E1F2D2EDC5400C7DBB6 /* WooShippingEditAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE852E1E2D2EDC4C00C7DBB6 /* WooShippingEditAddressView.swift */; };
 		CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */; };
 		CE855365209BA6A700938BDC /* CustomerInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */; };
 		CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */; };
@@ -5474,6 +5475,7 @@
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
 		CE7FE6932D1324BD000F9475 /* WooShippingOriginAddressListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingOriginAddressListView.swift; sourceTree = "<group>"; };
+		CE852E1E2D2EDC4C00C7DBB6 /* WooShippingEditAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingEditAddressView.swift; sourceTree = "<group>"; };
 		CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomerInfoTableViewCell.xib; sourceTree = "<group>"; };
 		CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoTableViewCell.swift; sourceTree = "<group>"; };
@@ -12076,6 +12078,7 @@
 				CECAE7102D23168D000AE10B /* WooShippingOriginAddress+Woo.swift */,
 				CE7FE6932D1324BD000F9475 /* WooShippingOriginAddressListView.swift */,
 				CECAE70B2D22EF9B000AE10B /* WooShippingOriginAddressListViewModel.swift */,
+				CE852E1E2D2EDC4C00C7DBB6 /* WooShippingEditAddressView.swift */,
 			);
 			path = WooShippingAddresses;
 			sourceTree = "<group>";
@@ -15340,6 +15343,7 @@
 				02C7EE8C2B22B21D008B7DF8 /* CollapsibleProductRowCardViewModel.swift in Sources */,
 				0245465F24EE9106004F531C /* ProductVariationFormEventLogger.swift in Sources */,
 				269A2F47295CC683000828A8 /* GenerateVariationsSelectorCommand.swift in Sources */,
+				CE852E1F2D2EDC5400C7DBB6 /* WooShippingEditAddressView.swift in Sources */,
 				DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */,
 				DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */,
 				02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This introduces UI to be used for editing an origin address in the Woo Shipping label flow. It includes:

* Tapping the edit (pencil) button on an origin address opens the editing UI in a sheet.
* A navigation bar with a cancel button.
* Text fields for each of the text-editable address fields. If the address doesn't have a company name, it will show an "Add company" button by default.
* Two menu-style buttons for country and state. For now these are non-actionable.
* A toggle to set the address as the default origin address.

The following UI elements (and a view model to handle the logic) will be added in a later PR:
* Selecting the country and (if applicable) state from a list.
* Navigation between text fields in the form.
* Local validation for each of the fields.
* A label for whether the address is verified.
* A button to save the changes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the `processing` status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. Confirm a sheet opens with the details of the selected origin address prefilled.
8. If the origin address does not have a company name, confirm the "Add company" button appears. Tap the button and confirm it is replaced by the "Company" field.
9. Confirm all fields are marked as required (marked with a `*` by the label) except Company.
10. Confirm the Company field has an "Optional" prompt when empty.
11. Tap the "Cancel" button and confirm the sheet is dismissed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No company name|After tapping "Add company"
-|-
![Simulator Screenshot - iPhone 16 Pro - 2025-01-09 at 18 05 12](https://github.com/user-attachments/assets/353cb1aa-03d4-4de4-b346-c29a25fdeed5)|![Simulator Screenshot - iPhone 16 Pro - 2025-01-09 at 18 05 15](https://github.com/user-attachments/assets/4260768e-d1dd-4797-bd15-e6fcd759f9a9)

Screencast:


https://github.com/user-attachments/assets/46b27227-0848-4c90-ba4f-73a686bd8f95





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.