### PR TITLE
[Shipping labels] Add navigation between text fields in edit address form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -66,6 +66,27 @@ struct WooShippingEditAddressView: View {
                         dismiss()
                     }
                 }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Button(action: {
+                        focusPreviousField()
+                    }, label: {
+                        Image(systemName: "chevron.backward")
+                    })
+                    .disabled(focusedField == AddressField.allCases.first)
+                    Button(action: {
+                        focusNextField()
+                    }, label: {
+                        Image(systemName: "chevron.forward")
+                    })
+                    .disabled(focusedField == AddressField.allCases.last)
+                    Spacer()
+                    Button {
+                        dismissKeyboard()
+                    } label: {
+                        Text(Localization.done)
+                            .bold()
+                    }
+                }
             }
         }
     }
@@ -143,7 +164,7 @@ struct WooShippingEditAddressView: View {
 }
 
 private extension WooShippingEditAddressView {
-    enum AddressField {
+    enum AddressField: CaseIterable {
         case name
         case company
         case country
@@ -176,6 +197,55 @@ private extension WooShippingEditAddressView {
                 return false
             }
         }
+    }
+
+    /// Navigates to the next address field in the form.
+    func focusNextField() {
+        switch focusedField {
+        case .name:
+            focusedField = showCompanyField ? .company : .address
+        case .company:
+            focusedField = .address
+        case .address:
+            focusedField = .city
+        case .city:
+            focusedField = .postalCode
+        case .postalCode:
+            focusedField = .email
+        case .email:
+            focusedField = .phone
+        case .phone:
+            focusedField = nil
+        case .none, .country, .state:
+            break
+        }
+    }
+
+    /// Navigates to the previous address field in the form.
+    func focusPreviousField() {
+        switch focusedField {
+        case .name:
+            focusedField = nil
+        case .company:
+            focusedField = .name
+        case .address:
+            focusedField = showCompanyField ? .company : .name
+        case .city:
+            focusedField = .address
+        case .postalCode:
+            focusedField = .city
+        case .email:
+            focusedField = .postalCode
+        case .phone:
+            focusedField = .email
+        case .none, .country, .state:
+            break
+        }
+    }
+
+    /// Dismisses the keyboard.
+    func dismissKeyboard() {
+        focusedField = nil
     }
 }
 
@@ -229,6 +299,9 @@ private extension WooShippingEditAddressView {
         static let cancel = NSLocalizedString("wooShipping.createLabels.editAddress.cancel",
                                             value: "Cancel",
                                             comment: "Button to cancel editing an address in the Woo Shipping label creation flow")
+        static let done = NSLocalizedString("wooShipping.createLabels.editAddress.done",
+                                            value: "Done",
+                                            comment: "Button to dismiss the keyboard")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/14838 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds navigation between the text fields when editing an address in the Woo Shipping edit address form:

* If the company field is not shown, the navigation skips that field (navigating between name and country).
* The navigation skips the selection menus (country and state), moving to the previous/next text field on the form.
* There is a Done button to dismiss the keyboard.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. Tap into a text field and confirm you can use the arrows in the keyboard toolbar to navigate between fields.
8. Tap the "Done" button and confirm the keyboard is dismissed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/625df12a-2f05-4bae-a962-10acf70fe91e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.