### PR TITLE
[Woo POS] [Variable Products] Analytics: track item type when adding item to cart

### DIFF
--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -1,10 +1,17 @@
 import enum Yosemite.CardPresentPaymentOnboardingState
+import enum Yosemite.POSItem
 
 extension WooAnalyticsEvent {
     enum PointOfSale {
+        enum CartItemType {
+            case simpleProduct
+            case variation
+        }
+
         /// Event property Key.
         private enum Key {
             static let paymentsOnboardingState = "onboarding_state"
+            static let productType = "product_type"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -14,6 +21,21 @@ extension WooAnalyticsEvent {
         static func paymentsOnboardingDismissed(onboardingState: CardPresentPaymentOnboardingState) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSalePaymentsOnboardingDismissed,
                               properties: [Key.paymentsOnboardingState: onboardingState.reasonForAnalytics])
+        }
+
+        static func addItemToCart(type: CartItemType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSaleAddItemToCart, properties: [Key.productType: type.analyticsValue])
+        }
+    }
+}
+
+private extension WooAnalyticsEvent.PointOfSale.CartItemType {
+    var analyticsValue: String {
+        switch self {
+        case .simpleProduct:
+            return "simple"
+        case .variation:
+            return "variation"
         }
     }
 }

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -1,5 +1,4 @@
 import enum Yosemite.CardPresentPaymentOnboardingState
-import enum Yosemite.POSItem
 
 extension WooAnalyticsEvent {
     enum PointOfSale {

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -10,7 +10,7 @@ extension WooAnalyticsEvent {
         /// Event property Key.
         private enum Key {
             static let paymentsOnboardingState = "onboarding_state"
-            static let productType = "product_type"
+            static let itemType = "product_type"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -23,7 +23,7 @@ extension WooAnalyticsEvent {
         }
 
         static func addItemToCart(type: CartItemType) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .pointOfSaleAddItemToCart, properties: [Key.productType: type.analyticsValue])
+            WooAnalyticsEvent(statName: .pointOfSaleAddItemToCart, properties: [Key.itemType: type.analyticsValue])
         }
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -118,9 +118,6 @@ extension PointOfSaleAggregateModel {
 extension PointOfSaleAggregateModel {
     func addToCart(_ item: POSOrderableItem) {
         cart.insert(CartItem(id: UUID(), item: item, quantity: 1), at: 0)
-        Task { @MainActor in
-            analytics.track(.pointOfSaleAddItemToCart)
-        }
     }
 
     func remove(cartItem: CartItem) {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -6,18 +6,14 @@ import struct Yosemite.POSVariableParentProduct
 /// Displays a list of POS items or placeholder card based on the given state.
 struct ItemList: View {
     let state: ItemListState
-    private let analytics: Analytics
 
-    init(state: ItemListState,
-         analytics: Analytics = ServiceLocator.analytics) {
+    init(state: ItemListState) {
         self.state = state
-        self.analytics = analytics
     }
 
     var body: some View {
         ForEach(state.items) { item in
-            ItemListRow(item: item,
-                        analytics: analytics)
+            ItemListRow(item: item)
         }
         GhostItemCardView()
             .renderedIf(state.isLoading)
@@ -26,7 +22,7 @@ struct ItemList: View {
 
 private struct ItemListRow: View {
     let item: POSItem
-    let analytics: Analytics
+    let analytics: Analytics = ServiceLocator.analytics
     @EnvironmentObject var posModel: PointOfSaleAggregateModel
 
     var body: some View {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -7,10 +7,6 @@ import struct Yosemite.POSVariableParentProduct
 struct ItemList: View {
     let state: ItemListState
 
-    init(state: ItemListState) {
-        self.state = state
-    }
-
     var body: some View {
         ForEach(state.items) { item in
             ItemListRow(item: item)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -1,14 +1,23 @@
 import SwiftUI
 import enum Yosemite.POSItem
+import protocol WooFoundation.Analytics
 import struct Yosemite.POSVariableParentProduct
 
 /// Displays a list of POS items or placeholder card based on the given state.
 struct ItemList: View {
     let state: ItemListState
+    private let analytics: Analytics
+
+    init(state: ItemListState,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.state = state
+        self.analytics = analytics
+    }
 
     var body: some View {
         ForEach(state.items) { item in
-            ItemListRow(item: item)
+            ItemListRow(item: item,
+                        analytics: analytics)
         }
         GhostItemCardView()
             .renderedIf(state.isLoading)
@@ -17,6 +26,7 @@ struct ItemList: View {
 
 private struct ItemListRow: View {
     let item: POSItem
+    let analytics: Analytics
     @EnvironmentObject var posModel: PointOfSaleAggregateModel
 
     var body: some View {
@@ -24,6 +34,7 @@ private struct ItemListRow: View {
         case let .simpleProduct(product):
             Button(action: {
                 posModel.addToCart(product)
+                analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
             }, label: {
                 SimpleProductCardView(product: product)
             })
@@ -40,6 +51,7 @@ private struct ItemListRow: View {
         case let .variation(variation):
             Button(action: {
                 posModel.addToCart(variation)
+                analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
             }, label: {
                 VariationCardView(variation: variation)
             })


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14705
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

- [x] @jaclync updates the Tracks event registration to include the new event property before merging

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request introduces implements the only one analytics change to add an event property `product_type: simple|variation` to the existing event `pos_item_added_to_cart` matching Android https://github.com/woocommerce/woocommerce-android/issues/12846.

Originally, I wanted to update the existing tracking in `PointOfSaleAggregateModel.addToCart`. But with the given `POSOrderableItem`, there is no type information and I don't think it's worthwhile adding one just for analytics. I decided to move the tracking to `ItemListRow` where the button is tapped, the downside is that it's not easy to unit test. I tried using the [ViewInspector library](https://github.com/nalexn/ViewInspector) that we already have in the app, but with the time I had I didn't figure out a way to find the button in `ItemList`. I'm open to other ideas though, please feel free to share any.

### Analytics Tracking Enhancements:

* [`WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift`](diffhunk://#diff-27d4d1a497bb3a1cf27e0264a9ee3b0aa091a5110e2907efd968f2efdaa2c751R5-R13): Added a new `CartItemType` enum with cases `simpleProduct` and `variation`, and updated the `WooAnalyticsEvent` to include a new static function `addItemToCart(type:)` for tracking when items are added to the cart. [[1]](diffhunk://#diff-27d4d1a497bb3a1cf27e0264a9ee3b0aa091a5110e2907efd968f2efdaa2c751R5-R13) [[2]](diffhunk://#diff-27d4d1a497bb3a1cf27e0264a9ee3b0aa091a5110e2907efd968f2efdaa2c751R24-R38)

### Codebase Updates:

* [`WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift`](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL121-L123): Removed the old analytics tracking call from the `addToCart` method in `PointOfSaleAggregateModel`.
* [`WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift`](diffhunk://#diff-4dabea090e9975b33e741405197fdc574e0876ec76ece41f80b312e6766f217dR3): Updated the `ItemListRow` struct to include the `analytics` property and added calls to `analytics.track` with the appropriate `CartItemType` when items are added to the cart. [[1]](diffhunk://#diff-4dabea090e9975b33e741405197fdc574e0876ec76ece41f80b312e6766f217dR3) [[2]](diffhunk://#diff-4dabea090e9975b33e741405197fdc574e0876ec76ece41f80b312e6766f217dR21-R29) [[3]](diffhunk://#diff-4dabea090e9975b33e741405197fdc574e0876ec76ece41f80b312e6766f217dR46)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

🗒️ As the variable products support requires WC version 9.6+ which is not publicly released at the time of writing, I'd recommend commenting out [L214 in ProductsRemote](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L214) to include all product types.

- Switch to a store eligible for POS and has at least one variable product with at least one variation
- Go to Menu > Point of Sale mode
- Tap on a simple product to add to cart --> should see `🔵 Tracked pos_item_added_to_cart, properties: [product_type: simple, ...]`
- Tap on a variable product and wait for variations to load
- Tap on a variation to add to cart --> should see `🔵 Tracked pos_item_added_to_cart, properties: [product_type: variation, ...]`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.