### PR TITLE
Performance improvement of unit tests: Limit large MockCardReaderService delays

### DIFF
--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -90,7 +90,7 @@ final class MockCardReaderService: CardReaderService {
         didReceiveAConfigurationProvider = true
         spyStartDiscoveryMethod = discoveryMethod
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {[weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {[weak self] in
             self?.discoveryStatusSubject.send(.discovering)
         }
     }
@@ -100,7 +100,7 @@ final class MockCardReaderService: CardReaderService {
 
         /// Delaying the effect of this method so that unit tests are actually async
         return Future { promise in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {[weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {[weak self] in
                 self?.discoveryStatusSubject.send(.idle)
                 promise(.success(()))
             }
@@ -110,7 +110,7 @@ final class MockCardReaderService: CardReaderService {
     func connect(_ reader: Hardware.CardReader, options: Hardware.CardReaderConnectionOptions?) -> AnyPublisher<CardReader, Error> {
         Future() { promise in
             /// Delaying the effect of this method so that unit tests are actually async
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {[weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {[weak self] in
                 let connectedReader = MockCardReader.bbposChipper2XBT()
                 promise(Result.success(connectedReader))
                 self?.connectedReadersSubject.send([connectedReader])
@@ -121,7 +121,7 @@ final class MockCardReaderService: CardReaderService {
     func disconnect() -> Future<Void, Error> {
         didHitDisconnect = true
         return Future() { promise in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                 promise(Result.success(()))
             }
         }
@@ -154,7 +154,7 @@ final class MockCardReaderService: CardReaderService {
 
     func cancelPaymentIntent() -> Future<Void, Error> {
         Future() { [weak self] promise in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                 self?.didTapCancelPayment = true
                 promise(Result.success(()))
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
Part of: #11228

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There's a 2.0 delay set on `MockCardReaderService` making `CardPresentPaymentStoreTests` sets slow. 

Do you know if there's a good reason to have a two second delay within unit tests?

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

CI should succeed

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.