### PR TITLE
[Shipping labels] Add view model for edit address view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -2,19 +2,7 @@ import SwiftUI
 
 /// View for editing an address in the Woo Shipping label creation flow.
 struct WooShippingEditAddressView: View {
-    @State var name: String
-    @State var company: String
-    @State var country: String
-    @State var address: String
-    @State var city: String
-    @State var state: String
-    @State var postalCode: String
-    @State var email: String
-    @State var phone: String
-    @State var saveAsDefault: Bool
-
-    /// Whether to show the company field by default.
-    @State var showCompanyField: Bool
+    @ObservedObject var viewModel: WooShippingEditAddressViewModel
 
     /// Tracks the focused address field.
     @FocusState private var focusedField: AddressField?
@@ -24,13 +12,13 @@ struct WooShippingEditAddressView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.verticalSpacing) {
-                AddressTextField(field: .name, text: $name, focused: $focusedField)
-                if showCompanyField {
-                    AddressTextField(field: .company, text: $company, focused: $focusedField)
+                AddressTextField(field: .name, text: $viewModel.name, focused: $focusedField)
+                if viewModel.showCompanyField {
+                    AddressTextField(field: .company, text: $viewModel.company, focused: $focusedField)
                 } else {
                     Button {
                         withAnimation {
-                            showCompanyField = true
+                            viewModel.showCompanyField = true
                         }
                     } label: {
                         Text(Localization.addCompany)
@@ -39,23 +27,23 @@ struct WooShippingEditAddressView: View {
                     .font(.subheadline)
                     .bold()
                 }
-                AddressSelection(field: .country, selected: country) {
+                AddressSelection(field: .country, selected: viewModel.country) {
                     // TODO: Handle country selection
                 }
                 .padding(.top, Constants.extraPadding)
-                AddressTextField(field: .address, text: $address, focused: $focusedField)
-                AddressTextField(field: .city, text: $city, focused: $focusedField)
+                AddressTextField(field: .address, text: $viewModel.address, focused: $focusedField)
+                AddressTextField(field: .city, text: $viewModel.city, focused: $focusedField)
                 AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
-                    AddressSelection(field: .state, selected: state) {
+                    AddressSelection(field: .state, selected: viewModel.state) {
                         // TODO: Handle state selection
                     }
-                    AddressTextField(field: .postalCode, text: $postalCode, focused: $focusedField)
+                    AddressTextField(field: .postalCode, text: $viewModel.postalCode, focused: $focusedField)
                 }
                 .padding(.bottom, Constants.extraPadding)
-                AddressTextField(field: .email, text: $email, focused: $focusedField)
-                AddressTextField(field: .phone, text: $phone, focused: $focusedField)
+                AddressTextField(field: .email, text: $viewModel.email, focused: $focusedField)
+                AddressTextField(field: .phone, text: $viewModel.phone, focused: $focusedField)
                     .padding(.bottom, Constants.extraPadding)
-                Toggle(Localization.defaultAddress, isOn: $saveAsDefault)
+                Toggle(Localization.defaultAddress, isOn: $viewModel.saveAsDefault)
                     .font(.subheadline)
                     .tint(Color(.accent))
             }
@@ -203,7 +191,7 @@ private extension WooShippingEditAddressView {
     func focusNextField() {
         switch focusedField {
         case .name:
-            focusedField = showCompanyField ? .company : .address
+            focusedField = viewModel.showCompanyField ? .company : .address
         case .company:
             focusedField = .address
         case .address:
@@ -229,7 +217,7 @@ private extension WooShippingEditAddressView {
         case .company:
             focusedField = .name
         case .address:
-            focusedField = showCompanyField ? .company : .name
+            focusedField = viewModel.showCompanyField ? .company : .name
         case .city:
             focusedField = .address
         case .postalCode:
@@ -306,29 +294,29 @@ private extension WooShippingEditAddressView {
 }
 
 #Preview("Without Company") {
-    WooShippingEditAddressView(name: "HEADQUARTERS",
-                               company: "",
-                               country: "UNITED STATES",
-                               address: "15 ALGONKIN ST",
-                               city: "TICONDEROGA",
-                               state: "NY",
-                               postalCode: "12883-1487",
-                               email: "",
-                               phone: "",
-                               saveAsDefault: true,
-                               showCompanyField: false)
+    WooShippingEditAddressView(viewModel: .init(name: "HEADQUARTERS",
+                                                company: "",
+                                                country: "UNITED STATES",
+                                                address: "15 ALGONKIN ST",
+                                                city: "TICONDEROGA",
+                                                state: "NY",
+                                                postalCode: "12883-1487",
+                                                email: "",
+                                                phone: "",
+                                                saveAsDefault: true,
+                                                showCompanyField: false))
 }
 
 #Preview("With Company") {
-    WooShippingEditAddressView(name: "HEADQUARTERS",
-                               company: "COMPANY",
-                               country: "UNITED STATES",
-                               address: "15 ALGONKIN ST",
-                               city: "TICONDEROGA",
-                               state: "NY",
-                               postalCode: "12883-1487",
-                               email: "",
-                               phone: "",
-                               saveAsDefault: false,
-                               showCompanyField: true)
+    WooShippingEditAddressView(viewModel: .init(name: "HEADQUARTERS",
+                                                company: "COMPANY",
+                                                country: "UNITED STATES",
+                                                address: "15 ALGONKIN ST",
+                                                city: "TICONDEROGA",
+                                                state: "NY",
+                                                postalCode: "12883-1487",
+                                                email: "",
+                                                phone: "",
+                                                saveAsDefault: false,
+                                                showCompanyField: true))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -294,7 +294,8 @@ private extension WooShippingEditAddressView {
 }
 
 #Preview("Without Company") {
-    WooShippingEditAddressView(viewModel: .init(name: "HEADQUARTERS",
+    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
+                                                name: "HEADQUARTERS",
                                                 company: "",
                                                 country: "UNITED STATES",
                                                 address: "15 ALGONKIN ST",
@@ -308,7 +309,8 @@ private extension WooShippingEditAddressView {
 }
 
 #Preview("With Company") {
-    WooShippingEditAddressView(viewModel: .init(name: "HEADQUARTERS",
+    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
+                                                name: "HEADQUARTERS",
                                                 company: "COMPANY",
                                                 country: "UNITED STATES",
                                                 address: "15 ALGONKIN ST",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// View model for editing an address in the Woo Shipping label flow.
+final class WooShippingEditAddressViewModel: ObservableObject {
+    @Published var name: String
+    @Published var company: String
+    @Published var country: String
+    @Published var address: String
+    @Published var city: String
+    @Published var state: String
+    @Published var postalCode: String
+    @Published var email: String
+    @Published var phone: String
+    @Published var saveAsDefault: Bool
+
+    /// Whether to show the company field by default.
+    @Published var showCompanyField: Bool
+
+    init(name: String,
+         company: String,
+         country: String,
+         address: String,
+         city: String,
+         state: String,
+         postalCode: String,
+         email: String,
+         phone: String,
+         saveAsDefault: Bool,
+         showCompanyField: Bool) {
+        self.name = name
+        self.company = company
+        self.country = country
+        self.address = address
+        self.city = city
+        self.state = state
+        self.postalCode = postalCode
+        self.email = email
+        self.phone = phone
+        self.saveAsDefault = saveAsDefault
+        self.showCompanyField = showCompanyField
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 /// View model for editing an address in the Woo Shipping label flow.
-final class WooShippingEditAddressViewModel: ObservableObject {
+final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
+    let id: String
     @Published var name: String
     @Published var company: String
     @Published var country: String
@@ -16,7 +17,8 @@ final class WooShippingEditAddressViewModel: ObservableObject {
     /// Whether to show the company field by default.
     @Published var showCompanyField: Bool
 
-    init(name: String,
+    init(id: String,
+         name: String,
          company: String,
          country: String,
          address: String,
@@ -27,6 +29,7 @@ final class WooShippingEditAddressViewModel: ObservableObject {
          phone: String,
          saveAsDefault: Bool,
          showCompanyField: Bool) {
+        self.id = id
         self.name = name
         self.company = company
         self.country = country

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddress+Woo.swift
@@ -11,41 +11,14 @@ extension WooShippingOriginAddress {
     /// then a single line is returned containing the other value.
     ///
     var fullNameWithCompany: String {
-        var output: [String] = []
-
-        if let fullName {
-            output.append(fullName)
-        }
-        if company.isNotEmpty {
-            output.append(company)
-        }
-
-        return output.joined(separator: "\n")
+        [fullName, company].compactMap { $0.isEmpty ? nil : $0 }.joined(separator: "\n")
     }
 
-    /// Returns the first and last name combined (if there are, effectively, two names).
+    /// Returns the first and last name combined.
     /// If only one name is present, that name is returned.
-    var fullName: String? {
-        switch (firstName.isNotEmpty, lastName.isNotEmpty) {
-        case (true, true):
-            return "\(firstName) \(lastName)"
-        case (true, false):
-            return firstName
-        case (false, true):
-            return lastName
-        case (false, false):
-            return nil
-        }
+    var fullName: String {
+        [firstName, lastName].compactMap { $0.isEmpty ? nil : $0 }.joined(separator: " ")
     }
-
-    /// Returns the Postal Address, formatted and ready for display.
-    ///
-    var formattedPostalAddress: String? {
-        return postalAddress.formatted(as: .mailingAddress)?.replacingOccurrences(of: "\n", with: ", ")
-    }
-}
-
-private extension WooShippingOriginAddress {
 
     /// Returns the two Address Lines combined (if there are, effectively, two lines).
     /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm
@@ -57,6 +30,15 @@ private extension WooShippingOriginAddress {
 
         return address1 + " " + address2
     }
+
+    /// Returns the Postal Address, formatted and ready for display.
+    ///
+    var formattedPostalAddress: String? {
+        return postalAddress.formatted(as: .mailingAddress)?.replacingOccurrences(of: "\n", with: ", ")
+    }
+}
+
+private extension WooShippingOriginAddress {
 
     /// Returns a CNPostalAddress with the receiver's properties
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
@@ -27,7 +27,7 @@ struct WooShippingOriginAddressListView: View {
                     }
                     Spacer()
                     PencilEditButton {
-                        viewModel.addressToEdit = address
+                        viewModel.editAddress(address)
                     }
                     .buttonStyle(TextButtonStyle())
                 }
@@ -45,21 +45,10 @@ struct WooShippingOriginAddressListView: View {
                 .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: Constants.verticalSpacing, trailing: 0))
             }
             .listStyle(.plain)
-            .sheet(item: $viewModel.addressToEdit) { address in
+            .sheet(item: $viewModel.addressToEdit) { addressToEdit in
                 // TODO: Handle edits to the address fields
-                // TODO: Confirm what to display for `address` field
                 NavigationStack {
-                    WooShippingEditAddressView(viewModel: .init(name: address.fullName ?? "",
-                                                                company: address.company,
-                                                                country: address.country,
-                                                                address: address.address1,
-                                                                city: address.city,
-                                                                state: address.state,
-                                                                postalCode: address.postcode,
-                                                                email: address.email,
-                                                                phone: address.phone,
-                                                                saveAsDefault: address.defaultAddress,
-                                                                showCompanyField: address.company.isNotEmpty))
+                    WooShippingEditAddressView(viewModel: addressToEdit)
                     .navigationTitle(Localization.editOrigin)
                     .navigationBarTitleDisplayMode(.inline)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
@@ -49,17 +49,17 @@ struct WooShippingOriginAddressListView: View {
                 // TODO: Handle edits to the address fields
                 // TODO: Confirm what to display for `address` field
                 NavigationStack {
-                    WooShippingEditAddressView(name: address.fullName ?? "",
-                                               company: address.company,
-                                               country: address.country,
-                                               address: address.address1,
-                                               city: address.city,
-                                               state: address.state,
-                                               postalCode: address.postcode,
-                                               email: address.email,
-                                               phone: address.phone,
-                                               saveAsDefault: address.defaultAddress,
-                                               showCompanyField: address.company.isNotEmpty)
+                    WooShippingEditAddressView(viewModel: .init(name: address.fullName ?? "",
+                                                                company: address.company,
+                                                                country: address.country,
+                                                                address: address.address1,
+                                                                city: address.city,
+                                                                state: address.state,
+                                                                postalCode: address.postcode,
+                                                                email: address.email,
+                                                                phone: address.phone,
+                                                                saveAsDefault: address.defaultAddress,
+                                                                showCompanyField: address.company.isNotEmpty))
                     .navigationTitle(Localization.editOrigin)
                     .navigationBarTitleDisplayMode(.inline)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -5,9 +5,9 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
     let addresses: [WooShippingOriginAddress]
     @Published private(set) var selectedAddressID: String?
 
-    /// Origin address to edit.
+    /// View model for address to edit.
     /// Setting this property will navigate to the address edit screen.
-    @Published var addressToEdit: WooShippingOriginAddress?
+    @Published var addressToEdit: WooShippingEditAddressViewModel?
 
     /// Closure (set externally) called when an address is selected.
     var onSelect: ((WooShippingOriginAddress) -> Void)?
@@ -30,6 +30,21 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
         }
         selectedAddressID = address.id
         onSelect?(address)
+    }
+
+    func editAddress(_ address: WooShippingOriginAddress) {
+        addressToEdit = WooShippingEditAddressViewModel(id: address.id,
+                                                        name: address.fullName,
+                                                        company: address.company,
+                                                        country: address.country,
+                                                        address: address.combinedAddress,
+                                                        city: address.city,
+                                                        state: address.state,
+                                                        postalCode: address.postcode,
+                                                        email: address.email,
+                                                        phone: address.phone,
+                                                        saveAsDefault: address.defaultAddress,
+                                                        showCompanyField: address.company.isNotEmpty)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2306,6 +2306,8 @@
 		CE583A082107849F00D73C1C /* SwitchTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE583A062107849F00D73C1C /* SwitchTableViewCell.xib */; };
 		CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A092107937F00D73C1C /* TextViewTableViewCell.swift */; };
 		CE583A0C2107937F00D73C1C /* TextViewTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE583A0A2107937F00D73C1C /* TextViewTableViewCell.xib */; };
+		CE5A9BBB2D3137F200FBADDF /* WooShippingEditAddressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5A9BBA2D3137ED00FBADDF /* WooShippingEditAddressViewModel.swift */; };
+		CE5A9BBD2D315E0500FBADDF /* WooShippingEditAddressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5A9BBC2D315E0500FBADDF /* WooShippingEditAddressViewModelTests.swift */; };
 		CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462623AAC8C0006B1A5C /* RefundDetailsViewModel.swift */; };
 		CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */; };
 		CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */; };
@@ -5448,6 +5450,8 @@
 		CE583A062107849F00D73C1C /* SwitchTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SwitchTableViewCell.xib; sourceTree = "<group>"; };
 		CE583A092107937F00D73C1C /* TextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewTableViewCell.swift; sourceTree = "<group>"; };
 		CE583A0A2107937F00D73C1C /* TextViewTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextViewTableViewCell.xib; sourceTree = "<group>"; };
+		CE5A9BBA2D3137ED00FBADDF /* WooShippingEditAddressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingEditAddressViewModel.swift; sourceTree = "<group>"; };
+		CE5A9BBC2D315E0500FBADDF /* WooShippingEditAddressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingEditAddressViewModelTests.swift; sourceTree = "<group>"; };
 		CE5F462623AAC8C0006B1A5C /* RefundDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsDataSource.swift; sourceTree = "<group>"; };
 		CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsResultController.swift; sourceTree = "<group>"; };
@@ -12079,6 +12083,7 @@
 				CE7FE6932D1324BD000F9475 /* WooShippingOriginAddressListView.swift */,
 				CECAE70B2D22EF9B000AE10B /* WooShippingOriginAddressListViewModel.swift */,
 				CE852E1E2D2EDC4C00C7DBB6 /* WooShippingEditAddressView.swift */,
+				CE5A9BBA2D3137ED00FBADDF /* WooShippingEditAddressViewModel.swift */,
 			);
 			path = WooShippingAddresses;
 			sourceTree = "<group>";
@@ -12214,6 +12219,7 @@
 				CE4AFE472CD239B90013C52B /* WooShippingPostPurchaseViewModelTests.swift */,
 				CE7269C72D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift */,
 				CE56C01D2D2431C000EBDE24 /* WooShippingOriginAddressListViewModelTests.swift */,
+				CE5A9BBC2D315E0500FBADDF /* WooShippingEditAddressViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -16780,6 +16786,7 @@
 				021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */,
 				456C7EEB25EE71F10016CBC6 /* ShippingLabelSuggestedAddressViewController.swift in Sources */,
 				D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */,
+				CE5A9BBB2D3137F200FBADDF /* WooShippingEditAddressViewModel.swift in Sources */,
 				CECAE7112D23168D000AE10B /* WooShippingOriginAddress+Woo.swift in Sources */,
 				DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */,
 				D8815B0126385E3F00EDAD62 /* CardPresentModalTapCard.swift in Sources */,
@@ -17498,6 +17505,7 @@
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 				023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */,
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
+				CE5A9BBD2D315E0500FBADDF /* WooShippingEditAddressViewModelTests.swift in Sources */,
 				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */,
 				68A38DF52B293B030090C263 /* MockProductListViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import WooCommerce
+
+final class WooShippingEditAddressViewModelTests: XCTestCase {
+
+    func test_it_inits_with_expected_values() {
+        // Given
+        let name = "JANE DOE"
+        let company = "HEADQUARTERS"
+        let address = "15 ALGONKIN ST STE 100"
+        let city = "TICONDEROGA"
+        let state = "NY"
+        let postalCode = "12883-1487"
+        let country = "US"
+        let email = "TEST@EXAMPLE.COM"
+        let phone = "123-456-7890"
+        let saveAsDefault = true
+        let showCompanyField = true
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(name: name,
+                                                        company: company,
+                                                        country: country,
+                                                        address: address,
+                                                        city: city,
+                                                        state: state,
+                                                        postalCode: postalCode,
+                                                        email: email,
+                                                        phone: phone,
+                                                        saveAsDefault: saveAsDefault,
+                                                        showCompanyField: showCompanyField)
+
+        // Then
+        XCTAssertEqual(viewModel.name, name)
+        XCTAssertEqual(viewModel.company, company)
+        XCTAssertEqual(viewModel.country, country)
+        XCTAssertEqual(viewModel.address, address)
+        XCTAssertEqual(viewModel.city, city)
+        XCTAssertEqual(viewModel.state, state)
+        XCTAssertEqual(viewModel.postalCode, postalCode)
+        XCTAssertEqual(viewModel.email, email)
+        XCTAssertEqual(viewModel.phone, phone)
+        XCTAssertEqual(viewModel.saveAsDefault, saveAsDefault)
+        XCTAssertEqual(viewModel.showCompanyField, showCompanyField)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -5,6 +5,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_it_inits_with_expected_values() {
         // Given
+        let id = "default_address"
         let name = "JANE DOE"
         let company = "HEADQUARTERS"
         let address = "15 ALGONKIN ST STE 100"
@@ -18,7 +19,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let showCompanyField = true
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(name: name,
+        let viewModel = WooShippingEditAddressViewModel(id: id,
+                                                        name: name,
                                                         company: company,
                                                         country: country,
                                                         address: address,
@@ -31,6 +33,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: showCompanyField)
 
         // Then
+        XCTAssertEqual(viewModel.id, id)
         XCTAssertEqual(viewModel.name, name)
         XCTAssertEqual(viewModel.company, company)
         XCTAssertEqual(viewModel.country, country)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
@@ -15,6 +15,7 @@ final class WooShippingOriginAddressListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.addresses, addresses)
         XCTAssertEqual(viewModel.selectedAddressID, selectedAddressID)
+        XCTAssertNil(viewModel.addressToEdit)
     }
 
     func test_isSelected_returns_expected_value_for_selected_address() {
@@ -72,6 +73,42 @@ final class WooShippingOriginAddressListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(selectedAddress, addressToSelect)
+    }
+
+    func test_editAddress_sets_addressToEdit_view_model_with_expected_values() throws {
+        // Given
+        let addressToEdit = WooShippingOriginAddress(id: "default_address",
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "123-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: true)
+        let viewModel = WooShippingOriginAddressListViewModel(addresses: [addressToEdit])
+
+        // When
+        viewModel.editAddress(addressToEdit)
+
+        // Then
+        let addressToEditViewModel = try XCTUnwrap(viewModel.addressToEdit, "addressToEdit was unexpectedly nil")
+        XCTAssertEqual(addressToEditViewModel.id, addressToEdit.id)
+        XCTAssertEqual(addressToEditViewModel.name, addressToEdit.fullName)
+        XCTAssertEqual(addressToEditViewModel.country, addressToEdit.country)
+        XCTAssertEqual(addressToEditViewModel.company, addressToEdit.company)
+        XCTAssertEqual(addressToEditViewModel.address, addressToEdit.combinedAddress)
+        XCTAssertEqual(addressToEditViewModel.city, addressToEdit.city)
+        XCTAssertEqual(addressToEditViewModel.state, addressToEdit.state)
+        XCTAssertEqual(addressToEditViewModel.postalCode, addressToEdit.postcode)
+        XCTAssertEqual(addressToEditViewModel.phone, addressToEdit.phone)
+        XCTAssertEqual(addressToEditViewModel.email, addressToEdit.email)
+        XCTAssertTrue(addressToEditViewModel.saveAsDefault)
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a view model for the new `WooShippingEditAddressView`, to hold the data and logic used in the view. This is used when editing an address in the Woo Shipping label flow.

Future PRs will add the UI and logic needed to validate and save the edited address.

### Changes

* Adds the view model with the necessary properties.
* Updates `WooShippingOriginAddress+Woo` to simplify the logic for its computed properties and make `combinedAddress` public (so we can use it when editing the origin address).
* Updates `WooShippingOriginAddressListView` and its view model to create and set the new `WooShippingEditAddressViewModel` for the address being edited.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

You can test that the same steps work as before:

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. Confirm a sheet opens with the details of the selected origin address prefilled.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.