### PR TITLE
[Woo POS] Fix infinite scroll not triggered when staying near the bottom

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -8,7 +8,7 @@ import class Yosemite.Store
 protocol PointOfSaleItemsControllerProtocol {
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> { get }
     func loadInitialItems() async
-    func loadNextItems() async throws
+    func loadNextItems() async
     func reload() async
     func loadInitialChildItems(for parent: POSItem) async
 }
@@ -46,7 +46,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     }
 
     @MainActor
-    func loadNextItems() async throws {
+    func loadNextItems() async {
         guard paginationTracker.hasNextPage else {
             return
         }
@@ -64,7 +64,6 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
             itemsViewState = .init(containerState: .error(PointOfSaleErrorState.errorOnLoadingProducts()),
                                    itemsStack: ItemsStackState(root: .loaded(currentItems, hasMoreItems: true),
                                                                itemStates: currentItemStates))
-            throw error
         }
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -98,8 +98,8 @@ extension PointOfSaleAggregateModel {
     }
 
     @MainActor
-    func loadNextItems() async throws {
-        try await itemsController.loadNextItems()
+    func loadNextItems() async {
+        await itemsController.loadNextItems()
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollTriggerDeterminable.swift
+++ b/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollTriggerDeterminable.swift
@@ -9,14 +9,9 @@ protocol InfiniteScrollTriggerDeterminable {
     ///   - contentHeight: The total height of all scrollable content.
     /// - Returns: A boolean indicating whether infinite scroll should be triggered.
     func shouldTriggerInfiniteScroll(scrollPosition: CGFloat, scrollViewHeight: CGFloat, contentHeight: CGFloat) -> Bool
-
-    /// Resets the internal scroll trigger tracking state.
-    /// This is typically called when content loading fails to allow retrying.
-    func resetStatesIfNeeded()
 }
 
 final class ThresholdInfiniteScrollTriggerDeterminer: InfiniteScrollTriggerDeterminable, ObservableObject {
-    private var lastTriggeredContentHeight: CGFloat?
     private let scrollTriggerThreshold: CGFloat
 
     /// Initializes a threshold-based infinite scroll trigger determiner.
@@ -37,16 +32,6 @@ final class ThresholdInfiniteScrollTriggerDeterminer: InfiniteScrollTriggerDeter
             return false
         }
 
-        // Prevents duplicate triggers by tracking the content height at which infinite scroll was last triggered.
-        if scrollRatio >= scrollTriggerThreshold && lastTriggeredContentHeight != contentHeight {
-            lastTriggeredContentHeight = contentHeight
-            return true
-        } else {
-            return false
-        }
-    }
-
-    func resetStatesIfNeeded() {
-        lastTriggeredContentHeight = nil
+        return scrollRatio >= scrollTriggerThreshold
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollView.swift
@@ -5,7 +5,7 @@ struct InfiniteScrollView<Content: View>: View {
     @State private var scrollViewHeight: CGFloat = 0
 
     private let triggerDeterminer: InfiniteScrollTriggerDeterminable
-    private let loadMore: () async throws -> Void
+    private let loadMore: () async -> Void
     private let content: Content
 
     /// - Parameters:
@@ -14,7 +14,7 @@ struct InfiniteScrollView<Content: View>: View {
     ///   - content: The main content view to display in the scroll view.
     init(
         triggerDeterminer: InfiniteScrollTriggerDeterminable,
-        loadMore: @escaping () async throws -> Void,
+        loadMore: @escaping () async -> Void,
         @ViewBuilder content: () -> Content
     ) {
         self.triggerDeterminer = triggerDeterminer
@@ -39,11 +39,7 @@ struct InfiniteScrollView<Content: View>: View {
                                         contentHeight: contentHeight
                                     ) {
                                     Task { @MainActor in
-                                        do {
-                                            try await loadMore()
-                                        } catch {
-                                            triggerDeterminer.resetStatesIfNeeded()
-                                        }
+                                        await loadMore()
                                     }
                                 }
                             }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -34,7 +34,7 @@ struct ItemList<HeaderView: View>: View {
                       case .loaded(_, let hasMoreItems) = state,
                       hasMoreItems
                 else { return }
-                try await posModel.loadNextItems()
+                await posModel.loadNextItems()
             },
             content: {
                 LazyVStack {

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -119,7 +119,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         #expect(itemsViewState.containerState == .empty)
@@ -134,7 +134,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -150,7 +150,7 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadInitialItems()
 
         // When
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         guard case .loaded(let items, _) = itemsViewState.itemsStack.root else {
@@ -167,7 +167,7 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadInitialItems()
 
         // When
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
@@ -182,7 +182,7 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadInitialItems()
 
         // When
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         guard case .loaded(let items, let hasMoreItems) = itemsViewState.itemsStack.root else {
@@ -234,12 +234,10 @@ final class PointOfSaleItemsControllerTests {
                                                   buttonText: "Retry")
 
         // When
-        do {
-            try await sut.loadNextItems()
-        } catch {
-            // Then
-            #expect(itemsViewState.containerState == .error(expectedError))
-        }
+        await sut.loadNextItems()
+
+        // Then
+        #expect(itemsViewState.containerState == .error(expectedError))
     }
 
     @Test func loadNextItems_after_itemProvider_throws_error_then_the_same_page_is_requested_next() async throws {
@@ -248,12 +246,12 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadInitialItems()
 
         itemProvider.shouldThrowError = true
-        try? await sut.loadNextItems()
+        await sut.loadNextItems()
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
         itemProvider.spyLastRequestedPageNumber = 0
 
         // When
-        try? await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
@@ -278,7 +276,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.shouldSimulateTwoPages = true
         await sut.loadInitialItems()
 
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
 
         // When
@@ -295,7 +293,7 @@ final class PointOfSaleItemsControllerTests {
 
         // When
         itemProvider.shouldReturnZeroItems = true
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -311,7 +309,7 @@ final class PointOfSaleItemsControllerTests {
 
         // When
         itemProvider.shouldReturnZeroItems = true
-        try await sut.loadNextItems()
+        await sut.loadNextItems()
 
         // Then
         try #require(itemProvider.spyLastRequestedPageNumber == 1)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -211,7 +211,7 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadInitialItems(base: baseItem)
 
         // When
-        try await sut.loadNextItems(base: baseItem)
+        await sut.loadNextItems(base: baseItem)
 
         // Then
         guard case .loaded(let items, let hasMoreItems) = itemsViewState.itemsStack.itemStates[parentItem] else {

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Infinite Scroll/ThresholdInfiniteScrollTriggerDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Infinite Scroll/ThresholdInfiniteScrollTriggerDeterminerTests.swift
@@ -58,7 +58,7 @@ struct ThresholdInfiniteScrollTriggerDeterminerTests {
         #expect(result == false)
     }
 
-    @Test func shouldTriggerInfiniteScroll_returns_false_when_triggered_twice_at_same_position() async throws {
+    @Test func shouldTriggerInfiniteScroll_returns_true_when_triggered_twice_at_same_position() async throws {
         // Given
         let sut = ThresholdInfiniteScrollTriggerDeterminer()
         let scrollViewHeight: CGFloat = 500
@@ -74,35 +74,6 @@ struct ThresholdInfiniteScrollTriggerDeterminerTests {
         )
 
         // Second attempt at same position
-        let secondResult = sut.shouldTriggerInfiniteScroll(
-            scrollPosition: scrollPosition,
-            scrollViewHeight: scrollViewHeight,
-            contentHeight: contentHeight
-        )
-
-        // Then
-        #expect(firstResult == true)
-        #expect(secondResult == false)
-    }
-
-    @Test func shouldTriggerInfiniteScroll_returns_true_when_triggered_after_reset() async throws {
-        // Given
-        let sut = ThresholdInfiniteScrollTriggerDeterminer()
-        let scrollViewHeight: CGFloat = 500
-        let contentHeight: CGFloat = 1000
-        let scrollPosition = contentHeight - scrollViewHeight - 100
-
-        // When
-        // First trigger
-        let firstResult = sut.shouldTriggerInfiniteScroll(
-            scrollPosition: scrollPosition,
-            scrollViewHeight: scrollViewHeight,
-            contentHeight: contentHeight
-        )
-
-        sut.resetStatesIfNeeded()
-
-        // Second attempt after reset
         let secondResult = sut.shouldTriggerInfiniteScroll(
             scrollPosition: scrollPosition,
             scrollViewHeight: scrollViewHeight,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to https://github.com/woocommerce/woocommerce-ios/issues/14735
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In https://github.com/woocommerce/woocommerce-ios/pull/14833, the content height was kept as a state so as not to trigger loading the next page twice. However, now that we're using a lazy VStack with potentially changing content size and the `loadMore` implementation only triggers the next page load if the state is loaded, I believe it's safe to remove the content state now. When the next page load is in progress, the state transitions to `loading` and it won't trigger next page load until the scroll ratio is above the threshold & the state is loaded with next page available.

Before this PR, I could reproduce the infinite scroll issue by scrolling & staying near the bottom of the list with ~110 products and page size 15. The reason is because `loadMore` is triggered for a content height when it's still loading, it early returns without an error in the `ItemList` `loadMore` implementation so that the content height is considered loaded in `ThresholdInfiniteScrollTriggerDeterminer`. The loaded state guard in `loadMore` should remove the duplicate next page load requests, and the content height tracking logic can be removed to simplify the overall logic.

### Removal of Error Handling in Asynchronous Methods:

* [`WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift`](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L11-R11): Removed `throws` keyword from `loadNextItems`, `loadNextRootItems`, and related methods. [[1]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L11-R11) [[2]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L59-R69) [[3]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L87)
* [`WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift`](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL27-R27): Removed `throws` keyword from `loadNextItems` method. [[1]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL27-R27) [[2]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL100-R101)
* [`WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift`](diffhunk://#diff-4dabea090e9975b33e741405197fdc574e0876ec76ece41f80b312e6766f217dL31-R31): Removed `throws` keyword from `loadNextItems` call.
* [`WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift`](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L125-R125): Updated test cases to reflect the removal of `throws` keyword from `loadNextItems` method. [[1]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L125-R125) [[2]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L140-R140) [[3]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L156-R156) [[4]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L173-R173) [[5]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L188-R188) [[6]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L266-R283) [[7]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L310-R308) [[8]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L327-R325) [[9]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L343-R341)

### Simplification of Infinite Scroll Logic:

* [`WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollTriggerDeterminable.swift`](diffhunk://#diff-79b5e9e893ce41baff6e8ec26ae7aceb14d7253154ce377cc704a9a0e230a1b7L12-L19): Removed `resetStatesIfNeeded` method and related state-tracking logic. [[1]](diffhunk://#diff-79b5e9e893ce41baff6e8ec26ae7aceb14d7253154ce377cc704a9a0e230a1b7L12-L19) [[2]](diffhunk://#diff-79b5e9e893ce41baff6e8ec26ae7aceb14d7253154ce377cc704a9a0e230a1b7L40-R35)
* [`WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollView.swift`](diffhunk://#diff-1e69c9fa84d502705982a6b9d9189630d7491a1537c5c53ce985aee3eeba9e5fL8-R8): Removed `throws` keyword from `loadMore` method and updated related logic. [[1]](diffhunk://#diff-1e69c9fa84d502705982a6b9d9189630d7491a1537c5c53ce985aee3eeba9e5fL8-R8) [[2]](diffhunk://#diff-1e69c9fa84d502705982a6b9d9189630d7491a1537c5c53ce985aee3eeba9e5fL17-R17) [[3]](diffhunk://#diff-1e69c9fa84d502705982a6b9d9189630d7491a1537c5c53ce985aee3eeba9e5fL42-R42)
* [`WooCommerce/WooCommerceTests/POS/Presentation/Infinite Scroll/ThresholdInfiniteScrollTriggerDeterminerTests.swift`](diffhunk://#diff-647f7099b0d3557457a2c8df96d28d54fb6847ec8d302c5dc6c3dc16a7b2b730L61-R61): Updated test cases to reflect the removal of state-tracking logic in infinite scroll. [[1]](diffhunk://#diff-647f7099b0d3557457a2c8df96d28d54fb6847ec8d302c5dc6c3dc16a7b2b730L61-R61) [[2]](diffhunk://#diff-647f7099b0d3557457a2c8df96d28d54fb6847ec8d302c5dc6c3dc16a7b2b730L83-L111)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

🗒️ I'd recommend reducing the page size from 100 to 15 for products [here](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L651) and variations [here](https://github.com/woocommerce/woocommerce-ios/blob/3c06196a313c1aa24dcff045fdb07ba40933be0e/Networking/Networking/Remote/ProductVariationsRemote.swift#L340).

- Switch to a store eligible for POS, and has multiple 15-item pages of purchasable simple/variable products
- Go to Menu > Point of Sale mode
- Scroll near 70% of the scrollable height --> the next page of data should be loaded
- Keep scrolling down to trigger the next page load quickly --> the next page of data should be loaded without duplicated items
- Try pulling to refresh --> the first page of data should be reloaded
- Tap on a variable product with more than one page of variations
- Scroll near 70% of the scrollable height --> the next page of data should be loaded
- Keep scrolling down to trigger the next page load quickly --> the next page of data should be loaded without duplicated items

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before:


https://github.com/user-attachments/assets/db4a6a60-5472-4a94-9f0c-728043421a1a


after:



https://github.com/user-attachments/assets/0244df21-63ed-4d88-8299-b91ad0e61f51




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.