### PR TITLE
[Woo POS] [Variable Products] Add pull-to-refresh support for variation sublists

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -7,9 +7,8 @@ import class Yosemite.Store
 
 protocol PointOfSaleItemsControllerProtocol {
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> { get }
-    func loadInitialItems(base: ItemListBaseItem) async
+    func reloadItems(base: ItemListBaseItem) async
     func loadNextItems(base: ItemListBaseItem) async throws
-    func reload() async
 }
 
 class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
@@ -30,23 +29,21 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     }
 
     @MainActor
-    func loadInitialItems(base: ItemListBaseItem) async {
+    func reloadItems(base: ItemListBaseItem) async {
         switch base {
         case .root:
-            await loadInitialRootItems()
+            await loadRootItems()
         case .parent(let parent):
-            await loadInitialChildItems(for: parent)
+            await loadChildItems(for: parent)
         }
     }
 
     @MainActor
-    private func loadInitialRootItems() async {
-        itemsViewState = .init(containerState: .loading, itemsStack: ItemsStackState(root: .loading([]),
-                                                                                     itemStates: [:]))
+    private func loadRootItems() async {
         do {
-            try await paginationTracker.syncFirstPage { [weak self] pageNumber in
+            try await paginationTracker.resync { [weak self] pageNumber in
                 guard let self else { return true }
-                return try await fetchItems(pageNumber: pageNumber)
+                return try await fetchItems(pageNumber: pageNumber, appendToExistingItems: false)
             }
         } catch {
             itemsViewState = .init(containerState: .error(PointOfSaleErrorState.errorOnLoadingProducts()),
@@ -89,29 +86,13 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     }
 
     @MainActor
-    func reload() async {
-        do {
-            try await paginationTracker.resync { [weak self] pageNumber in
-                guard let self else { return true }
-                return try await fetchItems(pageNumber: pageNumber, appendToExistingItems: false)
-            }
-        } catch {
-            // TODO: 14694 - Handle error from pull-to-refresh, like showing an error UI at the beginning or as an overlay.
-            itemsViewState = .init(containerState: .error(PointOfSaleErrorState.errorOnLoadingProducts()),
-                                   itemsStack: ItemsStackState(root: .loaded([], hasMoreItems: false),
-                                                               itemStates: [:]))
-        }
-    }
-
-    @MainActor
-    private func loadInitialChildItems(for parent: POSItem) async {
-        updateState(for: parent, to: .loading([]))
+    private func loadChildItems(for parent: POSItem) async {
 
         let paginationTracker = paginationTracker(for: parent)
         do {
-            try await paginationTracker.syncFirstPage { [weak self] pageNumber in
+            try await paginationTracker.resync { [weak self] pageNumber in
                 guard let self else { return true }
-                return try await fetchChildItems(for: parent, pageNumber: Store.Default.firstPageNumber)
+                return try await fetchChildItems(for: parent, pageNumber: Store.Default.firstPageNumber, appendToExistingItems: false)
             }
         } catch {
             // TODO: 14694 - Handle error from loading initial variations.
@@ -131,7 +112,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
         do {
             _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
                 guard let self else { return true }
-                return try await fetchChildItems(for: parent, pageNumber: pageNumber)
+                return try await fetchChildItems(for: parent, pageNumber: pageNumber, appendToExistingItems: true)
             }
         } catch {
             // TODO: 14694 - Handle error from loading the next page, like showing an error UI at the end or as an overlay.
@@ -140,10 +121,13 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     }
 
     @MainActor
-    private func fetchChildItems(for parent: POSItem, pageNumber: Int) async throws -> Bool {
+    private func fetchChildItems(for parent: POSItem, pageNumber: Int, appendToExistingItems: Bool) async throws -> Bool {
         switch parent {
         case let .variableParentProduct(parentProduct):
-            return try await fetchVariationItems(parentProduct: parentProduct, parentItem: parent, pageNumber: pageNumber)
+            return try await fetchVariationItems(parentProduct: parentProduct,
+                                                 parentItem: parent,
+                                                 pageNumber: pageNumber,
+                                                 appendToExistingItems: appendToExistingItems)
         case .simpleProduct, .variation:
             assertionFailure("Unsupported parent type for loading child items: \(parent)")
             return false

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -7,7 +7,9 @@ import class Yosemite.Store
 
 protocol PointOfSaleItemsControllerProtocol {
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> { get }
-    func reloadItems(base: ItemListBaseItem) async
+    /// Loads the first page of items for a given base item.
+    func loadItems(base: ItemListBaseItem) async
+    /// Loads the next page of items for a given base item.
     func loadNextItems(base: ItemListBaseItem) async
 }
 
@@ -29,7 +31,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     }
 
     @MainActor
-    func reloadItems(base: ItemListBaseItem) async {
+    func loadItems(base: ItemListBaseItem) async {
         switch base {
         case .root:
             await loadRootItems()

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -92,7 +92,7 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func reloadItems(base: ItemListBaseItem) async {
-        await itemsController.reloadItems(base: base)
+        await itemsController.loadItems(base: base)
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -23,9 +23,8 @@ protocol PointOfSaleAggregateModelProtocol {
     func trackCardPaymentsOnboardingShown()
 
     var itemsViewState: ItemsViewState { get }
-    func loadInitialItems(base: ItemListBaseItem) async
+    func reloadItems(base: ItemListBaseItem) async
     func loadNextItems(base: ItemListBaseItem) async throws
-    func reload() async
 
     var cart: [CartItem] { get }
     func addToCart(_ item: POSOrderableItem)
@@ -92,18 +91,13 @@ extension PointOfSaleAggregateModel {
     }
 
     @MainActor
-    func loadInitialItems(base: ItemListBaseItem) async {
-        await itemsController.loadInitialItems(base: base)
+    func reloadItems(base: ItemListBaseItem) async {
+        await itemsController.reloadItems(base: base)
     }
 
     @MainActor
     func loadNextItems(base: ItemListBaseItem) async throws {
         try await itemsController.loadNextItems(base: base)
-    }
-
-    @MainActor
-    func reload() async {
-        await itemsController.reload()
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -39,11 +39,14 @@ struct ChildItemList: View {
                 .transition(.opacity)
         }
         .background(Color.posPrimaryBackground)
+        .refreshable {
+            await posModel.reloadItems(base: .parent(parentItem))
+        }
         .task {
             guard state.items.isEmpty else {
                 return
             }
-            await posModel.loadInitialItems(base: .parent(parentItem))
+            await posModel.reloadItems(base: .parent(parentItem))
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -34,7 +34,7 @@ struct ItemListView: View {
             })
         }
         .refreshable {
-            await posModel.reload()
+            await posModel.reloadItems(base: .root)
         }
         .background(Color.posPrimaryBackground)
         .accessibilityElement(children: .contain)
@@ -273,7 +273,7 @@ private extension ItemListView {
 #Preview("Loaded with all product types") {
     let itemsController = PointOfSalePreviewItemsController()
     Task { @MainActor in
-        await itemsController.loadInitialItems(base: .root)
+        await itemsController.reloadItems(base: .root)
     }
     let posModel = PointOfSaleAggregateModel(
         itemsController: itemsController,

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -273,7 +273,7 @@ private extension ItemListView {
 #Preview("Loaded with all product types") {
     let itemsController = PointOfSalePreviewItemsController()
     Task { @MainActor in
-        await itemsController.reloadItems(base: .root)
+        await itemsController.loadItems(base: .root)
     }
     let posModel = PointOfSaleAggregateModel(
         itemsController: itemsController,

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleDashboardView: View {
             case .error(let errorContents):
                 PointOfSaleItemListErrorView(error: errorContents, onRetry: {
                     Task {
-                        await posModel.loadInitialItems(base: .root)
+                        await posModel.reloadItems(base: .root)
                     }
                 })
             case .content:
@@ -66,7 +66,7 @@ struct PointOfSaleDashboardView: View {
             supportForm
         }
         .task {
-            await posModel.loadInitialItems(base: .root)
+            await posModel.reloadItems(base: .root)
         }
     }
 

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -64,7 +64,7 @@ final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtoco
                                                                                                itemStates: [:]))
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> { $itemsViewState }
 
-    func reloadItems(base: ItemListBaseItem) async {
+    func loadItems(base: ItemListBaseItem) async {
         switch base {
         case .root:
             itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded(mockItems, hasMoreItems: true),

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -64,7 +64,7 @@ final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtoco
                                                                                                itemStates: [:]))
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> { $itemsViewState }
 
-    func loadInitialItems(base: ItemListBaseItem) async {
+    func reloadItems(base: ItemListBaseItem) async {
         switch base {
         case .root:
             itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded(mockItems, hasMoreItems: true),
@@ -76,11 +76,6 @@ final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtoco
 
     func loadNextItems(base: ItemListBaseItem) async {
         itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loading(mockItems),
-                                                                                              itemStates: [:]))
-    }
-
-    func reload() async {
-        itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded([], hasMoreItems: false),
                                                                                               itemStates: [:]))
     }
 

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -18,7 +18,7 @@ final class PointOfSaleItemsControllerTests {
         sut.itemsViewStatePublisher.assign(to: &$itemsViewState)
     }
 
-    @Test func reloadItems_requests_first_page_after_loading_two_pages() async throws {
+    @Test func loadItems_requests_first_page_after_loading_two_pages() async throws {
         // Given
         try #require(itemsViewState.containerState == .loading)
         itemProvider.shouldSimulateTwoPages = true
@@ -34,7 +34,7 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
     }
 
-    @Test func reloadItems_results_in_loaded_state() async throws {
+    @Test func loadItems_results_in_loaded_state() async throws {
         // Given
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
         try #require(itemsViewState.containerState == .loading)
@@ -48,7 +48,7 @@ final class PointOfSaleItemsControllerTests {
                                                                              itemStates: [:])))
     }
 
-    @Test func reloadItems_with_more_pages_sets_hasMoreItems() async throws {
+    @Test func loadItems_with_more_pages_sets_hasMoreItems() async throws {
         // Given
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
         try #require(itemsViewState.containerState == .loading)
@@ -63,7 +63,7 @@ final class PointOfSaleItemsControllerTests {
                                                                              itemStates: [:])))
     }
 
-    @Test func reloadItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
+    @Test func loadItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
         // Given
         try #require(itemsViewState.containerState == .loading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
@@ -99,7 +99,7 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemsViewState.containerState == .empty)
     }
 
-    @Test func reloadItems_when_initial_items_has_items_but_no_more_pages_then_state_is_loaded_with_initial_items() async throws {
+    @Test func loadItems_when_initial_items_has_items_but_no_more_pages_then_state_is_loaded_with_initial_items() async throws {
         // Given
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
         itemProvider.items = initialItems
@@ -193,7 +193,7 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == 4)
     }
 
-    @Test func reloadItems_when_no_items_then_state_is_loaded_empty() async throws {
+    @Test func loadItems_when_no_items_then_state_is_loaded_empty() async throws {
         // Given
         itemProvider.shouldReturnZeroItems = true
 
@@ -206,7 +206,7 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemsViewState.containerState == .empty)
     }
 
-    @Test func reloadItems_when_itemProvider_throws_error_then_state_is_error() async throws {
+    @Test func loadItems_when_itemProvider_throws_error_then_state_is_error() async throws {
         // Given
         itemProvider.shouldThrowError = true
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
@@ -257,7 +257,7 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
     }
 
-    @Test func reloadItems_results_in_state_loaded_with_expected_items() async throws {
+    @Test func loadItems_results_in_state_loaded_with_expected_items() async throws {
         // Given
         try #require(itemsViewState.containerState == .loading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -18,24 +18,29 @@ final class PointOfSaleItemsControllerTests {
         sut.itemsViewStatePublisher.assign(to: &$itemsViewState)
     }
 
-    @Test func loadInitialItems_requests_first_page() async throws {
+    @Test func reloadItems_requests_first_page_after_loading_two_pages() async throws {
         // Given
         try #require(itemsViewState.containerState == .loading)
+        itemProvider.shouldSimulateTwoPages = true
+        await sut.reloadItems(base: .root)
+
+        try await sut.loadNextItems(base: .root)
+        try #require(itemProvider.spyLastRequestedPageNumber == 2)
 
         // When
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
     }
 
-    @Test func loadInitialItems_results_in_loaded_state() async throws {
+    @Test func reloadItems_results_in_loaded_state() async throws {
         // Given
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -43,14 +48,14 @@ final class PointOfSaleItemsControllerTests {
                                                                              itemStates: [:])))
     }
 
-    @Test func loadInitialItems_with_more_pages_sets_hasMoreItems() async throws {
+    @Test func reloadItems_with_more_pages_sets_hasMoreItems() async throws {
         // Given
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
         try #require(itemsViewState.containerState == .loading)
         itemProvider.shouldSimulateTwoPages = true
 
         // When
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -58,49 +63,15 @@ final class PointOfSaleItemsControllerTests {
                                                                              itemStates: [:])))
     }
 
-    @Test func loadInitialItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
+    @Test func reloadItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
         // Given
         try #require(itemsViewState.containerState == .loading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.loadInitialItems(base: .root)
-        await sut.loadInitialItems(base: .root)
-        await sut.loadInitialItems(base: .root)
-
-        // Then
-        guard case .loaded(let items, _) = itemsViewState.itemsStack.root else {
-            Issue.record("Expected loaded ItemList state, but got \(itemsViewState)")
-            return
-        }
-        #expect(items.count == expectedItems.count)
-    }
-
-    @Test func reload_results_in_loaded_state() async throws {
-        // Given
-        try #require(itemsViewState.containerState == .loading)
-        let expectedItems = MockPointOfSaleItemService.makeInitialItems()
-
-        // When
-        await sut.reload()
-
-        // Then
-        guard case .loaded(let items, _) = itemsViewState.itemsStack.root else {
-            Issue.record("Expected loaded ItemList state, but got \(itemsViewState)")
-            return
-        }
-        #expect(items.count == expectedItems.count)
-    }
-
-    @Test func reload_when_called_multiple_times_then_items_are_not_duplicated() async throws {
-        // Given
-        try #require(itemsViewState.containerState == .loading)
-        let expectedItems = MockPointOfSaleItemService.makeInitialItems()
-
-        // When
-        await sut.reload()
-        await sut.reload()
-        await sut.reload()
+        await sut.reloadItems(base: .root)
+        await sut.reloadItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // Then
         guard case .loaded(let items, _) = itemsViewState.itemsStack.root else {
@@ -128,7 +99,7 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemsViewState.containerState == .empty)
     }
 
-    @Test func loadInitialItems_when_initial_items_has_items_but_no_more_pages_then_state_is_loaded_with_initial_items() async throws {
+    @Test func reloadItems_when_initial_items_has_items_but_no_more_pages_then_state_is_loaded_with_initial_items() async throws {
         // Given
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
         itemProvider.items = initialItems
@@ -150,7 +121,7 @@ final class PointOfSaleItemsControllerTests {
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
         itemProvider.items = initialItems
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // When
         try await sut.loadNextItems(base: .root)
@@ -167,7 +138,7 @@ final class PointOfSaleItemsControllerTests {
         // Given
         try #require(itemsViewState.containerState == .loading)
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // When
         try await sut.loadNextItems(base: .root)
@@ -182,7 +153,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.items = initialItems
         itemProvider.shouldSimulateTwoPages = true
         itemProvider.shouldSimulateMorePages = true
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // When
         try await sut.loadNextItems(base: .root)
@@ -207,8 +178,8 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.shouldSimulateTwoPagesOfVariations = true
         itemProvider.shouldSimulateMorePagesOfVariations = true
 
-        await sut.loadInitialItems(base: .root)
-        await sut.loadInitialItems(base: baseItem)
+        await sut.reloadItems(base: .root)
+        await sut.reloadItems(base: baseItem)
 
         // When
         try await sut.loadNextItems(base: baseItem)
@@ -222,20 +193,20 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == 4)
     }
 
-    @Test func loadInitialItems_when_no_items_then_state_is_loaded_empty() async throws {
+    @Test func reloadItems_when_no_items_then_state_is_loaded_empty() async throws {
         // Given
         itemProvider.shouldReturnZeroItems = true
 
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // Then
         #expect(itemsViewState.containerState == .empty)
     }
 
-    @Test func loadInitialItems_when_itemProvider_throws_error_then_state_is_error() async throws {
+    @Test func reloadItems_when_itemProvider_throws_error_then_state_is_error() async throws {
         // Given
         itemProvider.shouldThrowError = true
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
@@ -244,7 +215,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         // Then
         #expect(itemsViewState.containerState == .error(expectedError))
@@ -255,7 +226,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         itemProvider.shouldThrowError = true
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
@@ -274,7 +245,7 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadNextItems_after_itemProvider_throws_error_then_the_same_page_is_requested_next() async throws {
         // Given
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
 
         itemProvider.shouldThrowError = true
         try? await sut.loadNextItems(base: .root)
@@ -288,13 +259,13 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
     }
 
-    @Test func reload_results_in_state_loaded_with_expected_items() async throws {
+    @Test func reloadItems_results_in_state_loaded_with_expected_items() async throws {
         // Given
         try #require(itemsViewState.containerState == .loading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.reload()
+        await sut.reloadItems(base: .root)
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -302,24 +273,9 @@ final class PointOfSaleItemsControllerTests {
                                                                              itemStates: [:])))
     }
 
-    @Test func reload_requests_first_page() async throws {
-        // Given
-        itemProvider.shouldSimulateTwoPages = true
-        await sut.loadInitialItems(base: .root)
-
-        try await sut.loadNextItems(base: .root)
-        try #require(itemProvider.spyLastRequestedPageNumber == 2)
-
-        // When
-        await sut.reload()
-
-        // Then
-        #expect(itemProvider.spyLastRequestedPageNumber == 1)
-    }
-
     @Test func loadNextItems_when_next_page_is_empty_then_state_is_loaded() async throws {
         // Given
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
         // When
@@ -335,7 +291,7 @@ final class PointOfSaleItemsControllerTests {
 
     @Test func loadNextItems_when_next_page_is_empty_then_the_same_page_is_requested_next() async throws {
         // Given
-        await sut.loadInitialItems(base: .root)
+        await sut.reloadItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
         // When
@@ -344,21 +300,5 @@ final class PointOfSaleItemsControllerTests {
 
         // Then
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
-    }
-
-    @Test func reload_when_itemProvider_throws_error_then_state_is_error() async throws {
-        // Given
-        itemProvider.shouldThrowError = true
-        let expectedError = PointOfSaleErrorState(title: "Error loading products",
-                                                  subtitle: "Give it another go?",
-                                                  buttonText: "Retry")
-
-        try #require(itemsViewState.containerState == .loading)
-
-        // When
-        await sut.reload()
-
-        // Then
-        #expect(itemsViewState.containerState == .error(expectedError))
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -22,13 +22,13 @@ final class PointOfSaleItemsControllerTests {
         // Given
         try #require(itemsViewState.containerState == .loading)
         itemProvider.shouldSimulateTwoPages = true
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
-        try await sut.loadNextItems(base: .root)
+        await sut.loadNextItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
 
         // When
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
@@ -40,7 +40,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -55,7 +55,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.shouldSimulateTwoPages = true
 
         // When
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -69,9 +69,9 @@ final class PointOfSaleItemsControllerTests {
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.reloadItems(base: .root)
-        await sut.reloadItems(base: .root)
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         guard case .loaded(let items, _) = itemsViewState.itemsStack.root else {
@@ -121,7 +121,7 @@ final class PointOfSaleItemsControllerTests {
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
         itemProvider.items = initialItems
         itemProvider.shouldSimulateTwoPages = true
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // When
         await sut.loadNextItems(base: .root)
@@ -138,7 +138,7 @@ final class PointOfSaleItemsControllerTests {
         // Given
         try #require(itemsViewState.containerState == .loading)
         itemProvider.shouldSimulateTwoPages = true
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // When
         await sut.loadNextItems(base: .root)
@@ -153,7 +153,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.items = initialItems
         itemProvider.shouldSimulateTwoPages = true
         itemProvider.shouldSimulateMorePages = true
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // When
         await sut.loadNextItems(base: .root)
@@ -178,8 +178,8 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.shouldSimulateTwoPagesOfVariations = true
         itemProvider.shouldSimulateMorePagesOfVariations = true
 
-        await sut.reloadItems(base: .root)
-        await sut.reloadItems(base: baseItem)
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: baseItem)
 
         // When
         await sut.loadNextItems(base: baseItem)
@@ -200,7 +200,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(itemsViewState.containerState == .empty)
@@ -215,7 +215,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         // When
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(itemsViewState.containerState == .error(expectedError))
@@ -226,7 +226,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemsViewState.containerState == .loading)
 
         itemProvider.shouldSimulateTwoPages = true
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         itemProvider.shouldThrowError = true
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
@@ -243,7 +243,7 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadNextItems_after_itemProvider_throws_error_then_the_same_page_is_requested_next() async throws {
         // Given
         itemProvider.shouldSimulateTwoPages = true
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         itemProvider.shouldThrowError = true
         await sut.loadNextItems(base: .root)
@@ -263,7 +263,7 @@ final class PointOfSaleItemsControllerTests {
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
 
         // When
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
@@ -273,7 +273,7 @@ final class PointOfSaleItemsControllerTests {
 
     @Test func loadNextItems_when_next_page_is_empty_then_state_is_loaded() async throws {
         // Given
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
         // When
@@ -289,7 +289,7 @@ final class PointOfSaleItemsControllerTests {
 
     @Test func loadNextItems_when_next_page_is_empty_then_the_same_page_is_requested_next() async throws {
         // Given
-        await sut.reloadItems(base: .root)
+        await sut.loadItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
         // When

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -42,11 +42,9 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
         self.paymentState = paymentState
     }
 
-    func loadInitialItems(base: ItemListBaseItem) async { }
+    func reloadItems(base: ItemListBaseItem) async { }
 
     func loadNextItems(base: ItemListBaseItem) async { }
-
-    func reload() async { }
 
     var cart: [CartItem] = []
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
@@ -6,9 +6,7 @@ import enum Yosemite.POSItem
 final class MockPointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> = Empty()
 
-    func loadInitialItems(base: ItemListBaseItem) async { }
+    func reloadItems(base: ItemListBaseItem) async { }
 
     func loadNextItems(base: ItemListBaseItem) async { }
-
-    func reload() async { }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
@@ -6,7 +6,7 @@ import enum Yosemite.POSItem
 final class MockPointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     var itemsViewStatePublisher: any Publisher<ItemsViewState, Never> = Empty()
 
-    func reloadItems(base: ItemListBaseItem) async { }
+    func loadItems(base: ItemListBaseItem) async { }
 
     func loadNextItems(base: ItemListBaseItem) async { }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14695 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds pull-to-refresh support to the variations list in POS. The initial load & PTR reload are now merged into one `reloadItems(base: ItemListBaseItem)`. There is little difference between the initial load and PT (pull-to-refresh) reload, other than resetting the initial state which should be set by default for the initial load.

Key changes include:

### Method Renaming and Refactoring:
* [`WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift`](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L10-L12): Renamed `loadInitialItems` to `reloadItems`, and removed the `reload` method. Updated the logic within `reloadItems` to call `loadRootItems` and `loadChildItems` instead of their initial counterparts. [[1]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L10-L12) [[2]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L33-R46) [[3]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L92-R95) [[4]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L134-R115) [[5]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L143-R130)

### Interface Updates:
* [`WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift`](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL26-L28): Updated the protocol and methods to reflect the renaming from `loadInitialItems` to `reloadItems`. [[1]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL26-L28) [[2]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL95-L107)

### UI Components:
* [`WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift`](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bR42-R49): Modified the `ChildItemList` view to use `reloadItems` for refreshable for PTR and task actions for the initial load.
* [`WooCommerce/Classes/POS/Presentation/ItemListView.swift`](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L37-R37): Updated the `ItemListView` to call `reloadItems` instead of `reload` for refreshable and preview actions. [[1]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L37-R37) [[2]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L276-R276)
* [`WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift`](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL23-R23): Adjusted the `PointOfSaleDashboardView` to use `reloadItems` for error handling and initial loading. [[1]](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL23-R23) [[2]](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL69-R69)

### Test Cases:
* [`WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift`](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L21-R74): Updated test cases to reflect the method renaming and ensure proper functionality of `reloadItems`. Removed tests related to the old `reload` method. [[1]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L21-R74) [[2]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L131-R102) [[3]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L153-R124) [[4]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L170-R141) [[5]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L185-R156) [[6]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L210-R182) [[7]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L225-R209) [[8]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L247-R218) [[9]](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4L258-R229)

### Preview Helpers:
* [`WooCommerce/Classes/POS/Utils/PreviewHelpers.swift`](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dL67-R67): Updated the `PointOfSalePreviewItemsController` to use `reloadItems` instead of `loadInitialItems` and removed the old `reload` method. [[1]](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dL67-R67) [[2]](diffhunk://#diff-97e03cb12a8d584183bc71ac17d2034fc198adb981132042599469d40e9c8b3dL82-L86)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

🗒️ I'd recommend reducing the page size from 100 to 15 for products [here](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L651) and variations [here](https://github.com/woocommerce/woocommerce-ios/blob/3c06196a313c1aa24dcff045fdb07ba40933be0e/Networking/Networking/Remote/ProductVariationsRemote.swift#L340).

- Switch to a store eligible for POS, and has multiple pages of purchasable simple/variable products. It has at least one variable product with multiple pages of variations
- Go to Menu > Point of Sale mode
- Pull to refresh --> the first page of data should be reloaded
  -  🗒️ Notice that if infinite scroll is triggered in-progress, it results in an error as a pre-existing issue https://github.com/woocommerce/woocommerce-ios/issues/14853
- Tap on a variable product with more than one page of variations
- Scroll near 70% of the scrollable height --> the next page of data should be loaded
- Scroll back to the top and pull to refresh --> the first page of data should be loaded

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/fc67879a-ca6f-4762-a651-13c1b94f46a4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.