### PR TITLE
[Shipping labels] Ensure entire address view is tappable for selection in origin address list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
@@ -38,6 +38,7 @@ struct WooShippingOriginAddressListView: View {
                 .roundedBorder(cornerRadius: Constants.cornerRadius,
                                lineColor: Color(viewModel.isSelected(address) ? .wooCommercePurple(.shade60) : .separator),
                                lineWidth: viewModel.isSelected(address) ? 2 : 0.5)
+                .contentShape(Rectangle())
                 .onTapGesture {
                     viewModel.select(address)
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14835
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the Woo Shipping label flow, this updates the address view in the origin address list to make the entire cell tappable/selectable.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Select a store with the Woo Shipping extension active and set up.
2. Create or open an order with at least one physical product and the processing order status.
3. Tap "Create Shipping Label."
4. Open the Shipment details bottom sheet.
5. Tap the "Ship from" address to open the origin address list.
6. Confirm you can tap anywhere in the address view/cell to select a new address.
7. Confirm tapping the pencil edit still opens the edit address form.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/5ba5c13f-f24a-4213-a41e-6fb31f4f9841



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.