### PR TITLE
[Woo POS] [Variable Products] Show error UI from pull-to-refresh or initial load failure

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -96,7 +96,7 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
                 return try await fetchChildItems(for: parent, pageNumber: Store.Default.firstPageNumber, appendToExistingItems: false)
             }
         } catch {
-            // TODO: 14694 - Handle error from loading initial variations.
+            updateState(for: parent, to: .error(.errorOnLoadingVariations()))
         }
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -23,7 +23,7 @@ protocol PointOfSaleAggregateModelProtocol {
     func trackCardPaymentsOnboardingShown()
 
     var itemsViewState: ItemsViewState { get }
-    func reloadItems(base: ItemListBaseItem) async
+    func loadItems(base: ItemListBaseItem) async
     func loadNextItems(base: ItemListBaseItem) async
 
     var cart: [CartItem] { get }
@@ -91,7 +91,7 @@ extension PointOfSaleAggregateModel {
     }
 
     @MainActor
-    func reloadItems(base: ItemListBaseItem) async {
+    func loadItems(base: ItemListBaseItem) async {
         await itemsController.loadItems(base: base)
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -6,9 +6,15 @@ struct PointOfSaleErrorState: Equatable {
     let buttonText: String
 
     static func errorOnLoadingProducts() -> Self {
-        PointOfSaleErrorState(title: Constants.failedToLoadTitle,
-                              subtitle: Constants.failedToLoadSubtitle,
-                              buttonText: Constants.failedToLoadButtonTitle)
+        PointOfSaleErrorState(title: Constants.failedToLoadProductsTitle,
+                              subtitle: Constants.failedToLoadProductsSubtitle,
+                              buttonText: Constants.failedToLoadProductsButtonTitle)
+    }
+
+    static func errorOnLoadingVariations() -> Self {
+        PointOfSaleErrorState(title: Constants.failedToLoadVariationsTitle,
+                              subtitle: Constants.failedToLoadVariationsSubtitle,
+                              buttonText: Constants.failedToLoadVariationsButtonTitle)
     }
 
     static func errorOnLoadingProductsNextPage() -> Self {
@@ -24,20 +30,35 @@ struct PointOfSaleErrorState: Equatable {
     }
 
     enum Constants {
-        static let failedToLoadTitle = NSLocalizedString(
-            "pos.itemList.failedToLoadTitle",
+        static let failedToLoadProductsTitle = NSLocalizedString(
+            "pos.itemList.failedToLoadProductsTitle",
             value: "Error loading products",
             comment: "Text appearing on the item list screen when there's an error loading products."
         )
-        static let failedToLoadSubtitle = NSLocalizedString(
-            "pos.itemList.failedToLoadSubtitle",
+        static let failedToLoadProductsSubtitle = NSLocalizedString(
+            "pos.itemList.failedToLoadProductsSubtitle",
             value: "Give it another go?",
             comment: "Text appearing on the item list screen as subtitle when there's an error loading products."
         )
-        static let failedToLoadButtonTitle = NSLocalizedString(
-            "pos.itemList.failedToLoadButtonTitle",
+        static let failedToLoadProductsButtonTitle = NSLocalizedString(
+            "pos.itemList.failedToLoadProductsButtonTitle",
             value: "Retry",
             comment: "Text for the button appearing on the item list screen when there's an error loading products."
+        )
+        static let failedToLoadVariationsTitle = NSLocalizedString(
+            "pos.itemList.failedToLoadVariationsTitle",
+            value: "Error loading variations",
+            comment: "Text appearing on the item list screen when there's an error loading variations."
+        )
+        static let failedToLoadVariationsSubtitle = NSLocalizedString(
+            "pos.itemList.failedToLoadVariationsSubtitle",
+            value: "Give it another go?",
+            comment: "Text appearing on the item list screen as subtitle when there's an error loading variations."
+        )
+        static let failedToLoadVariationsButtonTitle = NSLocalizedString(
+            "pos.itemList.failedToLoadVariationsButtonTitle",
+            value: "Retry",
+            comment: "Text for the button appearing on the item list screen when there's an error loading variations."
         )
         static let failedToLoadProductsNextPageTitle = NSLocalizedString(
             "pos.itemList.failedToLoadProductsNextPageTitle",

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// A view that displays an error message with a retry CTA when the list of POS items fails to load.
 struct PointOfSaleItemListErrorView: View {
     private let error: PointOfSaleErrorState
     private let onRetry: (() -> Void)?

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct PointOfSaleItemListErrorView: View {
-    private var error: PointOfSaleErrorState
-    private var onRetry: (() -> Void)? = nil
+    private let error: PointOfSaleErrorState
+    private let onRetry: (() -> Void)?
 
     init(error: PointOfSaleErrorState, onRetry: (() -> Void)? = nil) {
         self.error = error
@@ -10,32 +10,34 @@ struct PointOfSaleItemListErrorView: View {
     }
 
     var body: some View {
-        PointOfSaleItemListFullscreenView {
-            VStack {
-                Spacer()
-                VStack(alignment: .center) {
-                    POSErrorExclamationMark()
-                        .padding(.bottom)
-                    Text(error.title)
-                        .accessibilityAddTraits(.isHeader)
-                        .foregroundStyle(Color.posPrimaryText)
-                        .font(.posTitleEmphasized)
-                        .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
-                    Text(error.subtitle)
-                        .foregroundStyle(Color.posPrimaryText)
-                        .font(.posBodyRegular)
-                        .padding([.leading, .trailing])
-                        .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
-                    Button(action: {
-                        onRetry?()
-                    }, label: {
-                        Text(error.buttonText)
-                    })
-                    .buttonStyle(POSPrimaryButtonStyle())
-                    .frame(width: PointOfSaleItemListErrorLayout.buttonWidth)
-                }
-                Spacer()
+        VStack {
+            Spacer()
+            VStack(alignment: .center) {
+                POSErrorExclamationMark()
+                    .padding(.bottom)
+                Text(error.title)
+                    .accessibilityAddTraits(.isHeader)
+                    .foregroundStyle(Color.posPrimaryText)
+                    .font(.posTitleEmphasized)
+                    .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
+                Text(error.subtitle)
+                    .foregroundStyle(Color.posPrimaryText)
+                    .font(.posBodyRegular)
+                    .padding([.leading, .trailing])
+                    .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
+                Button(action: {
+                    onRetry?()
+                }, label: {
+                    Text(error.buttonText)
+                })
+                .buttonStyle(POSPrimaryButtonStyle())
+                .frame(width: PointOfSaleItemListErrorLayout.buttonWidth)
             }
+            Spacer()
         }
     }
+}
+
+#Preview {
+    PointOfSaleItemListErrorView(error: .errorOnLoadingProducts(), onRetry: nil)
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct PointOfSaleItemListFullscreenErrorView: View {
+    private let error: PointOfSaleErrorState
+    private let onRetry: (() -> Void)?
+
+    init(error: PointOfSaleErrorState, onRetry: (() -> Void)? = nil) {
+        self.error = error
+        self.onRetry = onRetry
+    }
+
+    var body: some View {
+        PointOfSaleItemListFullscreenView {
+            PointOfSaleItemListErrorView(error: error, onRetry: onRetry)
+        }
+    }
+}
+
+#Preview {
+    PointOfSaleItemListFullscreenErrorView(error: .errorOnLoadingProducts(), onRetry: nil)
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// A view that displays an error message with a retry CTA when the list of products fails to load.
 struct PointOfSaleItemListFullscreenErrorView: View {
     private let error: PointOfSaleErrorState
     private let onRetry: (() -> Void)?

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -33,12 +33,16 @@ struct ChildItemList: View {
                 Spacer()
             }
             .padding(.horizontal, Constants.itemListPadding)
-            ItemList(state: state,
-                     node: .parent(parentItem))
-                .toolbar(.hidden, for: .navigationBar)
-                .transition(.opacity)
+
+            switch state {
+            case .loading, .loaded, .inlineError:
+                listView
+            case let .error(error):
+                errorView(error: error)
+            }
         }
         .background(Color.posPrimaryBackground)
+        .toolbar(.hidden, for: .navigationBar)
         .refreshable {
             await posModel.reloadItems(base: .parent(parentItem))
         }
@@ -48,6 +52,24 @@ struct ChildItemList: View {
             }
             await posModel.reloadItems(base: .parent(parentItem))
         }
+    }
+}
+
+private extension ChildItemList {
+    @ViewBuilder
+    var listView: some View {
+        ItemList(state: state,
+                 node: .parent(parentItem))
+            .transition(.opacity)
+    }
+
+    @ViewBuilder
+    func errorView(error: PointOfSaleErrorState) -> some View {
+        PointOfSaleItemListErrorView(error: error, onRetry: {
+            Task {
+                await posModel.reloadItems(base: .root)
+            }
+        })
     }
 }
 
@@ -103,6 +125,29 @@ private extension ChildItemList {
                                                             )
                                                         )
                                                     ], hasMoreItems: false)]))
+    let posModel = PointOfSaleAggregateModel(
+        itemsController: itemsController,
+        cardPresentPaymentService: CardPresentPaymentPreviewService(),
+        orderController: PointOfSalePreviewOrderController())
+    return ChildItemList(parentItem: parentItem, title: parentProduct.name)
+        .environmentObject(posModel)
+}
+
+#Preview("Variable items load error") {
+    let parentProduct = POSVariableParentProduct(
+        id: .init(),
+        name: "Variable latte",
+        productImageSource: nil,
+        productID: 1
+    )
+    let parentItem = POSItem.variableParentProduct(parentProduct)
+    let itemsController = PointOfSalePreviewItemsController()
+    itemsController.itemsViewState = .init(containerState: .content,
+                                           itemsStack: ItemsStackState(
+                                            root: .loading([]),
+                                            itemStates: [
+                                                parentItem: .error(.errorOnLoadingVariations())
+                                            ]))
     let posModel = PointOfSaleAggregateModel(
         itemsController: itemsController,
         cardPresentPaymentService: CardPresentPaymentPreviewService(),

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -44,13 +44,13 @@ struct ChildItemList: View {
         .background(Color.posPrimaryBackground)
         .toolbar(.hidden, for: .navigationBar)
         .refreshable {
-            await posModel.reloadItems(base: .parent(parentItem))
+            await posModel.loadItems(base: .parent(parentItem))
         }
         .task {
             guard state.items.isEmpty else {
                 return
             }
-            await posModel.reloadItems(base: .parent(parentItem))
+            await posModel.loadItems(base: .parent(parentItem))
         }
     }
 }
@@ -67,7 +67,7 @@ private extension ChildItemList {
     func errorView(error: PointOfSaleErrorState) -> some View {
         PointOfSaleItemListErrorView(error: error, onRetry: {
             Task {
-                await posModel.reloadItems(base: .root)
+                await posModel.loadItems(base: .root)
             }
         })
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -76,7 +76,7 @@ private extension ChildItemList {
                 headerView
                 Spacer()
             }
-            
+
             PointOfSaleItemListErrorView(error: error, onRetry: {
                 Task {
                     await posModel.loadItems(base: .parent(parentItem))

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -67,7 +67,7 @@ private extension ChildItemList {
     func errorView(error: PointOfSaleErrorState) -> some View {
         PointOfSaleItemListErrorView(error: error, onRetry: {
             Task {
-                await posModel.loadItems(base: .root)
+                await posModel.loadItems(base: .parent(parentItem))
             }
         })
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -21,19 +21,6 @@ struct ChildItemList: View {
 
     var body: some View {
         VStack {
-            HStack {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "chevron.backward")
-                        .font(.posBodyEmphasized, maximumContentSizeCategory: .accessibilityLarge)
-                        .foregroundColor(.primary)
-                }
-                POSHeaderTitleView(title: title)
-                Spacer()
-            }
-            .padding(.horizontal, Constants.itemListPadding)
-
             switch state {
             case .loading, .loaded, .inlineError:
                 listView
@@ -56,20 +43,47 @@ struct ChildItemList: View {
 }
 
 private extension ChildItemList {
+    @ViewBuilder var headerView: some View {
+        HStack {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "chevron.backward")
+                    .font(.posBodyEmphasized, maximumContentSizeCategory: .accessibilityLarge)
+                    .foregroundColor(.primary)
+            }
+            POSHeaderTitleView(title: title)
+            Spacer()
+        }
+        .padding(.horizontal, Constants.itemListPadding)
+    }
+
     @ViewBuilder
     var listView: some View {
-        ItemList(state: state,
-                 node: .parent(parentItem))
-            .transition(.opacity)
+        VStack {
+            headerView
+
+            ItemList(state: state,
+                     node: .parent(parentItem))
+                .transition(.opacity)
+        }
     }
 
     @ViewBuilder
     func errorView(error: PointOfSaleErrorState) -> some View {
-        PointOfSaleItemListErrorView(error: error, onRetry: {
-            Task {
-                await posModel.loadItems(base: .parent(parentItem))
+        ZStack {
+            VStack {
+                headerView
+                Spacer()
             }
-        })
+            
+            PointOfSaleItemListErrorView(error: error, onRetry: {
+                Task {
+                    await posModel.loadItems(base: .parent(parentItem))
+                }
+            })
+            .zIndex(1)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -35,7 +35,7 @@ struct ItemListView: View {
             })
         }
         .refreshable {
-            await posModel.reloadItems(base: .root)
+            await posModel.loadItems(base: .root)
         }
         .background(Color.posPrimaryBackground)
         .accessibilityElement(children: .contain)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -18,7 +18,7 @@ struct PointOfSaleDashboardView: View {
             case .empty:
                 PointOfSaleItemListEmptyView()
             case .error(let errorContents):
-                PointOfSaleItemListErrorView(error: errorContents, onRetry: {
+                PointOfSaleItemListFullscreenErrorView(error: errorContents, onRetry: {
                     Task {
                         await posModel.reloadItems(base: .root)
                     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleDashboardView: View {
             case .error(let errorContents):
                 PointOfSaleItemListFullscreenErrorView(error: errorContents, onRetry: {
                     Task {
-                        await posModel.reloadItems(base: .root)
+                        await posModel.loadItems(base: .root)
                     }
                 })
             case .content:
@@ -69,7 +69,7 @@ struct PointOfSaleDashboardView: View {
             supportForm
         }
         .task {
-            await posModel.reloadItems(base: .root)
+            await posModel.loadItems(base: .root)
         }
     }
 

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -80,13 +80,7 @@ final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtoco
     }
 
     private func loadInitialChildItems(for parent: POSItem) async {
-        itemsViewState = ItemsViewState(
-            containerState: .content,
-            itemsStack: ItemsStackState(
-                root: .loading(mockItems),
-                itemStates: [parent: .loaded(mockVariationItems, hasMoreItems: true)]
-            )
-        )
+        // Set `itemsViewState` instead.
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		021AC6662AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AC6652AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift */; };
 		021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */; };
 		021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */; };
+		021BCDF82D3648CD002E9F15 /* PointOfSaleItemListFullscreenErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021BCDF72D3648CD002E9F15 /* PointOfSaleItemListFullscreenErrorView.swift */; };
 		021DD44D286A3A8D004F0468 /* UIViewController+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */; };
 		021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */; };
 		021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021E2A1623A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib */; };
@@ -3323,6 +3324,7 @@
 		021AC6652AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleProductViewModelTests.swift; sourceTree = "<group>"; };
 		021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductImageStatus+HelpersTests.swift"; sourceTree = "<group>"; };
 		021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHAssetImageLoader.swift; sourceTree = "<group>"; };
+		021BCDF72D3648CD002E9F15 /* PointOfSaleItemListFullscreenErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListFullscreenErrorView.swift; sourceTree = "<group>"; };
 		021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Navigation.swift"; sourceTree = "<group>"; };
 		021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewController.swift; sourceTree = "<group>"; };
 		021E2A1623A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductInventorySettingsViewController.xib; sourceTree = "<group>"; };
@@ -7066,6 +7068,7 @@
 				2004E2E82C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift */,
 				2023E2AD2C21D8EA00FC365A /* PointOfSaleCardPresentPaymentInLineMessage.swift */,
 				68600A8E2C65BC5500252EDD /* PointOfSaleItemListErrorView.swift */,
+				021BCDF72D3648CD002E9F15 /* PointOfSaleItemListFullscreenErrorView.swift */,
 				20018FFF2C80AEAC002C1E4B /* PointOfSaleItemListFullscreenView.swift */,
 				68600A902C65BC9C00252EDD /* PointOfSaleItemListEmptyView.swift */,
 				68C7E5C32C69B3CD00856513 /* PointOfSaleItemListErrorLayout.swift */,
@@ -16465,6 +16468,7 @@
 				E1E125AA26EB42530068A9B0 /* CardPresentModalUpdateProgress.swift in Sources */,
 				B998DF4A2A98AE4200D1C6E8 /* TaxEducationalDialogViewModel.swift in Sources */,
 				DE02ABC22B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift in Sources */,
+				021BCDF82D3648CD002E9F15 /* PointOfSaleItemListFullscreenErrorView.swift in Sources */,
 				E1C5E78226C2A971008D4C47 /* InPersonPaymentsPluginNotSetup.swift in Sources */,
 				022F941E257F8E820011CD94 /* BoldableTextParser.swift in Sources */,
 				26FE09DD24D9F3F600B9BDF5 /* LoadingView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -42,7 +42,7 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
         self.paymentState = paymentState
     }
 
-    func reloadItems(base: ItemListBaseItem) async { }
+    func loadItems(base: ItemListBaseItem) async { }
 
     func loadNextItems(base: ItemListBaseItem) async { }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14695 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR shows the error UI when loading variations fails with a retry CTA. This reuses the SwiftUI view in the root view with some refactoring to have a view without the "Products" title.

🗒️  Please notice an existing issue on the latest trunk from a recent change, I logged it separately in https://github.com/woocommerce/woocommerce-ios/issues/14860.

This pull request includes several changes to improve error handling and code consistency in the Point of Sale (POS) module of the WooCommerce project. The key changes involve updating error states, renaming methods for clarity, and adding new views for error display.

### Error Handling Improvements:
* [`WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift`](diffhunk://#diff-15e40514fbb21160e9ccbfdb2e2212b8b36baf552cac769d62861cfaf042ad2aL9-R17): Added new error states for loading variations and updated existing error state methods to reflect these changes. [[1]](diffhunk://#diff-15e40514fbb21160e9ccbfdb2e2212b8b36baf552cac769d62861cfaf042ad2aL9-R17) [[2]](diffhunk://#diff-15e40514fbb21160e9ccbfdb2e2212b8b36baf552cac769d62861cfaf042ad2aL27-R62)
* [`WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift`](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9L99-R99): Updated the error handling for loading variations to use the new error state.

### Method Renaming:
* [`WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift`](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL26-R26): Renamed `reloadItems` to `loadItems` for better clarity and consistency across the codebase, something I forgot in https://github.com/woocommerce/woocommerce-ios/pull/14852. [[1]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL26-R26) [[2]](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL94-R94)

### New Error Views:
* [`WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift`](diffhunk://#diff-82429f2bf5e76342d5ecd74acb3049331f1036470b8a014617e06ccc13a5917bR3-L13): Added a new reusable view to display error messages with a retry call-to-action (CTA). [[1]](diffhunk://#diff-82429f2bf5e76342d5ecd74acb3049331f1036470b8a014617e06ccc13a5917bR3-L13) [[2]](diffhunk://#diff-82429f2bf5e76342d5ecd74acb3049331f1036470b8a014617e06ccc13a5917bR41-R43)
* [`WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift`](diffhunk://#diff-3b85911e370cd27313d4bd56043d3c0d36cc7cb04a07663f55858a0845d9e20fR1-R22): Created a fullscreen error view for displaying error messages with a retry CTA, used in the root view.

### Integration of New Views:
* [`WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift`](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bL36-R75): Integrated the new error views into the item list view by updating the state handling and adding preview support. [[1]](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bL36-R75) [[2]](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bR136-R158)
* [`WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift`](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL21-R23): Updated the dashboard view to use the new fullscreen error view. [[1]](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL21-R23) [[2]](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL72-R72)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Switch to a store eligible for POS, with at least one variable product
- Go to Menu > Point of Sale
- Simulate a network error by going offline, or using a proxy tool to abort the request
- Pull to refresh --> the same fullscreen error UI should be shown as before
- Simulate a success response for the products request
- Tap `Retry` --> after a bit, the items should be shown. 🗒️  Please note an existing issue where the loading state isn't shown right away in https://github.com/woocommerce/woocommerce-ios/issues/14860
- Do the same steps above for a variation item list, tapping on a variable product

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d04daa4b-491b-402a-808e-e762cdedf28e

products | variations
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-14 at 16 03 25](https://github.com/user-attachments/assets/4fd974d1-b444-4961-a7e5-61ce183e973e) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-14 at 16 04 28](https://github.com/user-attachments/assets/e6d1388f-57f3-42ca-8098-eb773602bba2)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.14