### PR TITLE
[Shipping Labels - Customs] Fix font color for dark mode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -15,8 +15,8 @@ struct WooShippingCustomsRow: View {
             Spacer()
 
             Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
-                .captionStyle()
                 .foregroundColor(.black)
+                .captionStyle()
                 .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
                 .padding(.vertical, Layout.statusBadgeVerticalPadding)
                 .background(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we set the font black color in the Customs Row (Shipping Labels main screen) also in the dark mode so it can be more visible.

We achieve this by moving the font modifier before the style.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. In dark mode, select a store with the Woo Shipping extension active and set up.
2. Create or open an order with at least one physical product and the processing order status.
3. Tap "Create Shipping Label."
4. See that the "Completed"/"Missing Info" box is fully visible

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before
<img src="https://github.com/user-attachments/assets/fbceb625-125e-4d44-a355-ab4402228913" width="375">

### After
<img src="https://github.com/user-attachments/assets/3d56ef74-aa76-4d8b-a3b7-a64884483e06" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
