### PR TITLE
Enable failed receipt sending for Stripe Gateway 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 21.5
 -----
 - [Internal] [*] Improved handling of the navigation to the Woo Installation screen post Jetpack setup [https://github.com/woocommerce/woocommerce-ios/pull/14837]
+- [*] Receipts: Email receipts can now be sent to customers after failed payments using WooCommerce Stripe 9.1.0+. [https://github.com/woocommerce/woocommerce-ios/pull/14864].
 
 21.4
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -83,28 +83,40 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
     /// WooCommerce 9.5 allows to attach a customer email after payment is made and send email receipt via the API.
     /// WooCommerc 9.5 automatically sends failure receipt after the order fails if the customer email is attached to the order.
     /// WooPayments 8.6 aligns the app with the web and automatically sets the order as failed when the payment processing fails.
-    /// Stripe Gateway doesn't automatically set the order to failed therefore the functionality is not supported.
+    /// WooCommerce Stripe Gateway 9.1.0 aligns the app with the web and automatically sets the order as failed when the payment processing fails.
     ///
     func isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: String, onCompletion: @escaping (Bool) -> Void) {
         guard featureFlagService.isFeatureFlagEnabled(.sendReceiptAfterPayment) else {
             return onCompletion(false)
         }
 
-        guard paymentGatewayID == Constants.ReceiptAfterPayment.woocommercePaymentsGatewayID else {
+        switch paymentGatewayID {
+        case CardPresentPaymentsPlugin.wcPay.gatewayID:
+            Task { @MainActor in
+                async let isWooCommerceSupported = isPluginSupported(Constants.wcPluginName,
+                                                                     minimumVersion: Constants.ReceiptAfterPayment.wcPluginMinimumVersion)
+                async let isWooPaymentsSupported = isPluginSupported(CardPresentPaymentsPlugin.wcPay.pluginName,
+                                                                     minimumVersion: Constants.ReceiptAfterPayment.wcPayPluginMinimumVersion)
+                let wooCommerceResult = await isWooCommerceSupported
+                let wooPaymentsResult = await isWooPaymentsSupported
+                let isSupported = wooCommerceResult && wooPaymentsResult
+
+                onCompletion(isSupported)
+            }
+        case CardPresentPaymentsPlugin.stripe.gatewayID:
+            Task { @MainActor in
+                async let isWooCommerceSupported = isPluginSupported(Constants.wcPluginName,
+                                                                     minimumVersion: Constants.ReceiptAfterPayment.wcPluginMinimumVersion)
+                async let isStripeSupported = isPluginSupported(CardPresentPaymentsPlugin.stripe.pluginName,
+                                                                minimumVersion: Constants.ReceiptAfterPayment.stripePluginMinimumVersion)
+                let wooCommerceResult = await isWooCommerceSupported
+                let stripeResult = await isStripeSupported
+                let isSupported = wooCommerceResult && stripeResult
+
+                onCompletion(isSupported)
+            }
+        default:
             onCompletion(false)
-            return
-        }
-
-        Task { @MainActor in
-            async let isWooCommerceSupported = isPluginSupported(Constants.wcPluginName,
-                                                                 minimumVersion: Constants.ReceiptAfterPayment.wcPluginMinimumVersion)
-            async let isWooPaymentsSupported = isPluginSupported(Constants.wcPayPluginName,
-                                                                 minimumVersion: Constants.ReceiptAfterPayment.wcPayPluginMinimumVersion)
-            let wooCommerceResult = await isWooCommerceSupported
-            let wooPaymentsResult = await isWooPaymentsSupported
-            let isSupported = wooCommerceResult && wooPaymentsResult
-
-            onCompletion(isSupported)
         }
     }
 }
@@ -137,7 +149,6 @@ private extension ReceiptEligibilityUseCase {
 private extension ReceiptEligibilityUseCase {
     enum Constants {
         static let wcPluginName = "WooCommerce"
-        static let wcPayPluginName = "WooPayments"
 
         enum BackendReceipt {
             static let wcPluginMinimumVersion = "8.7.0"
@@ -147,7 +158,7 @@ private extension ReceiptEligibilityUseCase {
         enum ReceiptAfterPayment {
             static let wcPluginMinimumVersion = "9.5.0"
             static let wcPayPluginMinimumVersion = "8.6.0"
-            static let woocommercePaymentsGatewayID = "woocommerce-payments"
+            static let stripePluginMinimumVersion = "9.1.0"
         }
 
         enum PointOfSaleReceipts {

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -90,33 +90,25 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
             return onCompletion(false)
         }
 
-        switch paymentGatewayID {
-        case CardPresentPaymentsPlugin.wcPay.gatewayID:
-            Task { @MainActor in
-                async let isWooCommerceSupported = isPluginSupported(Constants.wcPluginName,
-                                                                     minimumVersion: Constants.ReceiptAfterPayment.wcPluginMinimumVersion)
-                async let isWooPaymentsSupported = isPluginSupported(CardPresentPaymentsPlugin.wcPay.pluginName,
-                                                                     minimumVersion: Constants.ReceiptAfterPayment.wcPayPluginMinimumVersion)
-                let wooCommerceResult = await isWooCommerceSupported
-                let wooPaymentsResult = await isWooPaymentsSupported
-                let isSupported = wooCommerceResult && wooPaymentsResult
+        Task { @MainActor in
+            async let wooCommerceSupported = isPluginSupported(Constants.wcPluginName,
+                                                               minimumVersion: Constants.ReceiptAfterPayment.wcPluginMinimumVersion)
 
-                onCompletion(isSupported)
-            }
-        case CardPresentPaymentsPlugin.stripe.gatewayID:
-            Task { @MainActor in
-                async let isWooCommerceSupported = isPluginSupported(Constants.wcPluginName,
-                                                                     minimumVersion: Constants.ReceiptAfterPayment.wcPluginMinimumVersion)
-                async let isStripeSupported = isPluginSupported(CardPresentPaymentsPlugin.stripe.pluginName,
-                                                                minimumVersion: Constants.ReceiptAfterPayment.stripePluginMinimumVersion)
-                let wooCommerceResult = await isWooCommerceSupported
-                let stripeResult = await isStripeSupported
-                let isSupported = wooCommerceResult && stripeResult
+            async let gatewaySupported: Bool = {
+                switch paymentGatewayID {
+                case CardPresentPaymentsPlugin.wcPay.gatewayID:
+                    return await isPluginSupported(CardPresentPaymentsPlugin.wcPay.pluginName,
+                                                   minimumVersion: Constants.ReceiptAfterPayment.wcPayPluginMinimumVersion)
+                case CardPresentPaymentsPlugin.stripe.gatewayID:
+                    return await isPluginSupported(CardPresentPaymentsPlugin.stripe.pluginName,
+                                                   minimumVersion: Constants.ReceiptAfterPayment.stripePluginMinimumVersion)
+                default:
+                    return false
+                }
+            }()
 
-                onCompletion(isSupported)
-            }
-        default:
-            onCompletion(false)
+            let (isWooCommerceSupported, isGatewaySupported) = await (wooCommerceSupported, gatewaySupported)
+            onCompletion(isWooCommerceSupported && isGatewaySupported)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
@@ -205,7 +205,7 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
 
         // When
         let isEligible: Bool = waitFor { promise in
-            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: GatewayID.wcPayments, onCompletion: { result in
+            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: CardPresentPaymentsPlugin.wcPay.gatewayID, onCompletion: { result in
                 promise(result)
             })
         }
@@ -219,14 +219,14 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.6.0", active: false)
-        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "8.9.0", active: false)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: CardPresentPaymentsPlugin.wcPay.pluginName, version: "8.9.0", active: false)
 
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
                 if systemPluginName == "WooCommerce" {
                     onCompletion(wooCommercePlugin)
-                } else if systemPluginName == "WooPayments" {
+                } else if systemPluginName == CardPresentPaymentsPlugin.wcPay.pluginName {
                     onCompletion(wooPaymentsPlugin)
                 }
             default:
@@ -238,7 +238,7 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
 
         // When
         let isEligible: Bool = waitFor { promise in
-            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: GatewayID.wcPayments, onCompletion: { result in
+            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: CardPresentPaymentsPlugin.wcPay.gatewayID, onCompletion: { result in
                 promise(result)
             })
         }
@@ -252,14 +252,14 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.5.0", active: true)
-        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "8.6.0", active: true)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: CardPresentPaymentsPlugin.wcPay.pluginName, version: "8.6.0", active: true)
 
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
                 if systemPluginName == "WooCommerce" {
                     onCompletion(wooCommercePlugin)
-                } else if systemPluginName == "WooPayments" {
+                } else if systemPluginName == CardPresentPaymentsPlugin.wcPay.pluginName {
                     onCompletion(wooPaymentsPlugin)
                 }
             default:
@@ -271,7 +271,7 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
 
         // When
         let isEligible: Bool = waitFor { promise in
-            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: GatewayID.wcPayments, onCompletion: { result in
+            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: CardPresentPaymentsPlugin.wcPay.gatewayID, onCompletion: { result in
                 promise(result)
             })
         }
@@ -285,14 +285,14 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.6.0-dev-1181231238", active: true)
-        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "8.6.0-test-1", active: true)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: CardPresentPaymentsPlugin.wcPay.pluginName, version: "8.6.0-test-1", active: true)
 
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
                 if systemPluginName == "WooCommerce" {
                     onCompletion(wooCommercePlugin)
-                } else if systemPluginName == "WooPayments" {
+                } else if systemPluginName == CardPresentPaymentsPlugin.wcPay.pluginName {
                     onCompletion(wooPaymentsPlugin)
                 }
             default:
@@ -304,7 +304,7 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
 
         // When
         let isEligible: Bool = waitFor { promise in
-            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: GatewayID.wcPayments, onCompletion: { result in
+            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: CardPresentPaymentsPlugin.wcPay.gatewayID, onCompletion: { result in
                 promise(result)
             })
         }
@@ -318,14 +318,14 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.5.0", active: true)
-        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "5.0.0-dev", active: true)
+        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: CardPresentPaymentsPlugin.wcPay.pluginName, version: "5.0.0-dev", active: true)
 
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
                 if systemPluginName == "WooCommerce" {
                     onCompletion(wooCommercePlugin)
-                } else if systemPluginName == "WooPayments" {
+                } else if systemPluginName == CardPresentPaymentsPlugin.wcPay.pluginName {
                     onCompletion(wooPaymentsPlugin)
                 }
             default:
@@ -337,7 +337,7 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
 
         // When
         let isEligible: Bool = waitFor { promise in
-            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: GatewayID.wcPayments, onCompletion: { result in
+            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: CardPresentPaymentsPlugin.wcPay.gatewayID, onCompletion: { result in
                 promise(result)
             })
         }
@@ -346,20 +346,53 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_isEligibleForFailedPaymentEmailReceipts_when_plugins_are_supported_but_stripe_gateway_then_returns_false() {
+    func test_isEligibleForFailedPaymentEmailReceipts_when_stripe_gateway_then_returns_true() {
         // Given
         let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.5.0", active: true)
-        let wooPaymentsPlugin = SystemPlugin.fake().copy(name: "WooPayments", version: "8.6.0", active: true)
+        let stripePaymentsPlugin = SystemPlugin.fake().copy(name: CardPresentPaymentsPlugin.stripe.pluginName, version: "9.1.0", active: true)
 
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
                 if systemPluginName == "WooCommerce" {
                     onCompletion(wooCommercePlugin)
-                } else if systemPluginName == "WooPayments" {
-                    onCompletion(wooPaymentsPlugin)
+                } else if systemPluginName == CardPresentPaymentsPlugin.stripe.pluginName {
+                    onCompletion(stripePaymentsPlugin)
+                }
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: "woocommerce-stripe", onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_isEligibleForFailedPaymentEmailReceipts_when_stripe_gateway_is_outdated_then_returns_false() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isSendReceiptAfterPaymentEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let wooCommercePlugin = SystemPlugin.fake().copy(name: "WooCommerce", version: "9.5.0", active: true)
+        let stripePaymentsPlugin = SystemPlugin.fake().copy(name: CardPresentPaymentsPlugin.stripe.pluginName, version: "9.0.0", active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
+                if systemPluginName == "WooCommerce" {
+                    onCompletion(wooCommercePlugin)
+                } else if systemPluginName == CardPresentPaymentsPlugin.stripe.pluginName {
+                    onCompletion(stripePaymentsPlugin)
                 }
             default:
                 XCTFail("Unexpected action")
@@ -377,11 +410,5 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertFalse(isEligible)
-    }
-}
-
-private extension ReceiptEligibilityUseCaseTests {
-    enum GatewayID {
-        static let wcPayments: String = "woocommerce-payments"
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14494
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After [WooCommerce Stripe Gateway update](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3631), failed payment receipts are now supported for Stripe Gateway.

Enabling it for versions >=9.1.0

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Eligible + Sending Receipt After

1. [Install and configure WooCommerce Stripe Gateway 9.1.0](https://github.com/woocommerce/woocommerce-gateway-stripe/releases/tag/9.1.0)
2. Create an order with a failure amount, e.g $1.05
3. Make a Card Reader / TTP payment
4. Confirm error alert is shown with the "Email Receipt" option
5. Send email receipt
6. Confirm it's received on the email

### Eligible + Attach Customer Before Payment

1. [Install and configure WooCommerce Stripe Gateway 9.1.0](https://github.com/woocommerce/woocommerce-gateway-stripe/releases/tag/9.1.0)
2. Create an order with a failure amount, e.g $1.05
3. Attach a customer with an email
4. Make a Card Reader / TTP payment
5. Confirm error alert is shown with "Email sent" message
7. Confirm email is received

### Non-eligible

1. Install a non-eligible [Stripe Gateway version](https://github.com/woocommerce/woocommerce-gateway-stripe/releases/tag/9.0.0)
2. Create an order with a failure amount, e.g $1.05
3. Attach a customer with an email
4. Make a Card Reader / TTP payment
5. Confirm error alert is shown with no "Email Receipt" option

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There are unit tests written for different cases. Also confirmed WooPayments continues to work.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.