### PR TITLE
[Shipping labels] Update local requirements for address fields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -383,7 +383,8 @@ private extension WooShippingEditAddressView {
                                                 phone: "",
                                                 saveAsDefault: true,
                                                 showCompanyField: false,
-                                                isVerified: true))
+                                                isVerified: true,
+                                                phoneNumberRequired: true))
 }
 
 #Preview("With Company") {
@@ -399,5 +400,6 @@ private extension WooShippingEditAddressView {
                                                 phone: "",
                                                 saveAsDefault: false,
                                                 showCompanyField: true,
-                                                isVerified: false))
+                                                isVerified: false,
+                                                phoneNumberRequired: true))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -19,9 +19,9 @@ struct WooShippingEditAddressView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.verticalSpacing) {
-                AddressTextField(field: .name, text: $viewModel.name, focused: $focusedField)
+                AddressTextField(field: .name, text: $viewModel.name, required: viewModel.isRequired(.name), focused: $focusedField)
                 if viewModel.showCompanyField {
-                    AddressTextField(field: .company, text: $viewModel.company, focused: $focusedField)
+                    AddressTextField(field: .company, text: $viewModel.company, required: viewModel.isRequired(.company), focused: $focusedField)
                 } else {
                     Button {
                         withAnimation {
@@ -34,21 +34,21 @@ struct WooShippingEditAddressView: View {
                     .font(.subheadline)
                     .bold()
                 }
-                AddressSelection(field: .country, selected: viewModel.country) {
+                AddressSelection(field: .country, selected: viewModel.country, required: viewModel.isRequired(.country)) {
                     // TODO: Handle country selection
                 }
                 .padding(.top, Constants.extraPadding)
-                AddressTextField(field: .address, text: $viewModel.address, focused: $focusedField)
-                AddressTextField(field: .city, text: $viewModel.city, focused: $focusedField)
+                AddressTextField(field: .address, text: $viewModel.address, required: viewModel.isRequired(.address), focused: $focusedField)
+                AddressTextField(field: .city, text: $viewModel.city, required: viewModel.isRequired(.city), focused: $focusedField)
                 AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
-                    AddressSelection(field: .state, selected: viewModel.state) {
+                    AddressSelection(field: .state, selected: viewModel.state, required: viewModel.isRequired(.state)) {
                         // TODO: Handle state selection
                     }
-                    AddressTextField(field: .postalCode, text: $viewModel.postalCode, focused: $focusedField)
+                    AddressTextField(field: .postalCode, text: $viewModel.postalCode, required: viewModel.isRequired(.postalCode), focused: $focusedField)
                 }
                 .padding(.bottom, Constants.extraPadding)
-                AddressTextField(field: .email, text: $viewModel.email, focused: $focusedField)
-                AddressTextField(field: .phone, text: $viewModel.phone, focused: $focusedField)
+                AddressTextField(field: .email, text: $viewModel.email, required: viewModel.isRequired(.email), focused: $focusedField)
+                AddressTextField(field: .phone, text: $viewModel.phone, required: viewModel.isRequired(.phone), focused: $focusedField)
                     .padding(.bottom, Constants.extraPadding)
                 Toggle(Localization.defaultAddress, isOn: $viewModel.saveAsDefault)
                     .font(.subheadline)
@@ -117,6 +117,9 @@ struct WooShippingEditAddressView: View {
         /// The text to display in the text field.
         @Binding var text: String
 
+        /// Whether the field is required.
+        let required: Bool
+
         /// The focused state of the field.
         @FocusState.Binding var focused: AddressField?
 
@@ -124,14 +127,14 @@ struct WooShippingEditAddressView: View {
             VStack(spacing: Constants.innerSpacing) {
                 HStack(spacing: Constants.requiredLabelSpacing) {
                     Text(field.title)
-                    if field.required {
+                    if required {
                         Text("*")
                     }
                     Spacer()
                 }
                 .font(.subheadline)
                 .foregroundStyle(Color(.text))
-                TextField(field.title, text: $text, prompt: Text(field.required ? "" : Localization.optional))
+                TextField(field.title, text: $text, prompt: Text(required ? "" : Localization.optional))
                     .focused($focused, equals: field)
                     .padding()
                     .roundedBorder(cornerRadius: Constants.cornerRadius,
@@ -148,6 +151,9 @@ struct WooShippingEditAddressView: View {
         /// The text to display for the selection.
         let selected: String
 
+        /// Whether the field is required.
+        let required: Bool
+
         /// The action to perform when the button is tapped.
         var action: () -> Void
 
@@ -155,7 +161,7 @@ struct WooShippingEditAddressView: View {
             VStack(spacing: Constants.innerSpacing) {
                 HStack(spacing: Constants.requiredLabelSpacing) {
                     Text(field.title)
-                    if field.required {
+                    if required {
                         Text("*")
                     }
                     Spacer()
@@ -182,7 +188,7 @@ struct WooShippingEditAddressView: View {
     }
 }
 
-private extension WooShippingEditAddressView {
+extension WooShippingEditAddressView {
     enum AddressField: CaseIterable {
         case name
         case company
@@ -207,19 +213,10 @@ private extension WooShippingEditAddressView {
             case .phone: return Localization.phone
             }
         }
-
-        var required: Bool {
-            switch self {
-            case .name, .country, .address, .city, .state, .postalCode, .email, .phone:
-                return true
-            case .company:
-                return false
-            }
-        }
     }
 
     /// Navigates to the next address field in the form.
-    func focusNextField() {
+    private func focusNextField() {
         switch focusedField {
         case .name:
             focusedField = viewModel.showCompanyField ? .company : .address
@@ -241,7 +238,7 @@ private extension WooShippingEditAddressView {
     }
 
     /// Navigates to the previous address field in the form.
-    func focusPreviousField() {
+    private func focusPreviousField() {
         switch focusedField {
         case .name:
             focusedField = nil
@@ -263,7 +260,7 @@ private extension WooShippingEditAddressView {
     }
 
     /// Dismisses the keyboard.
-    func dismissKeyboard() {
+    private func dismissKeyboard() {
         focusedField = nil
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -48,4 +48,13 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.showCompanyField = showCompanyField
         self.status = isVerified ? .verified : .unverified
     }
+
+    func isRequired(_ field: WooShippingEditAddressView.AddressField) -> Bool {
+        switch field {
+        case .name, .country, .address, .city, .state, .postalCode, .email, .phone:
+            return true
+        case .company:
+            return false
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -17,6 +17,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Whether to show the company field by default.
     @Published var showCompanyField: Bool
 
+    /// Whether the phone number is required.
+    private let phoneNumberRequired: Bool
+
     // TODO: Set status based on initial verified status, whether any changes have been made, and local validation.
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus
@@ -33,7 +36,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          phone: String,
          saveAsDefault: Bool,
          showCompanyField: Bool,
-         isVerified: Bool) {
+         isVerified: Bool,
+         phoneNumberRequired: Bool) {
         self.id = id
         self.name = name
         self.company = company
@@ -47,12 +51,15 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.saveAsDefault = saveAsDefault
         self.showCompanyField = showCompanyField
         self.status = isVerified ? .verified : .unverified
+        self.phoneNumberRequired = phoneNumberRequired
     }
 
     func isRequired(_ field: WooShippingEditAddressView.AddressField) -> Bool {
         switch field {
-        case .name, .country, .address, .city, .state, .postalCode, .email, .phone:
+        case .name, .country, .address, .city, .state, .postalCode, .email:
             return true
+        case .phone:
+            return phoneNumberRequired
         case .company:
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -56,12 +56,14 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     func isRequired(_ field: WooShippingEditAddressView.AddressField) -> Bool {
         switch field {
-        case .name, .country, .address, .city, .state, .postalCode, .email:
+        case .name:
+            return company.isEmpty
+        case .company:
+            return name.isEmpty
+        case .country, .address, .city, .state, .postalCode, .email:
             return true
         case .phone:
             return phoneNumberRequired
-        case .company:
-            return false
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -45,7 +45,8 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
                                                         phone: address.phone,
                                                         saveAsDefault: address.defaultAddress,
                                                         showCompanyField: address.company.isNotEmpty,
-                                                        isVerified: address.isVerified)
+                                                        isVerified: address.isVerified,
+                                                        phoneNumberRequired: true) // Always required for origin address
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -32,7 +32,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         phone: phone,
                                                         saveAsDefault: saveAsDefault,
                                                         showCompanyField: showCompanyField,
-                                                        isVerified: isVerified)
+                                                        isVerified: isVerified,
+                                                        phoneNumberRequired: true)
 
         // Then
         XCTAssertEqual(viewModel.id, id)
@@ -52,19 +53,20 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_isRequired_returns_expected_values() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "default_address",
-                                                        name: "JANE DOE",
-                                                        company: "HEADQUARTERS",
-                                                        country: "US",
-                                                        address: "15 ALGONKIN ST STE 100",
-                                                        city: "TICONDEROGA",
-                                                        state: "NY",
-                                                        postalCode: "12883-1487",
-                                                        email: "TEST@EXAMPLE.COM",
-                                                        phone: "123-456-7890",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
                                                         saveAsDefault: true,
                                                         showCompanyField: true,
-                                                        isVerified: true)
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true)
 
         // When
         var requirements: [WooShippingEditAddressView.AddressField: Bool] = [:]
@@ -82,6 +84,30 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(requirements[.postalCode], true)
         XCTAssertEqual(requirements[.email], true)
         XCTAssertEqual(requirements[.phone], true)
+    }
+
+    func test_isRequired_returns_false_when_phone_number_not_required() {
+        // Given
+        let viewModel = WooShippingEditAddressViewModel(id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        saveAsDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: false)
+
+        // When
+        let isPhoneRequired = viewModel.isRequired(.phone)
+
+        // Then
+        XCTAssertFalse(isPhoneRequired)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -50,4 +50,38 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.status, .verified)
     }
 
+    func test_isRequired_returns_expected_values() {
+        // Given
+        let viewModel = WooShippingEditAddressViewModel(id: "default_address",
+                                                        name: "JANE DOE",
+                                                        company: "HEADQUARTERS",
+                                                        country: "US",
+                                                        address: "15 ALGONKIN ST STE 100",
+                                                        city: "TICONDEROGA",
+                                                        state: "NY",
+                                                        postalCode: "12883-1487",
+                                                        email: "TEST@EXAMPLE.COM",
+                                                        phone: "123-456-7890",
+                                                        saveAsDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true)
+
+        // When
+        var requirements: [WooShippingEditAddressView.AddressField: Bool] = [:]
+        for field in WooShippingEditAddressView.AddressField.allCases {
+            requirements[field] = viewModel.isRequired(field)
+        }
+
+        // Then
+        XCTAssertEqual(requirements[.name], true)
+        XCTAssertEqual(requirements[.company], false)
+        XCTAssertEqual(requirements[.country], true)
+        XCTAssertEqual(requirements[.address], true)
+        XCTAssertEqual(requirements[.city], true)
+        XCTAssertEqual(requirements[.state], true)
+        XCTAssertEqual(requirements[.postalCode], true)
+        XCTAssertEqual(requirements[.email], true)
+        XCTAssertEqual(requirements[.phone], true)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -76,7 +76,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(requirements[.name], true)
-        XCTAssertEqual(requirements[.company], false)
+        XCTAssertEqual(requirements[.company], true)
         XCTAssertEqual(requirements[.country], true)
         XCTAssertEqual(requirements[.address], true)
         XCTAssertEqual(requirements[.city], true)
@@ -84,6 +84,54 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(requirements[.postalCode], true)
         XCTAssertEqual(requirements[.email], true)
         XCTAssertEqual(requirements[.phone], true)
+    }
+
+    func test_isRequired_returns_false_for_company_when_name_is_not_empty() {
+        // Given
+        let viewModel = WooShippingEditAddressViewModel(id: "",
+                                                        name: "JANE DOE",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        saveAsDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: false)
+
+        // When
+        let isCompanyRequired = viewModel.isRequired(.company)
+
+        // Then
+        XCTAssertFalse(isCompanyRequired)
+    }
+
+    func test_isRequired_returns_false_for_name_when_company_is_not_empty() {
+        // Given
+        let viewModel = WooShippingEditAddressViewModel(id: "",
+                                                        name: "",
+                                                        company: "HEADQUARTERS",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        saveAsDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: false)
+
+        // When
+        let isNameRequired = viewModel.isRequired(.name)
+
+        // Then
+        XCTAssertFalse(isNameRequired)
     }
 
     func test_isRequired_returns_false_when_phone_number_not_required() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates some of the local requirements for address fields in the Woo Shipping label flow. Instead of a fixed set of required fields, this moves the checks for whether a field is required into the view model. This will allow us to update the requirements based on data in the view model.

Changes in this PR:

* Moves the checks for whether a field is required into the view model.
* Adds the `phoneNumberRequired` property. The phone number is always required for origin addresses but not always required for destination addresses, so this is a step toward making the view and view model useful for both address types.
* Updates the check for name and company fields, so that only one is required. (If one field is non-empty, the other becomes optional.)

Future PRs will continue to update the local requirements, add validation, and prepare the view model for reuse for destination addresses.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the Woo Shipping extension is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. In the address form, confirm you see a `*` to indicate the phone number field is required.
8. Clear the company field and confirm the name field is marked as required, while the company field is optional.
9. Clear the name field and confirm the company field is marked as required, while the name field is optional.
10. Confirm all other fields are still marked as required.

Note: If both the name and company field are empty, they are both marked as required until one is entered. If both the name and company field are populated, they are both marked as optional until one is cleared.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Name required|Company required|Phone required
-|-|-
![Simulator Screenshot - iPhone 16 Pro - 2025-01-14 at 17 00 53](https://github.com/user-attachments/assets/2d1316c4-3408-454d-b483-714597fdec41)|![Simulator Screenshot - iPhone 16 Pro - 2025-01-14 at 17 03 10](https://github.com/user-attachments/assets/912a3769-d963-47d8-a435-39774b81e2a8)|![Simulator Screenshot - iPhone 16 Pro - 2025-01-14 at 17 00 57](https://github.com/user-attachments/assets/65d9a68e-524d-4adf-b37b-b2788662b139)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.