### PR TITLE
[Shipping labels] Make edit address form reusable for both origin and destination addresses

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -50,9 +50,11 @@ struct WooShippingEditAddressView: View {
                 AddressTextField(field: .email, text: $viewModel.email, required: viewModel.isRequired(.email), focused: $focusedField)
                 AddressTextField(field: .phone, text: $viewModel.phone, required: viewModel.isRequired(.phone), focused: $focusedField)
                     .padding(.bottom, Constants.extraPadding)
-                Toggle(Localization.defaultAddress, isOn: $viewModel.saveAsDefault)
-                    .font(.subheadline)
-                    .tint(Color(.accent))
+                if viewModel.showSaveAsDefault {
+                    Toggle(Localization.defaultAddress, isOn: $viewModel.isDefault)
+                        .font(.subheadline)
+                        .tint(Color(.accent))
+                }
             }
             .padding()
             .toolbar {
@@ -371,7 +373,8 @@ private extension WooShippingEditAddressView {
 }
 
 #Preview("Without Company") {
-    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
+    WooShippingEditAddressView(viewModel: .init(type: .origin,
+                                                id: UUID().uuidString,
                                                 name: "HEADQUARTERS",
                                                 company: "",
                                                 country: "UNITED STATES",
@@ -381,14 +384,15 @@ private extension WooShippingEditAddressView {
                                                 postalCode: "12883-1487",
                                                 email: "",
                                                 phone: "",
-                                                saveAsDefault: true,
+                                                isDefault: true,
                                                 showCompanyField: false,
                                                 isVerified: true,
                                                 phoneNumberRequired: true))
 }
 
 #Preview("With Company") {
-    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
+    WooShippingEditAddressView(viewModel: .init(type: .destination,
+                                                id: UUID().uuidString,
                                                 name: "HEADQUARTERS",
                                                 company: "COMPANY",
                                                 country: "UNITED STATES",
@@ -398,7 +402,7 @@ private extension WooShippingEditAddressView {
                                                 postalCode: "12883-1487",
                                                 email: "",
                                                 phone: "",
-                                                saveAsDefault: false,
+                                                isDefault: false,
                                                 showCompanyField: true,
                                                 isVerified: false,
                                                 phoneNumberRequired: true))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -51,7 +51,7 @@ struct WooShippingEditAddressView: View {
                 AddressTextField(field: .phone, text: $viewModel.phone, required: viewModel.isRequired(.phone), focused: $focusedField)
                     .padding(.bottom, Constants.extraPadding)
                 if viewModel.showSaveAsDefault {
-                    Toggle(Localization.defaultAddress, isOn: $viewModel.isDefault)
+                    Toggle(Localization.defaultAddress, isOn: $viewModel.isDefaultAddress)
                         .font(.subheadline)
                         .tint(Color(.accent))
                 }
@@ -384,7 +384,7 @@ private extension WooShippingEditAddressView {
                                                 postalCode: "12883-1487",
                                                 email: "",
                                                 phone: "",
-                                                isDefault: true,
+                                                isDefaultAddress: true,
                                                 showCompanyField: false,
                                                 isVerified: true,
                                                 phoneNumberRequired: true))
@@ -402,7 +402,7 @@ private extension WooShippingEditAddressView {
                                                 postalCode: "12883-1487",
                                                 email: "",
                                                 phone: "",
-                                                isDefault: false,
+                                                isDefaultAddress: false,
                                                 showCompanyField: true,
                                                 isVerified: false,
                                                 phoneNumberRequired: true))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 /// View model for editing an address in the Woo Shipping label flow.
 final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
@@ -71,6 +72,24 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.showCompanyField = showCompanyField
         self.status = isVerified ? .verified : .unverified
         self.phoneNumberRequired = phoneNumberRequired
+    }
+
+    convenience init(address: WooShippingOriginAddress) {
+        self.init(type: .origin,
+                  id: address.id,
+                  name: address.fullName,
+                  company: address.company,
+                  country: address.country,
+                  address: address.combinedAddress,
+                  city: address.city,
+                  state: address.state,
+                  postalCode: address.postcode,
+                  email: address.email,
+                  phone: address.phone,
+                  isDefault: address.defaultAddress,
+                  showCompanyField: address.company.isNotEmpty,
+                  isVerified: address.isVerified,
+                  phoneNumberRequired: true)
     }
 
     func isRequired(_ field: WooShippingEditAddressView.AddressField) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -23,9 +23,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     @Published var postalCode: String
     @Published var email: String
     @Published var phone: String
-    @Published var isDefault: Bool
 
-    /// Whether to show the "save as default" toggle.
+    /// Whether the address is the default address for shipping labels; this is only used for origin addresses.
+    @Published var isDefaultAddress: Bool
+
+    /// Whether to show the "save as default" toggle, to save the address as the default origin address.
     var showSaveAsDefault: Bool {
         addressType == .origin
     }
@@ -53,7 +55,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          postalCode: String,
          email: String,
          phone: String,
-         isDefault: Bool,
+         isDefaultAddress: Bool,
          showCompanyField: Bool,
          isVerified: Bool,
          phoneNumberRequired: Bool) {
@@ -68,7 +70,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.postalCode = postalCode
         self.email = email
         self.phone = phone
-        self.isDefault = isDefault
+        self.isDefaultAddress = isDefaultAddress
         self.showCompanyField = showCompanyField
         self.status = isVerified ? .verified : .unverified
         self.phoneNumberRequired = phoneNumberRequired
@@ -86,7 +88,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   postalCode: address.postcode,
                   email: address.email,
                   phone: address.phone,
-                  isDefault: address.defaultAddress,
+                  isDefaultAddress: address.defaultAddress,
                   showCompanyField: address.company.isNotEmpty,
                   isVerified: address.isVerified,
                   phoneNumberRequired: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -2,6 +2,16 @@ import SwiftUI
 
 /// View model for editing an address in the Woo Shipping label flow.
 final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
+    enum AddressType {
+        case origin
+        case destination
+    }
+
+    /// Type of address being edited.
+    private let addressType: AddressType
+
+    // MARK: Address properties
+
     let id: String
     @Published var name: String
     @Published var company: String
@@ -12,10 +22,17 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     @Published var postalCode: String
     @Published var email: String
     @Published var phone: String
-    @Published var saveAsDefault: Bool
+    @Published var isDefault: Bool
+
+    /// Whether to show the "save as default" toggle.
+    var showSaveAsDefault: Bool {
+        addressType == .origin
+    }
 
     /// Whether to show the company field by default.
     @Published var showCompanyField: Bool
+
+    // MARK: Local requirements & validation
 
     /// Whether the phone number is required.
     private let phoneNumberRequired: Bool
@@ -24,7 +41,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus
 
-    init(id: String,
+    init(type: AddressType,
+         id: String,
          name: String,
          company: String,
          country: String,
@@ -34,10 +52,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          postalCode: String,
          email: String,
          phone: String,
-         saveAsDefault: Bool,
+         isDefault: Bool,
          showCompanyField: Bool,
          isVerified: Bool,
          phoneNumberRequired: Bool) {
+        self.addressType = type
         self.id = id
         self.name = name
         self.company = company
@@ -48,7 +67,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.postalCode = postalCode
         self.email = email
         self.phone = phone
-        self.saveAsDefault = saveAsDefault
+        self.isDefault = isDefault
         self.showCompanyField = showCompanyField
         self.status = isVerified ? .verified : .unverified
         self.phoneNumberRequired = phoneNumberRequired

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -33,21 +33,7 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
     }
 
     func editAddress(_ address: WooShippingOriginAddress) {
-        addressToEdit = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: address.id,
-                                                        name: address.fullName,
-                                                        company: address.company,
-                                                        country: address.country,
-                                                        address: address.combinedAddress,
-                                                        city: address.city,
-                                                        state: address.state,
-                                                        postalCode: address.postcode,
-                                                        email: address.email,
-                                                        phone: address.phone,
-                                                        isDefault: address.defaultAddress,
-                                                        showCompanyField: address.company.isNotEmpty,
-                                                        isVerified: address.isVerified,
-                                                        phoneNumberRequired: true) // Always required for origin address
+        addressToEdit = WooShippingEditAddressViewModel(address: address)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -33,7 +33,8 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
     }
 
     func editAddress(_ address: WooShippingOriginAddress) {
-        addressToEdit = WooShippingEditAddressViewModel(id: address.id,
+        addressToEdit = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: address.id,
                                                         name: address.fullName,
                                                         company: address.company,
                                                         country: address.country,
@@ -43,7 +44,7 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
                                                         postalCode: address.postcode,
                                                         email: address.email,
                                                         phone: address.phone,
-                                                        saveAsDefault: address.defaultAddress,
+                                                        isDefault: address.defaultAddress,
                                                         showCompanyField: address.company.isNotEmpty,
                                                         isVerified: address.isVerified,
                                                         phoneNumberRequired: true) // Always required for origin address

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+import Yosemite
 
 final class WooShippingEditAddressViewModelTests: XCTestCase {
 
@@ -54,9 +55,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_origin_address_inits_with_expected_values() {
         // Given
-        let storageManager = MockStorageManager()
-        let countries = [Country(code: "US", name: "United States", states: []), Country(code: "CA", name: "Canada", states: [])]
-        storageManager.insertSampleCountries(readOnlyCountries: countries)
         let address = WooShippingOriginAddress(id: "default_address",
                                                company: "HEADQUARTERS",
                                                address1: "15 ALGONKIN ST",
@@ -73,7 +71,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                isVerified: true)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(address: address, storageManager: storageManager)
+        let viewModel = WooShippingEditAddressViewModel(address: address)
 
         // Then
         XCTAssertEqual(viewModel.id, address.id)
@@ -90,7 +88,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.showCompanyField)
         XCTAssertEqual(viewModel.status, .verified)
         XCTAssertTrue(viewModel.showSaveAsDefault)
-        XCTAssertEqual(viewModel.countries.count, 1, "Should only include USPS-supported countries for origin addresses")
     }
 
     func test_isRequired_returns_expected_values() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -32,7 +32,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: postalCode,
                                                         email: email,
                                                         phone: phone,
-                                                        isDefault: saveAsDefault,
+                                                        isDefaultAddress: saveAsDefault,
                                                         showCompanyField: showCompanyField,
                                                         isVerified: isVerified,
                                                         phoneNumberRequired: true)
@@ -48,7 +48,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.postalCode, postalCode)
         XCTAssertEqual(viewModel.email, email)
         XCTAssertEqual(viewModel.phone, phone)
-        XCTAssertEqual(viewModel.isDefault, saveAsDefault)
+        XCTAssertEqual(viewModel.isDefaultAddress, saveAsDefault)
         XCTAssertEqual(viewModel.showCompanyField, showCompanyField)
         XCTAssertEqual(viewModel.status, .verified)
     }
@@ -84,7 +84,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.postalCode, address.postcode)
         XCTAssertEqual(viewModel.phone, address.phone)
         XCTAssertEqual(viewModel.email, address.email)
-        XCTAssertTrue(viewModel.isDefault)
+        XCTAssertTrue(viewModel.isDefaultAddress)
         XCTAssertTrue(viewModel.showCompanyField)
         XCTAssertEqual(viewModel.status, .verified)
         XCTAssertTrue(viewModel.showSaveAsDefault)
@@ -103,7 +103,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        isDefault: true,
+                                                        isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true)
@@ -139,7 +139,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        isDefault: true,
+                                                        isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: false)
@@ -164,7 +164,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        isDefault: true,
+                                                        isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: false)
@@ -189,7 +189,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        isDefault: true,
+                                                        isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: false)
@@ -214,7 +214,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        isDefault: true,
+                                                        isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true)
@@ -236,7 +236,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        isDefault: true,
+                                                        isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -20,7 +20,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let isVerified = true
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(id: id,
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: id,
                                                         name: name,
                                                         company: company,
                                                         country: country,
@@ -30,7 +31,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: postalCode,
                                                         email: email,
                                                         phone: phone,
-                                                        saveAsDefault: saveAsDefault,
+                                                        isDefault: saveAsDefault,
                                                         showCompanyField: showCompanyField,
                                                         isVerified: isVerified,
                                                         phoneNumberRequired: true)
@@ -46,14 +47,15 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.postalCode, postalCode)
         XCTAssertEqual(viewModel.email, email)
         XCTAssertEqual(viewModel.phone, phone)
-        XCTAssertEqual(viewModel.saveAsDefault, saveAsDefault)
+        XCTAssertEqual(viewModel.isDefault, saveAsDefault)
         XCTAssertEqual(viewModel.showCompanyField, showCompanyField)
         XCTAssertEqual(viewModel.status, .verified)
     }
 
     func test_isRequired_returns_expected_values() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -63,7 +65,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        saveAsDefault: true,
+                                                        isDefault: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true)
@@ -88,7 +90,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_isRequired_returns_false_for_company_when_name_is_not_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "JANE DOE",
                                                         company: "",
                                                         country: "",
@@ -98,7 +101,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        saveAsDefault: true,
+                                                        isDefault: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: false)
@@ -112,7 +115,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_isRequired_returns_false_for_name_when_company_is_not_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "",
                                                         company: "HEADQUARTERS",
                                                         country: "",
@@ -122,7 +126,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        saveAsDefault: true,
+                                                        isDefault: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: false)
@@ -136,7 +140,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_isRequired_returns_false_when_phone_number_not_required() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -146,7 +151,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         postalCode: "",
                                                         email: "",
                                                         phone: "",
-                                                        saveAsDefault: true,
+                                                        isDefault: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: false)
@@ -158,4 +163,47 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertFalse(isPhoneRequired)
     }
 
+    func test_it_inits_with_expected_values_for_origin_address_type() {
+        // Given/When
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true)
+
+        // Then
+        XCTAssertTrue(viewModel.showSaveAsDefault)
+    }
+
+    func test_it_inits_with_expected_values_for_destination_address_type() {
+        // Given/When
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true)
+
+        // Then
+        XCTAssertFalse(viewModel.showSaveAsDefault)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -52,6 +52,47 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.status, .verified)
     }
 
+    func test_origin_address_inits_with_expected_values() {
+        // Given
+        let storageManager = MockStorageManager()
+        let countries = [Country(code: "US", name: "United States", states: []), Country(code: "CA", name: "Canada", states: [])]
+        storageManager.insertSampleCountries(readOnlyCountries: countries)
+        let address = WooShippingOriginAddress(id: "default_address",
+                                               company: "HEADQUARTERS",
+                                               address1: "15 ALGONKIN ST",
+                                               address2: "STE 100",
+                                               city: "TICONDEROGA",
+                                               state: "NY",
+                                               postcode: "12883-1487",
+                                               country: "US",
+                                               phone: "123-456-7890",
+                                               firstName: "JANE",
+                                               lastName: "DOE",
+                                               email: "TEST@EXAMPLE.COM",
+                                               defaultAddress: true,
+                                               isVerified: true)
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(address: address, storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.id, address.id)
+        XCTAssertEqual(viewModel.name, address.fullName)
+        XCTAssertEqual(viewModel.country, address.country)
+        XCTAssertEqual(viewModel.company, address.company)
+        XCTAssertEqual(viewModel.address, address.combinedAddress)
+        XCTAssertEqual(viewModel.city, address.city)
+        XCTAssertEqual(viewModel.state, address.state)
+        XCTAssertEqual(viewModel.postalCode, address.postcode)
+        XCTAssertEqual(viewModel.phone, address.phone)
+        XCTAssertEqual(viewModel.email, address.email)
+        XCTAssertTrue(viewModel.isDefault)
+        XCTAssertTrue(viewModel.showCompanyField)
+        XCTAssertEqual(viewModel.status, .verified)
+        XCTAssertTrue(viewModel.showSaveAsDefault)
+        XCTAssertEqual(viewModel.countries.count, 1, "Should only include USPS-supported countries for origin addresses")
+    }
+
     func test_isRequired_returns_expected_values() {
         // Given
         let viewModel = WooShippingEditAddressViewModel(type: .origin,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
@@ -108,7 +108,7 @@ final class WooShippingOriginAddressListViewModelTests: XCTestCase {
         XCTAssertEqual(addressToEditViewModel.postalCode, addressToEdit.postcode)
         XCTAssertEqual(addressToEditViewModel.phone, addressToEdit.phone)
         XCTAssertEqual(addressToEditViewModel.email, addressToEdit.email)
-        XCTAssertTrue(addressToEditViewModel.saveAsDefault)
+        XCTAssertTrue(addressToEditViewModel.isDefault)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
@@ -108,7 +108,7 @@ final class WooShippingOriginAddressListViewModelTests: XCTestCase {
         XCTAssertEqual(addressToEditViewModel.postalCode, addressToEdit.postcode)
         XCTAssertEqual(addressToEditViewModel.phone, addressToEdit.phone)
         XCTAssertEqual(addressToEditViewModel.email, addressToEdit.email)
-        XCTAssertTrue(addressToEditViewModel.isDefault)
+        XCTAssertTrue(addressToEditViewModel.isDefaultAddress)
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/14865 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This makes the address form in the Woo Shipping label flow reusable for editing both origin and destination addresses.

Changes in this PR:

* Adds an `addressType` property to track what type of address is being edited.
* Only shows the "Save as default" toggle for origin addresses. (And renames the `saveAsDefault` property to `isDefault` for clarity.)
* Adds a convenience initializer to the view model for editing origin addresses.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There should be no visible changes to the current behavior:

1. Ensure the Woo Shipping extension is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. In the address form, confirm you still see the "save as default" toggle at the bottom of the form.
8. Confirm all of the fields are pre-populated with the expected address details.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.