### PR TITLE
[Shipping labels] Handle country and state selection for origin addresses

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -96,12 +96,32 @@ struct WooShippingEditAddressView: View {
                 NavigationStack {
                     FilterListSelector(viewModel: viewModel.countrySelectorVM)
                         .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button {
+                                    isPresentingCountrySelector = false
+                                } label: {
+                                    Text(Localization.done)
+                                        .bold()
+                                }
+                            }
+                        }
                 }
             }
             .sheet(isPresented: $isPresentingStateSelector) {
                 NavigationStack {
                     FilterListSelector(viewModel: viewModel.stateSelectorVM)
                         .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button {
+                                    isPresentingStateSelector = false
+                                } label: {
+                                    Text(Localization.done)
+                                        .bold()
+                                }
+                            }
+                        }
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -16,6 +16,9 @@ struct WooShippingEditAddressView: View {
 
     @Environment(\.dismiss) private var dismiss
 
+    @State private var isPresentingCountrySelector: Bool = false
+    @State private var isPresentingStateSelector: Bool = false
+
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.verticalSpacing) {
@@ -34,15 +37,15 @@ struct WooShippingEditAddressView: View {
                     .font(.subheadline)
                     .bold()
                 }
-                AddressSelection(field: .country, selected: viewModel.country, required: viewModel.isRequired(.country)) {
-                    // TODO: Handle country selection
+                AddressSelection(field: .country, selected: viewModel.selectedCountry?.name ?? "", required: viewModel.isRequired(.country)) {
+                    isPresentingCountrySelector = true
                 }
                 .padding(.top, Constants.extraPadding)
                 AddressTextField(field: .address, text: $viewModel.address, required: viewModel.isRequired(.address), focused: $focusedField)
                 AddressTextField(field: .city, text: $viewModel.city, required: viewModel.isRequired(.city), focused: $focusedField)
                 AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
-                    AddressSelection(field: .state, selected: viewModel.state, required: viewModel.isRequired(.state)) {
-                        // TODO: Handle state selection
+                    AddressSelection(field: .state, selected: viewModel.selectedState?.name ?? "", required: viewModel.isRequired(.state)) {
+                        isPresentingStateSelector = true
                     }
                     AddressTextField(field: .postalCode, text: $viewModel.postalCode, required: viewModel.isRequired(.postalCode), focused: $focusedField)
                 }
@@ -83,6 +86,18 @@ struct WooShippingEditAddressView: View {
                         Text(Localization.done)
                             .bold()
                     }
+                }
+            }
+            .sheet(isPresented: $isPresentingCountrySelector) {
+                NavigationStack {
+                    FilterListSelector(viewModel: viewModel.countrySelectorVM)
+                        .navigationBarTitleDisplayMode(.inline)
+                }
+            }
+            .sheet(isPresented: $isPresentingStateSelector) {
+                NavigationStack {
+                    FilterListSelector(viewModel: viewModel.stateSelectorVM)
+                        .navigationBarTitleDisplayMode(.inline)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -44,8 +44,12 @@ struct WooShippingEditAddressView: View {
                 AddressTextField(field: .address, text: $viewModel.address, required: viewModel.isRequired(.address), focused: $focusedField)
                 AddressTextField(field: .city, text: $viewModel.city, required: viewModel.isRequired(.city), focused: $focusedField)
                 AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: Constants.innerSpacing) {
-                    AddressSelection(field: .state, selected: viewModel.selectedState?.name ?? "", required: viewModel.isRequired(.state)) {
-                        isPresentingStateSelector = true
+                    if viewModel.statesOfSelectedCountry.isNotEmpty {
+                        AddressSelection(field: .state, selected: viewModel.selectedState?.name ?? " ", required: viewModel.isRequired(.state)) {
+                            isPresentingStateSelector = true
+                        }
+                    } else {
+                        AddressTextField(field: .state, text: $viewModel.state, required: viewModel.isRequired(.state), focused: $focusedField)
                     }
                     AddressTextField(field: .postalCode, text: $viewModel.postalCode, required: viewModel.isRequired(.postalCode), focused: $focusedField)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -1,8 +1,14 @@
+import Foundation
 import SwiftUI
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// View model for editing an address in the Woo Shipping label flow.
 final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
+
     enum AddressType {
         case origin
         case destination
@@ -42,6 +48,35 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus
 
+    // MARK: State/Country
+
+    /// ResultsController: Loads Countries from the Storage Layer.
+    ///
+    private lazy var resultsController: ResultsController<StorageCountry> = {
+        let descriptor = NSSortDescriptor(key: "name", ascending: true)
+        return ResultsController(storageManager: storageManager, matching: nil, sortedBy: [descriptor])
+    }()
+
+    /// List of countries that can be used as an origin address.
+    var countries: [Country] {
+        switch addressType {
+        case .origin:
+            resultsController.fetchedObjects.filter { Constants.acceptedUSPSCountries.contains($0.code) }
+        case .destination:
+            resultsController.fetchedObjects
+        }
+    }
+
+    /// States of the selected country.
+    var statesOfSelectedCountry: [StateOfACountry] {
+        countries.first { $0.code == country }?.states.sorted { $0.name < $1.name } ?? []
+    }
+
+    /// Whether the state is required for the selected country.
+    var stateRequired: Bool {
+        statesOfSelectedCountry.isNotEmpty
+    }
+
     init(type: AddressType,
          id: String,
          name: String,
@@ -56,7 +91,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          isDefault: Bool,
          showCompanyField: Bool,
          isVerified: Bool,
-         phoneNumberRequired: Bool) {
+         phoneNumberRequired: Bool,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.addressType = type
         self.id = id
         self.name = name
@@ -72,9 +109,16 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.showCompanyField = showCompanyField
         self.status = isVerified ? .verified : .unverified
         self.phoneNumberRequired = phoneNumberRequired
+        self.stores = stores
+        self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
+        self.storageManager = storageManager
+
+        fetchCountries()
     }
 
-    convenience init(address: WooShippingOriginAddress) {
+    convenience init(address: WooShippingOriginAddress,
+                     stores: StoresManager = ServiceLocator.stores,
+                     storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.init(type: .origin,
                   id: address.id,
                   name: address.fullName,
@@ -89,7 +133,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   isDefault: address.defaultAddress,
                   showCompanyField: address.company.isNotEmpty,
                   isVerified: address.isVerified,
-                  phoneNumberRequired: true)
+                  phoneNumberRequired: true,
+                  stores: stores,
+                  storageManager: storageManager)
     }
 
     func isRequired(_ field: WooShippingEditAddressView.AddressField) -> Bool {
@@ -98,10 +144,50 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
             return company.isEmpty
         case .company:
             return name.isEmpty
-        case .country, .address, .city, .state, .postalCode, .email:
+        case .country, .address, .city, .postalCode, .email:
             return true
+        case .state:
+            return stateRequired
         case .phone:
             return phoneNumberRequired
         }
+    }
+}
+
+// MARK: Remote
+private extension WooShippingEditAddressViewModel {
+    func fetchCountries() {
+        try? resultsController.performFetch()
+        let action = DataAction.synchronizeCountries(siteID: siteID) { [weak self] (result) in
+            guard let self = self else { return }
+            switch result {
+            case .success:
+                try? self.resultsController.performFetch()
+            case .failure:
+                break
+            }
+        }
+
+        stores.dispatch(action)
+    }
+}
+
+// MARK: Constants
+private extension WooShippingEditAddressViewModel {
+    enum Constants {
+        /// This is hardcoded for now based on: https://git.io/JBuja.
+        /// It would be great if this can be fetched remotely.
+        ///
+        static let acceptedUSPSCountries = [
+            "US", // United States
+            "PR", // Puerto Rico
+            "VI", // Virgin Islands
+            "GU", // Guam
+            "AS", // American Samoa
+            "UM", // United States Minor Outlying Islands
+            "MH", // Marshall Islands
+            "FM", // Micronesia
+            "MP" // Northern Mariana Islands
+        ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -2,12 +2,14 @@ import Foundation
 import SwiftUI
 import Yosemite
 import protocol Storage.StorageManagerType
+import Combine
 
 /// View model for editing an address in the Woo Shipping label flow.
 final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private let siteID: Int64
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private var cancellables: Set<AnyCancellable> = []
 
     enum AddressType {
         case origin
@@ -22,10 +24,10 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     let id: String
     @Published var name: String
     @Published var company: String
-    @Published var country: String
+    private(set) var country: String
     @Published var address: String
     @Published var city: String
-    @Published var state: String
+    private(set) var state: String
     @Published var postalCode: String
     @Published var email: String
     @Published var phone: String
@@ -57,6 +59,30 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         return ResultsController(storageManager: storageManager, matching: nil, sortedBy: [descriptor])
     }()
 
+    /// Selected country. We observe this to update the `country` property.
+    @Published private(set) var selectedCountry: Country?
+
+    /// Selected state. We observe this to update the `state` property.
+    @Published private(set) var selectedState: StateOfACountry?
+
+    /// View model for selecting a country from a list.
+    var countrySelectorVM: CountrySelectorViewModel {
+        let selectedCountryBinding = Binding<AreaSelectorCommandProtocol?>(
+            get: { self.selectedCountry },
+            set: { self.selectedCountry = $0 as? Country}
+        )
+        return CountrySelectorViewModel(countries: countries, selected: selectedCountryBinding)
+    }
+
+    /// View model for selecting a state from a list.
+    var stateSelectorVM: StateSelectorViewModel {
+        let selectedStateBinding = Binding<AreaSelectorCommandProtocol?>(
+            get: { self.selectedState },
+            set: { self.selectedState = $0 as? StateOfACountry }
+        )
+        return StateSelectorViewModel(states: statesOfSelectedCountry, selected: selectedStateBinding)
+    }
+
     /// List of countries that can be used as an origin address.
     var countries: [Country] {
         switch addressType {
@@ -73,7 +99,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     }
 
     /// Whether the state is required for the selected country.
-    var stateRequired: Bool {
+    private var stateRequired: Bool {
         statesOfSelectedCountry.isNotEmpty
     }
 
@@ -113,6 +139,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
 
+        observeSelectedCountry()
+        observeSelectedState()
         fetchCountries()
     }
 
@@ -154,21 +182,53 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     }
 }
 
+private extension WooShippingEditAddressViewModel {
+    func observeSelectedCountry() {
+        $selectedCountry
+            .dropFirst()
+            .sink { [weak self] selectedCountry in
+                guard let self, let selectedCountry, self.selectedCountry != selectedCountry else { return }
+                country = selectedCountry.code
+                selectedState = nil
+            }
+            .store(in: &cancellables)
+    }
+
+    func observeSelectedState() {
+        $selectedState
+            .dropFirst()
+            .sink { [weak self] selectedState in
+                guard let self else { return }
+                state = selectedState?.code ?? ""
+            }
+            .store(in: &cancellables)
+    }
+}
+
 // MARK: Remote
 private extension WooShippingEditAddressViewModel {
     func fetchCountries() {
-        try? resultsController.performFetch()
+        refreshCountriesAndUpdateSelections()
         let action = DataAction.synchronizeCountries(siteID: siteID) { [weak self] (result) in
             guard let self = self else { return }
             switch result {
             case .success:
-                try? self.resultsController.performFetch()
+                refreshCountriesAndUpdateSelections()
             case .failure:
                 break
             }
         }
 
         stores.dispatch(action)
+    }
+
+    func refreshCountriesAndUpdateSelections() {
+        try? resultsController.performFetch()
+        // Updating the selected country clears the selected state.
+        // We track the initial state code so we can set the correct selected state.
+        let stateCode = state
+        selectedCountry = countries.first { $0.code == country }
+        selectedState = statesOfSelectedCountry.first { $0.code == stateCode }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -27,7 +27,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private(set) var country: String
     @Published var address: String
     @Published var city: String
-    private(set) var state: String
+    @Published var state: String
     @Published var postalCode: String
     @Published var email: String
     @Published var phone: String

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -56,7 +56,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     func test_origin_address_inits_with_expected_values() {
         // Given
         let storageManager = MockStorageManager()
-        let countries = [Country(code: "US", name: "United States", states: []), Country(code: "CA", name: "Canada", states: [])]
+        let state = StateOfACountry(code: "NY", name: "New York")
+        let countries = [Country(code: "US", name: "United States", states: [state]), Country(code: "CA", name: "Canada", states: [])]
         storageManager.insertSampleCountries(readOnlyCountries: countries)
         let address = WooShippingOriginAddress(id: "default_address",
                                                company: "HEADQUARTERS",
@@ -331,5 +332,101 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(isStateRequired)
+    }
+
+    func test_selected_country_and_state_properies_set_when_address_contains_country_and_state_in_countries() {
+        // Given
+        let storageManager = MockStorageManager()
+        let state = StateOfACountry(code: "NY", name: "New York")
+        let country = Country(code: "US", name: "United States", states: [state])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: country.code,
+                                                        address: "",
+                                                        city: "",
+                                                        state: state.code,
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedCountry, country)
+        XCTAssertEqual(viewModel.selectedState, state)
+        XCTAssertEqual(viewModel.country, country.code)
+        XCTAssertEqual(viewModel.state, state.code)
+    }
+
+    func test_selectedState_cleared_when_new_country_is_selected() {
+        // Given
+        let storageManager = MockStorageManager()
+        let state = StateOfACountry(code: "NY", name: "New York")
+        let country = Country(code: "US", name: "United States", states: [state])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: country.code,
+                                                        address: "",
+                                                        city: "",
+                                                        state: state.code,
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // When
+        let countrySelectorCommand = viewModel.countrySelectorVM.command
+        let viewController = ListSelectorViewController(command: countrySelectorCommand, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        countrySelectorCommand.handleSelectedChange(selected: Country.fake(), viewController: viewController)
+
+        // Then
+        XCTAssertNil(viewModel.selectedState)
+    }
+
+    func test_selectedState_not_cleared_when_same_country_is_selected() {
+        // Given
+        let storageManager = MockStorageManager()
+        let state = StateOfACountry(code: "NY", name: "New York")
+        let country = Country(code: "US", name: "United States", states: [state])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: country.code,
+                                                        address: "",
+                                                        city: "",
+                                                        state: state.code,
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // When
+        let countrySelectorCommand = viewModel.countrySelectorVM.command
+        let viewController = ListSelectorViewController(command: countrySelectorCommand, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        countrySelectorCommand.handleSelectedChange(selected: country, viewController: viewController)
+
+        // Then
+        XCTAssertNotNil(viewModel.selectedState)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -20,6 +20,10 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let showCompanyField = true
         let isVerified = true
 
+        let storageManager = MockStorageManager()
+        let countries = [Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])]
+        storageManager.insertSampleCountries(readOnlyCountries: countries)
+
         // When
         let viewModel = WooShippingEditAddressViewModel(type: .origin,
                                                         id: id,
@@ -35,7 +39,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefault: saveAsDefault,
                                                         showCompanyField: showCompanyField,
                                                         isVerified: isVerified,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
 
         // Then
         XCTAssertEqual(viewModel.id, id)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+import Yosemite
 
 final class WooShippingEditAddressViewModelTests: XCTestCase {
 
@@ -95,6 +96,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_isRequired_returns_expected_values() {
         // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storageManager = MockStorageManager()
         let viewModel = WooShippingEditAddressViewModel(type: .origin,
                                                         id: "",
                                                         name: "",
@@ -109,7 +112,9 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefault: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        storageManager: storageManager)
 
         // When
         var requirements: [WooShippingEditAddressView.AddressField: Bool] = [:]
@@ -123,7 +128,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(requirements[.country], true)
         XCTAssertEqual(requirements[.address], true)
         XCTAssertEqual(requirements[.city], true)
-        XCTAssertEqual(requirements[.state], true)
+        XCTAssertEqual(requirements[.state], false)
         XCTAssertEqual(requirements[.postalCode], true)
         XCTAssertEqual(requirements[.email], true)
         XCTAssertEqual(requirements[.phone], true)
@@ -205,7 +210,12 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     }
 
     func test_it_inits_with_expected_values_for_origin_address_type() {
-        // Given/When
+        // Given
+        let storageManager = MockStorageManager()
+        let countries = [Country(code: "US", name: "United States", states: []), Country(code: "CA", name: "Canada", states: [])]
+        storageManager.insertSampleCountries(readOnlyCountries: countries)
+
+        // When
         let viewModel = WooShippingEditAddressViewModel(type: .origin,
                                                         id: "",
                                                         name: "",
@@ -220,14 +230,21 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefault: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
 
         // Then
         XCTAssertTrue(viewModel.showSaveAsDefault)
+        XCTAssertEqual(viewModel.countries.count, 1, "Should only include USPS-supported countries for origin addresses")
     }
 
     func test_it_inits_with_expected_values_for_destination_address_type() {
-        // Given/When
+        // Given
+        let storageManager = MockStorageManager()
+        let countries = [Country(code: "US", name: "United States", states: []), Country(code: "CA", name: "Canada", states: [])]
+        storageManager.insertSampleCountries(readOnlyCountries: countries)
+
+        // When
         let viewModel = WooShippingEditAddressViewModel(type: .destination,
                                                         id: "",
                                                         name: "",
@@ -242,9 +259,77 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefault: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
 
         // Then
         XCTAssertFalse(viewModel.showSaveAsDefault)
+        XCTAssertEqual(viewModel.countries.count, 2, "Should include all countries for destination addresses")
+    }
+
+    func test_init_fetches_countries_from_remote() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [])
+        stores.whenReceivingAction(ofType: DataAction.self) { action in
+            switch action {
+            case .synchronizeCountries(_, let completion):
+                storageManager.insertSampleCountries(readOnlyCountries: [country])
+                completion(.success([country]))
+            }
+        }
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.countries.count, 1)
+        XCTAssertTrue(stores.receivedActions.first is DataAction)
+    }
+
+    func test_isRequired_returns_true_when_selected_country_contains_states() {
+        // Given
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [.init(code: "NY", name: "New York")])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: country.code,
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefault: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // When
+        let isStateRequired = viewModel.isRequired(.state)
+
+        // Then
+        XCTAssertTrue(isStateRequired)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingOriginAddressListViewModelTests.swift
@@ -75,22 +75,9 @@ final class WooShippingOriginAddressListViewModelTests: XCTestCase {
         XCTAssertEqual(selectedAddress, addressToSelect)
     }
 
-    func test_editAddress_sets_addressToEdit_view_model_with_expected_values() throws {
+    func test_editAddress_sets_addressToEdit_view_model() throws {
         // Given
-        let addressToEdit = WooShippingOriginAddress(id: "default_address",
-                                                     company: "HEADQUARTERS",
-                                                     address1: "15 ALGONKIN ST",
-                                                     address2: "STE 100",
-                                                     city: "TICONDEROGA",
-                                                     state: "NY",
-                                                     postcode: "12883-1487",
-                                                     country: "US",
-                                                     phone: "123-456-7890",
-                                                     firstName: "JANE",
-                                                     lastName: "DOE",
-                                                     email: "TEST@EXAMPLE.COM",
-                                                     defaultAddress: true,
-                                                     isVerified: true)
+        let addressToEdit = WooShippingOriginAddress.fake()
         let viewModel = WooShippingOriginAddressListViewModel(addresses: [addressToEdit])
 
         // When
@@ -98,17 +85,6 @@ final class WooShippingOriginAddressListViewModelTests: XCTestCase {
 
         // Then
         let addressToEditViewModel = try XCTUnwrap(viewModel.addressToEdit, "addressToEdit was unexpectedly nil")
-        XCTAssertEqual(addressToEditViewModel.id, addressToEdit.id)
-        XCTAssertEqual(addressToEditViewModel.name, addressToEdit.fullName)
-        XCTAssertEqual(addressToEditViewModel.country, addressToEdit.country)
-        XCTAssertEqual(addressToEditViewModel.company, addressToEdit.company)
-        XCTAssertEqual(addressToEditViewModel.address, addressToEdit.combinedAddress)
-        XCTAssertEqual(addressToEditViewModel.city, addressToEdit.city)
-        XCTAssertEqual(addressToEditViewModel.state, addressToEdit.state)
-        XCTAssertEqual(addressToEditViewModel.postalCode, addressToEdit.postcode)
-        XCTAssertEqual(addressToEditViewModel.phone, addressToEdit.phone)
-        XCTAssertEqual(addressToEditViewModel.email, addressToEdit.email)
-        XCTAssertTrue(addressToEditViewModel.isDefault)
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
⚠️  Depends on https://github.com/woocommerce/woocommerce-ios/pull/14866 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for selecting a country and state when editing an origin address in the Woo Shipping label flow.

Apologies for the slightly large PR; many of the lines of changes are from unit tests. I thought this was preferable to splitting the PR, given that it's hard to test the fetching behavior without the corresponding selection UI.

Updated behavior:

* The address form now fetches a list of countries from remote/storage to use for selecting a new country and state.
* You can now tap on the country in the address form to open a list of countries and select a new country.
* When editing an origin address, the list of countries is filtered to USPS-approved countries. (This matches the legacy behavior and extension behavior; it is hardcoded because there isn't a list of supported countries available from the API.)
* When you select a new country, it clears the previous state selection. (If you keep the same country selection, the state won't change.)
* If you select a country with a list of states, you can tap on the state in the address form to open the list and select a new state.
* If you select a country that doesn't have a list of states, the state field becomes an optional text field. (This matches the web behavior.)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the Woo Shipping extension is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. Confirm the country and state fields show the expected values for the selected address.
8. Tap the country and confirm it opens the list of USPS-approved countries.
9. Confirm you can filter the list and select a new country.
10. Confirm that if you select a new country, the state field is cleared.
11. Select a country that includes states (i.e. the US) and confirm you can tap the state field to open a list of states to select form. Confirm your new selection is reflected in the form.
12. Select a country without states and confirm the state field becomes a text field that you can edit.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/60ffbc90-e645-48a4-8fc4-fb84ba3a6a69



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.