### PR TITLE
[Woo POS] Workaround for refreshable task being canceled by redraw

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -42,11 +42,12 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     private func loadRootItems() async {
-        let items = itemsViewState.itemsStack.root.items
-        let containerState: ItemsContainerState = items.isEmpty ? .loading : .content
+        let currentItems = itemsViewState.itemsStack.root.items
+        let currentItemStates = itemsViewState.itemsStack.itemStates
+        let containerState: ItemsContainerState = currentItems.isEmpty ? .loading : .content
         itemsViewState = .init(containerState: containerState,
-                               itemsStack: ItemsStackState(root: .loading(items),
-                                                           itemStates: [:]))
+                               itemsStack: ItemsStackState(root: .loading(currentItems),
+                                                           itemStates: currentItemStates))
 
         do {
             try await paginationTracker.resync { [weak self] pageNumber in

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -42,6 +42,12 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     private func loadRootItems() async {
+        let items = itemsViewState.itemsStack.root.items
+        let containerState: ItemsContainerState = items.isEmpty ? .loading : .content
+        itemsViewState = .init(containerState: containerState,
+                               itemsStack: ItemsStackState(root: .loading(items),
+                                                           itemStates: [:]))
+
         do {
             try await paginationTracker.resync { [weak self] pageNumber in
                 guard let self else { return true }
@@ -88,6 +94,8 @@ class PointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     @MainActor
     private func loadChildItems(for parent: POSItem) async {
+        let items = itemsViewState.itemsStack.itemStates[parent]?.items ?? []
+        updateState(for: parent, to: .loading(items))
 
         let paginationTracker = paginationTracker(for: parent)
         do {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -8,6 +8,10 @@ struct ChildItemList: View {
     @EnvironmentObject private var posModel: PointOfSaleAggregateModel
     @Environment(\.dismiss) private var dismiss
 
+    // Used for refresh control workaround for an issue where the view is redrawn and the refresh control task is canceled.
+    // As a workaround, Task is perserved and can be associated with a unique ID from each refresh control trigger.
+    @State private var refreshControlTaskID: UUID?
+
     private var state: ItemListState {
         posModel.itemsViewState.itemsStack
             .itemStates[parentItem] ??
@@ -31,7 +35,18 @@ struct ChildItemList: View {
         .background(Color.posPrimaryBackground)
         .toolbar(.hidden, for: .navigationBar)
         .refreshable {
+            // Only allows one refresh task at a time now that the refresh control is released on redraw.
+            guard refreshControlTaskID == nil else {
+                return
+            }
+            refreshControlTaskID = .init()
+        }
+        .task(id: refreshControlTaskID) {
+            guard refreshControlTaskID != nil else {
+                return
+            }
             await posModel.loadItems(base: .parent(parentItem))
+            refreshControlTaskID = nil
         }
         .task {
             guard state.items.isEmpty else {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -8,10 +8,6 @@ struct ChildItemList: View {
     @EnvironmentObject private var posModel: PointOfSaleAggregateModel
     @Environment(\.dismiss) private var dismiss
 
-    // Used for refresh control workaround for an issue where the view is redrawn and the refresh control task is canceled.
-    // As a workaround, Task is perserved and can be associated with a unique ID from each refresh control trigger.
-    @State private var refreshControlTaskID: UUID?
-
     private var state: ItemListState {
         posModel.itemsViewState.itemsStack
             .itemStates[parentItem] ??
@@ -35,18 +31,9 @@ struct ChildItemList: View {
         .background(Color.posPrimaryBackground)
         .toolbar(.hidden, for: .navigationBar)
         .refreshable {
-            // Only allows one refresh task at a time now that the refresh control is released on redraw.
-            guard refreshControlTaskID == nil else {
-                return
-            }
-            refreshControlTaskID = .init()
-        }
-        .task(id: refreshControlTaskID) {
-            guard refreshControlTaskID != nil else {
-                return
-            }
-            await posModel.loadItems(base: .parent(parentItem))
-            refreshControlTaskID = nil
+            await Task {
+                await posModel.loadItems(base: .parent(parentItem))
+            }.value
         }
         .task {
             guard state.items.isEmpty else {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -15,10 +15,6 @@ struct ItemListView: View {
     @AppStorage(BannerState.isSimpleProductsOnlyBannerDismissedKey)
     private var isHeaderBannerDismissed: Bool = false
 
-    // Used for refresh control workaround for an issue where the view is redrawn and the refresh control task is canceled.
-    // As a workaround, Task is perserved and can be associated with a unique ID from each refresh control trigger.
-    @State private var refreshControlTaskID: UUID?
-
     var body: some View {
         NavigationStack {
             VStack {
@@ -39,18 +35,9 @@ struct ItemListView: View {
             })
         }
         .refreshable {
-            // Only allows one refresh task at a time now that the refresh control is released on redraw.
-            guard refreshControlTaskID == nil else {
-                return
-            }
-            refreshControlTaskID = .init()
-        }
-        .task(id: refreshControlTaskID) {
-            guard refreshControlTaskID != nil else {
-                return
-            }
-            await posModel.loadItems(base: .root)
-            refreshControlTaskID = nil
+            await Task {
+                await posModel.loadItems(base: .root)
+            }.value
         }
         .background(Color.posPrimaryBackground)
         .accessibilityElement(children: .contain)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -15,6 +15,10 @@ struct ItemListView: View {
     @AppStorage(BannerState.isSimpleProductsOnlyBannerDismissedKey)
     private var isHeaderBannerDismissed: Bool = false
 
+    // Used for refresh control workaround for an issue where the view is redrawn and the refresh control task is canceled.
+    // As a workaround, Task is perserved and can be associated with a unique ID from each refresh control trigger.
+    @State private var refreshControlTaskID: UUID?
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -35,7 +39,18 @@ struct ItemListView: View {
             })
         }
         .refreshable {
+            // Only allows one refresh task at a time now that the refresh control is released on redraw.
+            guard refreshControlTaskID == nil else {
+                return
+            }
+            refreshControlTaskID = .init()
+        }
+        .task(id: refreshControlTaskID) {
+            guard refreshControlTaskID != nil else {
+                return
+            }
             await posModel.loadItems(base: .root)
+            refreshControlTaskID = nil
         }
         .background(Color.posPrimaryBackground)
         .accessibilityElement(children: .contain)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -37,6 +37,7 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadItems_results_in_loaded_state() async throws {
         // Given
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
+        itemProvider.itemPages = [expectedItems]
         try #require(itemsViewState.containerState == .loading)
 
         // When
@@ -67,6 +68,7 @@ final class PointOfSaleItemsControllerTests {
         // Given
         try #require(itemsViewState.containerState == .loading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
+        itemProvider.itemPages = [expectedItems]
 
         // When
         await sut.loadItems(base: .root)
@@ -102,8 +104,7 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadItems_when_initial_items_has_items_but_no_more_pages_then_state_is_loaded_with_initial_items() async throws {
         // Given
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
-        itemProvider.items = initialItems
-        itemProvider.shouldSimulateTwoPages = false
+        itemProvider.itemPages = [initialItems]
 
         try #require(itemsViewState.containerState == .loading)
 
@@ -119,7 +120,6 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadNextItems_when_simulateFetchNextPage_then_state_is_loaded_with_expected_items() async throws {
         // Given
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
-        itemProvider.items = initialItems
         itemProvider.shouldSimulateTwoPages = true
         await sut.loadItems(base: .root)
 
@@ -150,7 +150,6 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadNextItems_when_simulateFetchNextPage_then_state_is_loaded_with_hasMoreItems() async throws {
         // Given
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
-        itemProvider.items = initialItems
         itemProvider.shouldSimulateTwoPages = true
         itemProvider.shouldSimulateMorePages = true
         await sut.loadItems(base: .root)
@@ -174,7 +173,6 @@ final class PointOfSaleItemsControllerTests {
                                                                                 productImageSource: nil,
                                                                                 productID: 12345))
         let baseItem = ItemListBaseItem.parent(parentItem)
-        itemProvider.items = [parentItem]
         itemProvider.shouldSimulateTwoPagesOfVariations = true
         itemProvider.shouldSimulateMorePagesOfVariations = true
 
@@ -200,7 +198,6 @@ final class PointOfSaleItemsControllerTests {
                                                                                 productImageSource: nil,
                                                                                 productID: 12345))
         let baseItem = ItemListBaseItem.parent(parentItem)
-        itemProvider.items = [parentItem]
         itemProvider.shouldSimulateTwoPagesOfVariations = true
 
         await sut.loadItems(base: .root)
@@ -292,6 +289,7 @@ final class PointOfSaleItemsControllerTests {
         // Given
         try #require(itemsViewState.containerState == .loading)
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
+        itemProvider.itemPages = [expectedItems]
 
         // When
         await sut.loadItems(base: .root)
@@ -304,6 +302,8 @@ final class PointOfSaleItemsControllerTests {
 
     @Test func loadNextItems_when_next_page_is_empty_then_state_is_loaded() async throws {
         // Given
+        let expectedItems = MockPointOfSaleItemService.makeInitialItems()
+        itemProvider.itemPages = [expectedItems]
         await sut.loadItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
@@ -313,7 +313,7 @@ final class PointOfSaleItemsControllerTests {
 
         // Then
         #expect(itemsViewState == ItemsViewState(containerState: .content,
-                                                 itemsStack: ItemsStackState(root: .loaded(MockPointOfSaleItemService.makeInitialItems(),
+                                                 itemsStack: ItemsStackState(root: .loaded(expectedItems,
                                                                                            hasMoreItems: false),
                                                                              itemStates: [:])))
     }
@@ -334,6 +334,7 @@ final class PointOfSaleItemsControllerTests {
     @Test func loadItems_sets_root_items_to_loading_state_while_preserving_existing_items() async throws {
         // Given
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
+        itemProvider.itemPages = [initialItems]
         await sut.loadItems(base: .root)
         try #require(itemsViewState.itemsStack.root.items == initialItems)
 
@@ -377,6 +378,25 @@ final class PointOfSaleItemsControllerTests {
         cancellable.cancel()
     }
 
+    @Test func loadItems_preserves_itemStates() async throws {
+        // Given
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+                                                                              name: "Parent product",
+                                                                              productImageSource: nil,
+                                                                              productID: 125))
+        itemProvider.itemPages = [[parentItem]]
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: .parent(parentItem))
+        let itemStates = itemsViewState.itemsStack.itemStates
+        try #require(itemStates != [:])
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        try #require(itemsViewState.itemsStack.itemStates == itemStates)
+    }
+
     @Test func loadItems_sets_child_items_to_loading_state_while_preserving_existing_items() async throws {
         // Given
         let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
@@ -384,7 +404,7 @@ final class PointOfSaleItemsControllerTests {
                                                                               productImageSource: nil,
                                                                               productID: 125))
         let baseItem = ItemListBaseItem.parent(parentItem)
-        itemProvider.items = [parentItem]
+        itemProvider.itemPages = [[parentItem]]
 
         // Loads initial items.
         await sut.loadItems(base: .root)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -330,4 +330,85 @@ final class PointOfSaleItemsControllerTests {
         // Then
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
     }
+
+    @Test func loadItems_sets_root_items_to_loading_state_while_preserving_existing_items() async throws {
+        // Given
+        let initialItems = MockPointOfSaleItemService.makeInitialItems()
+        await sut.loadItems(base: .root)
+        try #require(itemsViewState.itemsStack.root.items == initialItems)
+
+        var states: [ItemListState] = []
+        let cancellable = sut.itemsViewStatePublisher
+            .sink { state in
+                states.append(state.itemsStack.root)
+            }
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        let loadingStates = states.filter { $0.isLoading }
+        #expect(loadingStates.count == 1)
+        if case .loading(let items) = loadingStates.first {
+            #expect(items == initialItems)
+        }
+        cancellable.cancel()
+    }
+
+    @Test func loadItems_sets_container_state_to_loading_and_root_state_to_loading_state_when_no_existing_items() async throws {
+        // Given
+        itemProvider.shouldReturnZeroItems = true
+        await sut.loadItems(base: .root)
+        try #require(itemsViewState.itemsStack.root.items == [])
+
+        var states: [ItemsViewState] = []
+        let cancellable = sut.itemsViewStatePublisher
+            .sink { state in
+                states.append(state)
+            }
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        let loadingStates = states.filter { $0.containerState == .loading }
+        #expect(loadingStates.count == 1)
+        #expect(loadingStates.first?.itemsStack.root == .loading([]))
+        cancellable.cancel()
+    }
+
+    @Test func loadItems_sets_child_items_to_loading_state_while_preserving_existing_items() async throws {
+        // Given
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+                                                                              name: "Parent product",
+                                                                              productImageSource: nil,
+                                                                              productID: 125))
+        let baseItem = ItemListBaseItem.parent(parentItem)
+        itemProvider.items = [parentItem]
+
+        // Loads initial items.
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: baseItem)
+
+        let initialChildItems = itemsViewState.itemsStack.itemStates[parentItem]?.items ?? []
+        try #require(!initialChildItems.isEmpty)
+
+        var states: [ItemListState] = []
+        let cancellable = sut.itemsViewStatePublisher.sink { state in
+            if let childState = state.itemsStack.itemStates[parentItem] {
+                states.append(childState)
+            }
+        }
+
+        // When
+        await sut.loadItems(base: baseItem)
+
+        // Then
+        let loadingStates = states.filter { $0.isLoading }
+        #expect(loadingStates.count == 1)
+        if case .loading(let items) = loadingStates.first {
+            #expect(items == initialChildItems)
+        }
+        cancellable.cancel()
+    }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -8,7 +8,8 @@ import struct Yosemite.PagedItems
 import struct Yosemite.POSVariableParentProduct
 
 final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
-    var items: [POSItem] = []
+    /// An array of pages of items, returned when other flags are not set.
+    var itemPages: [[POSItem]] = []
     var shouldThrowError = false
     var shouldReturnZeroItems = false
     var shouldSimulateTwoPages = false
@@ -23,11 +24,12 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
         if shouldReturnZeroItems {
             return .init(items: [], hasMorePages: false)
         }
-        if shouldSimulateTwoPages,
-            pageNumber > 1 {
-            return .init(items: MockPointOfSaleItemService.makeSecondPageItems(), hasMorePages: shouldSimulateMorePages)
+        if shouldSimulateTwoPages {
+            return pageNumber > 1 ?
+                .init(items: MockPointOfSaleItemService.makeSecondPageItems(), hasMorePages: shouldSimulateMorePages):
+                .init(items: MockPointOfSaleItemService.makeInitialItems(), hasMorePages: shouldSimulateTwoPages)
         }
-        return .init(items: MockPointOfSaleItemService.makeInitialItems(), hasMorePages: shouldSimulateTwoPages)
+        return .init(items: (itemPages[safe: pageNumber - 1] ?? []), hasMorePages: itemPages.count > pageNumber)
     }
 
     var shouldSimulateTwoPagesOfVariations = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14853 
Closes: #14860

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There is a known issue initially from Previous discussion in https://github.com/woocommerce/woocommerce-ios/pull/14728#discussion_r1892286471, where the refreshable async task (triggered by pull-to-refresh, abbreviated PTR) gets canceled when the view is redrawn from POS aggregate model's state change. For example, when we set the initial loading state before the remote request. The initial state was removed to prevent redraws to fix the PTR error in the loaded state, but this results in issue #14860 where the Retry action has no loading UI.

Before we can refactor POS aggregate model to provide more granular updates for the SwiftUI views (created an issue in the backlog https://github.com/woocommerce/woocommerce-ios/issues/14869), we want to explore workarounds for the linked issues at the top. Moving `refreshable` task to a detached Task was one option, but the changes looked quite complicated and hard to test. Alternatively, from [this SO answer](https://stackoverflow.com/a/74977961) > Option 1, we can use `task` associated with a unique ID set in `refreshable` to preserve the async task. The UI/UX tradeoff is that the refresh control does not stay visible until the async task is complete. I haven't found a way to programmatically display the refresh control in SwiftUI, we might have to implement a custom refreshable view if we want to ensure the refresh control staying visible when awaiting the async task for these workarounds.

### Set initial loading state in `loadItems`:

* [`WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift`](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9R45-R50): Updated `loadRootItems` and `loadChildItems` methods to set the loading state while preserving existing items. [[1]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9R45-R50) [[2]](diffhunk://#diff-b34ef3931ae78bf4b51520edbe9c11abd6bf36d31dfce4882f3b621c5a7e2af9R97-R98)

### View updates to use `task` instead of `refreshable` for the async `loadItems`:

* [`WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift`](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bR11-R14): Added a workaround for refresh control issues by introducing a `refreshControlTaskID` state and ensuring only one refresh task is allowed at a time. [[1]](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bR11-R14) [[2]](diffhunk://#diff-e00b9006e8350a3bbba23158a3c7109cda5523bf7eb46287e08588f69439227bR38-R49)
* [`WooCommerce/Classes/POS/Presentation/ItemListView.swift`](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071R18-R21): Similar to `ChildItemList`, added a `refreshControlTaskID` state to handle refresh control issues and ensure only one refresh task is allowed at a time. [[1]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071R18-R21) [[2]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071R42-R53)

### New test cases:

* [`WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift`](diffhunk://#diff-035efdb132bc0f5bf81f75e3cf647335bf2e4532162bc08f16ead4095da998e4R333-R413): Added new test cases to verify that the loading state is correctly set for root and child items while preserving existing items.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Issue 1: PTR while the next page is being loaded

🗒️ If the page size for products is still 100, it's much easier to reproduce this issue by reducing the page size from 100 to 15 or 25 for products [here](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L651).

- Switch to a store eligible for POS, with more than one page of products and variations in POS
- Go to Menu > Point of Sale
- Scroll toward the bottom of the list to trigger the next page load
- Quickly scroll to the top and pull to refresh --> no fullscreen error should appear
- Repeat the above steps for variations of a variable product

### Issue 2: Retry UX

- Switch to a store eligible for POS, with at least one variable product
- Go to Menu > Point of Sale --> items should be loaded
- Simulate a network error by going offline, or using a proxy tool to abort the request
- Pull to refresh --> error UI should be shown
- Simulate a success response for the products request
- Tap Retry --> the loading UI should be shown, and then the loaded state
- Repeat the above steps above for variation item list

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/020daa65-c734-42bf-953b-23a629ab941b




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.