### PR TITLE
Address flaky TapToPayEducationViewModelTests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderMerchantEducationPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderMerchantEducationPresenter.swift
@@ -6,14 +6,14 @@ protocol BuiltInCardReaderMerchantEducationPresenting {
     func presentMerchantEducation(completion: @escaping () -> Void)
 }
 
-final class BuiltInCardReaderMerchantEducationPresenter: BuiltInCardReaderMerchantEducationPresenting {
+final class BuiltInCardReaderMerchantEducationPresenter: @preconcurrency BuiltInCardReaderMerchantEducationPresenting {
     private weak var rootViewController: ViewControllerPresenting?
 
     init(rootViewController: UIViewController) {
         self.rootViewController = rootViewController
     }
 
-    func presentMerchantEducation(completion: @escaping () -> Void) {
+    @MainActor func presentMerchantEducation(completion: @escaping () -> Void) {
         let viewController = UIHostingController(rootView: TapToPayEducationView(viewModel: .init(completion: { _ in
             completion()
         })))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/Tap to Pay Education/TapToPayEducationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/Tap to Pay Education/TapToPayEducationViewModel.swift
@@ -7,6 +7,7 @@ enum TapToPayEducationResult {
     case setUpTapToPay
 }
 
+@MainActor
 final class TapToPayEducationViewModel: ObservableObject {
     struct Action {
         let title: String

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayEducationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayEducationViewModelTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Combine
 @testable import WooCommerce
 
+@MainActor
 struct TapToPayEducationViewModelTests {
     private let cardReaderSupportDeterminer: MockCardReaderSupportDeterminer
 


### PR DESCRIPTION
Addresses: https://github.com/woocommerce/woocommerce-ios/pull/14861#issuecomment-2591863138
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Running TapToPayEducationViewModelTests hundreds or thousands of times consistently reproduces unexpected results.
<img width="488" alt="run repeat" src="https://github.com/user-attachments/assets/7a5db31b-7b4a-49c7-a553-680031aee398" />

Based on a close inspection the issue is that `SwiftTesting` runs tests on background thread by default, compared to `XCTest` what runs them on a main thread. 

No `TapToPayEducationViewModel` functionality is not supposed to work in the background since the only thing it does is update the `@Published` variables intended for the UI.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Right click `TapToPayEducationViewModelTests` on the testing navigator
2. Select `Run Repeatedly`
3. Choose 1000 times
4. Confirm the test passes

Before the changes, at least one test would reliably fail.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

No functionality was changed. The tests should succeed locally or CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.