### PR TITLE
[Woo POS] Item card UI updates

### DIFF
--- a/WooCommerce/Classes/POS/Models/CartItem.swift
+++ b/WooCommerce/Classes/POS/Models/CartItem.swift
@@ -4,11 +4,7 @@ import protocol Yosemite.POSOrderableItem
 struct CartItem {
     let id: UUID
     let item: POSOrderableItem
+    let title: String
+    let subtitle: String?
     let quantity: Int
-
-    init(id: UUID, item: POSOrderableItem, quantity: Int) {
-        self.id = id
-        self.item = item
-        self.quantity = quantity
-    }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -27,7 +27,7 @@ protocol PointOfSaleAggregateModelProtocol {
     func loadNextItems(base: ItemListBaseItem) async
 
     var cart: [CartItem] { get }
-    func addToCart(_ item: POSOrderableItem)
+    func addToCart(_ item: POSItem)
     func remove(cartItem: CartItem)
     func removeAllItemsFromCart()
     func addMoreToCart()
@@ -103,9 +103,23 @@ extension PointOfSaleAggregateModel {
 
 // MARK: - Cart
 
+private extension POSItem {
+    var cartItem: CartItem? {
+        switch self {
+        case .simpleProduct(let simpleProduct):
+            return CartItem(id: UUID(), item: simpleProduct, title: simpleProduct.name, subtitle: nil, quantity: 1)
+        case .variation(let variation):
+            return CartItem(id: UUID(), item: variation, title: variation.parentProductName, subtitle: variation.name, quantity: 1)
+        case .variableParentProduct:
+            return nil
+        }
+    }
+}
+
 extension PointOfSaleAggregateModel {
-    func addToCart(_ item: POSOrderableItem) {
-        cart.insert(CartItem(id: UUID(), item: item, quantity: 1), at: 0)
+    func addToCart(_ item: POSItem) {
+        guard let cartItem = item.cartItem else { return }
+        cart.insert(cartItem, at: cart.startIndex)
     }
 
     func remove(cartItem: CartItem) {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -176,6 +176,7 @@ private extension CartView {
         static let cartHeaderElementSpacing: CGFloat = 16
         static let cartAnimation: Animation = .spring(duration: 0.2)
         static let checkoutButtonVerticalPadding: CGFloat = 16
+        static let cartItemSpacing: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -67,7 +67,7 @@ struct CartView: View {
             if posModel.cart.isNotEmpty {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        VStack(spacing: 0) {
+                        VStack(spacing: Constants.cartItemSpacing) {
                             ForEach(posModel.cart, id: \.id) { cartItem in
                                 ItemRowView(cartItem: cartItem,
                                             onItemRemoveTapped: posModel.orderStage == .building ? {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -89,7 +89,8 @@ private extension ChildItemList {
                                                                 formattedPrice: "$5.75",
                                                                 price: "5.75",
                                                                 productID: 134,
-                                                                variationID: 256
+                                                                variationID: 256,
+                                                                parentProductName: parentProduct.name
                                                             )
                                                         ),
                                                         .variation(
@@ -99,7 +100,8 @@ private extension ChildItemList {
                                                                 formattedPrice: "$6.5",
                                                                 price: "6.5",
                                                                 productID: 134,
-                                                                variationID: 256
+                                                                variationID: 256,
+                                                                parentProductName: parentProduct.name
                                                             )
                                                         )
                                                     ], hasMoreItems: false)]))

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -89,11 +89,7 @@ private struct ItemListRow: View {
             NavigationLink(value: item) {
                 ParentProductCardView(name: parentProduct.name,
                                       imageSource: parentProduct.productImageSource,
-                                      detailView: {
-                    Text(Localization.variationsAvailable)
-                        .foregroundStyle(Color.posSecondaryText)
-                        .font(PointOfSaleItemListCardConstants.itemDetailFont)
-                })
+                                      detailText: Localization.variationsAvailable)
             }
         case let .variation(variation):
             Button(action: {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -92,7 +92,7 @@ private struct ItemListRow: View {
                                       detailView: {
                     Text(Localization.variationsAvailable)
                         .foregroundStyle(Color.posSecondaryText)
-                        .font(.posBodyRegular)
+                        .font(PointOfSaleItemListCardConstants.itemDetailFont)
                 })
             }
         case let .variation(variation):

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -31,7 +31,7 @@ struct ItemList<HeaderView: View>: View {
                 await posModel.loadNextItems(base: node)
             },
             content: {
-                LazyVStack {
+                LazyVStack(spacing: Constants.itemSpacing) {
                     headerView
 
                     ForEach(state.items) { item in
@@ -68,6 +68,7 @@ struct ItemList<HeaderView: View>: View {
 
 private enum Constants {
     static let itemListPadding: CGFloat = 16
+    static let itemSpacing: CGFloat = 16
 }
 
 private struct ItemListRow: View {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -79,7 +79,7 @@ private struct ItemListRow: View {
         switch item {
         case let .simpleProduct(product):
             Button(action: {
-                posModel.addToCart(product)
+                posModel.addToCart(item)
                 analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
             }, label: {
                 SimpleProductCardView(product: product)
@@ -96,7 +96,7 @@ private struct ItemListRow: View {
             }
         case let .variation(variation):
             Button(action: {
-                posModel.addToCart(variation)
+                posModel.addToCart(item)
                 analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
             }, label: {
                 VariationCardView(variation: variation)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ParentProductCardView.swift
@@ -1,18 +1,18 @@
 import SwiftUI
 
 /// Displays a card for a parent product in POS.
-struct ParentProductCardView<DetailView: View>: View {
+struct ParentProductCardView: View {
     private let name: String
     private let imageSource: String?
-    private let detailView: DetailView
+    private let detailText: String
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
-    init(name: String, imageSource: String?, @ViewBuilder detailView: () -> DetailView) {
+    init(name: String, imageSource: String?, detailText: String) {
         self.name = name
         self.imageSource = imageSource
-        self.detailView = detailView()
+        self.detailText = detailText
     }
 
     var body: some View {
@@ -31,7 +31,9 @@ struct ParentProductCardView<DetailView: View>: View {
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemNameFont)
 
-                detailView
+                Text(detailText)
+                    .foregroundStyle(Color.posSecondaryText)
+                    .font(Constants.itemDetailFont)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
@@ -48,8 +50,7 @@ private typealias Constants = PointOfSaleItemListCardConstants
 #if DEBUG
 #Preview {
     ParentProductCardView(name: "Parent product",
-                          imageSource: nil) {
-        Text("Detail view")
-    }
+                          imageSource: nil,
+                          detailText: "Detail text")
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
@@ -5,7 +5,7 @@ enum PointOfSaleItemListCardConstants {
     static let maximumProductCardSize: CGFloat = PointOfSaleItemListCardConstants.productCardSize * 2
     static let cardSpacing: CGFloat = 0
     static let textSpacing: CGFloat = 6
-    static let horizontalTextPadding: CGFloat = 32
+    static let horizontalTextPadding: CGFloat = 16
     static let verticalTextPadding: CGFloat = 8
     static let itemNameFont: POSFontStyle = .posLargeDetailEmphasized
     static let itemDetailFont: POSFontStyle = .posLargeDetailRegular

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
@@ -4,11 +4,11 @@ enum PointOfSaleItemListCardConstants {
     static let productCardSize: CGFloat = 112
     static let maximumProductCardSize: CGFloat = PointOfSaleItemListCardConstants.productCardSize * 2
     static let cardSpacing: CGFloat = 0
-    static let textSpacing: CGFloat = 8
+    static let textSpacing: CGFloat = 6
     static let horizontalTextPadding: CGFloat = 32
     static let verticalTextPadding: CGFloat = 8
-    static let itemNameFont: POSFontStyle = .posBodyEmphasized
-    static let itemPriceFont: POSFontStyle = .posBodyRegular
+    static let itemNameFont: POSFontStyle = .posLargeDetailEmphasized
+    static let itemDetailFont: POSFontStyle = .posLargeDetailRegular
     static let accessoryButtonMaxWidth: CGFloat = 136
     static let accessoryButtonPadding: CGFloat = 16
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/SimpleProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/SimpleProductCardView.swift
@@ -20,18 +20,16 @@ struct SimpleProductCardView: View {
                    height: Constants.productCardSize * scale)
             .clipped()
 
-            DynamicHStack(spacing: Constants.textSpacing) {
-                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
+            VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(product.name)
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemNameFont)
-                Spacer()
+
                 Text(product.formattedPrice)
-                    .foregroundStyle(Color.posPrimaryText)
-                    .font(Constants.itemPriceFont)
-                Spacer().renderedIf(dynamicTypeSize.isAccessibilitySize)
+                    .foregroundStyle(Color.posSecondaryText)
+                    .font(Constants.itemDetailFont)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
@@ -50,7 +50,8 @@ private extension VariationCardView {
                                  formattedPrice: "$5.00",
                                  price: "5.00",
                                  productID: 134,
-                                 variationID: 256)
+                                 variationID: 256,
+                                 parentProductName: "Coffee")
     VariationCardView(variation: variation)
 }
 
@@ -61,6 +62,7 @@ private extension VariationCardView {
                                  price: "5.00",
                                  productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg",
                                  productID: 134,
-                                 variationID: 256)
+                                 variationID: 256,
+                                 parentProductName: "Coffee")
     VariationCardView(variation: variation)
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
@@ -27,8 +27,8 @@ struct VariationCardView: View {
                     .font(Constants.itemNameFont)
 
                 Text(variation.formattedPrice)
-                    .foregroundStyle(Color.posPrimaryText)
-                    .font(Constants.itemPriceFont)
+                    .foregroundStyle(Color.posSecondaryText)
+                    .font(Constants.itemDetailFont)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -33,11 +33,11 @@ struct ItemListView: View {
             .navigationDestination(for: POSItem.self, destination: { item in
                 childListView(parentItem: item)
             })
+            .background(Color.posPrimaryBackground)
         }
         .refreshable {
             await posModel.reloadItems(base: .root)
         }
-        .background(Color.posPrimaryBackground)
         .accessibilityElement(children: .contain)
         .posModal(isPresented: $showSimpleProductsModal) {
             SimpleProductsOnlyInformation(isPresented: $showSimpleProductsModal)

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -49,12 +49,10 @@ struct ItemRowView: View {
         .background(backgroundColor)
         .overlay {
             RoundedRectangle(cornerRadius: Constants.productCardCornerRadius)
-                .stroke(Color.black, lineWidth: Constants.nilOutline)
+                .stroke(Color.posCartItemOutline, lineWidth: cardOutlineWidth)
         }
         .clipShape(RoundedRectangle(cornerRadius: Constants.productCardCornerRadius))
         .padding(.horizontal, Constants.horizontalPadding)
-        .padding(.vertical, Constants.verticalPadding)
-        .shadow(color: Color.black.opacity(0.08), radius: 4, y: 2)
     }
 
     @ViewBuilder
@@ -80,6 +78,15 @@ struct ItemRowView: View {
 }
 
 private extension ItemRowView {
+    var cardOutlineWidth: CGFloat {
+        switch colorScheme {
+        case .dark:
+            return 0
+        default:
+            return Constants.cardOutlineWidth
+        }
+    }
+
     var backgroundColor: Color {
         switch colorScheme {
         case .dark:
@@ -95,10 +102,7 @@ private extension ItemRowView {
         static let productCardSize: CGFloat = 96
         static let maximumProductCardSize: CGFloat = Self.productCardSize * 1.5
         static let productCardCornerRadius: CGFloat = 8
-        // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
-        // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
-        static let nilOutline: CGFloat = 0
-        static let verticalPadding: CGFloat = 4
+        static let cardOutlineWidth: CGFloat = 1
         static let horizontalPadding: CGFloat = 16
         static let horizontalElementSpacing: CGFloat = 16
         static let itemTitleAndPriceSpacing: CGFloat = 4

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -14,23 +14,25 @@ struct ItemRowView: View {
     }
 
     var body: some View {
-        HStack(spacing: Constants.horizontalCardSpacing) {
+        HStack(spacing: Constants.horizontalElementSpacing) {
             productImage
 
-            VStack(alignment: .leading, spacing: Constants.itemNameAndPriceSpacing) {
-                Text(cartItem.item.name)
+            VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
+                Text(cartItem.title)
                     .foregroundColor(Color.posPrimaryText)
-                    .font(Constants.itemNameFont)
-                    .padding(.leading, Constants.horizontalElementSpacing * (1 / scale))
-                    .padding(.top, Constants.verticalPadding * (1 / scale))
+                    .font(Constants.itemTitleFont)
+                if let subtitle = cartItem.subtitle {
+                    Text(subtitle)
+                        .foregroundColor(Color.posSecondaryText)
+                        .font(Constants.itemSubtitleFont)
+                }
                 Text(cartItem.item.formattedPrice)
-                    .foregroundColor(Color.posPrimaryText)
+                    .foregroundColor(Color.posSecondaryText)
                     .font(Constants.itemPriceFont)
-                    .padding(.leading, Constants.horizontalElementSpacing * (1 / scale))
-                    .padding(.bottom, Constants.verticalPadding * (1 / scale))
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
-            Spacer()
+
             if let onItemRemoveTapped {
                 Button(action: {
                     onItemRemoveTapped()
@@ -90,7 +92,7 @@ private extension ItemRowView {
 
 private extension ItemRowView {
     enum Constants {
-        static let productCardSize: CGFloat = 76
+        static let productCardSize: CGFloat = 96
         static let maximumProductCardSize: CGFloat = Self.productCardSize * 1.5
         static let productCardCornerRadius: CGFloat = 8
         // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
@@ -98,10 +100,10 @@ private extension ItemRowView {
         static let nilOutline: CGFloat = 0
         static let verticalPadding: CGFloat = 4
         static let horizontalPadding: CGFloat = 16
-        static let horizontalCardSpacing: CGFloat = 0
         static let horizontalElementSpacing: CGFloat = 16
-        static let itemNameAndPriceSpacing: CGFloat = 8
-        static let itemNameFont: POSFontStyle = .posDetailEmphasized
+        static let itemTitleAndPriceSpacing: CGFloat = 4
+        static let itemTitleFont: POSFontStyle = .posDetailEmphasized
+        static let itemSubtitleFont: POSFontStyle = .posDetailLight
         static let itemPriceFont: POSFontStyle = .posDetailLight
     }
 
@@ -115,9 +117,22 @@ private extension ItemRowView {
 }
 
 #if DEBUG
-#Preview {
+@available(iOS 17.0, *)
+#Preview(traits: .sizeThatFitsLayout) {
     ItemRowView(cartItem: CartItem(id: UUID(),
                                    item: PointOfSalePreviewItemService().providePointOfSaleItem(),
+                                   title: "Item Title",
+                                   subtitle: "Item Subtitle",
+                                   quantity: 2),
+                onItemRemoveTapped: { })
+}
+
+@available(iOS 17.0, *)
+#Preview(traits: .sizeThatFitsLayout) {
+    ItemRowView(cartItem: CartItem(id: UUID(),
+                                   item: PointOfSalePreviewItemService().providePointOfSaleItem(),
+                                   title: "Item Title",
+                                   subtitle: nil,
                                    quantity: 2),
                 onItemRemoveTapped: { })
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemCardBorderStylesModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemCardBorderStylesModifier.swift
@@ -8,7 +8,6 @@ struct POSItemCardBorderStylesModifier: ViewModifier {
                     .stroke(Color.black, lineWidth: Constants.nilOutline)
             }
             .clipShape(RoundedRectangle(cornerRadius: Constants.cardCornerRadius))
-            .shadow(color: Color.black.opacity(0.08), radius: 4, y: 2)
     }
 }
 

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -55,6 +55,14 @@ extension Color {
         )
     }
 
+    // An ugly duckling; intended for use for borders where the bordered view has
+    // `.posSecondaryBackground` in light mode, even though it's on another `.posSecondaryBackground` view. Does not adapt
+    static var posCartItemOutline: Color {
+        Color(
+            UIColor(red: 220.0/255.0, green: 220.0/255.0, blue: 222.0/255.0, alpha: 1.0)
+        )
+    }
+
     // MARK: - Text
 
     static var posPrimaryText: Color {

--- a/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
+++ b/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
@@ -7,6 +7,8 @@ enum POSFontStyle {
     case posTitleEmphasized
     case posBodyRegular
     case posBodyEmphasized
+    case posLargeDetailEmphasized
+    case posLargeDetailRegular
     case posDetailLight
     case posDetailRegular
     case posDetailEmphasized
@@ -22,6 +24,10 @@ enum POSFontStyle {
             Font.system(size: scaledValue(24, maximumContentSizeCategory: maximumContentSizeCategory), weight: .regular)
         case .posBodyEmphasized:
             Font.system(size: scaledValue(24, maximumContentSizeCategory: maximumContentSizeCategory), weight: .bold)
+        case .posLargeDetailEmphasized:
+            Font.system(size: scaledValue(20, maximumContentSizeCategory: maximumContentSizeCategory), weight: .semibold)
+        case .posLargeDetailRegular:
+            Font.system(size: scaledValue(20, maximumContentSizeCategory: maximumContentSizeCategory), weight: .regular)
         case .posDetailLight:
             Font.system(size: scaledValue(16, maximumContentSizeCategory: maximumContentSizeCategory), weight: .regular)
         case .posDetailRegular:

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -114,13 +114,15 @@ private var mockVariationItems: [POSItem] {
                          formattedPrice: "$1.00",
                          price: "1.00",
                          productID: 134,
-                         variationID: 256)),
+                         variationID: 256,
+                         parentProductName: "Variable product")),
         .variation(.init(id: UUID(),
                          name: "Variation 2",
                          formattedPrice: "$2.00",
                          price: "2.00",
                          productID: 134,
-                         variationID: 256)),
+                         variationID: 256,
+                         parentProductName: "Variable product")),
     ]
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -193,5 +193,7 @@ private func makeItem(name: String = "",
                     item: MockPOSOrderableItem(name: name,
                                                formattedPrice: formattedPrice,
                                                orderItemsToMatch: orderItemsToMatch),
+                    title: name,
+                    subtitle: nil,
                     quantity: quantity)
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -91,14 +91,16 @@ extension MockPointOfSaleItemService {
                                       formattedPrice: "$2.00",
                                       price: "2.00",
                                       productID: 1,
-                                      variationID: 1)
+                                      variationID: 1,
+                                      parentProductName: "Ice cream")
 
         let variation2 = POSVariation(id: fakeUUID2,
                                       name: "Vanilla",
                                       formattedPrice: "$2.00",
                                       price: "2.00",
                                       productID: 1,
-                                      variationID: 2)
+                                      variationID: 2,
+                                      parentProductName: "Ice cream")
         return [.variation(variation1), .variation(variation2)]
     }
 
@@ -111,14 +113,16 @@ extension MockPointOfSaleItemService {
                                       formattedPrice: "$2.00",
                                       price: "2.00",
                                       productID: 1,
-                                      variationID: 3)
+                                      variationID: 3,
+                                      parentProductName: "Ice cream")
 
         let variation4 = POSVariation(id: fakeUUID4,
                                       name: "Pistachio",
                                       formattedPrice: "$3.00",
                                       price: "2.00",
                                       productID: 1,
-                                      variationID: 4)
+                                      variationID: 4,
+                                      parentProductName: "Ice cream")
         return [.variation(variation3), .variation(variation4)]
     }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -48,7 +48,7 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
 
     var cart: [CartItem] = []
 
-    func addToCart(_ item: POSOrderableItem) { }
+    func addToCart(_ item: POSItem) { }
 
     func remove(cartItem: CartItem) { }
 

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import WooCommerce
 import protocol Yosemite.POSOrderableItem
+import enum Yosemite.POSItem
 @testable import struct Yosemite.POSSimpleProduct
 import struct Yosemite.Order
 import Combine
@@ -113,7 +114,7 @@ struct PointOfSaleAggregateModelTests {
 
             // Then
             #expect(sut.cart.count == 1)
-            #expect(sut.cart.first?.item.name == item.name)
+            #expect(sut.cart.first?.title == "Item 1")
         }
 
         @Test func removeAllItemsFromCart_removes_everything() async throws {
@@ -525,8 +526,13 @@ struct PointOfSaleAggregateModelTests {
     }
 }
 
-private func makeItem(name: String = "") -> POSOrderableItem {
-    return MockPOSOrderableItem(name: name, formattedPrice: "")
+private func makeItem(name: String = "") -> POSItem {
+    return .simpleProduct(POSSimpleProduct(
+        id: UUID(),
+        name: name,
+        formattedPrice: "",
+        productID: 1,
+        price: ""))
 }
 
 private func makeLoadedOrderState(cartTotal: String = "",

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewHelperTests.swift
@@ -84,5 +84,9 @@ struct CartViewHelperTests {
 }
 
 private func makeItem() -> CartItem {
-    CartItem(id: UUID(), item: MockPOSOrderableItem(name: "Item", formattedPrice: "$1.00"), quantity: 1)
+    CartItem(id: UUID(),
+             item: MockPOSOrderableItem(name: "Item", formattedPrice: "$1.00"),
+             title: "Item",
+             subtitle: nil,
+             quantity: 1)
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/ProductVariationFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/ProductVariationFormatterTests.swift
@@ -28,6 +28,20 @@ final class ProductVariationFormatterTests: XCTestCase {
         XCTAssertEqual(name, "Blue - Any Size")
     }
 
+    func test_generateNameWithAttributeNames_returns_expected_name_with_attribute_names() {
+        // Given
+        let productAttributes = [ProductAttribute.fake().copy(attributeID: 1, name: "Color"), ProductAttribute.fake().copy(attributeID: 2, name: "Size")]
+        let variation = ProductVariation.fake().copy(attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")])
+
+        // When
+        let name = ProductVariationFormatter().generateNameWithAttributeNames(for: variation,
+                                                                              from: productAttributes,
+                                                                              separator: ", ")
+
+        // Then
+        XCTAssertEqual(name, "Color: Blue, Any Size")
+    }
+
     func test_generateAttributes_returns_expected_attributes() {
         // Given
         let productAttributes = [ProductAttribute.fake().copy(attributeID: 1, name: "Color"), ProductAttribute.fake().copy(attributeID: 2, name: "Size")]

--- a/Yosemite/Yosemite/PointOfSale/POSVariation.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSVariation.swift
@@ -14,7 +14,10 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
     public let productVariationID: Int64
     public let price: String
 
-    public init(id: UUID, name: String, formattedPrice: String, price: String, productImageSource: String? = nil, productID: Int64, variationID: Int64) {
+    // Variation specific
+    public let parentProductName: String
+
+    public init(id: UUID, name: String, formattedPrice: String, price: String, productImageSource: String? = nil, productID: Int64, variationID: Int64, parentProductName: String) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -22,6 +25,7 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
         self.productImageSource = productImageSource
         self.productID = productID
         self.productVariationID = variationID
+        self.parentProductName = parentProductName
     }
 }
 

--- a/Yosemite/Yosemite/PointOfSale/POSVariation.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSVariation.swift
@@ -17,7 +17,14 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
     // Variation specific
     public let parentProductName: String
 
-    public init(id: UUID, name: String, formattedPrice: String, price: String, productImageSource: String? = nil, productID: Int64, variationID: Int64, parentProductName: String) {
+    public init(id: UUID,
+                name: String,
+                formattedPrice: String,
+                price: String,
+                productImageSource: String? = nil,
+                productID: Int64,
+                variationID: Int64,
+                parentProductName: String) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -74,7 +74,8 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             items: variations.compactMap({ variation in
                 let variationName = ProductVariationFormatter().generateName(
                     for: variation,
-                    from: parentProduct.allAttributes
+                    from: parentProduct.allAttributes,
+                    separator: ", "
                 )
                 return POSItem
                     .variation(.init(id: UUID(),

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -72,7 +72,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
         let variations = pagedVariations.items
         return .init(
             items: variations.compactMap({ variation in
-                let variationName = ProductVariationFormatter().generateName(
+                let variationName = ProductVariationFormatter().generateNameWithAttributeNames(
                     for: variation,
                     from: parentProduct.allAttributes,
                     separator: ", "

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -83,7 +83,8 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                                      price: variation.price,
                                      productImageSource: variation.image?.src,
                                      productID: variation.productID,
-                                     variationID: variation.productVariationID))
+                                     variationID: variation.productVariationID,
+                                     parentProductName: parentProduct.name))
             }),
             hasMorePages: pagedVariations.hasMorePages
         )

--- a/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
@@ -9,10 +9,13 @@ public struct ProductVariationFormatter {
     /// - Parameters:
     ///   - variation: The product variation whose name is being generated
     ///   - allAttributes: A list of attributes from the parent `Product`
+    ///   - separator: The string to use to separate attributes used to make up the name. Default `" - "`
     ///
-    public func generateName(for variation: ProductVariation, from allAttributes: [ProductAttribute]) -> String {
+    public func generateName(for variation: ProductVariation,
+                             from allAttributes: [ProductAttribute],
+                             separator: String = " - ") -> String {
         let variationAttributes = generateAttributes(for: variation, from: allAttributes)
-        return variationAttributes.map { $0.nameOrValue }.joined(separator: " - ")
+        return variationAttributes.map { $0.nameOrValue }.joined(separator: separator)
     }
 
     /// Generates the variation attributes, given a list of the parent product attributes.

--- a/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
@@ -18,6 +18,19 @@ public struct ProductVariationFormatter {
         return variationAttributes.map { $0.nameOrValue }.joined(separator: separator)
     }
 
+    /// Generates a name for the product variation, given a list of the parent product attributes, e.g. "Color: Blue - Any Size"
+    /// - Parameters:
+    ///   - variation: The product variation whose name is being generated
+    ///   - allAttributes: A list of attributes from the parent `Product`
+    ///   - separator: The string to use to separate attributes used to make up the name. Default `" - "`
+    ///
+    public func generateNameWithAttributeNames(for variation: ProductVariation,
+                                               from allAttributes: [ProductAttribute],
+                                               separator: String = " - ") -> String {
+        let variationAttributes = generateAttributes(for: variation, from: allAttributes)
+        return variationAttributes.map { $0.namedValue }.joined(separator: separator)
+    }
+
     /// Generates the variation attributes, given a list of the parent product attributes.
     /// - Parameters:
     ///   - variation: The product variation whose attributes are being generated

--- a/Yosemite/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
@@ -11,13 +11,26 @@ public struct VariationAttributeViewModel: Equatable {
     ///
     public let value: String?
 
-    /// Returns the attribute value, or "Any \(name)" if the attribute value is nil or empty
+    /// Returns the attribute value, e.g. "100g", or "Any \(name)" if the attribute value is nil or empty
     ///
     public var nameOrValue: String {
         guard let value = value, !value.isEmpty else {
-            return String(format: Localization.anyAttributeFormat, name)
+            return anyAttributeDescription
         }
         return value
+    }
+
+    /// Returns the named attribute value, e.g. "Size: 100g", or "Any \(name)" if the attribute value is nil or empty
+    ///
+    public var namedValue: String {
+        guard let value, !value.isEmpty else {
+            return anyAttributeDescription
+        }
+        return String(format: Localization.namedAttributeFormat, name, value)
+    }
+
+    private var anyAttributeDescription: String {
+        String(format: Localization.anyAttributeFormat, name)
     }
 
     public init(name: String, value: String? = nil) {
@@ -36,7 +49,17 @@ public struct VariationAttributeViewModel: Equatable {
 
 extension VariationAttributeViewModel {
     enum Localization {
-        static let anyAttributeFormat =
-            NSLocalizedString("Any %1$@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
+        static let anyAttributeFormat = NSLocalizedString(
+            "Any %1$@",
+            comment: "Format of a product variation attribute description where the attribute is set to any value."
+        )
+
+        static let namedAttributeFormat = NSLocalizedString(
+            "",
+            value: "%1$@: %2$@",
+            comment: "Format of a named variation attribute description. %1$@ is the attribute name, and %2$@ is the " +
+            "attribute value. Displayed in a whole variation of a Coffee beans/grounds product, it could look like: +" +
+            "'Roast: Dark, Size: 100g, Origin: Brazil, Any grind'"
+        )
     }
 }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -205,7 +205,8 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         }
         XCTAssertEqual(
             firstVariation.name,
-            "marble, nuts, 99%, \(String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Size"))"
+            "Shape: marble, Flavor: nuts, Darkness: 99%, " +
+            String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Size")
         )
         XCTAssertEqual(firstVariation.formattedPrice, "$12.00")
         XCTAssertEqual(firstVariation.price, "12")

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -205,7 +205,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         }
         XCTAssertEqual(
             firstVariation.name,
-            "marble - nuts - 99% - \(String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Size"))"
+            "marble, nuts, 99%, \(String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Size"))"
         )
         XCTAssertEqual(firstVariation.formattedPrice, "$12.00")
         XCTAssertEqual(firstVariation.price, "12")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14772
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the various item cards to match the essential elements of the designs.

Some of the design details will be iterated on further outside this project when the design system is updated, so these changes do not match every detail of the designs in Figma yet. Context: p1736943933521109-slack-C070SJRA8DP

### Areas covered:
- Simple Product item list card
- Parent Product item list card
- Variation item list card
- Cart Item card

On the cart item, for variations, an additional row is shown containing the parent product name to give proper context.
Wherever variations are displayed, their attributes are now comma-separated, not dash separated.

Note that the delete icon has not been updated to a trash can yet; this will be done along with the change to the `Clear all` button.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS
2. Add items to your cart and review their UI designs
3. Check dark mode and accessibility sizes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There's not a single, canonical link or screenshot for the design, unfortunately. Here are some P2 posts and figma links that may be of use:

p91TBi-crW-p2
p91TBi-cpF-p2
rNAclWFAdQRw7EXEcsNVai-fi-2662_8766

I've tested on an iPad Air running iOS 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![IMG_0283](https://github.com/user-attachments/assets/ae433193-e0a9-4507-a279-f3aff7d86435)
![IMG_0284](https://github.com/user-attachments/assets/3a14f6ea-5819-4760-915c-a9b52ee7f83a)
![IMG_0285](https://github.com/user-attachments/assets/ce8c05df-2b51-4c41-9c3f-ea993614717d)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.