### PR TITLE
[Revamp Shipping Labels - Customs] Wire data

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -147,10 +147,10 @@ struct WooShippingCustomsForm: View {
                         presentationMode.wrappedValue.dismiss()
                         viewModel.onDismiss()
                     } label: {
-                        Text(viewModel.informationIsMissing ? Localization.addMissingInformationButtonTitle : Localization.saveCustomsDetailsButtonTitle)
+                        Text(viewModel.requiredInformationIsEntered ? Localization.saveCustomsDetailsButtonTitle : Localization.addMissingInformationButtonTitle)
                     }
                     .buttonStyle(PrimaryButtonStyle())
-                    .disabled(viewModel.informationIsMissing)
+                    .disabled(!viewModel.requiredInformationIsEntered)
                     .padding(Constants.bottomButtonPadding)
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -12,6 +12,7 @@ struct WooShippingCustomsForm: View {
             // show selection
             ForEach(WooShippingContentType.allCases, id: \.self) { option in
                 Button {
+                    viewModel.contentType = option
                 } label: {
                     Text(option.name)
                         .bodyStyle()
@@ -37,6 +38,7 @@ struct WooShippingCustomsForm: View {
             // show selection
             ForEach(WooShippingRestrictionType.allCases, id: \.self) { option in
                 Button {
+                    viewModel.restrictionType = option
                 } label: {
                     Text(option.name)
                         .bodyStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -115,15 +115,9 @@ struct WooShippingCustomsForm: View {
                                     .tertiaryTitleStyle()
                                     .padding(.bottom, Constants.defaultVerticalSpacing)
 
-                                // Dummy data
-                                WooShippingCustomsItem(viewModel: WooShippingCustomsItemViewModel(
-                                    title: "Little Nap Brazil 250g",
-                                    description: "",
-                                    hsTariffNumber: "",
-                                    valuePerUnit: "",
-                                    weightPerUnit: "",
-                                    originCountry: WooShippingCustomsCountry(code: "US", name: "United States"))
-                                )
+                                ForEach(viewModel.itemsViewModels, id: \.title) { itemViewModel in
+                                    WooShippingCustomsItem(viewModel: itemViewModel)
+                                }
                             }
                             .padding()
                             .toolbar {
@@ -151,6 +145,7 @@ struct WooShippingCustomsForm: View {
                     Button {
                         // TODO: Save values
                         presentationMode.wrappedValue.dismiss()
+                        viewModel.onDismiss()
                     } label: {
                         Text(viewModel.informationIsMissing ? Localization.addMissingInformationButtonTitle : Localization.saveCustomsDetailsButtonTitle)
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -57,6 +57,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
 
 private extension WooShippingCustomsFormViewModel {
     func listenToItemsRequiredInformationValues() {
+        // Listen to the items required information and enable the button depending on it
         $itemsViewModels
             .map { childViewModels in
                 childViewModels.map { $0.$requiredInformationIsEntered.eraseToAnyPublisher() }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import Yosemite
+import Combine
+import WooFoundation
 
 final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published var internationalTransactionNumber: String = ""
@@ -8,22 +10,20 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     let onCompletion: (ShippingLabelCustomsForm) -> ()
     let orderItems: [OrderItem]
 
-    var informationIsMissing: Bool {
-        true
-    }
+    @Published var requiredInformationIsEntered: Bool = false
 
     let contentType: WooShippingContentType = .merchandise
     let restrictionType: WooShippingRestrictionType = .none
 
     let itnInfoURL = URL(string: "https://pe.usps.com/text/imm/immc5_010.htm")
 
+    private var cancellables = Set<AnyCancellable>()
+
     init(orderItems: [OrderItem], onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
         self.onCompletion = onCompletion
         self.orderItems = orderItems
-    }
 
-    var itemsViewModels: [WooShippingCustomsItemViewModel] {
-        orderItems.map {
+        itemsViewModels = orderItems.map {
             WooShippingCustomsItemViewModel(
                 title: $0.name,
                 description: $0.name,
@@ -33,7 +33,11 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                 originCountry: WooShippingCustomsCountry(code: "US", name: "United States")
             )
         }
+
+        listenToItemsRequiredInformationValues()
     }
+
+    @Published var itemsViewModels: [WooShippingCustomsItemViewModel] = []
 
     func onDismiss() {
         let form = ShippingLabelCustomsForm(packageID: "",
@@ -46,6 +50,25 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                             itn: internationalTransactionNumber,
                                             items: [])
         onCompletion(form)
+    }
+}
+
+private extension WooShippingCustomsFormViewModel {
+    func listenToItemsRequiredInformationValues() {
+        $itemsViewModels
+            .map { childViewModels in
+                childViewModels.map { $0.$requiredInformationIsEntered.eraseToAnyPublisher() }
+            }
+            .flatMap { childPublishers in
+                childPublishers.combineLatest() // Combine the latest values from all child publishers
+            }
+            .map { childValidityArray in
+                childValidityArray.allSatisfy { $0 } // Check if all are valid
+            }
+            .sink { [weak self] value in
+                self?.requiredInformationIsEntered = value
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -22,14 +22,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
         self.onCompletion = onCompletion
 
         itemsViewModels = orderItems.map {
-            WooShippingCustomsItemViewModel(
-                description: $0.name,
-                hsTariffNumber: "",
-                valuePerUnit: "",
-                weightPerUnit: "",
-                originCountry: WooShippingCustomsCountry(code: "US", name: "United States"),
-                orderItem: $0
-            )
+            WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "US", name: "United States"), orderItem: $0)
         }
 
         listenToItemsRequiredInformationValues()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -32,6 +32,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published var itemsViewModels: [WooShippingCustomsItemViewModel] = []
 
     func onDismiss() {
+        // TODO: Add missing values if possible
         let form = ShippingLabelCustomsForm(packageID: "",
                                             packageName: "",
                                             contentsType: contentType.toFormContentsType(),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -11,8 +11,8 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
 
     @Published var requiredInformationIsEntered: Bool = false
 
-    let contentType: WooShippingContentType = .merchandise
-    let restrictionType: WooShippingRestrictionType = .none
+    @Published var contentType: WooShippingContentType = .merchandise
+    @Published var restrictionType: WooShippingRestrictionType = .none
 
     let itnInfoURL = URL(string: "https://pe.usps.com/text/imm/immc5_010.htm")
 
@@ -22,7 +22,8 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
         self.onCompletion = onCompletion
 
         itemsViewModels = orderItems.map {
-            WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "US", name: "United States"), orderItem: $0)
+            WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "US", name: "United States"),
+                                            orderItem: $0)
         }
 
         listenToItemsRequiredInformationValues()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -7,8 +7,6 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published var internationalTransactionNumber: String = ""
     @Published var returnToSenderIfNotDelivered: Bool = false
 
-    let onCompletion: (ShippingLabelCustomsForm) -> ()
-
     @Published var requiredInformationIsEntered: Bool = false
 
     @Published var contentType: WooShippingContentType = .merchandise
@@ -17,6 +15,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     let itnInfoURL = URL(string: "https://pe.usps.com/text/imm/immc5_010.htm")
 
     private var cancellables = Set<AnyCancellable>()
+    private let onCompletion: (ShippingLabelCustomsForm) -> ()
 
     init(orderItems: [OrderItem], onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
         self.onCompletion = onCompletion

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -44,7 +44,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                           quantity: $0.orderItem.quantity,
                                           value: Double($0.valuePerUnit) ?? 0,
                                           weight: Double($0.weightPerUnit) ?? 0,
-                                          hsTariffNumber: $0.hsTariffNumber,
+                                          hsTariffNumber: $0.isValidTariffNumber ? $0.hsTariffNumber : "",
                                           originCountry: $0.originCountry.name,
                                           productID: $0.orderItem.productID)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -8,7 +8,6 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published var returnToSenderIfNotDelivered: Bool = false
 
     let onCompletion: (ShippingLabelCustomsForm) -> ()
-    let orderItems: [OrderItem]
 
     @Published var requiredInformationIsEntered: Bool = false
 
@@ -21,16 +20,15 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
 
     init(orderItems: [OrderItem], onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
         self.onCompletion = onCompletion
-        self.orderItems = orderItems
 
         itemsViewModels = orderItems.map {
             WooShippingCustomsItemViewModel(
-                title: $0.name,
                 description: $0.name,
                 hsTariffNumber: "",
                 valuePerUnit: "",
                 weightPerUnit: "",
-                originCountry: WooShippingCustomsCountry(code: "US", name: "United States")
+                originCountry: WooShippingCustomsCountry(code: "US", name: "United States"),
+                orderItem: $0
             )
         }
 
@@ -48,7 +46,16 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                             restrictionComments: "",
                                             nonDeliveryOption: returnToSenderIfNotDelivered ? .return : .abandon,
                                             itn: internationalTransactionNumber,
-                                            items: [])
+                                            items: itemsViewModels.map {
+            ShippingLabelCustomsForm.Item(description: $0.description,
+                                          quantity: $0.orderItem.quantity,
+                                          value: Double($0.valuePerUnit) ?? 0,
+                                          weight: Double($0.weightPerUnit) ?? 0,
+                                          hsTariffNumber: $0.hsTariffNumber,
+                                          originCountry: $0.originCountry.name,
+                                          productID: $0.orderItem.productID)
+            }
+        )
         onCompletion(form)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -1,11 +1,15 @@
 import SwiftUI
+import Yosemite
 
 final class WooShippingCustomsFormViewModel: ObservableObject {
-    @Published var internationalTransactionNumber: String
-    @Published var returnToSenderIfNotDelivered: Bool
+    @Published var internationalTransactionNumber: String = ""
+    @Published var returnToSenderIfNotDelivered: Bool = false
+
+    let onCompletion: (ShippingLabelCustomsForm) -> ()
+    let orderItems: [OrderItem]
 
     var informationIsMissing: Bool {
-        false
+        true
     }
 
     let contentType: WooShippingContentType = .merchandise
@@ -13,9 +17,35 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
 
     let itnInfoURL = URL(string: "https://pe.usps.com/text/imm/immc5_010.htm")
 
-    init(internationalTransactionNumber: String, returnToSenderIfNotDelivered: Bool) {
-        self.internationalTransactionNumber = internationalTransactionNumber
-        self.returnToSenderIfNotDelivered = returnToSenderIfNotDelivered
+    init(orderItems: [OrderItem], onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
+        self.onCompletion = onCompletion
+        self.orderItems = orderItems
+    }
+
+    var itemsViewModels: [WooShippingCustomsItemViewModel] {
+        orderItems.map {
+            WooShippingCustomsItemViewModel(
+                title: $0.name,
+                description: $0.name,
+                hsTariffNumber: "",
+                valuePerUnit: "",
+                weightPerUnit: "",
+                originCountry: WooShippingCustomsCountry(code: "US", name: "United States")
+            )
+        }
+    }
+
+    func onDismiss() {
+        let form = ShippingLabelCustomsForm(packageID: "",
+                                            packageName: "",
+                                            contentsType: contentType.toFormContentsType(),
+                                            contentExplanation: "",
+                                            restrictionType: restrictionType.toFormRestrictionType(),
+                                            restrictionComments: "",
+                                            nonDeliveryOption: returnToSenderIfNotDelivered ? .return : .abandon,
+                                            itn: internationalTransactionNumber,
+                                            items: [])
+        onCompletion(form)
     }
 }
 
@@ -53,6 +83,19 @@ extension WooShippingRestrictionType {
         static let other = NSLocalizedString("wooShipping.customs.restrictionType.other",
                                                    value: "Other",
                                                    comment: "Info label for shipping restriction type other")
+    }
+
+    func toFormRestrictionType() -> ShippingLabelCustomsForm.RestrictionType {
+        switch self {
+        case .none:
+            return .none
+        case .quarantine:
+            return .quarantine
+        case .sanitary:
+            return .sanitaryOrPhytosanitaryInspection
+        case .other:
+            return .other
+        }
     }
 }
 
@@ -101,5 +144,22 @@ extension WooShippingContentType {
         static let other = NSLocalizedString("wooShipping.customs.contentType.other",
                                                    value: "Other...",
                                                    comment: "Info label for shipping content type merchandise")
+    }
+
+    func toFormContentsType() -> ShippingLabelCustomsForm.ContentsType {
+        switch self {
+        case .merchandise:
+            return .merchandise
+        case .gift:
+            return .gift
+        case .returnedGoods:
+            return .other
+        case .sample:
+            return .sample
+        case .documents:
+            return .documents
+        case .other:
+            return .other
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -22,6 +22,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
         self.onCompletion = onCompletion
 
         itemsViewModels = orderItems.map {
+            // TODO: Pass the origin country
             WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "US", name: "United States"),
                                             orderItem: $0)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -26,7 +26,7 @@ struct WooShippingCustomsItem: View {
                     Spacer()
                     Image(systemName: "exclamationmark.circle")
                         .foregroundColor(warningRedColor)
-                        .renderedIf(viewModel.requiredInformationIsMissing)
+                        .renderedIf(!viewModel.requiredInformationIsEntered)
                 }
 
                 VStack(alignment: .leading, spacing: Layout.collapsibleViewBottomLabelVerticalSpacing) {
@@ -231,10 +231,10 @@ struct WooShippingCustomsItem: View {
 extension WooShippingCustomsItem {
     func productCardBorderColor() -> Color {
         if isCollapsed {
-            if viewModel.requiredInformationIsMissing {
-                return warningRedColor
-            } else {
+            if viewModel.requiredInformationIsEntered {
                 return Color(.separator)
+            } else {
+                return warningRedColor
             }
         } else {
             return .withColorStudio(name: .purple, shade: .shade60)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -1,5 +1,6 @@
 import Yosemite
 import SwiftUI
+import Combine
 import protocol Storage.StorageManagerType
 
 struct WooShippingCustomsCountry: Hashable {
@@ -49,9 +50,9 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
         return length >= 6 && length <= 12
     }
 
-    var requiredInformationIsMissing: Bool {
-        description.isEmpty || valuePerUnit.isEmpty || weightPerUnit.isEmpty
-    }
+    @Published var requiredInformationIsEntered: Bool = false
+
+    private var cancellables = Set<AnyCancellable>()
 
     init(title: String,
          description: String,
@@ -72,6 +73,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
 
         fetchCountries()
+        combineRequiredInformationIsEntered()
     }
 }
 
@@ -89,5 +91,13 @@ extension WooShippingCustomsItemViewModel {
         }
 
         stores.dispatch(action)
+    }
+
+    func combineRequiredInformationIsEntered() {
+        Publishers.CombineLatest3($description, $valuePerUnit, $weightPerUnit)
+            .sink { [weak self] description, valuePerUnit, weightPerUnit in
+                self?.requiredInformationIsEntered = description.isNotEmpty && valuePerUnit.isNotEmpty && weightPerUnit.isNotEmpty
+            }
+            .store(in: &cancellables)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -10,10 +10,10 @@ struct WooShippingCustomsCountry: Hashable {
 
 final class WooShippingCustomsItemViewModel: ObservableObject {
     @Published var title: String
-    @Published var description: String
-    @Published var hsTariffNumber: String
-    @Published var valuePerUnit: String
-    @Published var weightPerUnit: String
+    @Published var description: String = ""
+    @Published var hsTariffNumber: String = ""
+    @Published var valuePerUnit: String = ""
+    @Published var weightPerUnit: String = ""
     @Published var originCountry: WooShippingCustomsCountry
 
     private let storageManager: StorageManagerType
@@ -55,19 +55,11 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(description: String,
-         hsTariffNumber: String,
-         valuePerUnit: String,
-         weightPerUnit: String,
-         originCountry: WooShippingCustomsCountry,
+    init(originCountry: WooShippingCustomsCountry,
          orderItem: OrderItem,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores) {
         self.title = orderItem.name
-        self.description = description
-        self.hsTariffNumber = hsTariffNumber
-        self.valuePerUnit = valuePerUnit
-        self.weightPerUnit = weightPerUnit
         self.originCountry = originCountry
         self.orderItem = orderItem
         self.storageManager = storageManager

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -19,6 +19,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     private let storageManager: StorageManagerType
     private let stores: StoresManager
     private let siteID: Int64
+    let orderItem: OrderItem
 
     let hsTariffURL = WooConstants.URLs.hsTariffURL.asURL()
 
@@ -54,20 +55,21 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(title: String,
-         description: String,
+    init(description: String,
          hsTariffNumber: String,
          valuePerUnit: String,
          weightPerUnit: String,
          originCountry: WooShippingCustomsCountry,
+         orderItem: OrderItem,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores) {
-        self.title = title
+        self.title = orderItem.name
         self.description = description
         self.hsTariffNumber = hsTariffNumber
         self.valuePerUnit = valuePerUnit
         self.weightPerUnit = weightPerUnit
         self.originCountry = originCountry
+        self.orderItem = orderItem
         self.storageManager = storageManager
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 import WooFoundation
+import Yosemite
 
 struct WooShippingCustomsRow: View {
     let informationIsCompleted: Bool
+    let customsFormViewModel: WooShippingCustomsFormViewModel
+
     @ScaledMetric private var scale: CGFloat = 1.0
     @State private var showCustomsForm: Bool = false
 
@@ -35,8 +38,7 @@ struct WooShippingCustomsRow: View {
         .padding(Layout.borderPadding)
         .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
         .sheet(isPresented: $showCustomsForm) {
-            WooShippingCustomsForm(viewModel: WooShippingCustomsFormViewModel(internationalTransactionNumber: "123",
-                                                                              returnToSenderIfNotDelivered: true))
+            WooShippingCustomsForm(viewModel: customsFormViewModel)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -51,6 +51,7 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
                                           customsFormViewModel: WooShippingCustomsFormViewModel(orderItems: viewModel.orderItems, onCompletion: { form in
+                        // TODO: Remove debug print
                         debugPrint("form", form)
                     }))
                         .padding(.bottom, 16)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -49,7 +49,10 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingHazmat(enabled: !viewModel.canViewLabel)
 
-                    WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted)
+                    WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
+                                          customsFormViewModel: WooShippingCustomsFormViewModel(orderItems: viewModel.orderItems, onCompletion: { form in
+                        debugPrint("form", form)
+                    }))
                         .padding(.bottom, 16)
 
                     if viewModel.canViewLabel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -25,7 +25,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Whether the custom information is completed or not.
     var customsInformationIsCompleted: Bool {
         // To be synced with real data
-        true
+        false
     }
 
     var orderItems: [OrderItem] {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -28,6 +28,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         true
     }
 
+    var orderItems: [OrderItem] {
+        order.items
+    }
+
     /// View model for the section displayed after a shipping label is purchased.
     @Published private(set) var postPurchase: WooShippingPostPurchaseViewModel?
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2052,6 +2052,7 @@
 		B95B15C92B15EBA000A54044 /* UpdateProductInventoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95B15C82B15EBA000A54044 /* UpdateProductInventoryViewModel.swift */; };
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
+		B976D5BB2D3808A000D01E2E /* WooShippingCustomsFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B976D5BA2D38089C00D01E2E /* WooShippingCustomsFormViewModelTests.swift */; };
 		B97C6E562B15E51A008A2BF2 /* UpdateProductInventoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */; };
 		B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */; };
 		B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */; };
@@ -5201,6 +5202,7 @@
 		B95B15C82B15EBA000A54044 /* UpdateProductInventoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryViewModel.swift; sourceTree = "<group>"; };
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
+		B976D5BA2D38089C00D01E2E /* WooShippingCustomsFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsFormViewModelTests.swift; sourceTree = "<group>"; };
 		B97C6E552B15E51A008A2BF2 /* UpdateProductInventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryView.swift; sourceTree = "<group>"; };
 		B98968562A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxEducationalDialogViewModelTests.swift; sourceTree = "<group>"; };
 		B98BA12C2AE90023006F1E4A /* OrderCustomAmountsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSection.swift; sourceTree = "<group>"; };
@@ -11166,6 +11168,7 @@
 		B9A5317D2D2FCC3900208304 /* WooShipping Customs */ = {
 			isa = PBXGroup;
 			children = (
+				B976D5BA2D38089C00D01E2E /* WooShippingCustomsFormViewModelTests.swift */,
 				B9A5317E2D2FCC5000208304 /* WooShippingCustomsItemViewModelTests.swift */,
 			);
 			path = "WooShipping Customs";
@@ -17057,6 +17060,7 @@
 				DEBAB70B2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift in Sources */,
 				CE6302462BAB528900E3325C /* CustomerListViewModelTests.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
+				B976D5BB2D3808A000D01E2E /* WooShippingCustomsFormViewModelTests.swift in Sources */,
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
 				CEC3CC742C9343DF00B93FBE /* WooShippingItemsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -43,4 +43,22 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         XCTAssertEqual(passedForm?.items.first?.hsTariffNumber, viewModel.itemsViewModels.first?.hsTariffNumber)
         XCTAssertEqual(passedForm?.items.first?.originCountry, viewModel.itemsViewModels.first?.originCountry.name)
     }
+
+    func test_onDismiss_when_calls_onCompletion_with_invalid_hsTariffNumber_then_returns_empty() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        var passedForm: ShippingLabelCustomsForm?
+        viewModel = WooShippingCustomsFormViewModel(orderItems: orderItems, onCompletion: { form in
+            passedForm = form
+        })
+
+        viewModel.itemsViewModels.first?.hsTariffNumber = "12"
+
+        // When
+        viewModel.onDismiss()
+
+        // Then
+        XCTAssertTrue(passedForm?.items.first?.hsTariffNumber.isEmpty ?? false)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+class WooShippingCustomsFormViewModelTests: XCTestCase {
+    private var viewModel: WooShippingCustomsFormViewModel!
+
+    func test_onDismiss_calls_onCompletion_with_right_values() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        var passedForm: ShippingLabelCustomsForm?
+        viewModel = WooShippingCustomsFormViewModel(orderItems: orderItems, onCompletion: { form in
+            passedForm = form
+        })
+
+        viewModel.restrictionType = .quarantine
+        viewModel.contentType = .gift
+        viewModel.internationalTransactionNumber = "1234"
+        viewModel.returnToSenderIfNotDelivered = false
+
+        viewModel.itemsViewModels.first?.description = "Test Item"
+        viewModel.itemsViewModels.first?.valuePerUnit = "10"
+        viewModel.itemsViewModels.first?.weightPerUnit = "5"
+        viewModel.itemsViewModels.first?.hsTariffNumber = "123456"
+        viewModel.itemsViewModels.first?.originCountry = WooShippingCustomsCountry(code: "US", name: "United States")
+
+        // When
+        viewModel.onDismiss()
+
+        // Then
+        XCTAssertEqual(passedForm?.restrictionType, .quarantine)
+        XCTAssertEqual(passedForm?.contentsType, .gift)
+        XCTAssertEqual(passedForm?.itn, viewModel.internationalTransactionNumber)
+        XCTAssertEqual(passedForm?.nonDeliveryOption, .abandon)
+
+        XCTAssertEqual(passedForm?.items.count, orderItems.count)
+        XCTAssertEqual(passedForm?.items.first?.productID, orderItems.first?.productID)
+        XCTAssertEqual(passedForm?.items.first?.quantity, orderItems.first?.quantity)
+        XCTAssertEqual(passedForm?.items.first?.description, viewModel.itemsViewModels.first?.description)
+        XCTAssertEqual(passedForm?.items.first?.value, Double(viewModel.itemsViewModels.first?.valuePerUnit ?? "0"))
+        XCTAssertEqual(passedForm?.items.first?.weight, Double(viewModel.itemsViewModels.first?.weightPerUnit ?? "0"))
+        XCTAssertEqual(passedForm?.items.first?.hsTariffNumber, viewModel.itemsViewModels.first?.hsTariffNumber)
+        XCTAssertEqual(passedForm?.items.first?.originCountry, viewModel.itemsViewModels.first?.originCountry.name)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -6,12 +6,8 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        viewModel = WooShippingCustomsItemViewModel(title: "",
-                                                    description: "",
-                                                    hsTariffNumber: "",
-                                                    valuePerUnit: "",
-                                                    weightPerUnit: "",
-                                                    originCountry: WooShippingCustomsCountry(code: "", name: "United States"))
+        viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
+                                                    orderItem: MockOrderItem.sampleItem())
     }
 
     func test_when_tariff_number_is_empty_then_it_is_valid() {

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		B99BC2122A1FAE5100E6008A /* CIImage+ImageCombination.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99BC2112A1FAE5100E6008A /* CIImage+ImageCombination.swift */; };
 		B99BC2142A1FAEBC00E6008A /* URL+QRCodeGeneration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99BC2132A1FAEBC00E6008A /* URL+QRCodeGeneration.swift */; };
 		B99BC2162A1FB21700E6008A /* UIImage+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99BC2152A1FB21700E6008A /* UIImage+Background.swift */; };
+		B9A531812D37F57700208304 /* Array+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A531802D37F56F00208304 /* Array+Combine.swift */; };
 		B9C9C63F283E703C001B879F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9C9C635283E703C001B879F /* WooFoundation.framework */; };
 		B9C9C659283E7195001B879F /* NSDecimalNumber+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C658283E7195001B879F /* NSDecimalNumber+Helpers.swift */; };
 		B9C9C65D283E71C8001B879F /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65B283E71C8001B879F /* CurrencyFormatter.swift */; };
@@ -157,6 +158,7 @@
 		B99BC2112A1FAE5100E6008A /* CIImage+ImageCombination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CIImage+ImageCombination.swift"; sourceTree = "<group>"; };
 		B99BC2132A1FAEBC00E6008A /* URL+QRCodeGeneration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+QRCodeGeneration.swift"; sourceTree = "<group>"; };
 		B99BC2152A1FB21700E6008A /* UIImage+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Background.swift"; sourceTree = "<group>"; };
+		B9A531802D37F56F00208304 /* Array+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Combine.swift"; sourceTree = "<group>"; };
 		B9AED558283E7553002A2668 /* Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9AED55B283E755A002A2668 /* Hardware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Hardware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9C9C635283E703C001B879F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -368,6 +370,7 @@
 		B9C9C657283E7174001B879F /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B9A531802D37F56F00208304 /* Array+Combine.swift */,
 				AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */,
 				B9C9C65F283E71F4001B879F /* Double+Woo.swift */,
 				B9C9C658283E7195001B879F /* NSDecimalNumber+Helpers.swift */,
@@ -706,6 +709,7 @@
 				2027F7522C8F0B95004BDF73 /* MockScheduler.swift in Sources */,
 				B9C9C663283E7296001B879F /* Logging.swift in Sources */,
 				6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */,
+				B9A531812D37F57700208304 /* Array+Combine.swift in Sources */,
 				B97190D1292CF3BC0065E413 /* Result+Extensions.swift in Sources */,
 				203758752AD55670000E4281 /* CountryCode.swift in Sources */,
 				6896C82A2C75D60D002DDAE2 /* MockAnalyticsPreview.swift in Sources */,

--- a/WooFoundation/WooFoundation/Extensions/Array+Combine.swift
+++ b/WooFoundation/WooFoundation/Extensions/Array+Combine.swift
@@ -1,6 +1,7 @@
 import Combine
 
 public extension Array where Element: Publisher {
+    /// Combines all the elemens of the array
     func combineLatest() -> AnyPublisher<[Element.Output], Element.Failure> {
         guard !isEmpty else {
             // If the array is empty, immediately return an empty array

--- a/WooFoundation/WooFoundation/Extensions/Array+Combine.swift
+++ b/WooFoundation/WooFoundation/Extensions/Array+Combine.swift
@@ -1,0 +1,14 @@
+import Combine
+
+public extension Array where Element: Publisher {
+    func combineLatest() -> AnyPublisher<[Element.Output], Element.Failure> {
+        guard !isEmpty else {
+            // If the array is empty, immediately return an empty array
+            return Just([]).setFailureType(to: Element.Failure.self).eraseToAnyPublisher()
+        }
+
+        return reduce(Just([]).setFailureType(to: Element.Failure.self).eraseToAnyPublisher()) { combined, next in
+            combined.combineLatest(next) { $0 + [$1] }.eraseToAnyPublisher()
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we retrieve the entered data in the Customs form and pass it back in the completion block. In the next steps we will add that data to the request.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Tap on Create Shipping Label on an order
2. Tap on the Customs pencil
3. Add data in the Customs form
4. Tap on Save Customs Details
5. Verify that the data is properly passed by checking the print statement in Xcode console

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Please also check:
- That the Save Customs Details is only enabled when all the required information is added
- That we don't send the HS Tarrif number unless it's valid

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/58348abd-8b7f-469b-8c20-6a610ddf23f6

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
