### PR TITLE
Remove feedback survey for Store setup

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [Internal] [*] Improved handling of the navigation to the Woo Installation screen post Jetpack setup [https://github.com/woocommerce/woocommerce-ios/pull/14837]
 - [*] Receipts: Email receipts can now be sent to customers after failed payments using WooCommerce Stripe 9.1.0+. [https://github.com/woocommerce/woocommerce-ios/pull/14864].
+- [Internal] Removed feedback survey for Store Setup feature [https://github.com/woocommerce/woocommerce-ios/pull/14888]
 
 21.4
 -----

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -198,14 +198,6 @@ extension WooConstants {
         ///
         case productsFeedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
 
-        /// URL for the store setup feedback survey
-        ///
-#if DEBUG
-        case storeSetupFeedback = "https://automattic.survey.fm/testing-debug-woo-mobile-–-store-setup-survey-2022"
-#else
-        case storeSetupFeedback = "https://automattic.survey.fm/woo-mobile-–-store-setup-survey-2022"
-#endif
-
         /// URL for the shipping labels M3 feedback survey
         ///
 #if DEBUG

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -25,8 +25,6 @@ struct DashboardView: View {
     var onboardingTaskTapped: ((Site, StoreOnboardingTask) -> Void)?
     /// Set externally in the hosting controller.
     var viewAllOnboardingTasksTapped: ((Site) -> Void)?
-    /// Set externally in the hosting controller.
-    var onboardingShareFeedbackAction: (() -> Void)?
 
     /// Set externally in the hosting controller.
     var showAllBlazeCampaignsTapped: (() -> Void)?
@@ -215,8 +213,6 @@ private extension DashboardView {
                         }, onViewAllTapped: {
                             guard let currentSite else { return }
                             viewAllOnboardingTasksTapped?(currentSite)
-                        }, shareFeedbackAction: {
-                            onboardingShareFeedbackAction?()
                         })
                     case .blaze:
                         BlazeCampaignDashboardView(viewModel: viewModel.blazeCampaignDashboardViewModel,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -185,12 +185,6 @@ private extension DashboardViewHostingController {
             updateStoreOnboardingCoordinatorIfNeeded(with: site)
             storeOnboardingCoordinator?.start()
         }
-
-        rootView.onboardingShareFeedbackAction = { [weak self] in
-            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .onboarding))
-            let navigationController = SurveyCoordinatingController(survey: .storeSetup)
-            self?.present(navigationController, animated: true, completion: nil)
-        }
     }
 
     func updateStoreOnboardingCoordinatorIfNeeded(with site: Site) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -21,13 +21,11 @@ final class StoreOnboardingViewHostingController: SelfSizingHostingController<St
 
     init(viewModel: StoreOnboardingViewModel,
          navigationController: UINavigationController,
-         site: Site,
-         shareFeedbackAction: (() -> Void)? = nil) {
+         site: Site) {
         self.viewModel = viewModel
         self.sourceNavigationController = navigationController
         self.site = site
-        super.init(rootView: StoreOnboardingView(viewModel: viewModel,
-                                                 shareFeedbackAction: shareFeedbackAction))
+        super.init(rootView: StoreOnboardingView(viewModel: viewModel))
         if #unavailable(iOS 16.0) {
             viewModel.onStateChange = { [weak self] in
                 self?.view.invalidateIntrinsicContentSize()
@@ -99,16 +97,12 @@ struct StoreOnboardingView: View {
 
     @ObservedObject private var viewModel: StoreOnboardingViewModel
 
-    private let shareFeedbackAction: (() -> Void)?
-
     init(viewModel: StoreOnboardingViewModel,
          onTaskTapped: ((StoreOnboardingTask) -> Void)? = nil,
-         onViewAllTapped: (() -> Void)? = nil,
-         shareFeedbackAction: (() -> Void)? = nil) {
+         onViewAllTapped: (() -> Void)? = nil) {
         self.viewModel = viewModel
         self.taskTapped = onTaskTapped
         self.viewAllTapped = onViewAllTapped
-        self.shareFeedbackAction = shareFeedbackAction
     }
 
     var body: some View {
@@ -130,7 +124,6 @@ struct StoreOnboardingView: View {
                 StoreSetupProgressView(isExpanded: viewModel.isExpanded,
                                        totalNumberOfTasks: viewModel.taskViewModels.count,
                                        numberOfTasksCompleted: viewModel.numberOfTasksCompleted,
-                                       shareFeedbackAction: shareFeedbackAction,
                                        hideTaskListAction: viewModel.hideTaskList,
                                        isRedacted: viewModel.isRedacted,
                                        failedToLoadTasks: viewModel.failedToLoadTasks)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
@@ -8,8 +8,6 @@ struct StoreSetupProgressView: View {
 
     let numberOfTasksCompleted: Int
 
-    let shareFeedbackAction: (() -> Void)?
-
     let hideTaskListAction: (() -> Void)
 
     let isRedacted: Bool
@@ -54,10 +52,6 @@ struct StoreSetupProgressView: View {
 
             // More button
             Menu {
-                Button(Localization.shareFeedbackButton) {
-                    shareFeedbackAction?()
-                }
-
                 Button(Localization.hideStoreSetupListButton) {
                     hideTaskListAction()
                 }
@@ -102,11 +96,6 @@ private extension StoreSetupProgressView {
             )
         }
 
-        static let shareFeedbackButton = NSLocalizedString(
-            "Share feedback",
-            comment: "Title of the feedback button in the action sheet."
-        )
-
         static let hideStoreSetupListButton = NSLocalizedString(
             "Hide store setup list",
             comment: "Title of the Hide store setup list button in the action sheet."
@@ -120,7 +109,6 @@ struct StoreSetupProgressView_Previews: PreviewProvider {
         StoreSetupProgressView(isExpanded: false,
                                totalNumberOfTasks: 5,
                                numberOfTasksCompleted: 1,
-                               shareFeedbackAction: nil,
                                hideTaskListAction: {},
                                isRedacted: false,
                                failedToLoadTasks: false)
@@ -128,7 +116,6 @@ struct StoreSetupProgressView_Previews: PreviewProvider {
         StoreSetupProgressView(isExpanded: true,
                                totalNumberOfTasks: 5,
                                numberOfTasksCompleted: 1,
-                               shareFeedbackAction: nil,
                                hideTaskListAction: {},
                                isRedacted: false,
                                failedToLoadTasks: false)

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -68,7 +68,6 @@ extension SurveyViewController {
         case addOnsI1
         case orderCreation
         case couponManagement
-        case storeSetup
         case productCreationAI
         case orderFormShippingLines
 
@@ -105,11 +104,6 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
-            case .storeSetup:
-                return WooConstants.URLs.storeSetupFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
             case .productCreationAI:
                 return WooConstants.URLs.productCreationAIFeedback
                     .asURL()
@@ -132,7 +126,6 @@ extension SurveyViewController {
                     .addOnsI1,
                     .orderCreation,
                     .couponManagement,
-                    .storeSetup,
                     .productCreationAI,
                     .orderFormShippingLines:
                 return Localization.giveFeedback
@@ -154,8 +147,6 @@ extension SurveyViewController {
                 return .orderCreation
             case .couponManagement:
                 return .couponManagement
-            case .storeSetup:
-                return .storeSetup
             case .productCreationAI:
                 return .productCreationAI
             case .orderFormShippingLines:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewHostingControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewHostingControllerTests.swift
@@ -10,7 +10,7 @@ final class StoreOnboardingViewHostingControllerTests: XCTestCase {
     func test_it_reloads_tasks_when_view_appears() {
         // Given
         let mockViewModel = MockStoreOnboardingViewModel()
-        let sut = StoreOnboardingViewHostingController(viewModel: mockViewModel, navigationController: .init(), site: .fake(), shareFeedbackAction: nil)
+        let sut = StoreOnboardingViewHostingController(viewModel: mockViewModel, navigationController: .init(), site: .fake())
 
         // When
         sut.viewWillAppear(true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -63,7 +63,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.storeSetupFeedback
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.whatIsWPCom
                         .asURL()
                         .tagPlatform("ios")
                         .tagAppVersion(Bundle.main.bundleVersion()))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -53,22 +53,6 @@ final class SurveyViewControllerTests: XCTestCase {
                         .tagAppVersion(Bundle.main.bundleVersion()))
     }
 
-    func test_it_loads_the_correct_store_setup_survey() throws {
-        // Given
-        let viewController = SurveyViewController(survey: .storeSetup, onCompletion: {})
-
-        // When
-        _ = try XCTUnwrap(viewController.view)
-        let mirror = try self.mirror(of: viewController)
-
-        // Then
-        XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.whatIsWPCom
-                        .asURL()
-                        .tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion()))
-    }
-
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {
         // Given
         var surveyCompleted = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14529 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the outdated survey from the store setup dashboard card.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store with incomplete store setup steps.
- Enable the store setup card on the dashboard.
- Select the ellipsis menu on the top right and confirm that there is no entry point to the survey.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed that the survey for store setup is no longer accessible.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After
--- | ---
<img src="https://github.com/user-attachments/assets/359640aa-6f69-4fac-9072-78bc19ba992d" width=320 /> | <img src="https://github.com/user-attachments/assets/84dfaa7e-addf-46f5-8dc6-9571f843a328" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.

