### PR TITLE
[Woo POS] [Variable Products] Add WC 9.7+ downloadable parameter to variations request

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -82,6 +82,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         let request = productVariationsRequest(for: siteID,
                                                productID: parentProductID,
                                                variationIDs: [],
+                                               downloadable: false,
                                                context: nil,
                                                pageNumber: pageNumber,
                                                pageSize: POSConstants.variationsPerPage)
@@ -101,6 +102,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
     private func productVariationsRequest(for siteID: Int64,
                                           productID: Int64,
                                           variationIDs: [Int64],
+                                          downloadable: Bool? = nil,
                                           context: String?,
                                           pageNumber: Int,
                                           pageSize: Int) -> JetpackRequest {
@@ -109,6 +111,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
+            ParameterKey.downloadable: downloadable.map { String($0) },
             ParameterKey.contextKey: context ?? Default.context,
             ParameterKey.include: variationIDs.isEmpty ? nil: stringOfVariationIDs
         ]
@@ -332,6 +335,7 @@ public extension ProductVariationsRemote {
         static let contextKey: String = "context"
         static let image: String = "image"
         static let include: String    = "include"
+        static let downloadable: String = "downloadable"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -575,6 +575,36 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
     }
+
+    // MARK: Parameter Tests
+
+    func test_loadVariationsForPointOfSale_sets_correct_parameters() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID, pageNumber: 2)
+
+        // Then
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertEqual(queryParametersDictionary["downloadable"] as? String, String(false))
+        XCTAssertEqual(queryParametersDictionary["page"] as? String, "2")
+        XCTAssertEqual(queryParametersDictionary["per_page"] as? String, "25")
+    }
+
+    func test_loadAllProductVariations_sets_correct_parameters() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        remote.loadAllProductVariations(for: sampleSiteID, productID: sampleProductID, variationIDs: [], completion: { _, _ in })
+
+        // Then
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertNil(queryParametersDictionary["downloadable"] as? String)
+        XCTAssertEqual(queryParametersDictionary["page"] as? String, "1")
+        XCTAssertEqual(queryParametersDictionary["per_page"] as? String, "25")
+    }
 }
 
 private extension ProductVariationsRemoteTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #14871
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I decided to only PR the WC 9.7+ parameter addition without the local filter for easier testing. There will be a future PR for the local filter to filter out downloadable variations for < 9.7.

This pull request introduces a new `downloadable` parameter to `ProductVariationsRemote` and updates related tests in `ProductVariationsRemoteTests`. The most important changes include adding the `downloadable` parameter to the request methods and ensuring that the correct parameters are set in the tests.

Updates to `ProductVariationsRemote` class:

* Added the `downloadable` parameter to the `productVariationsRequest` method and updated the method signature to include this new parameter.
* Included the `downloadable` parameter in the request parameters dictionary.
* Added a new constant for the `downloadable` parameter key in the `ParameterKey` extension.

Updates to tests:

* Added a new test `test_loadVariationsForPointOfSale_sets_correct_parameters` to verify that the `downloadable` parameter is correctly set when loading variations for a point of sale.
* Added a new test `test_loadAllProductVariations_sets_correct_parameters` to verify that the `downloadable` parameter is not set when loading all product variations.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store has a variable product with a downloadable variation. This can only be set in wp-admin, not in the app. The WC plugin in the store can be managed manually.

### WC version < 9.7

🗒️ As 9.6 is not publicly released yet, you can enable variable products by removing [this line](https://github.com/woocommerce/woocommerce-ios/blob/efe8572e3c69a04a66bc76d2e41b855bb5ff02aa/Networking/Networking/Remote/ProductsRemote.swift#L214).

- Go to Menu > Point of Sale
- Tap on the variable product in the prerequisite --> after loading, the downloadable variation should be visible (since the local filter hasn't been implemented)

### WC version 9.7+

- In wp-admin, upload the zip from the nightly build [woocommerce-trunk-nightly.zip](https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip)
- Go to Menu > Point of Sale
- Tap on the variable product in the prerequisite --> after loading, the downloadable variation should not be visible

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested it with WC version 9.7.0-dev.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

< 9.7 | 9.7+
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-16 at 15 41 25](https://github.com/user-attachments/assets/5e149728-d466-4342-b2da-0f99b19e7b24) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-16 at 15 46 32](https://github.com/user-attachments/assets/24e094a9-389c-4e87-9a9f-e1fe685abdd0)

<img width="1126" alt="Screenshot 2025-01-16 at 3 49 28 PM" src="https://github.com/user-attachments/assets/0f5b3b6a-3a13-4644-a141-d01d232b3eab" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.487