### PR TITLE
[Revamp Shipping Labels • Customs] Currency Symbol

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -17,13 +17,13 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private let onCompletion: (ShippingLabelCustomsForm) -> ()
 
-    init(orderItems: [OrderItem], onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
+    init(order: Order, onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
         self.onCompletion = onCompletion
 
-        itemsViewModels = orderItems.map {
+        itemsViewModels = order.items.map {
             // TODO: Pass the origin country
             WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "US", name: "United States"),
-                                            orderItem: $0)
+                                            orderItem: $0, currencySymbol: currencySymbol(from: order))
         }
 
         listenToItemsRequiredInformationValues()
@@ -72,6 +72,13 @@ private extension WooShippingCustomsFormViewModel {
                 self?.requiredInformationIsEntered = value
             }
             .store(in: &cancellables)
+    }
+
+    func currencySymbol(from order: Order) -> String {
+        guard let currencyCode = CurrencyCode(rawValue: order.currency) else {
+            return ""
+        }
+        return ServiceLocator.currencySettings.symbol(from: currencyCode)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -141,7 +141,6 @@ struct WooShippingCustomsItem: View {
                         .roundedBorder(cornerRadius: Layout.borderCornerRadius,
                                        lineColor: viewModel.valuePerUnit.isEmpty ? warningRedColor : Color(.separator),
                                        lineWidth: Layout.borderLineWidth)
-                    
                         Text(Localization.valueRequiredWarningText)
                             .foregroundColor(warningRedColor)
                             .footnoteStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -141,7 +141,7 @@ struct WooShippingCustomsItem: View {
                         .roundedBorder(cornerRadius: Layout.borderCornerRadius,
                                        lineColor: viewModel.valuePerUnit.isEmpty ? warningRedColor : Color(.separator),
                                        lineWidth: Layout.borderLineWidth)
-                        
+                    
                         Text(Localization.valueRequiredWarningText)
                             .foregroundColor(warningRedColor)
                             .footnoteStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -46,20 +46,21 @@ struct WooShippingCustomsItem: View {
                         Text(viewModel.originCountry.name)
                         Spacer()
 
-                        if viewModel.valuePerUnit.isEmpty {
-                            emptyValuePlaceholder
-                        } else {
-                            Text(viewModel.valuePerUnit)
-                        }
-
-                        Text("•")
-                            .renderedIf(viewModel.weightPerUnit.isNotEmpty || viewModel.valuePerUnit.isNotEmpty)
-
                         if viewModel.weightPerUnit.isEmpty {
                             emptyValuePlaceholder
                         } else {
                             Text("\(viewModel.weightPerUnit) \(weightUnit)")
                         }
+
+                        Text("•")
+                            .renderedIf(viewModel.weightPerUnit.isNotEmpty || viewModel.valuePerUnit.isNotEmpty)
+
+                        if viewModel.valuePerUnit.isEmpty {
+                            emptyValuePlaceholder
+                        } else {
+                            Text("\(viewModel.currencySymbol)\(viewModel.valuePerUnit)")
+                        }
+
                     }
                 }.renderedIf(isCollapsed)
                     .foregroundColor(.primary)
@@ -127,12 +128,20 @@ struct WooShippingCustomsItem: View {
                         Text(Localization.valuePerUnitTitle)
                             .foregroundColor(.primary)
                             .subheadlineStyle()
-                        TextField("$ 0", text: $viewModel.valuePerUnit)
-                            .keyboardType(.decimalPad)
-                            .padding(Layout.extraPadding)
-                            .roundedBorder(cornerRadius: Layout.borderCornerRadius,
-                                           lineColor: viewModel.valuePerUnit.isEmpty ? warningRedColor : Color(.separator),
-                                           lineWidth: Layout.borderLineWidth)
+                        HStack(spacing: Layout.unitsHorizontalSpacing) {
+                            Text(viewModel.currencySymbol)
+                                .font(.body)
+                                .foregroundStyle(.secondary)
+
+                            TextField("0", text: $viewModel.valuePerUnit)
+                                .font(.body)
+                                .keyboardType(.decimalPad)
+                        }
+                        .padding(Layout.extraPadding)
+                        .roundedBorder(cornerRadius: Layout.borderCornerRadius,
+                                       lineColor: viewModel.valuePerUnit.isEmpty ? warningRedColor : Color(.separator),
+                                       lineWidth: Layout.borderLineWidth)
+                        
                         Text(Localization.valueRequiredWarningText)
                             .foregroundColor(warningRedColor)
                             .footnoteStyle()
@@ -145,10 +154,11 @@ struct WooShippingCustomsItem: View {
                             .subheadlineStyle()
                         HStack {
                             TextField("0", text: $viewModel.weightPerUnit)
+                                .font(.body)
                                 .keyboardType(.decimalPad)
                                 .padding(Layout.extraPadding)
                             Text(weightUnit)
-                                .font(.subheadline)
+                                .font(.body)
                                 .foregroundStyle(.secondary)
                                 .padding(.trailing, Layout.unitsHorizontalSpacing)
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -19,6 +19,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     private let storageManager: StorageManagerType
     private let stores: StoresManager
     private let siteID: Int64
+    let currencySymbol: String
     let orderItem: OrderItem
 
     let hsTariffURL = WooConstants.URLs.hsTariffURL.asURL()
@@ -57,11 +58,13 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     init(originCountry: WooShippingCustomsCountry,
          orderItem: OrderItem,
+         currencySymbol: String,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores) {
         self.title = orderItem.name
         self.originCountry = originCountry
         self.orderItem = orderItem
+        self.currencySymbol = currencySymbol
         self.storageManager = storageManager
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -50,7 +50,7 @@ struct WooShippingCreateLabelsView: View {
                     WooShippingHazmat(enabled: !viewModel.canViewLabel)
 
                     WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
-                                          customsFormViewModel: WooShippingCustomsFormViewModel(orderItems: viewModel.orderItems, onCompletion: { form in
+                                          customsFormViewModel: WooShippingCustomsFormViewModel(order: viewModel.order, onCompletion: { form in
                         // TODO: Remove debug print
                         debugPrint("form", form)
                     }))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -7,12 +7,13 @@ import Combine
 ///
 final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
-    private let order: Order
     private let itemsDataSource: WooShippingItemsDataSource
     private let destinationAddress: ShippingLabelAddress?
     private let stores: StoresManager
     private var subscriptions: Set<AnyCancellable> = []
     private var debounceDuration: Double = 1
+
+    let order: Order
 
     /// The purchased shipping label.
     @Published private var shippingLabel: ShippingLabel?
@@ -26,10 +27,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     var customsInformationIsCompleted: Bool {
         // To be synced with real data
         false
-    }
-
-    var orderItems: [OrderItem] {
-        order.items
     }
 
     /// View model for the section displayed after a shipping label is purchased.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -61,4 +61,15 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(passedForm?.items.first?.hsTariffNumber.isEmpty ?? false)
     }
+
+    func test_init_passes_right_currency() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        // When
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(currency: "USD", items: orderItems), onCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.itemsViewModels.first?.currencySymbol, "$")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -10,7 +10,7 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
 
         var passedForm: ShippingLabelCustomsForm?
-        viewModel = WooShippingCustomsFormViewModel(orderItems: orderItems, onCompletion: { form in
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { form in
             passedForm = form
         })
 
@@ -49,7 +49,7 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
 
         var passedForm: ShippingLabelCustomsForm?
-        viewModel = WooShippingCustomsFormViewModel(orderItems: orderItems, onCompletion: { form in
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { form in
             passedForm = form
         })
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -7,7 +7,7 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
-                                                    orderItem: MockOrderItem.sampleItem())
+                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
     }
 
     func test_when_tariff_number_is_empty_then_it_is_valid() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we pass the proper currency symbol, taken from the order, to the customs form.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Tap on Create Shipping Label on an order
2. Tap on the Customs pencil
3. Tap on a product
4. Check that currency symbol is properly displayed in both the expanded and collapsed states

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
N/A
## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/cbbca75d-8c63-417b-bdbd-ad8fa2edab8d



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
