### PR TITLE
[Shipping labels] Logic for locally validating an origin address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -48,6 +48,24 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Whether the phone number is required.
     private let phoneNumberRequired: Bool
 
+    /// Validates phone number for the address.
+    /// This take into account whether phone is not empty,
+    /// has length 10 with additional "1" area code for US.
+    ///
+    private var isPhoneNumberValid: Bool {
+        guard phone.isNotEmpty else {
+            return false
+        }
+        guard isUSAddress else {
+            return true
+        }
+        if phone.hasPrefix("1") {
+            return phone.count == 11
+        } else {
+            return phone.count == 10
+        }
+    }
+
     // TODO: Set status based on initial verified status, whether any changes have been made, and local validation.
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus
@@ -93,6 +111,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         case .destination:
             resultsController.fetchedObjects
         }
+    }
+
+    /// Whether the address is in the US.
+    var isUSAddress: Bool {
+        country == "US"
     }
 
     /// States of the selected country.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -45,26 +45,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     // MARK: Local requirements & validation
 
+    /// Fields that are invalid based on local validation.
+    @Published private(set) var invalidFields: [WooShippingEditAddressView.AddressField] = []
+
     /// Whether the phone number is required.
     private let phoneNumberRequired: Bool
-
-    /// Validates phone number for the address.
-    /// This take into account whether phone is not empty,
-    /// has length 10 with additional "1" area code for US.
-    ///
-    private var isPhoneNumberValid: Bool {
-        guard phone.isNotEmpty else {
-            return false
-        }
-        guard isUSAddress else {
-            return true
-        }
-        if phone.hasPrefix("1") {
-            return phone.count == 11
-        } else {
-            return phone.count == 10
-        }
-    }
 
     // TODO: Set status based on initial verified status, whether any changes have been made, and local validation.
     /// Status of the address, based on local validation and remote verification.
@@ -203,6 +188,69 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
             return stateRequired
         case .phone:
             return phoneNumberRequired
+        }
+    }
+}
+
+// MARK: Validation
+
+extension WooShippingEditAddressViewModel {
+    /// Locally validates all fields in the address at once.
+    func validateAddress() {
+        for field in WooShippingEditAddressView.AddressField.allCases {
+            validate(field)
+        }
+    }
+
+    /// Locally validates the given field and appends/removes it from the list of invalid fields.
+    func validate(_ field: WooShippingEditAddressView.AddressField) {
+        if isValid(field) {
+            invalidFields.removeAll { $0 == field }
+        } else if !invalidFields.contains(field) {
+            invalidFields.append(field)
+        }
+    }
+
+    /// Checks if the field is valid based on local validation.
+    private func isValid(_ field: WooShippingEditAddressView.AddressField) -> Bool {
+        switch field {
+        case .name:
+            return !isRequired(.name) || name.isNotEmpty
+        case .company:
+            return !isRequired(.company) || company.isNotEmpty
+        case .country:
+            return !isRequired(.country) || country.isNotEmpty
+        case .address:
+            return !isRequired(.address) || address.isNotEmpty
+        case .city:
+            return !isRequired(.city) || city.isNotEmpty
+        case .state:
+            return !isRequired(.state) || state.isNotEmpty
+        case .postalCode:
+            return !isRequired(.postalCode) || postalCode.isNotEmpty
+        case .email:
+            return !isRequired(.email) || email.isNotEmpty
+        case .phone:
+            return isPhoneNumberValid
+        }
+    }
+
+    /// Validates phone number for the address.
+    /// This take into account whether phone is not empty,
+    /// has length 10 with additional "1" area code for US.
+    ///
+    private var isPhoneNumberValid: Bool {
+        guard phone.isNotEmpty else {
+            return !phoneNumberRequired
+        }
+        guard isUSAddress else {
+            return true
+        }
+        let phoneDigits = phone.components(separatedBy: .decimalDigits.inverted).joined()
+        if phoneDigits.hasPrefix("1") {
+            return phoneDigits.count == 11
+        } else {
+            return phoneDigits.count == 10
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -45,15 +45,27 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     // MARK: Local requirements & validation
 
+    /// Whether the address has been remotely verified.
+    private var isVerified: Bool
+
     /// Fields that are invalid based on local validation.
     @Published private(set) var invalidFields: [WooShippingEditAddressView.AddressField] = []
 
     /// Whether the phone number is required.
     private let phoneNumberRequired: Bool
 
-    // TODO: Set status based on initial verified status, whether any changes have been made, and local validation.
+    // TODO: Set status to unverified if the address was verified remotely but there are unsaved changes.
     /// Status of the address, based on local validation and remote verification.
-    var status: WooShippingAddressStatus
+    var status: WooShippingAddressStatus {
+        switch (isVerified, invalidFields.isEmpty) {
+        case (true, true):
+            return .verified
+        case (false, true):
+            return .unverified
+        case (_, false):
+            return .missingInformation
+        }
+    }
 
     // MARK: State/Country
 
@@ -143,7 +155,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.phone = phone
         self.isDefaultAddress = isDefaultAddress
         self.showCompanyField = showCompanyField
-        self.status = isVerified ? .verified : .unverified
+        self.isVerified = isVerified
         self.phoneNumberRequired = phoneNumberRequired
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -434,4 +434,207 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(viewModel.selectedState)
     }
+
+    func test_validateAddress_sets_empty_invalidFields_when_all_fields_valid() {
+        // Given
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "JANE DOE",
+                                                        company: "HEADQUARTERS",
+                                                        country: "US",
+                                                        address: "15 ALGONKIN ST STE 100",
+                                                        city: "TICONDEROGA",
+                                                        state: "NY",
+                                                        postalCode: "12883-1487",
+                                                        email: "TEST@EXAMPLE.COM",
+                                                        phone: "1-234-456-7890",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // When
+        viewModel.validateAddress()
+
+        // Then
+        XCTAssertTrue(viewModel.invalidFields.isEmpty)
+    }
+
+    func test_validateAddress_sets_expected_invalidFields_when_all_fields_empty() {
+        // Given
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true)
+
+        // When
+        viewModel.validateAddress()
+
+        // Then
+        // Note that empty state is valid when country is empty (has no states).
+        let expectedInvalidFields = WooShippingEditAddressView.AddressField.allCases.filter { $0 != .state }
+        XCTAssertEqual(viewModel.invalidFields, expectedInvalidFields)
+    }
+
+    func test_validate_sets_empty_invalidFields_when_all_fields_valid() {
+        // Given
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "JANE DOE",
+                                                        company: "HEADQUARTERS",
+                                                        country: "US",
+                                                        address: "15 ALGONKIN ST STE 100",
+                                                        city: "TICONDEROGA",
+                                                        state: "NY",
+                                                        postalCode: "12883-1487",
+                                                        email: "TEST@EXAMPLE.COM",
+                                                        phone: "1-234-456-7890",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // When
+        for field in WooShippingEditAddressView.AddressField.allCases {
+            viewModel.validate(field)
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.invalidFields.isEmpty)
+    }
+
+    func test_validate_sets_expected_invalidFields_when_all_fields_empty() {
+        // Given
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true)
+
+        // When
+        for field in WooShippingEditAddressView.AddressField.allCases {
+            viewModel.validate(field)
+        }
+
+        // Then
+        // Note that empty state is valid when country is empty (has no states).
+        let expectedInvalidFields = WooShippingEditAddressView.AddressField.allCases.filter { $0 != .state }
+        XCTAssertEqual(viewModel.invalidFields, expectedInvalidFields)
+    }
+
+    func test_validate_sets_state_as_invalid_field_when_empty_and_country_contains_states() {
+        // Given
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [.fake()])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "US",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // When
+        viewModel.validate(.state)
+
+        // Then
+        XCTAssertEqual(viewModel.invalidFields, [.state])
+    }
+
+    func test_validate_sets_phone_as_invalid_field_when_invalid_for_US() {
+        // Given
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "US",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "123-4567",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // When
+        viewModel.validate(.phone)
+
+        // Then
+        XCTAssertEqual(viewModel.invalidFields, [.phone])
+    }
+
+    func test_validate_removes_valid_field_from_invalidFields() {
+        // Given
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true)
+        // Precondition check
+        viewModel.validate(.name)
+        XCTAssertTrue(viewModel.invalidFields.contains(.name))
+
+        // When
+        viewModel.name = "JANE DOE"
+        viewModel.validate(.name)
+
+        // Then
+        XCTAssertFalse(viewModel.invalidFields.contains(.name))
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -435,7 +435,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.selectedState)
     }
 
-    func test_validateAddress_sets_empty_invalidFields_when_all_fields_valid() {
+    func test_validateAddress_sets_expected_properties_when_all_fields_valid() {
         // Given
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
@@ -462,9 +462,10 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.invalidFields.isEmpty)
+        XCTAssertEqual(viewModel.status, .verified)
     }
 
-    func test_validateAddress_sets_expected_invalidFields_when_all_fields_empty() {
+    func test_validateAddress_sets_expected_properties_when_all_fields_empty() {
         // Given
         let viewModel = WooShippingEditAddressViewModel(type: .destination,
                                                         id: "",
@@ -489,9 +490,10 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Note that empty state is valid when country is empty (has no states).
         let expectedInvalidFields = WooShippingEditAddressView.AddressField.allCases.filter { $0 != .state }
         XCTAssertEqual(viewModel.invalidFields, expectedInvalidFields)
+        XCTAssertEqual(viewModel.status, .missingInformation)
     }
 
-    func test_validate_sets_empty_invalidFields_when_all_fields_valid() {
+    func test_validate_sets_expected_properties_when_all_fields_valid() {
         // Given
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
@@ -520,9 +522,10 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.invalidFields.isEmpty)
+        XCTAssertEqual(viewModel.status, .verified)
     }
 
-    func test_validate_sets_expected_invalidFields_when_all_fields_empty() {
+    func test_validate_sets_expected_properties_when_all_fields_empty() {
         // Given
         let viewModel = WooShippingEditAddressViewModel(type: .destination,
                                                         id: "",
@@ -549,6 +552,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Note that empty state is valid when country is empty (has no states).
         let expectedInvalidFields = WooShippingEditAddressView.AddressField.allCases.filter { $0 != .state }
         XCTAssertEqual(viewModel.invalidFields, expectedInvalidFields)
+        XCTAssertEqual(viewModel.status, .missingInformation)
     }
 
     func test_validate_sets_state_as_invalid_field_when_empty_and_country_contains_states() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This introduces the logic to locally validate an origin address; the next PR will update the UI to perform the validation while editing an address.

### How

* In the view model, we now track the status of the address based on two inputs:
   * `isVerified` determines if the address is verified remotely.
   * `invalidFields` tracks any fields that are invalid after local validation.
   * `status` is now updated to be based on those two inputs. Note that we don't yet take into account if an address was verified remotely but has since been edited (that will be handled in another PR).
* We add validation for US phone numbers, based on the number of digits in the number. All other fields are validated to confirm they are not empty if they are required.
* We have methods `validateAddress()` to validate all fields at once, and `validate(_:)` to validate individual fields.

In a following PR, we will update the UI to use these new methods to validate individual fields as the address is being edited or validate the entire address at once (e.g. when the edit form is first opened) and show the appropriate inline error messages in the form.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

For now, this logic isn't yet used in the UI. Confirm unit tests cover the expected cases.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.