### PR TITLE
[Woo POS] [Variable Products] Filter out downloadable variations locally & only include published variations in variations request

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -83,6 +83,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                                productID: parentProductID,
                                                variationIDs: [],
                                                downloadable: false,
+                                               status: .published,
                                                context: nil,
                                                pageNumber: pageNumber,
                                                pageSize: POSConstants.variationsPerPage)
@@ -103,6 +104,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                           productID: Int64,
                                           variationIDs: [Int64],
                                           downloadable: Bool? = nil,
+                                          status: ProductStatus? = nil,
                                           context: String?,
                                           pageNumber: Int,
                                           pageSize: Int) -> JetpackRequest {
@@ -113,7 +115,8 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
             ParameterKey.perPage: String(pageSize),
             ParameterKey.downloadable: downloadable.map { String($0) },
             ParameterKey.contextKey: context ?? Default.context,
-            ParameterKey.include: variationIDs.isEmpty ? nil: stringOfVariationIDs
+            ParameterKey.include: variationIDs.isEmpty ? nil: stringOfVariationIDs,
+            ParameterKey.status: status?.rawValue
         ]
             .compactMapValues { $0 }
 
@@ -336,6 +339,7 @@ public extension ProductVariationsRemote {
         static let image: String = "image"
         static let include: String    = "include"
         static let downloadable: String = "downloadable"
+        static let status: String = "status"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -588,6 +588,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Then
         let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
         XCTAssertEqual(queryParametersDictionary["downloadable"] as? String, String(false))
+        XCTAssertEqual(queryParametersDictionary["status"] as? String, "publish")
         XCTAssertEqual(queryParametersDictionary["page"] as? String, "2")
         XCTAssertEqual(queryParametersDictionary["per_page"] as? String, "25")
     }
@@ -602,6 +603,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Then
         let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
         XCTAssertNil(queryParametersDictionary["downloadable"] as? String)
+        XCTAssertNil(queryParametersDictionary["status"] as? String)
         XCTAssertEqual(queryParametersDictionary["page"] as? String, "1")
         XCTAssertEqual(queryParametersDictionary["per_page"] as? String, "25")
     }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -70,6 +70,8 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                                           parentProductID: parentProduct.productID,
                                           pageNumber: pageNumber)
         let variations = pagedVariations.items
+            // Remove this when WC version 9.7 has significant adoption in POS stores.
+            .filter { !$0.downloadable }
         return .init(
             items: variations.compactMap({ variation in
                 let variationName = ProductVariationFormatter().generateNameWithAttributeNames(

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -137,7 +137,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         XCTAssertEqual(network.queryParametersDictionary?["include_types"] as? String, "simple,variable")
     }
 
-    func test_providePointOfSaleVariationItems_returns_variations_when_load_succeeds() async throws {
+    func test_providePointOfSaleVariationItems_returns_variations_with_non_downloadable_filter_when_load_succeeds() async throws {
         // Given
         let itemProvider = PointOfSaleItemService(siteID: siteID,
                                                   currencySettings: currencySettings,
@@ -203,17 +203,18 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         guard case let .variation(firstVariation) = firstVariation else {
             return XCTFail("Variation is expected.")
         }
+        // The first variation in the `product-variations-load-all` response is a downloadble variation and should be filtered out by the service.
         XCTAssertEqual(
             firstVariation.name,
-            "Shape: marble, Flavor: nuts, Darkness: 99%, " +
+            "Shape: brick, Flavor: nuts, Darkness: 99%, " +
             String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Size")
         )
-        XCTAssertEqual(firstVariation.formattedPrice, "$12.00")
-        XCTAssertEqual(firstVariation.price, "12")
+        XCTAssertEqual(firstVariation.formattedPrice, "-")
+        XCTAssertEqual(firstVariation.price, "")
         XCTAssertEqual(firstVariation.productImageSource,
                        "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1")
         XCTAssertEqual(firstVariation.productID, parentProductID)
-        XCTAssertEqual(firstVariation.productVariationID, 1275)
+        XCTAssertEqual(firstVariation.productVariationID, 1274)
     }
 
     func test_providePointOfSaleVariationItems_returns_variation_page_details_when_load_succeeds() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14871 
Closes: #14815
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements 2 last changes based on the latest summary/decision in pdfdoF-62l-p2#comment-7285 for variations in POS:

### Exclude private/disabled variations:

Since the interface in wp-admin and the app only allow a variation to be enabled/disabled for a variation status, it can be achieved by only including enabled variations with `status: publish` parameter in the variations request.

* Added `status` parameter to the `fetchVariations` method and included it in the request parameters. [[1]](diffhunk://#diff-fa44db8cd4f05911d0bf515e02c8108729a7a649f31820a43ec91aee7306df67R107) [[2]](diffhunk://#diff-fa44db8cd4f05911d0bf515e02c8108729a7a649f31820a43ec91aee7306df67L116-R119)
* Updated the request creation to include the `status` parameter when provided.
* Updated `ProductVariationsRemoteTests` to verify the inclusion and exclusion of the `status` parameter in query parameters. [[1]](diffhunk://#diff-993b04f0083a1b6d4f24d6b9972fd23f7ff46183ff6cec4864d7081ce1762365R591) [[2]](diffhunk://#diff-993b04f0083a1b6d4f24d6b9972fd23f7ff46183ff6cec4864d7081ce1762365R606)

### Temporary local filter in `PointOfSaleItemService` to filter out downloadable variations:

* Added a filter to exclude downloadable variations until WC version 9.7 is widely adopted.
* Pagination should work with the local filter.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is eligible for POS, and has WC version < 9.7.

- In wp-admin, prepare a variable product with at least 2 variations: one is disabled and not downloadable, the other is enabled and downloadable
- In the app, switch to the store in the prerequisite
- Go to Menu > Point of Sale
- Tap on the variable product prepared in step 1 --> the 2 variations mentioned in step 1 should not be shown (whereas they are shown in trunk)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->



## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

variations | settings in core
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-17 at 15 43 05](https://github.com/user-attachments/assets/26c8e791-6015-47d9-9691-2ee98de62b32) | <img width="811" alt="Screenshot 2025-01-17 at 3 42 56 PM" src="https://github.com/user-attachments/assets/f1e149ca-549d-4419-a022-62681f57e435" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.148