### PR TITLE
Hide sites: Update footer for other stores section

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListView.swift
@@ -135,8 +135,8 @@ private extension EditStoreListView {
             comment: "Header of the Other Stores section on the Edit Store List view"
         )
         static let otherStoresFooter = NSLocalizedString(
-            "editStoreListView.otherStoresFooter",
-            value: "Stores that are not selected will be excluded from the store picker",
+            "editStoreListView.unselectedStoresNote",
+            value: "Unselected stores will be excluded from the store picker and won't receive push notifications for new orders or product.",
             comment: "Footer of the Other Stores section on the Edit Store List view"
         )
         static let retryButton = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14900 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the copy on the Visible Stores screen to include the detail about push notifications.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to an account connected to more than 1 store.
- Navigate to the Menu tab > open the store picker > Edit.
- Confirm that the footer text of the Other stores section now includes the detail about push notifications.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed that the copy is now correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After 
--- | ---
<img src="https://github.com/user-attachments/assets/bfa59170-21f9-4806-891a-5c0bad87e2e9" width=320 /> | <img src="https://github.com/user-attachments/assets/65058190-10c5-4876-8403-2160d28132b7" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
