### PR TITLE
Dashboard: Update stats instantly upon dragging on store performance chart

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [Internal] [*] Improved handling of the navigation to the Woo Installation screen post Jetpack setup [https://github.com/woocommerce/woocommerce-ios/pull/14837]
 - [*] Receipts: Email receipts can now be sent to customers after failed payments using WooCommerce Stripe 9.1.0+. [https://github.com/woocommerce/woocommerce-ios/pull/14864].
+- [*] Dashboard: Updated the drag gesture on the Performance chart to show stats instantly. [https://github.com/woocommerce/woocommerce-ios/pull/14906]
 
 21.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -265,7 +265,6 @@ private extension StorePerformanceView {
         if let chartViewModel = viewModel.chartViewModel {
             VStack {
                 StoreStatsChart(viewModel: chartViewModel) { selectedIndex in
-                    viewModel.trackInteraction()
                     viewModel.didSelectStatsInterval(at: selectedIndex)
                 }
                 .frame(height: Layout.chartViewHeight)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -72,23 +72,24 @@ struct StoreStatsChart: View {
                 Rectangle().fill(.clear).contentShape(Rectangle())
                     .gesture(DragGesture()
                         .onChanged { value in
-                            // Only show selection and don't trigger updating selected index.
                             updateSelectedDate(at: value.location,
                                                proxy: proxy,
                                                geometry: geometry)
+                            // Do not support deselection here to avoid UI glitch
+                            updateSelectedIndex(supportsDeselection: false)
                         }
                         .onEnded { value in
                             updateSelectedDate(at: value.location,
                                                proxy: proxy,
                                                geometry: geometry)
-                            updateSelectedIndex()
+                            updateSelectedIndex(supportsDeselection: true)
                         }
                     )
                     .onTapGesture { location in
                         updateSelectedDate(at: location,
                                            proxy: proxy,
                                            geometry: geometry)
-                        updateSelectedIndex()
+                        updateSelectedIndex(supportsDeselection: true)
                     }
             }
         }
@@ -113,9 +114,9 @@ struct StoreStatsChart: View {
         selectedRevenue = viewModel.intervals.first(where: { $0.date == selectedDate })?.revenue
     }
 
-    private func updateSelectedIndex() {
+    private func updateSelectedIndex(supportsDeselection: Bool) {
         if let index = viewModel.intervals.firstIndex(where: { $0.date == selectedDate }) {
-            if index == selectedIndex {
+            if supportsDeselection, index == selectedIndex {
                 onIntervalSelected(nil)
                 selectedIndex = nil
                 selectedDate = nil


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14904 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
From the general app feedback, we got a lot of complaints in the dragging behavior of the store performance chart.

This PR fixes the behavior by updating the stats instantly when dragging a finger across the chart.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store with existing revenues.
- On the My Store screen, enable the Store Performance dashboard card.
- Select a date range with existing revenues.
- Drag a finger across the chart and verify that the revenue/site visit stats are updated instantly when the drag changes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed that the drag gesture on the performance chart works as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/882c73d5-c0d0-487e-a2ae-454e29d496a5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
