### PR TITLE
[Woo POS] [Cash & Receipts] Fix for number formatting when using grouping separators

### DIFF
--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import class WooFoundation.CurrencyFormatter
 
 final class CollectCashViewHelper {
@@ -10,9 +11,9 @@ final class CollectCashViewHelper {
               let inputDecimal = parseCurrency(textFieldAmountInput) else {
             return nil
         }
-        if inputDecimal.compare(orderDecimal) == .orderedDescending {
-            let changeDue = inputDecimal.subtracting(orderDecimal)
-            return  String.localizedStringWithFormat(Localization.changeDueMessage, formatAsCurrency(changeDue))
+        if inputDecimal > orderDecimal {
+            let changeDue = inputDecimal - orderDecimal
+            return String.localizedStringWithFormat(Localization.changeDueMessage, formatAsCurrency(changeDue))
         } else {
             return nil
         }
@@ -27,18 +28,39 @@ final class CollectCashViewHelper {
             return false
         }
 
-        if inputDecimal.compare(orderDecimal) == .orderedAscending {
+        if inputDecimal < orderDecimal {
             onError(Localization.cashPaymentAmountNotEnough)
             return false
         }
         return true
     }
 
-    private func parseCurrency(_ amountString: String) -> NSDecimalNumber? {
-        currencyFormatter.convertToDecimal(amountString, locale: .current)
+    private func parseCurrency(_ amountString: String) -> Decimal? {
+        // Removes all leading/trailing whitespace, if any
+        let sanitized = amountString.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Removes currency symbol
+        let symbol = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
+        let stringWithoutSymbol = sanitized.replacingOccurrences(of: symbol, with: "")
+
+        // Configures the formatter as close as possible to use the Store's settings
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.generatesDecimalNumbers = true
+        formatter.groupingSeparator = ServiceLocator.currencySettings.groupingSeparator
+        formatter.decimalSeparator = ServiceLocator.currencySettings.decimalSeparator
+        formatter.minimumFractionDigits = ServiceLocator.currencySettings.fractionDigits
+        formatter.maximumFractionDigits = ServiceLocator.currencySettings.fractionDigits
+
+        // Attempts to parse
+        guard let number = formatter.number(from: stringWithoutSymbol) else {
+            DDLogError("❌ Failed to parse currency for \(stringWithoutSymbol)")
+            return nil
+        }
+        return number.decimalValue
     }
 
-    private func formatAsCurrency(_ amount: NSDecimalNumber) -> String {
+    private func formatAsCurrency(_ amount: Decimal) -> String {
         currencyFormatter.formatAmount(amount) ?? "$0.00"
     }
 }

--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -54,7 +54,7 @@ final class CollectCashViewHelper {
 
         // Attempts to parse
         guard let number = formatter.number(from: stringWithoutSymbol) else {
-            DDLogError("❌ Failed to parse currency for \(stringWithoutSymbol)")
+            DDLogError("❌ Failed to parse currency for \(stringWithoutSymbol). Details: \(formatter.logDebugDetails)")
             return nil
         }
         return number.decimalValue
@@ -83,5 +83,23 @@ private extension CollectCashViewHelper {
             value: "Amount must be more or equal to total.",
             comment: "Error message when the cash amount entered is less than the order total."
         )
+    }
+}
+
+
+extension NumberFormatter {
+    var logDebugDetails: String {
+        """
+        NumberFormatter Details:
+        ------------------------
+        Number Style: \(self.numberStyle)
+        Grouping Separator: \(self.groupingSeparator ?? "nil")
+        Decimal Separator: \(self.decimalSeparator ?? "nil")
+        Minimum Fraction Digits: \(self.minimumFractionDigits)
+        Maximum Fraction Digits: \(self.maximumFractionDigits)
+        Locale: \(self.locale.identifier)
+        Rounding Mode: \(self.roundingMode)
+        Uses Grouping Separator: \(self.usesGroupingSeparator)
+        """
     }
 }

--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -6,6 +6,19 @@ final class CollectCashViewHelper {
     private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
     private let currencySettings: CurrencySettings = ServiceLocator.currencySettings
 
+    // Configures the formatter as close as possible to use the Store's settings
+    private lazy var numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.generatesDecimalNumbers = true
+        formatter.groupingSeparator = currencySettings.groupingSeparator
+        formatter.decimalSeparator = currencySettings.decimalSeparator
+        formatter.minimumFractionDigits = currencySettings.fractionDigits
+        formatter.maximumFractionDigits = currencySettings.fractionDigits
+
+        return formatter
+    }()
+
     func updatechangeDueMessage(orderTotal: String,
                                 textFieldAmountInput: String) -> String? {
         guard let orderDecimal = parseCurrency(orderTotal),
@@ -44,18 +57,9 @@ final class CollectCashViewHelper {
         let symbol = currencySettings.symbol(from: currencySettings.currencyCode)
         let stringWithoutSymbol = sanitized.replacingOccurrences(of: symbol, with: "")
 
-        // Configures the formatter as close as possible to use the Store's settings
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.generatesDecimalNumbers = true
-        formatter.groupingSeparator = currencySettings.groupingSeparator
-        formatter.decimalSeparator = currencySettings.decimalSeparator
-        formatter.minimumFractionDigits = currencySettings.fractionDigits
-        formatter.maximumFractionDigits = currencySettings.fractionDigits
-
         // Attempts to parse
-        guard let number = formatter.number(from: stringWithoutSymbol) else {
-            DDLogError("❌ Failed to parse currency for \(stringWithoutSymbol). Details: \(formatter.logDebugDetails)")
+        guard let number = numberFormatter.number(from: stringWithoutSymbol) else {
+            DDLogError("❌ Failed to parse currency for \(stringWithoutSymbol). Details: \(numberFormatter.logDebugDetails)")
             return nil
         }
         return number.decimalValue

--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -1,9 +1,10 @@
 import Foundation
 import SwiftUI
-import class WooFoundation.CurrencyFormatter
+import WooFoundation
 
 final class CollectCashViewHelper {
     private let currencyFormatter: CurrencyFormatter = WooFoundation.CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+    private let currencySettings: CurrencySettings = ServiceLocator.currencySettings
 
     func updatechangeDueMessage(orderTotal: String,
                                 textFieldAmountInput: String) -> String? {
@@ -40,17 +41,17 @@ final class CollectCashViewHelper {
         let sanitized = amountString.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // Removes currency symbol
-        let symbol = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
+        let symbol = currencySettings.symbol(from: currencySettings.currencyCode)
         let stringWithoutSymbol = sanitized.replacingOccurrences(of: symbol, with: "")
 
         // Configures the formatter as close as possible to use the Store's settings
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.generatesDecimalNumbers = true
-        formatter.groupingSeparator = ServiceLocator.currencySettings.groupingSeparator
-        formatter.decimalSeparator = ServiceLocator.currencySettings.decimalSeparator
-        formatter.minimumFractionDigits = ServiceLocator.currencySettings.fractionDigits
-        formatter.maximumFractionDigits = ServiceLocator.currencySettings.fractionDigits
+        formatter.groupingSeparator = currencySettings.groupingSeparator
+        formatter.decimalSeparator = currencySettings.decimalSeparator
+        formatter.minimumFractionDigits = currencySettings.fractionDigits
+        formatter.maximumFractionDigits = currencySettings.fractionDigits
 
         // Attempts to parse
         guard let number = formatter.number(from: stringWithoutSymbol) else {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
@@ -46,6 +46,20 @@ struct CollectCashViewHelperTests {
         #expect(result == nil)
     }
 
+    @Test func updatechangeDueMessage_when_input_is_below_total_and_uses_grouping_separators_then_returns_nil() {
+        // Given
+        let orderTotal = "2,000.00"
+        let textFieldAmountInput = "1,000.00"
+
+        // When
+        let result = sut.updatechangeDueMessage(
+            orderTotal: orderTotal,
+            textFieldAmountInput: textFieldAmountInput)
+
+        // Then
+        #expect(result == nil)
+    }
+
     @Test func updatechangeDueMessage_when_input_is_above_total_then_returns_change_due_formatted_message() {
         // Given
         let orderTotal = "10.00"
@@ -138,5 +152,59 @@ struct CollectCashViewHelperTests {
         // Then
         #expect(result == true)
         #expect(capturedErrorMessage == nil)
+    }
+
+    @Test func validateAmountOnSubmit_when_inputDecimal_is_greater_than_or_equal_to_orderTotal_using_grouping_separators_then_returns_true() {
+        // Given
+        let orderTotal = "2,000.00"
+        let inputAmount = "2,000.00"
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount
+        ) { error in
+            capturedErrorMessage = error
+        }
+
+        // Then
+        #expect(result == true)
+        #expect(capturedErrorMessage == nil)
+    }
+
+    @Test func updateChangeDueMessage_when_input_has_both_dot_and_comma_grouping_separators_then_returns_formatted_change_due_correctly() {
+        // Given
+        let orderTotal = "$1,234.00"
+        let inputAmount = "$1,235.00"
+        let expectedMessage = "Change due: $1.00"
+
+        // When
+        let result = sut.updatechangeDueMessage(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount)
+
+        // Then
+        #expect(result == expectedMessage)
+    }
+
+    @Test func validateAmountOnSubmit_when_input_has_both_dot_and_comma_grouping_separators_returns_error_message_when_input_amount_is_not_enough() {
+        // Given
+        let orderTotal = "$2,000.00"
+        let inputAmount = "$1,235.00"
+        let expectedErrorMessage = "Amount must be more or equal to total."
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount
+        ) { error in
+            capturedErrorMessage = error
+        }
+
+        // Then
+        #expect(result == false)
+        #expect(capturedErrorMessage == expectedErrorMessage)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14909

## Description
This PR addresses an issue with cash validation found during testing ( pdfdoF-6dp#comment-7332-p2 ), where the values returned are incorrect depending on the store settings and if the amount has both `.` and `,` as grouping separators. 


<img width="631" alt="Screenshot 2025-01-20 at 10 01 29" src="https://github.com/user-attachments/assets/af3e3ed1-ecd8-492c-8c91-5a1e4c700799" />

This is a pre-existing issue with our own `CurrencyFormatter` implementation that we've attempted to mitigate several times ( eg: https://github.com/woocommerce/woocommerce-ios/pull/13854 and https://github.com/woocommerce/woocommerce-ios/pull/13979) and derives from using `convertToDecimal` when operating with values, which doesn't take into account different locale configurations and converts the values incorrectly. Eg:

```
1,000.50 becomes 1.000.50, and NSDecimalNumber ignores everything from the second . to leave us with th number 1.
```

This fix is a bandaid, as shared in the other PRs I believe there are further improvements we can do, but these are out of scope in the context of this PR as would touch many parts. There's also some iteration we can do in the POS side, for example [PointOfSaleOrderTotals](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/POS/Models/PointOfSaleOrderTotals.swift) passes the totals already formatted and could be improved.

## Changes
- Remove usage of `CurrencyFormatter.convertToDecimal`, in favour of `Decimal(string:)`. This is the same approach as on https://github.com/woocommerce/woocommerce-ios/pull/13854, with this we also update the return types to use `Decimal` as well.
- When parsing amounts to calculate change due or "not enough amount" we sanitize, remove the currency and make the built-in formatter take as many store configuration details as possible, otherwise it fails often and returns nil or the incorrect amount, which caused the original issue.
- Added some debug logs if fails to parse, which returns more info that could be useful to understand the merchant's store details: 
```
Number Style: NSNumberFormatterStyle(rawValue: 1)
Grouping Separator: ,
Decimal Separator: .
Minimum Fraction Digits: 2
Maximum Fraction Digits: 2
Locale: en_ES
Rounding Mode: NSNumberFormatterRoundingMode(rawValue: 4)
Uses Grouping Separator: true In: 1
```

## Testing information
- Enable `.acceptCashForPointOfSale` feature flag
- Add products to your cart for a value exceeding $1000 or create a product with that value for testing, by default you should see the price formatted with both thousand and decimal grouping indicators, like `$1,000.00`. For reference, here are my store settings:
<img width="793" alt="Screenshot 2025-01-20 at 09 52 22" src="https://github.com/user-attachments/assets/aaffa724-ead6-489a-b7e2-41dd215b7c84" />

- Observe that adding an input amount below the total, will return `Amount must be more or equal to total.`
- Observe that adding an input equal to total, will process the transaction normally.
- Observe that adding an input higher to total, will show the `change due`, and process the transaction normally.

![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 - 2025-01-20 at 09 01 03](https://github.com/user-attachments/assets/ec15d505-f8fe-4357-8520-4a429ff47c0f)

