### PR TITLE
[Woo POS] [Variable Products] Make inline itemlist error match other items

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
@@ -17,11 +17,11 @@ struct ItemListErrorCardView: View {
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
-                    .font(.posBodyEmphasized)
+                    .font(Constants.itemTitleFont)
 
                 Text(errorState.subtitle)
                     .foregroundStyle(Color.posSecondaryText)
-                    .font(.posBodyRegular)
+                    .font(Constants.itemDetailFont)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
@@ -32,6 +32,7 @@ struct ItemListErrorCardView: View {
                 buttonAction()
             } label: {
                 Text(errorState.buttonText)
+                    .font(Constants.itemTitleFont)
             }
             .buttonStyle(POSTertiaryButtonStyle())
             .frame(maxWidth: Constants.accessoryButtonMaxWidth * scale)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ParentProductCardView.swift
@@ -29,7 +29,7 @@ struct ParentProductCardView: View {
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
-                    .font(Constants.itemNameFont)
+                    .font(Constants.itemTitleFont)
 
                 Text(detailText)
                     .foregroundStyle(Color.posSecondaryText)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
@@ -7,7 +7,7 @@ enum PointOfSaleItemListCardConstants {
     static let textSpacing: CGFloat = 6
     static let horizontalTextPadding: CGFloat = 16
     static let verticalTextPadding: CGFloat = 8
-    static let itemNameFont: POSFontStyle = .posLargeDetailEmphasized
+    static let itemTitleFont: POSFontStyle = .posLargeDetailEmphasized
     static let itemDetailFont: POSFontStyle = .posLargeDetailRegular
     static let accessoryButtonMaxWidth: CGFloat = 136
     static let accessoryButtonPadding: CGFloat = 16

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/SimpleProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/SimpleProductCardView.swift
@@ -25,7 +25,7 @@ struct SimpleProductCardView: View {
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
-                    .font(Constants.itemNameFont)
+                    .font(Constants.itemTitleFont)
 
                 Text(product.formattedPrice)
                     .foregroundStyle(Color.posSecondaryText)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
@@ -24,7 +24,7 @@ struct VariationCardView: View {
                     .lineLimit(2)
                     .foregroundStyle(Color.posPrimaryText)
                     .multilineTextAlignment(.leading)
-                    .font(Constants.itemNameFont)
+                    .font(Constants.itemTitleFont)
 
                 Text(variation.formattedPrice)
                     .foregroundStyle(Color.posSecondaryText)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14914 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the in-line error state for the item list match the other items, where previously it used bigger fonts.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This is easiest to reproduce if you use a smaller product/variation remote request size – I set mine to 15 items.

1. Launch the app, open POS, and allow the item list to load.
2. Enable airplane mode
3. Scroll down until the next page load is attempted
4. Observe that the in-line error is shown with the same fonts as other items.

Repeat this with a variation if you like

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before
![inline error before](https://github.com/user-attachments/assets/529593e5-ee63-4b3e-9c2e-e68269d95c8d)


### After
![updated inline error](https://github.com/user-attachments/assets/a0d45ead-faa9-4909-ba0f-dba312eb2896)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.