### PR TITLE
[Woo POS] [Variable Products] Show a full page of ghost cells when loading

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -48,20 +48,20 @@ struct ItemList<HeaderView: View>: View {
     }
 
     @ViewBuilder var footerRows: some View {
-        VStack {
-            switch state {
-            case .loading:
+        switch state {
+        case .loading:
+            ForEach(0..<8) { _ in
                 GhostItemCardView()
-            case .inlineError(_, let errorState):
-                ItemListErrorCardView(errorState: errorState,
-                                      buttonAction: {
-                    Task { @MainActor in
-                        await posModel.loadNextItems(base: node)
-                    }
-                })
-            case .loaded, .error:
-                EmptyView()
             }
+        case .inlineError(_, let errorState):
+            ItemListErrorCardView(errorState: errorState,
+                                  buttonAction: {
+                Task { @MainActor in
+                    await posModel.loadNextItems(base: node)
+                }
+            })
+        case .loaded, .error:
+            EmptyView()
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14905
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, we showed a single ghost cell when loading the next page, or the first page of variations.

The most common case is that more than 1 item will load with each page; most likely the same number as the page size request.

Showing the same number of ghost cells as will show on the screen after the load is complete is the ideal situation

We can’t show 25 rows on screen at a time anyway, so this commit increases the number of ghost cells to 8. This is enough to fill the portrait screen on the smallest font size.

Now, we show a skeleton layout which more closely matches the eventual loaded layout. This approach matches Android’s behaviour too.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app, and go to POS
2. Scroll down on the product list; observe that a full screen of ghost items is shown before the next page loads.
3. Tap on a variable product; observe that a full screen of ghost items is shown as the initial loading screen.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

It can help to change the page size in ProductsRemote and ProductVariationsRemote to a smaller number, e.g. 15.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f5be6617-faac-4390-a5fa-3dbb6013fdc4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.