### PR TITLE
[Revamp Shipping Labels • Customs] Validation & Required

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -212,7 +212,8 @@ extension WooShippingCustomsForm {
                                                            value: "Please enter a valid ITN",
                                                            comment: "Customs validation warning for the ITN field")
         static let itnRequiredWarningMessage = NSLocalizedString("wooShipping.customs.itnValidation",
-                                                           value: "International Transaction Number is required for shipping items valued over $2,500",
+                                                           value: "International Transaction Number is required for shipping items " +
+                                                                 "valued over $2,500 per tariff number",
                                                            comment: "Customs validation warning for the ITN field")
 
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -3,6 +3,7 @@ import WooFoundation
 import Yosemite
 
 struct WooShippingCustomsForm: View {
+    @Environment(\.colorScheme) var colorScheme
     @Environment(\.presentationMode) var presentationMode
     @ObservedObject var viewModel: WooShippingCustomsFormViewModel
     @State private var isShowingITNInfoWebView = false
@@ -59,6 +60,12 @@ struct WooShippingCustomsForm: View {
         .roundedBorder(cornerRadius: Constants.borderCornerRadius, lineColor: Color(.separator), lineWidth: Constants.borderWidth)
     }
 
+    private var warningRedColor: Color {
+        let shade: ColorStudioShade = colorScheme == .dark ? .shade40 : .shade60
+
+        return .withColorStudio(name: .red, shade: shade)
+    }
+
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
@@ -94,6 +101,14 @@ struct WooShippingCustomsForm: View {
                                     .padding(Constants.borderPadding)
                                     .roundedBorder(cornerRadius: Constants.borderCornerRadius, lineColor: Color(.separator), lineWidth: Constants.borderWidth)
 
+                                Text(Localization.itnValidationWarningMessage)
+                                    .foregroundColor(warningRedColor)
+                                    .footnoteStyle()
+                                    .renderedIf(!viewModel.isValidITN())
+                                Text(Localization.itnRequiredWarningMessage)
+                                    .foregroundColor(warningRedColor)
+                                    .footnoteStyle()
+                                    .renderedIf(viewModel.internationalTransactionNumberIsRequired && viewModel.internationalTransactionNumber.isEmpty)
                                 Button {
                                     isShowingITNInfoWebView = true
                                 } label: {
@@ -193,6 +208,13 @@ extension WooShippingCustomsForm {
         static let productDetailsTitle = NSLocalizedString("wooShipping.customs.productDetails",
                                                            value: "Product Details",
                                                            comment: "Product Details Section title")
+        static let itnValidationWarningMessage = NSLocalizedString("wooShipping.customs.itnValidation",
+                                                           value: "Please enter a valid ITN",
+                                                           comment: "Customs validation warning for the ITN field")
+        static let itnRequiredWarningMessage = NSLocalizedString("wooShipping.customs.itnValidation",
+                                                           value: "International Transaction Number is required for shipping items valued over $2,500",
+                                                           comment: "Customs validation warning for the ITN field")
+
     }
 
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -104,12 +104,9 @@ private extension WooShippingCustomsFormViewModel {
             .flatMap { childPublishers in
                 childPublishers.combineLatest()
             }
-            .sink { [weak self] value in
-                // Remove nils
-                let compactedValues = value.compactMap { $0 }
-
+            .sink { [weak self] values in
                 var hsTariffNumberTotalValueDictionary: [String: Decimal] = [:]
-                for (hsTariffNumber, totalValuePerItem) in compactedValues {
+                for (hsTariffNumber, totalValuePerItem) in values.compacted() {
                     hsTariffNumberTotalValueDictionary[hsTariffNumber, default: 0] += totalValuePerItem
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -99,15 +99,21 @@ private extension WooShippingCustomsFormViewModel {
     func listenForInternationalTransactionNumberIsRequired() {
          $itemsViewModels
             .map { childViewModels in
-                childViewModels.map { $0.$internationalTransactionNumberIsRequired.eraseToAnyPublisher() }
+                childViewModels.map { $0.$hsTariffNumberTotalValue.eraseToAnyPublisher() }
             }
             .flatMap { childPublishers in
                 childPublishers.combineLatest()
             }
-            .map { childValidityArray in
-                childValidityArray.contains { $0 }
-            }.sink { [weak self] value in
-                self?.internationalTransactionNumberIsRequired = value
+            .sink { [weak self] value in
+                // Remove nils
+                let compactedValues = value.compactMap { $0 }
+
+                var hsTariffNumberTotalValueDictionary: [String: Decimal] = [:]
+                for (hsTariffNumber, totalValuePerItem) in compactedValues {
+                    hsTariffNumberTotalValueDictionary[hsTariffNumber, default: 0] += totalValuePerItem
+                }
+
+                self?.internationalTransactionNumberIsRequired = hsTariffNumberTotalValueDictionary.values.contains { $0 > 2500 }
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -5,9 +5,11 @@ import WooFoundation
 
 final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published var internationalTransactionNumber: String = ""
+    @Published var internationalTransactionNumberIsRequired: Bool = false
     @Published var returnToSenderIfNotDelivered: Bool = false
 
     @Published var requiredInformationIsEntered: Bool = false
+    @Published var itemsRequiredInformationIsEntered: Bool = false
 
     @Published var contentType: WooShippingContentType = .merchandise
     @Published var restrictionType: WooShippingRestrictionType = .none
@@ -27,6 +29,8 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
         }
 
         listenToItemsRequiredInformationValues()
+        listenForRequiredInformation()
+        listenForInternationalTransactionNumberIsRequired()
     }
 
     @Published var itemsViewModels: [WooShippingCustomsItemViewModel] = []
@@ -40,7 +44,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                             restrictionType: restrictionType.toFormRestrictionType(),
                                             restrictionComments: "",
                                             nonDeliveryOption: returnToSenderIfNotDelivered ? .return : .abandon,
-                                            itn: internationalTransactionNumber,
+                                            itn: isValidITN() ? internationalTransactionNumber : "",
                                             items: itemsViewModels.map {
             ShippingLabelCustomsForm.Item(description: $0.description,
                                           quantity: $0.orderItem.quantity,
@@ -53,9 +57,61 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
         )
         onCompletion(form)
     }
+
+    func isValidITN() -> Bool {
+        guard internationalTransactionNumber.isNotEmpty else {
+            return true
+        }
+
+        let pattern = "^(?:(?:AES X\\d{14})|(?:NOEEI 30\\.\\d{1,2}(?:\\([a-z]\\)(?:\\(\\d\\))?)?))$"
+
+        do {
+            let regex = try NSRegularExpression(pattern: pattern)
+            let range = NSRange(internationalTransactionNumber.startIndex..<internationalTransactionNumber.endIndex, in: internationalTransactionNumber)
+            return regex.firstMatch(in: internationalTransactionNumber, options: [], range: range) != nil
+        } catch {
+            return false
+        }
+    }
 }
 
 private extension WooShippingCustomsFormViewModel {
+    func listenForRequiredInformation() {
+        Publishers.CombineLatest3($itemsRequiredInformationIsEntered, $internationalTransactionNumber, $internationalTransactionNumberIsRequired)
+            .sink { [weak self] itemsRequiredInformationIsEntered, internationalTransactionNumber, internationalTransactionNumberIsRequired in
+                guard let self = self else { return }
+
+                guard itemsRequiredInformationIsEntered else {
+                    self.requiredInformationIsEntered = false
+                    return
+                }
+
+                guard internationalTransactionNumberIsRequired else {
+                    self.requiredInformationIsEntered = true
+                    return
+                }
+
+                self.requiredInformationIsEntered = internationalTransactionNumber.isNotEmpty && self.isValidITN()
+            }
+            .store(in: &cancellables)
+    }
+
+    func listenForInternationalTransactionNumberIsRequired() {
+         $itemsViewModels
+            .map { childViewModels in
+                childViewModels.map { $0.$internationalTransactionNumberIsRequired.eraseToAnyPublisher() }
+            }
+            .flatMap { childPublishers in
+                childPublishers.combineLatest()
+            }
+            .map { childValidityArray in
+                childValidityArray.contains { $0 }
+            }.sink { [weak self] value in
+                self?.internationalTransactionNumberIsRequired = value
+            }
+            .store(in: &cancellables)
+    }
+
     func listenToItemsRequiredInformationValues() {
         // Listen to the items required information and enable the button depending on it
         $itemsViewModels
@@ -69,7 +125,7 @@ private extension WooShippingCustomsFormViewModel {
                 childValidityArray.allSatisfy { $0 } // Check if all are valid
             }
             .sink { [weak self] value in
-                self?.requiredInformationIsEntered = value
+                self?.itemsRequiredInformationIsEntered = value
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -105,6 +105,7 @@ extension WooShippingCustomsItemViewModel {
             .sink { [weak self] valuePerUnit, hsTariffNumber in
                 guard let self = self else { return }
 
+                // Items valued more than $2500 with a valid HSTariff Number require an International Transaction Number
                 self.internationalTransactionNumberIsRequired = self.currencySymbol == "$" &&
                 (Double(valuePerUnit) ?? 0) > 2500 &&
                 hsTariffNumber.isNotEmpty &&

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -15,6 +15,8 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     @Published var valuePerUnit: String = ""
     @Published var weightPerUnit: String = ""
     @Published var originCountry: WooShippingCustomsCountry
+    // Useful to determine externally if the shipping requires an ITN
+    @Published var hsTariffNumberTotalValue: (String, Decimal)?
 
     private let storageManager: StorageManagerType
     private let stores: StoresManager
@@ -53,7 +55,6 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     }
 
     @Published var requiredInformationIsEntered: Bool = false
-    @Published var internationalTransactionNumberIsRequired: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -72,7 +73,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
         fetchCountries()
         combineRequiredInformationIsEntered()
-        combineInternationalTransactionNumberIsRequired()
+        combineHSTariffNumberTotalValue()
     }
 }
 
@@ -100,16 +101,20 @@ extension WooShippingCustomsItemViewModel {
             .store(in: &cancellables)
     }
 
-    func combineInternationalTransactionNumberIsRequired() {
+    func combineHSTariffNumberTotalValue() {
         Publishers.CombineLatest($valuePerUnit, $hsTariffNumber)
             .sink { [weak self] valuePerUnit, hsTariffNumber in
                 guard let self = self else { return }
 
-                // Items valued more than $2500 with a valid HSTariff Number require an International Transaction Number
-                self.internationalTransactionNumberIsRequired = self.currencySymbol == "$" &&
-                (Double(valuePerUnit) ?? 0) > 2500 &&
-                hsTariffNumber.isNotEmpty &&
-                isValidTariffNumber
+                guard self.currencySymbol == "$",
+                      let valuePerUnitDecimal = Decimal(string: valuePerUnit),
+                      hsTariffNumber.isNotEmpty,
+                      isValidTariffNumber else {
+                    self.hsTariffNumberTotalValue = nil
+                    return
+                }
+
+                self.hsTariffNumberTotalValue = (hsTariffNumber, valuePerUnitDecimal * orderItem.quantity)
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -77,7 +77,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     }
 }
 
-extension WooShippingCustomsItemViewModel {
+private extension WooShippingCustomsItemViewModel {
     func fetchCountries() {
         try? resultsController.performFetch()
         let action = DataAction.synchronizeCountries(siteID: siteID) { [weak self] (result) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -53,6 +53,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     }
 
     @Published var requiredInformationIsEntered: Bool = false
+    @Published var internationalTransactionNumberIsRequired: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -71,6 +72,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
         fetchCountries()
         combineRequiredInformationIsEntered()
+        combineInternationalTransactionNumberIsRequired()
     }
 }
 
@@ -94,6 +96,19 @@ extension WooShippingCustomsItemViewModel {
         Publishers.CombineLatest3($description, $valuePerUnit, $weightPerUnit)
             .sink { [weak self] description, valuePerUnit, weightPerUnit in
                 self?.requiredInformationIsEntered = description.isNotEmpty && valuePerUnit.isNotEmpty && weightPerUnit.isNotEmpty
+            }
+            .store(in: &cancellables)
+    }
+
+    func combineInternationalTransactionNumberIsRequired() {
+        Publishers.CombineLatest($valuePerUnit, $hsTariffNumber)
+            .sink { [weak self] valuePerUnit, hsTariffNumber in
+                guard let self = self else { return }
+
+                self.internationalTransactionNumberIsRequired = self.currencySymbol == "$" &&
+                (Double(valuePerUnit) ?? 0) > 2500 &&
+                hsTariffNumber.isNotEmpty &&
+                isValidTariffNumber
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -151,36 +151,40 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isValidITN())
     }
 
-    func test_internationalTransactionNumberIsRequired_when_item_view_models_does_not_require_internationalTransactionNumber_returns_false() {
+    func test_internationalTransactionNumberIsRequired_when_item_view_models_hsTariffNumberTotalValue_is_nil_then_returns_false() {
         // Given
         let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
 
         viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
 
-        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = false
+        // When
+        viewModel.itemsViewModels.first?.hsTariffNumberTotalValue = nil
 
+        // Then
         XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
     }
 
-    func test_requiredInformationIsEntered_when_one_item_view_model_requiredInformationIsEntered_is_false_then_returns_false() {
+    func test_internationalTransactionNumberIsRequired_when_item_view_models_hsTariffNumberTotalValue_is_less_than_2500_then_returns_false() {
         // Given
         let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
 
         viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
 
-        viewModel.itemsViewModels.first?.requiredInformationIsEntered = false
+        // When
+        viewModel.itemsViewModels.first?.hsTariffNumberTotalValue = ("123456", 1000)
 
         XCTAssertFalse(viewModel.requiredInformationIsEntered)
     }
 
-    func test_requiredInformationIsEntered_when_one_item_view_model_requiredInformationIsEntered_is_true_but_requires_itn_then_returns_false() {
+    func test_internationalTransactionNumberIsRequired_when_item_view_models_hsTariffNumberTotalValue_is_less_than_2500_then_returns_true() {
         // Given
         let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
 
         viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
 
         viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
-        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = true
+        viewModel.itemsViewModels.first?.hsTariffNumberTotalValue = ("123456", 1000)
+        viewModel.itemsViewModels[1].hsTariffNumberTotalValue = ("123456", 2000)
         viewModel.internationalTransactionNumber = ""
 
         XCTAssertFalse(viewModel.requiredInformationIsEntered)
@@ -193,7 +197,6 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
 
         viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
-        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = true
         viewModel.internationalTransactionNumber = "1234"
 
         XCTAssertFalse(viewModel.requiredInformationIsEntered)
@@ -209,7 +212,6 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
         viewModel.internationalTransactionNumber = "NOEEI 30.37(a)"
         viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
-        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = true
 
         XCTAssertTrue(viewModel.requiredInformationIsEntered)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -5,6 +5,18 @@ import Yosemite
 class WooShippingCustomsFormViewModelTests: XCTestCase {
     private var viewModel: WooShippingCustomsFormViewModel!
 
+    override func setUp() {
+        super.setUp()
+
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(), onCompletion: { _ in })
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        viewModel = nil
+    }
+
     func test_onDismiss_calls_onCompletion_with_right_values() {
         // Given
         let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
@@ -16,7 +28,7 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
         viewModel.restrictionType = .quarantine
         viewModel.contentType = .gift
-        viewModel.internationalTransactionNumber = "1234"
+        viewModel.internationalTransactionNumber = "NOEEI 30.37(a)"
         viewModel.returnToSenderIfNotDelivered = false
 
         viewModel.itemsViewModels.first?.description = "Test Item"
@@ -62,6 +74,24 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         XCTAssertTrue(passedForm?.items.first?.hsTariffNumber.isEmpty ?? false)
     }
 
+    func test_onDismiss_when_calls_onCompletion_with_invalid_itn_then_returns_empty() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        var passedForm: ShippingLabelCustomsForm?
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { form in
+            passedForm = form
+        })
+
+        viewModel.internationalTransactionNumber = "1234"
+
+        // When
+        viewModel.onDismiss()
+
+        // Then
+        XCTAssertTrue(passedForm?.itn.isEmpty ?? false)
+    }
+
     func test_init_passes_right_currency() {
         // Given
         let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
@@ -71,5 +101,53 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.itemsViewModels.first?.currencySymbol, "$")
+    }
+
+    func test_isValidITN_when_internationalTransactionNumber_is_empty_then_returns_true() {
+        // Given
+        viewModel.internationalTransactionNumber = ""
+
+        // Then
+        XCTAssertTrue(viewModel.isValidITN())
+    }
+
+    func test_isValidITN_when_passing_a_valid_AES_internationalTransactionNumber_then_returns_true() {
+        // Given
+        viewModel.internationalTransactionNumber = "AES X12345678901234"
+
+        // Then
+        XCTAssertTrue(viewModel.isValidITN())
+    }
+
+    func test_isValidITN_when_passing_a_valid_NOEEI_internationalTransactionNumber_then_returns_true() {
+        // Given
+        viewModel.internationalTransactionNumber = "NOEEI 30.37(a)"
+
+        // Then
+        XCTAssertTrue(viewModel.isValidITN())
+    }
+
+    func test_isValidITN_when_passing_an_invalid_internationalTransactionNumber_then_returns_false() {
+        // Given
+        viewModel.internationalTransactionNumber = "INVALID 123456"
+
+        // Then
+        XCTAssertFalse(viewModel.isValidITN())
+    }
+
+    func test_isValidITN_when_passing_an_AES_internationalTransactionNumber_with_special_characters_then_returns_false() {
+        // Given
+        viewModel.internationalTransactionNumber = "AES X123@#4567890"
+
+        // Then
+        XCTAssertFalse(viewModel.isValidITN())
+    }
+
+    func test_isValidITN_when_passing_a_long_internationalTransactionNumber_then_returns_false() {
+        // Given
+        viewModel.internationalTransactionNumber = "AES X12345678901234567890"
+
+        // Then
+        XCTAssertFalse(viewModel.isValidITN())
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -150,4 +150,67 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.isValidITN())
     }
+
+    func test_internationalTransactionNumberIsRequired_when_item_view_models_does_not_require_internationalTransactionNumber_returns_false() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+
+        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = false
+
+        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+    }
+
+    func test_requiredInformationIsEntered_when_one_item_view_model_requiredInformationIsEntered_is_false_then_returns_false() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+
+        viewModel.itemsViewModels.first?.requiredInformationIsEntered = false
+
+        XCTAssertFalse(viewModel.requiredInformationIsEntered)
+    }
+
+    func test_requiredInformationIsEntered_when_one_item_view_model_requiredInformationIsEntered_is_true_but_requires_itn_then_returns_false() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+
+        viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
+        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = true
+        viewModel.internationalTransactionNumber = ""
+
+        XCTAssertFalse(viewModel.requiredInformationIsEntered)
+    }
+
+    func test_requiredInformationIsEntered_when_itn_is_required_but_invalid_then_returns_false() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
+
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+
+        viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
+        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = true
+        viewModel.internationalTransactionNumber = "1234"
+
+        XCTAssertFalse(viewModel.requiredInformationIsEntered)
+    }
+
+    func test_requiredInformationIsEntered_when_itn_is_required_and_valid_then_returns_true() {
+        // Given
+        let orderItems = [MockOrderItem.sampleItem()]
+
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+
+        debugPrint("viewModel.itemsViewModels", viewModel.itemsViewModels)
+
+        viewModel.internationalTransactionNumber = "NOEEI 30.37(a)"
+        viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
+        viewModel.itemsViewModels.first?.internationalTransactionNumberIsRequired = true
+
+        XCTAssertTrue(viewModel.requiredInformationIsEntered)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -45,58 +45,53 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isValidTariffNumber)
     }
 
-    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_not_$_returns_false() {
+    func test_hsTariffNumberTotalValue_when_currency_symbol_is_not_$_returns_nil() {
         // When
+        let orderItem = MockOrderItem.sampleItem(quantity: 2)
         viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
-                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "€")
+                                                    orderItem: orderItem, currencySymbol: "$")
 
         // Then
-        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+        XCTAssertNil(viewModel.hsTariffNumberTotalValue)
 
     }
 
-    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_but_value_is_less_than_2500_returns_false() {
+    func test_hsTariffNumberTotalValue_when_currency_symbol_is_$_but_hsTariffNumber_is_empty_returns_nil() {
         // When
+        let orderItem = MockOrderItem.sampleItem(quantity: 2)
         viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
-                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
-        viewModel.valuePerUnit = "1000"
-
-        // Then
-        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
-
-    }
-
-    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_and_value_is_more_than_2500_but_no_hs_tariff_number_returns_false() {
-        // When
-        viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
-                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
+                                                    orderItem: orderItem, currencySymbol: "$")
         viewModel.valuePerUnit = "1000"
         viewModel.hsTariffNumber = ""
 
         // Then
-        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+        XCTAssertNil(viewModel.hsTariffNumberTotalValue)
 
     }
 
-    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_and_value_is_more_than_2500_but_invalid_hs_tariff_number_returns_false() {
+    func test_hsTariffNumberTotalValue_when_currency_symbol_is_$_but_invalid_hs_tariff_number_returns_nil() {
         // When
+        let orderItem = MockOrderItem.sampleItem(quantity: 2)
         viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
-                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
-        viewModel.valuePerUnit = "1000"
+                                                    orderItem: orderItem, currencySymbol: "$")
         viewModel.hsTariffNumber = "123"
+        viewModel.valuePerUnit = "1000"
+
 
         // Then
-        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+        XCTAssertNil(viewModel.hsTariffNumberTotalValue)
     }
 
-    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_and_value_is_more_than_2500_and_valid_hs_tariff_number_returns_true() {
+    func test_hsTariffNumberTotalValue_when_currency_symbol_is_$_and_value_is_more_than_2500_and_valid_hs_tariff_number_returns_values() {
         // When
+        let orderItem = MockOrderItem.sampleItem(quantity: 2)
         viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
-                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
+                                                    orderItem: orderItem, currencySymbol: "$")
         viewModel.valuePerUnit = "3000"
         viewModel.hsTariffNumber = "123456"
 
         // Then
-        XCTAssertTrue(viewModel.internationalTransactionNumberIsRequired)
+        XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.0, viewModel.hsTariffNumber)
+        XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.1, Decimal(string: viewModel.valuePerUnit)! * orderItem.quantity)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -44,4 +44,59 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
         viewModel.hsTariffNumber = "987654321098"
         XCTAssertTrue(viewModel.isValidTariffNumber)
     }
+
+    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_not_$_returns_false() {
+        // When
+        viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
+                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "€")
+
+        // Then
+        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+
+    }
+
+    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_but_value_is_less_than_2500_returns_false() {
+        // When
+        viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
+                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
+        viewModel.valuePerUnit = "1000"
+
+        // Then
+        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+
+    }
+
+    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_and_value_is_more_than_2500_but_no_hs_tariff_number_returns_false() {
+        // When
+        viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
+                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
+        viewModel.valuePerUnit = "1000"
+        viewModel.hsTariffNumber = ""
+
+        // Then
+        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+
+    }
+
+    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_and_value_is_more_than_2500_but_invalid_hs_tariff_number_returns_false() {
+        // When
+        viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
+                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
+        viewModel.valuePerUnit = "1000"
+        viewModel.hsTariffNumber = "123"
+
+        // Then
+        XCTAssertFalse(viewModel.internationalTransactionNumberIsRequired)
+    }
+
+    func test_internationalTransactionNumberIsRequired_when_currency_symbol_is_$_and_value_is_more_than_2500_and_valid_hs_tariff_number_returns_true() {
+        // When
+        viewModel = WooShippingCustomsItemViewModel(originCountry: WooShippingCustomsCountry(code: "", name: "United States"),
+                                                    orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
+        viewModel.valuePerUnit = "3000"
+        viewModel.hsTariffNumber = "123456"
+
+        // Then
+        XCTAssertTrue(viewModel.internationalTransactionNumberIsRequired)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement validation and requirements for the International Transaction Number in Customs in Woo Shipping Label:

- Validation: we follow this regular expression `"^(?:(?:AES X\\d{14})|(?:NOEEI 30\\.\\d{1,2}(?:\\([a-z]\\)(?:\\(\\d\\))?)?))$"`
- ~~Required ITN: If any item in Customs has a value of more than $2500 and a valid HS Tariff, the ITN is required.~~ Update: If the value of the items linked to an HS Tariff adds more than $2500
- Enable "Save Customs Details": If the ITN is required the button is only enabled if it's valid

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Validation

1. Tap on Create Shipping Label on an order
2. Tap on the Customs pencil
3. Play with the International Transaction Number validation. Valid numbers: NOEEI 30.37, NOEEI 30.37(a), AES X12345678901234

### ITN Required

1. Tap on Create Shipping Label on an order
2. Tap on the Customs pencil
3. Open an item. Add a value of $2500 and a HS Tariff. Below the ITN text field we show the message: `"International Transaction Number is required for shipping items valued over $2,500"`
4. Verify that the "Save Customs Details" button is not enabled until we enter a valid ITN


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
See above

I tested:
- When an item has more than 1 quantity
- When there are different HS tariff numbers
- When there are no HS tariff numbers

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Validation

https://github.com/user-attachments/assets/47f22015-3bcc-42e4-b54f-66ef9a99cdd6

### ITN required

In this video, we can see how the items linked to an HS Tariff add more than $2500 (the second item has a quantity of 2)

https://github.com/user-attachments/assets/1f67d46d-a5c9-41db-9e1b-3e4c33dda36e

### "Save Customs Details" button 

https://github.com/user-attachments/assets/728c45e6-3865-48bf-bcf6-634d1860206e

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
