### PR TITLE
[Woo POS] [Variable Products] Update info banner to include variable products

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -88,11 +88,11 @@ private extension ItemListView {
                 Spacer()
             }
             VStack(alignment: .leading, spacing: Constants.bannerTitleSpacing) {
-                Text(Localization.headerBannerTitle)
+                Text(headerBannerTitle)
                     .font(Constants.bannerTitleFont)
                     .accessibilityAddTraits(.isHeader)
                 VStack(alignment: .leading, spacing: Constants.bannerTextSpacing) {
-                    Text(Localization.headerBannerSubtitle)
+                    Text(headerBannerSubtitle)
                     bannerHintAndLearnMoreText
                 }
                 .font(Constants.bannerSubtitleFont)
@@ -127,7 +127,7 @@ private extension ItemListView {
     }
 
     private var bannerHintAndLearnMoreText: Text {
-        Text(Localization.headerBannerHint + " ") +
+        Text(headerBannerHint + " ") +
         Text(Localization.headerBannerLearnMoreHint)
             .font(POSFontStyle.posDetailEmphasized.font())
             .foregroundColor(Color(.accent))
@@ -232,6 +232,22 @@ private extension ItemListView {
         static let isSimpleProductsOnlyBannerDismissedKey = "isSimpleProductsOnlyBannerDismissed"
     }
 
+    var variableProductsEnabled: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale)
+    }
+
+    var headerBannerTitle: String {
+        variableProductsEnabled ? Localization.headerBannerTitleSimpleAndVariable : Localization.headerBannerTitle
+    }
+
+    var headerBannerSubtitle: String {
+        variableProductsEnabled ? Localization.headerBannerSubtitleSimpleAndVariable : Localization.headerBannerSubtitle
+    }
+
+    var headerBannerHint: String {
+        variableProductsEnabled ? Localization.headerBannerHintSimpleAndVariable : Localization.headerBannerHint
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "pos.itemlistview.title",
@@ -254,6 +270,24 @@ private extension ItemListView {
         static let headerBannerHint = NSLocalizedString(
             "pos.itemlistview.headerBanner.hint",
             value: "Other product types, such as variable and virtual, will become available in future updates.",
+            comment: "Additional text within the product selector header banner, which explains current POS limitations"
+        )
+
+        static let headerBannerTitleSimpleAndVariable = NSLocalizedString(
+            "pos.itemlistview.headerBanner.title.simpleAndVariable",
+            value: "Showing simple and variable products only",
+            comment: "Title of the product selector header banner, which explains current POS limitations"
+        )
+
+        static let headerBannerSubtitleSimpleAndVariable = NSLocalizedString(
+            "pos.itemlistview.headerBanner.subtitle.simpleAndVariable",
+            value: "Only simple and variable non-downloadable products can be used with POS right now.",
+            comment: "Subtitle of the product selector header banner, which explains current POS limitations"
+        )
+
+        static let headerBannerHintSimpleAndVariable = NSLocalizedString(
+            "pos.itemlistview.headerBanner.hint.simpleAndVariable",
+            value: "Other product types will become available in future updates.",
             comment: "Additional text within the product selector header banner, which explains current POS limitations"
         )
 

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct SimpleProductsOnlyInformation: View {
     @Binding var isPresented: Bool
+    private var variableProductsEnabled: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale)
+    }
     let deepLinkNavigator: DeepLinkNavigator?
 
     init(isPresented: Binding<Bool>,
@@ -17,14 +20,14 @@ struct SimpleProductsOnlyInformation: View {
                     .font(.posTitleEmphasized)
 
                 Group {
-                    Text(Localization.simpleProductsOnlyIssueMessage)
-                    Text(Localization.simpleProductsOnlyFutureMessage)
+                    Text(issueMessage)
+                    Text(futureMessage)
                         .padding(.bottom, Constants.textToModalBottomPadding)
                 }
                 .font(.posBodyRegular)
 
                 VStack(spacing: Constants.textSpacing) {
-                    Text(Localization.modalHint)
+                    Text(hintMessage)
                         .font(.posDetailLight)
 
                     Button {
@@ -52,6 +55,18 @@ struct SimpleProductsOnlyInformation: View {
         .padding(Constants.modalContentPadding)
         .frame(width: Constants.modalFrameWidth)
     }
+
+    private var issueMessage: String {
+        variableProductsEnabled ? Localization.variableAndSimpleProductsOnlyIssueMessage : Localization.simpleProductsOnlyIssueMessage
+    }
+
+    private var futureMessage: String {
+        variableProductsEnabled ? Localization.variableAndSimpleProductsOnlyFutureMessage : Localization.simpleProductsOnlyFutureMessage
+    }
+
+    private var hintMessage: String {
+        variableProductsEnabled ? Localization.variableAndSimpleProdustsOnlyHint : Localization.modalHint
+    }
 }
 
 // Constants and Localization enums
@@ -78,15 +93,30 @@ private extension SimpleProductsOnlyInformation {
             value: "Only simple physical products can be used with POS right now.",
             comment: "Message in the simple products information modal in POS"
         )
+        static let variableAndSimpleProductsOnlyIssueMessage = NSLocalizedString(
+            "pos.simpleProductsModal.message.issue.variableAndSimple",
+            value: "Only simple and variable non-downloadable products can be used with POS right now.",
+            comment: "Message in the simple products information modal in POS when variable products are supported"
+        )
         static let simpleProductsOnlyFutureMessage = NSLocalizedString(
             "pos.simpleProductsModal.message.future",
             value: "Other product types, such as variable and virtual, will be available in future updates.",
             comment: "Message in the simple products information modal in POS, explaining future plans"
         )
+        static let variableAndSimpleProductsOnlyFutureMessage = NSLocalizedString(
+            "pos.simpleProductsModal.message.future.variableAndSimple",
+            value: "Other product types will be available in future updates.",
+            comment: "Message in the simple products information modal in POS, explaining future plans when variable products are supported"
+        )
         static let modalHint = NSLocalizedString(
             "pos.simpleProductsModal.hint",
             value: "To take payment for a non-simple product, exit POS and create a new order from the orders tab.",
             comment: "Hint in the simple products information modal in POS"
+        )
+        static let variableAndSimpleProdustsOnlyHint = NSLocalizedString(
+            "pos.simpleProductsModal.hint.variableAndSimple",
+            value: "To take payment for an unsupported product, exit POS and create a new order from the orders tab.",
+            comment: "Hint in the simple products information modal in POS, explaining future plans when variable products are supported"
         )
         static let modalAction = NSLocalizedString(
             "pos.simpleProductsModal.action",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14925
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the "Simple Products Only" banner and modal to show that we also support variable products, and non-downloadable virtual products.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Reinstall the app if you don't currently see the info banner at the top of the item list
Launch the app and go to POS
Observe that the banner and the modal it opens mention virtual products, not simple products only.

Change the feature flag `variableProductsInPointOfSale` to true

Repeat the above test but observe that the banner and modal have the previous text.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Feature flag disabled

https://github.com/user-attachments/assets/68ef1a87-5227-4e06-9c5d-fc5a2d90b545

### Feature flag enabled

https://github.com/user-attachments/assets/5a01bf35-c725-4d40-bb89-a09958f47c9b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.