### PR TITLE
Jetpack Setup: Fix issue removing application password

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [Internal] [*] Improved handling of the navigation to the Woo Installation screen post Jetpack setup [https://github.com/woocommerce/woocommerce-ios/pull/14837]
 - [*] Receipts: Email receipts can now be sent to customers after failed payments using WooCommerce Stripe 9.1.0+. [https://github.com/woocommerce/woocommerce-ios/pull/14864].
 - [*] Dashboard: Updated the drag gesture on the Performance chart to show stats instantly. [https://github.com/woocommerce/woocommerce-ios/pull/14906]
+- [*] Jetpack Setup: Fix issue setting up Jetpack for JCP sites when authenticated without WPCom and removing application password after completion [https://github.com/woocommerce/woocommerce-ios/pull/14929]
 - [Internal] Removed feedback survey for Store Setup feature [https://github.com/woocommerce/woocommerce-ios/pull/14888]
 - [Internal] Removed feedback survey for shipping label creation [https://github.com/woocommerce/woocommerce-ios/pull/14889]
 - [Internal] Removed feedback survey for product creation AI [https://github.com/woocommerce/woocommerce-ios/pull/14890]

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -219,9 +219,9 @@ final class SessionManager: SessionManagerProtocol {
 
     /// Deletes application password
     ///
-    func deleteApplicationPassword() {
+    func deleteApplicationPassword(using credentials: Credentials?) {
         let useCase: ApplicationPasswordUseCase? = {
-            switch loadCredentials() {
+            switch credentials ?? loadCredentials() {
             case let .wporg(username, password, siteAddress):
                 return try? DefaultApplicationPasswordUseCase(username: username,
                                                               password: password,

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -261,7 +261,7 @@ private extension JetpackSetupCoordinator {
             guard let self else { return }
             switch result {
             case .success(let site):
-                self.stores.sessionManager.deleteApplicationPassword()
+                self.stores.sessionManager.deleteApplicationPassword(using: previousCredentials)
                 self.stores.updateDefaultStore(storeID: site.siteID)
                 self.stores.synchronizeEntities { [weak self] in
                     self?.stores.updateDefaultStore(site)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -222,7 +222,7 @@ private extension JetpackSetupCoordinator {
 
         /// WPCom credentials to authenticate the user in the Jetpack connection web view automatically
         let credentials: Credentials = .wpcom(username: username, authToken: authToken, siteAddress: site.url)
-        guard jetpackConnectedEmail == nil || !site.isJetpackThePluginInstalled else {
+        guard jetpackConnectedEmail == nil else {
             // authenticate user immediately
             return authenticateUserAndRefreshSite(with: credentials)
         }
@@ -257,7 +257,7 @@ private extension JetpackSetupCoordinator {
         let progressView = InProgressViewController(viewProperties: .init(title: Localization.syncingData, message: ""))
         rootViewController.topmostPresentedViewController.present(progressView, animated: true)
 
-        let action = SiteAction.syncSiteByDomain(domain: site.url.trimHTTPScheme()) { [weak self] result in
+        let resultHandler: (Result<Site, Error>) -> Void = { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let site):
@@ -289,7 +289,12 @@ private extension JetpackSetupCoordinator {
 
             }
         }
-        stores.dispatch(action)
+
+        if site.isJetpackCPConnected {
+            stores.dispatch(AccountAction.synchronizeSitesAndReturnSelectedSiteInfo(siteAddress: site.url, onCompletion: resultHandler))
+        } else {
+            stores.dispatch(SiteAction.syncSiteByDomain(domain: site.url.trimHTTPScheme(), completion: resultHandler))
+        }
     }
 
     func registerForPushNotifications() {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -222,7 +222,7 @@ private extension JetpackSetupCoordinator {
 
         /// WPCom credentials to authenticate the user in the Jetpack connection web view automatically
         let credentials: Credentials = .wpcom(username: username, authToken: authToken, siteAddress: site.url)
-        guard jetpackConnectedEmail == nil else {
+        guard jetpackConnectedEmail == nil || !site.isJetpackThePluginInstalled else {
             // authenticate user immediately
             return authenticateUserAndRefreshSite(with: credentials)
         }

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -535,6 +535,10 @@ final class MockSessionManager: SessionManagerProtocol {
         // Do nothing
     }
 
+    func deleteApplicationPassword(using credentials: Credentials?) {
+        deleteApplicationPasswordInvoked = true
+    }
+
     func deleteApplicationPassword() {
         deleteApplicationPasswordInvoked = true
     }

--- a/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
+++ b/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
@@ -51,5 +51,13 @@ public protocol SessionManagerProtocol {
 
     /// Deletes application password
     ///
-    func deleteApplicationPassword()
+    func deleteApplicationPassword(using credentials: Credentials?)
+}
+
+/// Helper methods
+public extension SessionManagerProtocol {
+    /// Let the session manager figure out the credentials by itself
+    func deleteApplicationPassword() {
+        deleteApplicationPassword(using: nil)
+    }
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
@@ -43,7 +43,7 @@ public struct MockSessionManager: SessionManagerProtocol {
         // Do nothing
     }
 
-    public func deleteApplicationPassword() {
+    public func deleteApplicationPassword(using credentials: Credentials?) {
         // Do nothing
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to #14897 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In #14897 I added a fix to keep the previous credentials when syncing sites after Jetpack setup. I also moved the removal of application password to after the Jetpack syncing completes to ensure user could still use the app if the syncing fails.

While reviewing the back-merge PR, I realized that the application password removal in this case would fail because the user is now authenticated with WPCom. 

This PR fixes the removal by sending the previous credentials (application password or username-nonce) to the application password removal request. The credentials would be used to determine the correct use case for handling the removal.

Note: While #14897 targets 21.4, I think this issue is not a blocker so I'm targeting 21.5. Let me know if you think otherwise.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Create a new JN site or use an existing self-hosted site.
- Connect Jetpack to your WPCom account if needed.
- Log in to the test site using site credentials.
- Tap the Jetpack benefit banner at the bottom of the My Store screen and proceed through the steps.
- Confirm that Jetpack setup succeeds.
- Before tapping Go to Store button, put a breakpoint in `SessionManager.deleteApplicationPassword` to confirm that the request is actually handled by a use case. Alternatively, use Proxyman or Charles to keep track of network requests.
- Tap Go to Store and confirm that the application password removal is successful.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested in simulator iPhone 16 Pro iOS 18.2 and confirmed that application password is removed successfully after successful Jetpack setup and site syncing.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.