### PR TITLE
[Shipping labels] Add networking support for address validation endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -898,6 +898,7 @@
 		CED9BCC12D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */; };
 		CED9BCC32D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */; };
 		CED9BCC52D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */; };
+		CED9BCC72D3FAD1500C063B8 /* WooShippingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
@@ -2097,6 +2098,7 @@
 		CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationError.swift; sourceTree = "<group>"; };
 		CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationResponse.swift; sourceTree = "<group>"; };
 		CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationSuccessMapper.swift; sourceTree = "<group>"; };
+		CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddress.swift; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
@@ -2559,6 +2561,7 @@
 				CED9BCBE2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift */,
 				CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */,
 				CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */,
+				CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */,
 				451A97C72609FDE50059D135 /* Packages */,
 			);
 			path = ShippingLabel;
@@ -5073,6 +5076,7 @@
 				EE62EE63295AD45E009C965B /* String+URL.swift in Sources */,
 				CE12AE9729F2AB3F0056DD17 /* SubscriptionMapper.swift in Sources */,
 				025CA2C2238EBBAA00B05C81 /* ProductShippingClassListMapper.swift in Sources */,
+				CED9BCC72D3FAD1500C063B8 /* WooShippingAddress.swift in Sources */,
 				74ABA1CD213F1B6B00FFAD30 /* TopEarnerStats.swift in Sources */,
 				CCAAD10F2683974000909664 /* ShippingLabelPackagePurchase.swift in Sources */,
 				265EFBDC285257950033BD33 /* Order+Fallbacks.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -892,6 +892,7 @@
 		CEC7D5932CDD0D9900111B79 /* WooShippingPredefinedOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */; };
 		CEC7D5952CDD164D00111B79 /* WooShippingCreatePackageMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
+		CED9BCBB2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
@@ -2085,6 +2086,7 @@
 		CEC7D5922CDD0D9900111B79 /* WooShippingPredefinedOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPredefinedOption.swift; sourceTree = "<group>"; };
 		CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreatePackageMapper.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
+		CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-address-validation-success.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
@@ -3560,6 +3562,7 @@
 				CE1EA4BA2CEB78F60039F477 /* wooshipping-purchase-success.json */,
 				CE90E99B2CEFCAA50068D852 /* wooshipping-label-status-success.json */,
 				CE2FB3972CF74C5C0046201C /* wooshipping-label-print-success.json */,
+				CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4299,6 +4302,7 @@
 				DE42F9602967C88400D514C2 /* report-orders-total-without-data.json in Resources */,
 				DE9DEEF5291CF1B40070AD7C /* site-plugin-without-envelope.json in Resources */,
 				EEFC4C972A5E996C004C5A83 /* jwt-token-success.json in Resources */,
+				CED9BCBB2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json in Resources */,
 				0261F5A928D4641500B7AC72 /* products-sku-search.json in Resources */,
 				EE57C14A2980CE4B00BC31E7 /* taxes-classes-without-data.json in Resources */,
 				DE20045B2BF6146700660A72 /* product-stock-without-data-envelope.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -894,6 +894,9 @@
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CED9BCBB2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */; };
 		CED9BCBD2D3EAE4400C063B8 /* wooshipping-address-validation-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCBC2D3EAE4400C063B8 /* wooshipping-address-validation-error.json */; };
+		CED9BCBF2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCBE2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift */; };
+		CED9BCC12D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */; };
+		CED9BCC32D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
@@ -2089,6 +2092,9 @@
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-address-validation-success.json"; sourceTree = "<group>"; };
 		CED9BCBC2D3EAE4400C063B8 /* wooshipping-address-validation-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-address-validation-error.json"; sourceTree = "<group>"; };
+		CED9BCBE2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationSuccess.swift; sourceTree = "<group>"; };
+		CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationError.swift; sourceTree = "<group>"; };
+		CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationResponse.swift; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
@@ -2548,6 +2554,9 @@
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
 				DAA259AE2CECF4A70035F028 /* WooShippingAccountSettings.swift */,
+				CED9BCBE2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift */,
+				CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */,
+				CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */,
 				451A97C72609FDE50059D135 /* Packages */,
 			);
 			path = ShippingLabel;
@@ -5008,6 +5017,7 @@
 				DE66C5532976508300DAA978 /* CookieNonceAuthenticator.swift in Sources */,
 				DE02ABB52B563E96008E0AC4 /* BlazePaymentInfoMapper.swift in Sources */,
 				CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */,
+				CED9BCBF2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift in Sources */,
 				02EBCB3E2AA03D520019085B /* OrderItemProductAddOn.swift in Sources */,
 				26650332261FFA1A0079A159 /* ProductAddOnEnvelope.swift in Sources */,
 				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,
@@ -5138,6 +5148,7 @@
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
 				EE078D912AD2EFBA00C1199E /* JWTokenMapper.swift in Sources */,
 				024124862AC93E470035A247 /* OrderItemBundleItem.swift in Sources */,
+				CED9BCC32D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift in Sources */,
 				CEB9BF392BB193020007978A /* ProductBundleStatsTotals.swift in Sources */,
 				CE71E22B2A4C363E00DB5376 /* ProductsReportsRemote.swift in Sources */,
 				45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */,
@@ -5258,6 +5269,7 @@
 				DE78DE482B2AEBEC002E58DE /* WordPressPageMapper.swift in Sources */,
 				CE430676234BA7920073CBFF /* RefundListMapper.swift in Sources */,
 				45551F122523E7F1007EF104 /* UserAgent.swift in Sources */,
+				CED9BCC12D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift in Sources */,
 				45CDAFAB2434CA9300F83C22 /* ProductCatalogVisibility.swift in Sources */,
 				3148977027232982007A86BD /* SystemStatus.swift in Sources */,
 				B557DA1820979D51005962F4 /* Credentials.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 		CEC7D5952CDD164D00111B79 /* WooShippingCreatePackageMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CED9BCBB2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */; };
+		CED9BCBD2D3EAE4400C063B8 /* wooshipping-address-validation-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCBC2D3EAE4400C063B8 /* wooshipping-address-validation-error.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
@@ -2087,6 +2088,7 @@
 		CEC7D5942CDD164D00111B79 /* WooShippingCreatePackageMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreatePackageMapper.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-address-validation-success.json"; sourceTree = "<group>"; };
+		CED9BCBC2D3EAE4400C063B8 /* wooshipping-address-validation-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-address-validation-error.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
@@ -3563,6 +3565,7 @@
 				CE90E99B2CEFCAA50068D852 /* wooshipping-label-status-success.json */,
 				CE2FB3972CF74C5C0046201C /* wooshipping-label-print-success.json */,
 				CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */,
+				CED9BCBC2D3EAE4400C063B8 /* wooshipping-address-validation-error.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4482,6 +4485,7 @@
 				021D741C2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json in Resources */,
 				B57B1E6C21C94C9F0046E764 /* timeout_error.json in Resources */,
 				0313651B28AE60E000EEE571 /* payment-gateway-cod.json in Resources */,
+				CED9BCBD2D3EAE4400C063B8 /* wooshipping-address-validation-error.json in Resources */,
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
 				3158FE7426129D9F00E566B9 /* wcpay-account-rejected-other.json in Resources */,
 				CE0F4EC92CE37547006339BD /* wooshipping-get-label-rates-success.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -897,6 +897,7 @@
 		CED9BCBF2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCBE2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift */; };
 		CED9BCC12D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */; };
 		CED9BCC32D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */; };
+		CED9BCC52D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
@@ -2095,6 +2096,7 @@
 		CED9BCBE2D3EAED700C063B8 /* WooShippingAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		CED9BCC02D3EAF7B00C063B8 /* WooShippingAddressValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationError.swift; sourceTree = "<group>"; };
 		CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationResponse.swift; sourceTree = "<group>"; };
+		CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationSuccessMapper.swift; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
@@ -3686,6 +3688,7 @@
 				CE0F4ECE2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift */,
 				DAF367A12CE75B9D00D1B327 /* WooShippingPackagesMapper.swift */,
 				DAEE64292D104B720031DCDC /* WooShippingOriginAddressesMapper.swift */,
+				CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */,
 				CE90E99D2CEFCB100068D852 /* WooShippingStatusMapper.swift */,
 				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
@@ -5181,6 +5184,7 @@
 				CE606D8F2BE39426001CB424 /* ShippingMethodMapper.swift in Sources */,
 				CEC7D5912CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift in Sources */,
 				4513382427A951B300AE5E78 /* InboxNoteMapper.swift in Sources */,
+				CED9BCC52D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift in Sources */,
 				B9CFF6522AB2118900C2F616 /* TaxRateMapper.swift in Sources */,
 				DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */,
 				B557DA0320975500005962F4 /* Remote.swift in Sources */,

--- a/Networking/Networking/Mapper/WooShippingAddressValidationSuccessMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingAddressValidationSuccessMapper.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+
+/// Mapper: Shipping Label Address Validation Response from WooCommerce Shipping extension
+///
+struct WooShippingAddressValidationSuccessMapper: Mapper {
+    /// (Attempts) to convert a dictionary into WooShippingAddressValidationResponse.
+    ///
+    func map(response: Data) throws -> WooShippingAddressValidationSuccess {
+        let decoder = JSONDecoder()
+        let data: WooShippingAddressValidationResponse = try {
+            if hasDataEnvelope(in: response) {
+                return try decoder.decode(WooShippingAddressValidationResponseEnvelope.self, from: response).data
+            } else {
+                return try decoder.decode(WooShippingAddressValidationResponse.self, from: response)
+            }
+        }()
+        return try data.result.get()
+    }
+}
+
+/// WooShippingAddressValidationResponseEnvelope Disposable Entity:
+/// `Normalize Address` endpoint returns the shipping label address document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct WooShippingAddressValidationResponseEnvelope: Decodable {
+    let data: WooShippingAddressValidationResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case data = "data"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddress.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Codegen
+
+/// Represents an address for the WooCommerce Shipping extension.
+///
+public struct WooShippingAddress: Equatable {
+    /// The name of the company at the address.
+    public let company: String
+
+    /// The name of the sender/receiver at the address.
+    public let name: String
+
+    /// The contact phone number at the address.
+    public let phone: String
+
+    /// The country the address is in (ISO code).
+    public let country: String
+
+    /// The state the address is in (ISO code).
+    public let state: String
+
+    /// The first line of address (street, number, floor, etc.).
+    public let address1: String
+
+    /// The second line of address, empty if the address is only one line.
+    public let address2: String
+
+    /// The city the address is in.
+    public let city: String
+
+    /// Postal code of the address.
+    public let postcode: String
+
+    public init(company: String,
+                name: String,
+                phone: String,
+                country: String,
+                state: String,
+                address1: String,
+                address2: String,
+                city: String,
+                postcode: String) {
+        self.company = company
+        self.name = name
+        self.phone = phone
+        self.country = country
+        self.state = state
+        self.address1 = address1
+        self.address2 = address2
+        self.city = city
+        self.postcode = postcode
+    }
+}
+
+// MARK: Codable
+extension WooShippingAddress: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // If no name is sent to validation address request, no name will be received in response.
+        // So make sure to decode it only if it's present.
+        let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        let company = try container.decode(String.self, forKey: .company)
+        let phone = try container.decode(String.self, forKey: .phone)
+        let country = try container.decode(String.self, forKey: .country)
+        let state = try container.decode(String.self, forKey: .state)
+        let address1 = try container.decodeIfPresent(String.self, forKey: .address1) ?? container.decode(String.self, forKey: .alternateAddress1)
+        let address2 = try container.decode(String.self, forKey: .address2)
+        let city = try container.decode(String.self, forKey: .city)
+        let postcode = try container.decode(String.self, forKey: .postcode)
+
+        self.init(company: company,
+                  name: name,
+                  phone: phone,
+                  country: country,
+                  state: state,
+                  address1: address1,
+                  address2: address2,
+                  city: city,
+                  postcode: postcode)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(company, forKey: .company)
+        // Make sure to only send address name if it's not empty,
+        // otherwise requests to fetch rates and purchase label will fail.
+        // Reference: https://git.io/JVQzC
+        if !name.isEmpty {
+            try container.encode(name, forKey: .name)
+        }
+        try container.encode(phone, forKey: .phone)
+        try container.encode(country, forKey: .country)
+        try container.encode(state, forKey: .state)
+        try container.encode(address1, forKey: .address1)
+        try container.encode(address2, forKey: .address2)
+        try container.encode(city, forKey: .city)
+        try container.encode(postcode, forKey: .postcode)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case company
+        case name
+        case phone
+        case country
+        case state
+        case address1 = "address"
+        case alternateAddress1 = "address_1"
+        case address2 = "address_2"
+        case city
+        case postcode
+    }
+}
+
+extension WooShippingAddress {
+    /// This empty initializer is used when parsing the API response for shipping labels, because the origin/destination addresses are not available in each
+    /// shipping label response and we have to manually populate them later.
+    init() {
+        self.init(company: "", name: "", phone: "", country: "", state: "", address1: "", address2: "", city: "", postcode: "")
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationError.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationError.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Codegen
+
+/// Represents Shipping Label Address Validation Error from the WooCommerce Shipping extension.
+///
+public struct WooShippingAddressValidationError: Error, Equatable {
+    public let addressError: String?
+    public let generalError: String?
+    public let nameError: String?
+
+    public init(addressError: String?, generalError: String?, nameError: String?) {
+        self.addressError = addressError
+        self.generalError = generalError
+        self.nameError = nameError
+    }
+}
+
+extension WooShippingAddressValidationError: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let addressError = try container.decodeIfPresent(String.self, forKey: .address)
+        let generalError = try container.decodeIfPresent(String.self, forKey: .general)
+        let nameError = try container.decodeIfPresent(String.self, forKey: .name)
+        self.init(addressError: addressError, generalError: generalError, nameError: nameError)
+    }
+}
+
+/// Defines all of the WooShippingAddressValidationError CodingKeys
+///
+private extension WooShippingAddressValidationError {
+    enum CodingKeys: String, CodingKey {
+        case general
+        case address
+        case name
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Represents Shipping Label Address that has been validated or that generated an error from the WooCommerce Shipping Extension.
+///
+/// Only used internally for JSON decoding since the response might contain validation errors.
+/// For public consumption, we'll convert those to a `WooShippingAddressValidationError`, and expose
+/// a `WooShippingAddressValidationSuccess` instead if there were no errors.
+///
+internal struct WooShippingAddressValidationResponse: Equatable {
+    let result: Result<WooShippingAddressValidationSuccess, WooShippingAddressValidationError>
+
+    init(normalizedAddress: ShippingLabelAddress?,
+         originalAddress: ShippingLabelAddress?,
+         isTrivialNormalization: Bool?,
+         errors: WooShippingAddressValidationError?) {
+        if let errors {
+            result = .failure(errors)
+        } else if let normalizedAddress,
+                  let originalAddress,
+                  let isTrivialNormalization {
+            result = .success(.init(normalizedAddress: normalizedAddress, originalAddress: originalAddress, isTrivialNormalization: isTrivialNormalization))
+        } else {
+            // This case should never happen, but that's not guaranteed.
+            // We'll treat the absence of both the addresses and errors as an error with no message.
+            result = .failure(.init(addressError: nil, generalError: nil, nameError: nil))
+        }
+    }
+}
+
+extension WooShippingAddressValidationResponse: Decodable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let normalizedAddress = try container.decodeIfPresent(ShippingLabelAddress.self, forKey: .normalized)
+        let originalAddress = try container.decodeIfPresent(ShippingLabelAddress.self, forKey: .original)
+        let isTrivialNormalization = try container.decodeIfPresent(Bool.self, forKey: .isTrivialNormalization)
+        let errors = try container.decodeIfPresent(WooShippingAddressValidationError.self, forKey: .errors)
+        self.init(normalizedAddress: normalizedAddress, originalAddress: originalAddress, isTrivialNormalization: isTrivialNormalization, errors: errors)
+    }
+}
+
+/// Defines all of the WooShippingAddressValidationResponse CodingKeys
+///
+private extension WooShippingAddressValidationResponse {
+    enum CodingKeys: String, CodingKey {
+        case normalized = "normalizedAddress"
+        case original = "address"
+        case errors = "errors"
+        case isTrivialNormalization = "isTrivialNormalization"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift
@@ -9,8 +9,8 @@ import Foundation
 internal struct WooShippingAddressValidationResponse: Equatable {
     let result: Result<WooShippingAddressValidationSuccess, WooShippingAddressValidationError>
 
-    init(normalizedAddress: ShippingLabelAddress?,
-         originalAddress: ShippingLabelAddress?,
+    init(normalizedAddress: WooShippingAddress?,
+         originalAddress: WooShippingAddress?,
          isTrivialNormalization: Bool?,
          errors: WooShippingAddressValidationError?) {
         if let errors {
@@ -30,8 +30,8 @@ internal struct WooShippingAddressValidationResponse: Equatable {
 extension WooShippingAddressValidationResponse: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let normalizedAddress = try container.decodeIfPresent(ShippingLabelAddress.self, forKey: .normalized)
-        let originalAddress = try container.decodeIfPresent(ShippingLabelAddress.self, forKey: .original)
+        let normalizedAddress = try container.decodeIfPresent(WooShippingAddress.self, forKey: .normalized)
+        let originalAddress = try container.decodeIfPresent(WooShippingAddress.self, forKey: .original)
         let isTrivialNormalization = try container.decodeIfPresent(Bool.self, forKey: .isTrivialNormalization)
         let errors = try container.decodeIfPresent(WooShippingAddressValidationError.self, forKey: .errors)
         self.init(normalizedAddress: normalizedAddress, originalAddress: originalAddress, isTrivialNormalization: isTrivialNormalization, errors: errors)

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationSuccess.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationSuccess.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Codegen
+
+
+/// Represents Shipping Label Address that has been validated by the WooCommerce Shipping extension.
+///
+public struct WooShippingAddressValidationSuccess: Equatable {
+    public let normalizedAddress: ShippingLabelAddress
+    public let originalAddress: ShippingLabelAddress
+
+    /// When sending an address to normalize to the server, if the response has the is_trivial_normalization property set to true,
+    /// then the normalized address will be automatically accepted without user intervention.
+    /// As its name indicates, that flag will be set when the changes made by the address normalizator were trivial,
+    /// such as adding the +4 portion to a ZIP code, or changing capitalization, or changing street to st for example.
+    ///
+    public let isTrivialNormalization: Bool
+
+    public init(normalizedAddress: ShippingLabelAddress, originalAddress: ShippingLabelAddress, isTrivialNormalization: Bool) {
+        self.normalizedAddress = normalizedAddress
+        self.originalAddress = originalAddress
+        self.isTrivialNormalization = isTrivialNormalization
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationSuccess.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationSuccess.swift
@@ -5,8 +5,8 @@ import Codegen
 /// Represents Shipping Label Address that has been validated by the WooCommerce Shipping extension.
 ///
 public struct WooShippingAddressValidationSuccess: Equatable {
-    public let normalizedAddress: ShippingLabelAddress
-    public let originalAddress: ShippingLabelAddress
+    public let normalizedAddress: WooShippingAddress
+    public let originalAddress: WooShippingAddress
 
     /// When sending an address to normalize to the server, if the response has the is_trivial_normalization property set to true,
     /// then the normalized address will be automatically accepted without user intervention.
@@ -15,7 +15,7 @@ public struct WooShippingAddressValidationSuccess: Equatable {
     ///
     public let isTrivialNormalization: Bool
 
-    public init(normalizedAddress: ShippingLabelAddress, originalAddress: ShippingLabelAddress, isTrivialNormalization: Bool) {
+    public init(normalizedAddress: WooShippingAddress, originalAddress: WooShippingAddress, isTrivialNormalization: Bool) {
         self.normalizedAddress = normalizedAddress
         self.originalAddress = originalAddress
         self.isTrivialNormalization = isTrivialNormalization

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -35,6 +35,9 @@ public protocol WooShippingRemoteProtocol {
 
     func loadOriginAddresses(siteID: Int64,
                              completion: @escaping (Result<[WooShippingOriginAddress], Error>) -> Void)
+    func addressValidation(siteID: Int64,
+                           address: ShippingLabelAddress,
+                           completion: @escaping (Result<WooShippingAddressValidationSuccess, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -287,6 +290,32 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Address validation for a shipping address.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site that owns the shipping label.
+    ///   - address: The address that should be verified.
+    ///   - completion: Closure to be executed upon completion.
+    public func addressValidation(siteID: Int64,
+                                  address: ShippingLabelAddress,
+                                  completion: @escaping (Result<WooShippingAddressValidationSuccess, Error>) -> Void) {
+        do {
+            let parameters = [
+                ParameterKey.address: try address.toDictionary()
+            ]
+            let path = "\(Path.normalizeAddress)"
+            let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                         method: .post,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
+            let mapper = WooShippingAddressValidationSuccessMapper()
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constants
@@ -299,6 +328,7 @@ private extension WooShippingRemote {
         static let status = "label/status"
         static let print = "label/print"
         static let originAddresses = "address/origins"
+        static let normalizeAddress = "address/normalize"
     }
 
     enum ParameterKey {
@@ -314,6 +344,7 @@ private extension WooShippingRemote {
         static let customs = "customs"
         static let paperSize = "paper_size"
         static let labelIDCSV = "label_id_csv"
+        static let address = "address"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -429,6 +429,44 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         XCTAssertNotNil(result.failure)
     }
+
+    func test_addressValidation_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/normalize", filename: "wooshipping-address-validation-success")
+
+        // When
+        let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
+            remote.addressValidation(siteID: self.sampleSiteID,
+                                     address: ShippingLabelAddress.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let validationResponse = try XCTUnwrap(result.get())
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(validationResponse.normalizedAddress)
+        XCTAssertNotNil(validationResponse.originalAddress)
+        XCTAssertFalse(validationResponse.isTrivialNormalization)
+    }
+
+    func test_addressValidation_returns_error_on_failure() {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/normalize", filename: "generic_error")
+
+        // When
+        let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
+            remote.addressValidation(siteID: self.sampleSiteID,
+                                     address: ShippingLabelAddress.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension WooShippingRemoteTests {

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -451,7 +451,28 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertFalse(validationResponse.isTrivialNormalization)
     }
 
-    func test_addressValidation_returns_error_on_failure() {
+    func test_addressValidation_returns_errors_on_failure() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/normalize", filename: "wooshipping-address-validation-error")
+
+        // When
+        let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
+            remote.addressValidation(siteID: self.sampleSiteID,
+                                     address: ShippingLabelAddress.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure as? WooShippingAddressValidationError)
+        XCTAssertEqual(error.addressError, "House number is missing")
+        XCTAssertEqual(error.generalError, "Address not found")
+        XCTAssertEqual(error.nameError, "Either Name or Company is required")
+    }
+
+    func test_addressValidation_returns_error_on_network_failure() {
         // Given
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "address/normalize", filename: "generic_error")

--- a/Networking/NetworkingTests/Responses/wooshipping-address-validation-error.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-address-validation-error.json
@@ -1,0 +1,23 @@
+{
+    "data": {
+        "success": false,
+        "errors": {
+            "address": "House number is missing",
+            "name": "Either Name or Company is required",
+            "general": "Address not found"
+        },
+        "isTrivialNormalization": false,
+        "address": {
+            "company": "",
+            "name": "",
+            "address_1": "20W 34th St",
+            "address_2": "Suite 100",
+            "city": "New York",
+            "state": "NY",
+            "postcode": "10001",
+            "country": "US",
+            "phone": "555-1234",
+            "email": "john.doe@example.com"
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/wooshipping-address-validation-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-address-validation-success.json
@@ -1,0 +1,31 @@
+{
+    "data": {
+        "success": true,
+        "normalizedAddress": {
+            "company": "",
+            "address_2": "",
+            "city": "NEW YORK",
+            "state": "NY",
+            "postcode": "10118-0114",
+            "country": "US",
+            "phone": "555-1234",
+            "address_1": "20 W 34TH ST STE 100",
+            "first_name": "NEW",
+            "last_name": "YORK STORE",
+            "email": "john.doe@example.com"
+        },
+        "isTrivialNormalization": false,
+        "address": {
+            "company": "",
+            "name": "New York store",
+            "address_1": "20W 34th St",
+            "address_2": "Suite 100",
+            "city": "New York",
+            "state": "NY",
+            "postcode": "10001",
+            "country": "US",
+            "phone": "555-1234",
+            "email": "john.doe@example.com"
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -39,6 +39,9 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `loadOriginAddresses`
     private var loadOriginAddresses = [ResultKey: Result<[WooShippingOriginAddress], Error>]()
 
+    /// The results to return based on the given arguments in `addressValidation`
+    private var addressValidation = [ResultKey: Result<WooShippingAddressValidationSuccess, Error>]()
+
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
                            thenReturn result: Result<WooShippingCreatePackageResponse, Error>) {
@@ -100,6 +103,13 @@ final class MockWooShippingRemote {
                              thenReturn result: Result<[WooShippingOriginAddress], Error>) {
         let key = ResultKey(siteID: siteID)
         loadOriginAddresses[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `addressValidation` is called.
+    func whenAddressValidation(siteID: Int64,
+                               thenReturn result: Result<WooShippingAddressValidationSuccess, Error>) {
+        let key = ResultKey(siteID: siteID)
+        addressValidation[key] = result
     }
 }
 
@@ -239,6 +249,21 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
             let key = ResultKey(siteID: siteID)
             if let result = self.loadOriginAddresses[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func addressValidation(siteID: Int64,
+                           address: ShippingLabelAddress,
+                           completion: @escaping (Result<WooShippingAddressValidationSuccess, any Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = ResultKey(siteID: siteID)
+            if let result = self.addressValidation[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13780
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the networking layer for validating an address for the Woo Shipping extension. Apologies for the large number of changes — let me know if you'd prefer I split it up, but I decided to keep all these changes together since we test all the changes together with the new endpoint support.

The first step for updating an address for Woo Shipping is to validate it. We send the address, and the validating (normalizing) endpoint returns three things for a successful response:

1. The original address that we sent.
2. The normalized (validated) address.
3. A `Bool` indicating if the changes in the normalized address are trivial.

If the validation fails, it returns a specific error about why it failed (e.g. the address could not be found, the name/company for the address is missing, or the house number is missing).

### Changes

This is very similar to the legacy shipping label implementation, with small changes due to the API differences:

* Adds two mock API responses (success and errors)
* Adds models for the validation response, to parse both success and error responses:
   * `WooShippingAddressValidationResponse`
   * `WooShippingAddressValidationSuccess`
   * `WooShippingAddressValidationError`
* Adds a new model for the address, `WooShippingAddress`. This is identical to the legacy `ShippingLabelAddress` except that it includes an alternate key for the first address line (to support `address` or `address_1`), since the normalized address uses the key `address_1`.
* Adds the mapper `WooShippingAddressValidationSuccessMapper` to map the response.
* Adds support for the validation endpoint to `WooShippingRemote`, along with corresponding unit tests and support in `MockWooShippingRemote`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This endpoint is not yet used; confirm unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.