### PR TITLE
Try to address Stripe Terminal SDK crashes when checking local mobile reader support

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -10,17 +10,14 @@ protocol ReceiptEligibilityUseCaseProtocol {
 final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
-    private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
 
     private var siteID: Int64 {
         stores.sessionManager.defaultStoreID ?? 0
     }
 
     init(stores: StoresManager = ServiceLocator.stores,
-         cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.stores = stores
-        self.cardPresentPaymentsOnboarding = cardPresentPaymentsOnboarding
         self.featureFlagService = featureFlagService
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
@@ -16,6 +16,7 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
     private let configuration: CardPresentPaymentsConfiguration
     private let siteID: Int64
     private var locationManager: CLLocationManager = CLLocationManager()
+    private static var deviceSupportsLocalMobileReader: [Int64: Bool] = [:]
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
@@ -59,7 +60,16 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
 
     @MainActor
     func deviceSupportsLocalMobileReader() async -> Bool {
-        await withCheckedContinuation { continuation in
+        /// There may be crashes due to multiple consecutive calls checkDeviceSupport
+        /// Local mobile reader (Tap to Pay) support shouldn't change during the app lifecycle
+        /// Only a change in operating system version can affect it which would require a restart of the app
+        ///
+        if let cachedResult = Self.deviceSupportsLocalMobileReader[siteID] {
+            return cachedResult
+        }
+
+
+        let deviceSupportsLocalMobileReader = await withCheckedContinuation { continuation in
             let action = CardPresentPaymentAction.checkDeviceSupport(
                 siteID: siteID,
                 cardReaderType: .appleBuiltIn,
@@ -69,6 +79,9 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
                 }
             stores.dispatch(action)
         }
+
+        Self.deviceSupportsLocalMobileReader[siteID] = deviceSupportsLocalMobileReader
+        return deviceSupportsLocalMobileReader
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderSupportDeterminer.swift
@@ -16,7 +16,7 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
     private let configuration: CardPresentPaymentsConfiguration
     private let siteID: Int64
     private var locationManager: CLLocationManager = CLLocationManager()
-    private static var deviceSupportsLocalMobileReader: [Int64: Bool] = [:]
+    private static var deviceSupportsLocalMobileReader: [Int64: ExpiringBool] = [:]
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
@@ -61,11 +61,10 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
     @MainActor
     func deviceSupportsLocalMobileReader() async -> Bool {
         /// There may be crashes due to multiple consecutive calls checkDeviceSupport
-        /// Local mobile reader (Tap to Pay) support shouldn't change during the app lifecycle
-        /// Only a change in operating system version can affect it which would require a restart of the app
+        /// Limit the calls to once every 30 seconds and cache the result
         ///
-        if let cachedResult = Self.deviceSupportsLocalMobileReader[siteID] {
-            return cachedResult
+        if let cachedResult = Self.deviceSupportsLocalMobileReader[siteID], !cachedResult.isExpired {
+            return cachedResult.value
         }
 
 
@@ -80,7 +79,7 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
             stores.dispatch(action)
         }
 
-        Self.deviceSupportsLocalMobileReader[siteID] = deviceSupportsLocalMobileReader
+        Self.deviceSupportsLocalMobileReader[siteID] = ExpiringBool(value: deviceSupportsLocalMobileReader, expirationInSeconds: 30)
         return deviceSupportsLocalMobileReader
     }
 
@@ -95,5 +94,17 @@ final class CardReaderSupportDeterminer: CardReaderSupportDetermining {
 
             self.stores.dispatch(action)
         }
+    }
+}
+
+// MARK: - Helper for caching local reader device support check
+
+private struct ExpiringBool {
+    let value: Bool
+    let expirationInSeconds: Int
+    private let created = Date()
+
+    var isExpired: Bool {
+        Date().timeIntervalSince(created) > Double(expirationInSeconds)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

We have numerous Stripe Terminal crashes which all lead to `deviceSupportsLocalMobileReader()` call. 

The number of crashes has increased after 21.3
 
See:
- peaMlT-17b-p2
- peaMlT-15r-p2
- peaMlT-X6-p2

Most popular Sentry issue:
- https://a8c.sentry.io/issues/6062503962/events/01aee469b95a4d459d1c53316e1af8dd/

## Investigation

I couldn't reproduce the issue locally. I tried calling `deviceSupportsLocalMobileReader` multiple times at different times in the App Cycle but I couldn't force the crash. 

I checked Mobile Logs and most of the new 21.3 crashes happen after the order is opened. It all points to this seemingly unrelated PR: https://github.com/woocommerce/woocommerce-ios/pull/14716. Check one of the stack traces:

```
#0 TapToPayBadgePromotionChecker.refreshBadgeVisibility() - Line 78
#1 @objc TapToPayBadgePromotionChecker.refreshBadgeVisibility()
#2 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__
#3 ___CFXRegistrationPost_block_invoke
#4 _CFXRegistrationPost
#5 _CFXNotificationPost
#6 -[NSNotificationCenter postNotificationName:object:userInfo:]
#7 SelectedSiteSettings.refreshResultsPredicate() - Line 74
#8 SelectedSiteSettings.configureResultsController() - Line 55
#9 SelectedSiteSettings.init(stores:storageManager:) - Line 33
#10 SelectedSiteSettings.__allocating_init(stores:storageManager:)
#11 CardPresentPaymentsOnboardingUseCase.storeCountryCode.getter - Line 438
#12 CardPresentPaymentsOnboardingUseCase.checkOnboardingState() - Line 276
#13 CardPresentPaymentsOnboardingUseCase.updateState() - Line 190
#14 CardPresentPaymentsOnboardingUseCase.init(storageManager:stores:cardPresentPaymentOnboardingStateCache:analytics:) - Line 88
#15 CardPresentPaymentsOnboardingUseCase.__allocating_init(storageManager:stores:cardPresentPaymentOnboardingStateCache:analytics:)
#16 ReceiptEligibilityUseCase.init(stores:cardPresentPaymentsOnboarding:featureFlagService:) - Line 20
#17 OrderDetailsViewModel.init(order:stores:storageManager:currencyFormatter:featureFlagService:syncStateController:receiptEligibilityUseCase:) - Line 38
#18 OrderListViewModel.detailsViewModel(withID:) - Line 340
#19 OrderListViewController.tableView(_:didSelectRowAt:) - Line 831
```

When `OrderDetailsViewModel` is initialized it initializes `ReceiptEligibilityUseCase` which from version 21.3 also initializes `CardPresentPaymentsOnboardingUseCase` which leads to `SelectedSiteSettings.refreshResultsPredicate()` call that throws notification. The notification is listened by `TapToPayBadgePromotionChecker` which in turns call `deviceSupportsLocalMobileReader`.  It causes multiple additional calls to `deviceSupportsLocalMobileReader`.

⚠️  Opening a single order resulted in 20-30 calls to `deviceSupportsLocalMobileReader` when I tested it. 

`TapToPayAwarenessModal` also introduced additional calls to `deviceSupportsLocalMobileReader`. 

I hypothesize that multiple calls to check local reader eligibility result in occasional crashes. I checked with Stripe https://github.com/stripe/stripe-terminal-ios/issues/342 devs on this issue, hoping to get more insights into what is happening inside. 

## Solution

The root cause is still not addressed. I wouldn't expect a call to Stripe Terminal SDK to check for reader eligibility to result in a crash.

However, I tried to limit the hypothesized causes:

1. Removed initialization of `CardPresentPaymentsOnboardingUseCase()` within `ReceiptEligibilityUseCase`, it's not needed after the most recent improvements on 21.4.
2. Cached result of `checkDeviceSupport` for local mobile reader. Only a change in the operating system version can affect it which would require a restart of the app.

This way Stripe Terminal SDK will only be called once.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

I couldn't find a way to reproduce the issue. 

A good testing scenario is to test with eligible and ineligible device to see if Menu -> Payments Tap to Pay section appears or does not appear as expected.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Testing was done on:
- iPhone 14 Pro iOS 17.7
- iPad Air M2 iOS 18.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.