### PR TITLE
[Shipping labels] Add networking support for updating origin address endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -900,6 +900,7 @@
 		CED9BCC52D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */; };
 		CED9BCC72D3FAD1500C063B8 /* WooShippingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */; };
 		CED9BCC92D3FDFD400C063B8 /* wooshipping-update-origin-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */; };
+		CED9BCCB2D3FE0E400C063B8 /* WooShippingOriginAddressMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCCA2D3FE0E400C063B8 /* WooShippingOriginAddressMapper.swift */; };
 		CED9BCCD2D3FE1F000C063B8 /* WooShippingOriginAddressUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCCC2D3FE1E600C063B8 /* WooShippingOriginAddressUpdate.swift */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
@@ -2102,6 +2103,7 @@
 		CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationSuccessMapper.swift; sourceTree = "<group>"; };
 		CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddress.swift; sourceTree = "<group>"; };
 		CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-update-origin-success.json"; sourceTree = "<group>"; };
+		CED9BCCA2D3FE0E400C063B8 /* WooShippingOriginAddressMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingOriginAddressMapper.swift; sourceTree = "<group>"; };
 		CED9BCCC2D3FE1E600C063B8 /* WooShippingOriginAddressUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingOriginAddressUpdate.swift; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
@@ -3697,6 +3699,7 @@
 				CE0F4ECE2CE37C4F006339BD /* WooShippingLabelRatesMapper.swift */,
 				DAF367A12CE75B9D00D1B327 /* WooShippingPackagesMapper.swift */,
 				DAEE64292D104B720031DCDC /* WooShippingOriginAddressesMapper.swift */,
+				CED9BCCA2D3FE0E400C063B8 /* WooShippingOriginAddressMapper.swift */,
 				CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */,
 				CE90E99D2CEFCB100068D852 /* WooShippingStatusMapper.swift */,
 				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
@@ -4988,6 +4991,7 @@
 				FE28F6E426842848004465C7 /* UserMapper.swift in Sources */,
 				CE430670234B99F50073CBFF /* RefundsRemote.swift in Sources */,
 				B56C1EB620EA757B00D749F9 /* SiteListMapper.swift in Sources */,
+				CED9BCCB2D3FE0E400C063B8 /* WooShippingOriginAddressMapper.swift in Sources */,
 				B50A583921AD861700617455 /* APNSDevice.swift in Sources */,
 				DE2D642829F0E85600F3659B /* Mapper+DataEnvelope.swift in Sources */,
 				DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -900,6 +900,7 @@
 		CED9BCC52D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */; };
 		CED9BCC72D3FAD1500C063B8 /* WooShippingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */; };
 		CED9BCC92D3FDFD400C063B8 /* wooshipping-update-origin-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */; };
+		CED9BCCD2D3FE1F000C063B8 /* WooShippingOriginAddressUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCCC2D3FE1E600C063B8 /* WooShippingOriginAddressUpdate.swift */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
@@ -2101,6 +2102,7 @@
 		CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationSuccessMapper.swift; sourceTree = "<group>"; };
 		CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddress.swift; sourceTree = "<group>"; };
 		CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-update-origin-success.json"; sourceTree = "<group>"; };
+		CED9BCCC2D3FE1E600C063B8 /* WooShippingOriginAddressUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingOriginAddressUpdate.swift; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
@@ -2608,6 +2610,7 @@
 				DAF367A72CE75C5B00D1B327 /* WooShippingPackagesResponse.swift */,
 				CE1EA4BE2CEBA0AF0039F477 /* WooShippingPackagePurchase.swift */,
 				DAEE64272D1048930031DCDC /* WooShippingOriginAddress.swift */,
+				CED9BCCC2D3FE1E600C063B8 /* WooShippingOriginAddressUpdate.swift */,
 				451A97C82609FF050059D135 /* ShippingLabelPackagesResponse.swift */,
 				451A97CC260A01A40059D135 /* ShippingLabelStoreOptions.swift */,
 				CCAAD10E2683974000909664 /* ShippingLabelPackagePurchase.swift */,
@@ -5155,6 +5158,7 @@
 				EE57C1152979371B00BC31E7 /* ApplicationPassword.swift in Sources */,
 				B554FA8F2180BC7000C54DFF /* NoteHashListMapper.swift in Sources */,
 				DE78DE462B2AE880002E58DE /* WordPressPage.swift in Sources */,
+				CED9BCCD2D3FE1F000C063B8 /* WooShippingOriginAddressUpdate.swift in Sources */,
 				EE1CB9122B4BCC0D00AD24D5 /* BlazeAISuggestionListMapper.swift in Sources */,
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
 				EE078D912AD2EFBA00C1199E /* JWTokenMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -899,6 +899,7 @@
 		CED9BCC32D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */; };
 		CED9BCC52D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */; };
 		CED9BCC72D3FAD1500C063B8 /* WooShippingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */; };
+		CED9BCC92D3FDFD400C063B8 /* wooshipping-update-origin-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */; };
 		CEDA78622B30A4460076AA09 /* payment-gateway-cod-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */; };
 		CEE02EE92B34579E00162F63 /* DecodingError+CodingPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */; };
 		CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */; };
@@ -2099,6 +2100,7 @@
 		CED9BCC22D3EBA9700C063B8 /* WooShippingAddressValidationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationResponse.swift; sourceTree = "<group>"; };
 		CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressValidationSuccessMapper.swift; sourceTree = "<group>"; };
 		CED9BCC62D3FAD1500C063B8 /* WooShippingAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddress.swift; sourceTree = "<group>"; };
+		CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-update-origin-success.json"; sourceTree = "<group>"; };
 		CEDA78612B30A4460076AA09 /* payment-gateway-cod-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod-malformed.json"; sourceTree = "<group>"; };
 		CEE02EE82B34579E00162F63 /* DecodingError+CodingPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPath.swift"; sourceTree = "<group>"; };
 		CEE02EEA2B34811400162F63 /* DecodingError+CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+CodingPathTests.swift"; sourceTree = "<group>"; };
@@ -3580,6 +3582,7 @@
 				CE2FB3972CF74C5C0046201C /* wooshipping-label-print-success.json */,
 				CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */,
 				CED9BCBC2D3EAE4400C063B8 /* wooshipping-address-validation-error.json */,
+				CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4620,6 +4623,7 @@
 				74159623224D2C86003C21CF /* settings-product.json in Resources */,
 				266C7F9225AD3C88006ED243 /* attribute-term.json in Resources */,
 				EEAB476A2A851AFD00E55B25 /* site-upload-profiler-answers-success.json in Resources */,
+				CED9BCC92D3FDFD400C063B8 /* wooshipping-update-origin-success.json in Resources */,
 				D865CE6E278CC19A002C8520 /* stripe-location.json in Resources */,
 				DEA6B1C4296C0F45005AA5E9 /* payment-gateway-cod-without-data.json in Resources */,
 				DEA662A22A84DD5100731D36 /* site-settings-success.json in Resources */,

--- a/Networking/Networking/Mapper/WooShippingOriginAddressMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingOriginAddressMapper.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct WooShippingOriginAddressUpdateMapper: Mapper {
+    /// (Attempts) to convert a dictionary into a WooShippingOriginAddressUpdate.
+    ///
+    func map(response: Data) throws -> WooShippingOriginAddressUpdate {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(WooShippingOriginAddressUpdateMapperEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode(WooShippingOriginAddressUpdate.self, from: response)
+        }
+    }
+}
+
+/// WooShippingOriginAddressUpdateMapperEnvelope Disposable Entity:
+/// `Woo Shipping Update Origin Address` endpoint returns the updated data in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct WooShippingOriginAddressUpdateMapperEnvelope: Decodable {
+    let data: WooShippingOriginAddressUpdate
+
+    private enum CodingKeys: String, CodingKey {
+        case data = "data"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingOriginAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingOriginAddress.swift
@@ -50,7 +50,7 @@ public struct WooShippingOriginAddress: Identifiable, Equatable, GeneratedFakeab
 }
 
 // MARK: Decodable
-extension WooShippingOriginAddress: Decodable {
+extension WooShippingOriginAddress: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -84,6 +84,24 @@ extension WooShippingOriginAddress: Decodable {
                   email: email,
                   defaultAddress: defaultAddress,
                   isVerified: isVerified)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.company, forKey: .company)
+        try container.encode(self.address1, forKey: .address1)
+        try container.encode(self.address2, forKey: .address2)
+        try container.encode(self.city, forKey: .city)
+        try container.encode(self.state, forKey: .state)
+        try container.encode(self.postcode, forKey: .postcode)
+        try container.encode(self.country, forKey: .country)
+        try container.encode(self.phone, forKey: .phone)
+        try container.encode(self.firstName, forKey: .firstName)
+        try container.encode(self.lastName, forKey: .lastName)
+        try container.encode(self.email, forKey: .email)
+        try container.encode(self.defaultAddress, forKey: .defaultAddress)
+        try container.encode(self.isVerified, forKey: .isVerified)
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingOriginAddressUpdate.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingOriginAddressUpdate.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Codegen
+
+/// Represents the response when an origin address is updated in the WooCommerce Shipping extension.
+public struct WooShippingOriginAddressUpdate: Equatable {
+    public let address: WooShippingOriginAddress
+    public let isVerified: Bool
+
+    public init(address: WooShippingOriginAddress,
+                isVerified: Bool) {
+        self.address = address
+        self.isVerified = isVerified
+    }
+}
+
+// MARK: Decodable
+extension WooShippingOriginAddressUpdate: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let address = try container.decode(WooShippingOriginAddress.self, forKey: .address)
+        let isVerified = try container.decode(Bool.self, forKey: .isVerified)
+
+        self.init(address: address,
+                  isVerified: isVerified)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case address
+        case isVerified
+    }
+}

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -38,6 +38,10 @@ public protocol WooShippingRemoteProtocol {
     func addressValidation(siteID: Int64,
                            address: ShippingLabelAddress,
                            completion: @escaping (Result<WooShippingAddressValidationSuccess, Error>) -> Void)
+    func updateOriginAddress(siteID: Int64,
+                             address: WooShippingOriginAddress,
+                             isVerified: Bool,
+                             completion: @escaping (Result<WooShippingOriginAddressUpdate, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -316,6 +320,34 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    /// Updates an origin address.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site.
+    ///   - address: The updated origin address.
+    ///   - isVerified: Whether the address has been remotely verified.
+    ///   - completion: Closure to be executed upon completion.
+    public func updateOriginAddress(siteID: Int64,
+                                    address: WooShippingOriginAddress,
+                                    isVerified: Bool,
+                                    completion: @escaping (Result<WooShippingOriginAddressUpdate, Error>) -> Void) {
+        do {
+            let parameters: [String: Any] = [
+                ParameterKey.address: try address.toDictionary(),
+                ParameterKey.isVerified: isVerified
+            ]
+            let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                         method: .post,
+                                         siteID: siteID,
+                                         path: Path.updateOrigin,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
+            let mapper = WooShippingOriginAddressUpdateMapper()
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constants
@@ -329,6 +361,7 @@ private extension WooShippingRemote {
         static let print = "label/print"
         static let originAddresses = "address/origins"
         static let normalizeAddress = "address/normalize"
+        static let updateOrigin = "address/update_origin"
     }
 
     enum ParameterKey {
@@ -345,6 +378,7 @@ private extension WooShippingRemote {
         static let paperSize = "paper_size"
         static let labelIDCSV = "label_id_csv"
         static let address = "address"
+        static let isVerified = "isVerified"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -399,19 +399,7 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         let addresses = try XCTUnwrap(result.get())
         XCTAssertEqual(addresses.count, 1)
-        XCTAssertEqual(addresses.first?.company, "Superlative Centaur")
-        XCTAssertEqual(addresses.first?.city, "SAN FRANCISCO")
-        XCTAssertEqual(addresses.first?.state, "CA")
-        XCTAssertEqual(addresses.first?.postcode, "94110-4929")
-        XCTAssertEqual(addresses.first?.country, "US")
-        XCTAssertEqual(addresses.first?.phone, "12345678901")
-        XCTAssertEqual(addresses.first?.address1, "60 29TH ST PMB 343")
-        XCTAssertEqual(addresses.first?.firstName, "First")
-        XCTAssertEqual(addresses.first?.lastName, "Last")
-        XCTAssertEqual(addresses.first?.email, "email@automattic.com")
-        XCTAssertEqual(addresses.first?.id, "store_details")
-        XCTAssertEqual(addresses.first?.defaultAddress, true)
-        XCTAssertEqual(addresses.first?.isVerified, true)
+        XCTAssertEqual(addresses.first, sampleOriginAddress())
     }
 
     func test_loadOriginAddresses_returns_error_on_failure() throws {
@@ -488,6 +476,44 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         XCTAssertNotNil(result.failure)
     }
+
+    func test_updateOriginAddress_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/update_origin", filename: "wooshipping-update-origin-success")
+
+        // When
+        let result: Result<WooShippingOriginAddressUpdate, Error> = waitFor { promise in
+            remote.updateOriginAddress(siteID: self.sampleSiteID,
+                                       address: WooShippingOriginAddress.fake(),
+                                       isVerified: true) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let addressUpdate = try XCTUnwrap(result.get())
+        XCTAssertEqual(addressUpdate.address, sampleOriginAddress())
+        XCTAssertTrue(addressUpdate.isVerified)
+    }
+
+    func test_updateOriginAddress_returns_error_on_network_failure() {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/update_origin", filename: "generic_error")
+
+        // When
+        let result: Result<WooShippingOriginAddressUpdate, Error> = waitFor { promise in
+            remote.updateOriginAddress(siteID: self.sampleSiteID,
+                                       address: WooShippingOriginAddress.fake(),
+                                       isVerified: true) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension WooShippingRemoteTests {
@@ -513,5 +539,22 @@ private extension WooShippingRemoteTests {
                                  rawType: "box",
                                  dimensions: "12 x 12 x 12",
                                  boxWeight: 0.01)
+    }
+
+    func sampleOriginAddress() -> WooShippingOriginAddress {
+        WooShippingOriginAddress(id: "store_details",
+                                 company: "Superlative Centaur",
+                                 address1: "60 29TH ST PMB 343",
+                                 address2: "",
+                                 city: "SAN FRANCISCO",
+                                 state: "CA",
+                                 postcode: "94110-4929",
+                                 country: "US",
+                                 phone: "12345678901",
+                                 firstName: "First",
+                                 lastName: "Last",
+                                 email: "email@automattic.com",
+                                 defaultAddress: true,
+                                 isVerified: true)
     }
 }

--- a/Networking/NetworkingTests/Responses/wooshipping-update-origin-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-update-origin-success.json
@@ -1,0 +1,22 @@
+{
+    "data": {
+        "success": true,
+        "address": {
+            "company": "Superlative Centaur",
+            "address_1": "60 29TH ST PMB 343",
+            "address_2": "",
+            "city": "SAN FRANCISCO",
+            "state": "CA",
+            "postcode": "94110-4929",
+            "country": "US",
+            "phone": "12345678901",
+            "email": "email@automattic.com",
+            "default_address": true,
+            "is_verified": true,
+            "first_name": "First",
+            "last_name": "Last",
+            "id": "store_details"
+        },
+        "isVerified": true
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -287,7 +287,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                              completion: @escaping (Result<WooShippingOriginAddressUpdate, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            
+
             let key = ResultKey(siteID: siteID)
             if let result = self.updateOriginAddress[key] {
                 completion(result)

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -42,6 +42,9 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `addressValidation`
     private var addressValidation = [ResultKey: Result<WooShippingAddressValidationSuccess, Error>]()
 
+    /// The results to return based on the given arguments in `updateOriginAddress`
+    private var updateOriginAddress = [ResultKey: Result<WooShippingOriginAddressUpdate, Error>]()
+
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
                            thenReturn result: Result<WooShippingCreatePackageResponse, Error>) {
@@ -110,6 +113,13 @@ final class MockWooShippingRemote {
                                thenReturn result: Result<WooShippingAddressValidationSuccess, Error>) {
         let key = ResultKey(siteID: siteID)
         addressValidation[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `updateOriginAddress` is called.
+    func whenupdatingOriginAddress(siteID: Int64,
+                                   thenReturn result: Result<WooShippingOriginAddressUpdate, Error>) {
+        let key = ResultKey(siteID: siteID)
+        updateOriginAddress[key] = result
     }
 }
 
@@ -264,6 +274,22 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
             let key = ResultKey(siteID: siteID)
             if let result = self.addressValidation[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func updateOriginAddress(siteID: Int64,
+                             address: WooShippingOriginAddress,
+                             isVerified: Bool,
+                             completion: @escaping (Result<WooShippingOriginAddressUpdate, any Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            let key = ResultKey(siteID: siteID)
+            if let result = self.updateOriginAddress[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13780 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the networking layer for updating (saving) an origin address for the Woo Shipping extension.

We send the origin address and whether it has already been verified, and the updated address and verified status are sent in the response.

### Changes

* Adds a mock API success response for an origin address update.
* Adds encoding support to `WooShippingOriginAddress` so we can send an origin address to the endpoint.
* Adds the model `WooShippingOriginAddressUpdate` to represent the update response.
* Adds the mapper `WooShippingOriginAddressUpdateMapper` to map the update response.
* Adds support for the update endpoint to `WooShippingRemote`, along with corresponding unit tests and support in `MockWooShippingRemote`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This endpoint is not yet used; confirm unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.