### PR TITLE
[Brand Updates] Remove underline from links in the app

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -140,7 +140,7 @@ private extension ULAccountMismatchViewController {
     func configureTermsLabel() {
         let linkAttributes: [NSAttributedString.Key: Any] = [
             NSAttributedString.Key.foregroundColor: UIColor.accent,
-            NSAttributedString.Key.underlineColor: UIColor.accent,
+            NSAttributedString.Key.underlineColor: UIColor.clear,
             NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue
         ]
         termsLabel.linkTextAttributes = linkAttributes

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -140,7 +140,7 @@ private extension ULErrorViewController {
     func configureTermsLabel() {
         let linkAttributes: [NSAttributedString.Key: Any] = [
             NSAttributedString.Key.foregroundColor: UIColor.accent,
-            NSAttributedString.Key.underlineColor: UIColor.accent,
+            NSAttributedString.Key.underlineColor: UIColor.clear,
             NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue
         ]
         termsLabel.linkTextAttributes = linkAttributes

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
@@ -17,7 +17,7 @@ struct POSProgressViewStyle: ProgressViewStyle {
                 lineWidth: lineWidth,
                 lineCap: .butt,
                 circleColor: Color(.wooCommercePurple(.shade10)),
-                fillColor: Color.accent
+                fillColor: Color.posAccent
             ))
     }
 }

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 extension Color {
 
-    static var accent: Color {
+    static var posAccent: Color {
         return Color(
             UIColor(
                 light: .withColorStudio(.wooCommercePurple, shade: .shade40),
@@ -107,11 +107,11 @@ extension Color {
 
     // MARK: - Buttons
 
-    static var posPrimaryButtonBackground: Color = .accent
+    static var posPrimaryButtonBackground: Color = .posAccent
 
-    static var posSecondaryButtonForeground: Color = .accent
+    static var posSecondaryButtonForeground: Color = .posAccent
 
-    static var posTextButtonForeground: Color = .accent
+    static var posTextButtonForeground: Color = .posAccent
 
     static var posTextButtonForegroundPressed: Color {
         return Color(

--- a/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticeView.swift
@@ -29,7 +29,6 @@ private struct PermanentNoticeContentView: View {
                     .bodyStyle()
                 Button(action: notice.callToActionHandler, label: {
                     Text(notice.callToActionTitle)
-                        .underline()
                         .font(.body)
                         .foregroundColor(Color(.accent))
                 })

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -92,7 +92,7 @@ struct AccountCreationForm: View {
                     .renderedIf(viewModel.currentField == .password)
 
                     // Terms of Service link.
-                    AttributedText(tosAttributedText, enablesLinkUnderline: true)
+                    AttributedText(tosAttributedText)
                         .attributedTextLinkColor(Color(.secondaryLabel))
                         .environment(\.customOpenURL) { url in
                             tosURL = url

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/LaunchStore/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/LaunchStore/StoreOnboardingLaunchStoreViewModel.swift
@@ -37,9 +37,9 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
                         ]
         )
         let upgradeLink = NSAttributedString(string: linkContent, attributes: [.font: font,
-                                                                                      .foregroundColor: linkColor,
-                                                                                      .underlineStyle: NSUnderlineStyle.single.rawValue,
-                                                                                      .underlineColor: UIColor.textLink])
+                                                                               .foregroundColor: linkColor,
+                                                                               .underlineStyle: NSUnderlineStyle.single.rawValue,
+                                                                               .underlineColor: UIColor.clear])
         attributedString.replaceFirstOccurrence(of: linkContent, with: upgradeLink)
         return attributedString
     }()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -273,7 +273,7 @@ private extension PrivacySettingsViewController {
         textView.delegate = self
 
         var linkTextAttributes = textView.linkTextAttributes ?? [:]
-        linkTextAttributes[.underlineColor] = UIColor.primary
+        linkTextAttributes[.underlineColor] = UIColor.clear
         linkTextAttributes[.foregroundColor] = UIColor.primary
         textView.linkTextAttributes = linkTextAttributes
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/EntryPoint/AddProductWithAIActionSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/EntryPoint/AddProductWithAIActionSheet.swift
@@ -74,7 +74,7 @@ struct AddProductWithAIActionSheet: View {
                             .subheadlineStyle()
                         AdaptiveStack(horizontalAlignment: .leading) {
                             Text(Localization.CreateProductWithAI.legalText)
-                            Text(.init(Localization.CreateProductWithAI.learnMore)).underline()
+                            Text(.init(Localization.CreateProductWithAI.learnMore))
                         }
                         .environment(\.openURL, OpenURLAction { url in
                             legalURL = url

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -293,7 +293,7 @@ private extension ProductFormTableViewDataSource {
                                                attributes: [.font: font,
                                                             .foregroundColor: linkColor,
                                                             .underlineStyle: NSUnderlineStyle.single.rawValue,
-                                                            .underlineColor: linkColor,
+                                                            .underlineColor: UIColor.clear,
                                                             .link: Constants.legalURL])
             attributedString.replaceFirstOccurrence(of: linkContent, with: legalLink)
             return attributedString


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: woocommerce/woomobile-private#413

## Description
This PR removes all underlines from links in the app, except the login screens, where we need to wait until #14779 is merged.

The PR also adds another fix that I'll mention in the comments below.

## Steps to reproduce
I think checking the screenshots below is enough (I tried to collect the screenshots of all the modified and still used screens in the app), but feel free to check the corresponding screens in the app too.

## Testing information
Tested using iPhone 16 simulator, iOS 18.1

## Screenshots
| Light | Dark |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 15 34 44](https://github.com/user-attachments/assets/5232555c-de85-40ff-b521-8ad499583d8b) | ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 15 34 50](https://github.com/user-attachments/assets/368ffe3f-89cb-4a6a-b340-761b1f5c4ec7) |
| ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 15 35 45](https://github.com/user-attachments/assets/26ecf075-cead-4df1-891f-a0d01cb9d9ba) | ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 15 35 37](https://github.com/user-attachments/assets/548ccee4-476e-40bb-a6de-4e0968a53135) |
| ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 05 36](https://github.com/user-attachments/assets/f7611655-8ad5-4e00-8846-b81c612f1904) |![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 05 40](https://github.com/user-attachments/assets/c6b8b283-b092-413e-ba9e-1f3eba67006f) |
| ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 06 03](https://github.com/user-attachments/assets/2b5f0bb5-227d-47cf-be60-d696c680d6c9) |![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 05 58](https://github.com/user-attachments/assets/24949720-ef19-4ae9-a2ec-064be6d9be59) |
|![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 08 46](https://github.com/user-attachments/assets/07dae138-e630-4d73-9051-13b840e90bbc) |![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 08 51](https://github.com/user-attachments/assets/2cbb8575-7e5b-4e4b-9383-b0b6d2275a48) |
| ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 09 13](https://github.com/user-attachments/assets/0a02a21a-a17b-4f57-910e-be2aef5dd039) |![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 09 07](https://github.com/user-attachments/assets/8aae0c9d-50d8-40da-8c40-3f1d7402cefc) |
| ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 51 47](https://github.com/user-attachments/assets/33169a28-1b65-4a8f-9c9a-18e348b59118) | ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 16 51 33](https://github.com/user-attachments/assets/b5992b5b-9961-48b0-bc08-110006bd558d) |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.