### PR TITLE
[Brand Updates] Fixes for Skip button of the onboarding carousel

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -138,6 +138,9 @@ private extension LoginOnboardingViewController {
         let button = UIButton(frame: .zero)
         button.accessibilityIdentifier = "Login Onboarding Skip Button"
         button.applyLinkButtonStyle()
+        button.titleLabel?.applyHeadlineStyle()
+        button.setTitleColor(.init(light: .black, dark: .white), for: .normal)
+        button.setTitleColor(.init(light: .gray(.shade80), dark: .gray(.shade20)), for: .highlighted)
         button.setTitle(Localization.skipButtonTitle, for: .normal)
         button.on(.touchUpInside) { [weak self] _ in
             self?.onDismiss(.skip)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: woocommerce/woomobile-private#414
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR updates the style of the "Skip" button to match the design (Ntkk0ER4hHt5y9KjEGIiGk-fi-2880_2625):
- Use headline font style.
- Use black color on light and white color on dark.

## Steps to reproduce
1. Launch the app from a clean install.
2. Check the onboarding screen.

## Testing information
Tested on an iPhone 16 simulator, iOS 18.1.

## Screenshots
| Light | Dark |
| --- | --- |
|  ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 17 23 50](https://github.com/user-attachments/assets/1cee0d72-61b6-4c04-bdc0-4427f8573b59) | ![Simulator Screenshot - iPhone 16 - 2025-01-21 at 17 23 40](https://github.com/user-attachments/assets/f181d10f-a59c-4af8-a6ab-ac0c857b0cec) |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.