### PR TITLE
[Brand Updates] Add missing periods to Empty State messages

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -200,7 +200,7 @@ private extension BlazeCampaignListView {
         static let create = NSLocalizedString("Create", comment: "Title of the button to create a new campaign on the Blaze campaign list view")
         static let emptyStateTitle = NSLocalizedString("No campaigns yet", comment: "Title of the empty state of the Blaze campaign list view")
         static let emptyStateMessage = NSLocalizedString(
-            "Drive more sales to your store with Blaze",
+            "Drive more sales to your store with Blaze.",
             comment: "Subtitle of the empty state of the Blaze campaign list view"
         )
         static let done = NSLocalizedString("Done", comment: "Button to dismiss the Blaze campaign detail view")

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetLocations/BlazeTargetLocationPickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetLocations/BlazeTargetLocationPickerViewModel.swift
@@ -132,7 +132,7 @@ extension BlazeTargetLocationPickerViewModel {
     enum Localization {
         static let searchViewHintMessage = NSLocalizedString(
             "blazeTargetLocationPickerViewModel.searchViewHintMessage",
-            value: "Start typing country, state or city to see available options",
+            value: "Start typing country, state or city to see available options.",
             comment: "Hint message to enter search query on the target location picker for campaign creation"
         )
         static let longerQuery = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -353,7 +353,7 @@ extension CustomFieldsListHostingController {
         static let emptyStateDescription = NSLocalizedString(
             "customFieldsListHostingController.emptyStateDescription",
             value: "Custom fields are optional metadata to display extra information or customize "
-            + "your store's shopping experience",
+            + "your store's shopping experience.",
             comment: "Message when the list is empty."
         )
         static let emptyStateButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -96,7 +96,7 @@ private extension CustomersListView {
                                                        value: "No customers yet",
                                                        comment: "Title when there are no customers to show in the Customers list screen.")
         static let emptyStateMessage = NSLocalizedString("customerList.emptyStateMessage",
-                                                         value: "Create an order to start gathering customer insights",
+                                                         value: "Create an order to start gathering customer insights.",
                                                          comment: "Message when there are no customers to show in the Customers list screen.")
         static let searchPlaceholder = NSLocalizedString("customersList.searchPlaceholder",
                                                          value: "Search for customers",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -437,7 +437,7 @@ private extension DashboardView {
 
             static let subtitle = NSLocalizedString(
                 "dashboardView.shareStoreCard.subtitle",
-                value: "Use email or social media to spread the word about your store",
+                value: "Use email or social media to spread the word about your store.",
                 comment: "Subtitle of the Share Your Store card"
             )
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/Inbox.swift
@@ -103,7 +103,7 @@ private extension Inbox {
         static let title = NSLocalizedString("Inbox", comment: "Title for the screen that shows inbox notes.")
         static let emptyStateTitle = NSLocalizedString("Congrats, you’ve read everything!",
                                                          comment: "Title displayed if there are no inbox notes in the inbox screen.")
-        static let emptyStateMessage = NSLocalizedString("Come back soon for more tips and insights on growing your store",
+        static let emptyStateMessage = NSLocalizedString("Come back soon for more tips and insights on growing your store.",
                                                          comment: "Message displayed if there are no inbox notes to display in the inbox screen.")
         static let dismissAllNotes = NSLocalizedString("Dismiss All",
                                                               comment: "Dismiss All button in Inbox Notes for dismissing all the notes.")

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -1000,7 +1000,7 @@ private extension OrderListViewController {
     enum Localization {
         static let allOrdersEmptyStateMessage = NSLocalizedString("Waiting for your first order",
                                                                   comment: "The message shown in the Orders → All Orders tab if the list is empty.")
-        static let allOrdersEmptyStateDetail = NSLocalizedString("Explore how you can increase your store sales",
+        static let allOrdersEmptyStateDetail = NSLocalizedString("Explore how you can increase your store sales.",
                                                                  comment: "The detailed message shown in the Orders → All Orders tab if the list is empty.")
         static let learnMore = NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty.")
         static let createTestOrderDetail = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -807,7 +807,7 @@ private extension ProductVariationsViewController {
     enum Localization {
         static let emptyStateTitle = NSLocalizedString("Create your first variation",
                                                        comment: "Title on the variations list screen when there are no variations")
-        static let emptyStateSubtitle = NSLocalizedString("To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first",
+        static let emptyStateSubtitle = NSLocalizedString("To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first.",
                                                           comment: "Subtitle on the variations list screen when there are no variations and attributes")
         static let addAttributesAction = NSLocalizedString("Add Attributes",
                                                            comment: "Title on empty state button when the product has no attributes and variations")

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1916,9 +1916,6 @@ which should be translated separately and considered part of this sentence. */
 /* Message indicating no search result on the target location picker for campaign creation */
 "blazeTargetLocationPickerViewModel.noResult" = "No location found.\nPlease try again.";
 
-/* Hint message to enter search query on the target location picker for campaign creation */
-"blazeTargetLocationPickerViewModel.searchViewHintMessage" = "Start typing country, state or city to see available options";
-
 /* Title of the row to select all target location for Blaze campaign creation */
 "blazeTargetLocationSearchView.allTitle" = "Everywhere";
 
@@ -2698,9 +2695,6 @@ which should be translated separately and considered part of this sentence. */
 /* Country option for a site address. */
 "Colombia" = "Colombia";
 
-/* Message displayed if there are no inbox notes to display in the inbox screen. */
-"Come back soon for more tips and insights on growing your store" = "Come back soon for more tips and insights on growing your store";
-
 /* Country option for a site address. */
 "Comoros" = "Comoros";
 
@@ -3383,9 +3377,6 @@ which should be translated separately and considered part of this sentence. */
 /* Title when there are no customers in the search results in the Customers list screen. */
 "customerList.emptySearchTitle" = "No customers found";
 
-/* Message when there are no customers to show in the Customers list screen. */
-"customerList.emptyStateMessage" = "Create an order to start gathering customer insights";
-
 /* Title when there are no customers to show in the Customers list screen. */
 "customerList.emptyStateTitle" = "No customers yet";
 
@@ -3475,9 +3466,6 @@ which should be translated separately and considered part of this sentence. */
 
 /* Text for button that's shown when the list is empty. */
 "customFieldsListHostingController.emptyStateButton" = "Learn more";
-
-/* Message when the list is empty. */
-"customFieldsListHostingController.emptyStateDescription" = "Custom fields are optional metadata to display extra information or customize your store's shopping experience";
 
 /* Title for the message when the list is empty. */
 "customFieldsListHostingController.emptyStateTitle" = "No custom fields found";
@@ -3605,9 +3593,6 @@ which should be translated separately and considered part of this sentence. */
 
 /* Label of the button to share the store */
 "dashboardView.shareStoreCard.shareButtonLabel" = "Share Your Store";
-
-/* Subtitle of the Share Your Store card */
-"dashboardView.shareStoreCard.subtitle" = "Use email or social media to spread the word about your store";
 
 /* Title of the Share Your Store card */
 "dashboardView.shareStoreCard.title" = "Get the word out!";
@@ -3976,9 +3961,6 @@ which should be translated separately and considered part of this sentence. */
 
 /* Drag and drop helper text above photo list in Product images screen */
 "Drag and drop to re-order photos" = "Drag and drop to re-order photos";
-
-/* Subtitle of the empty state of the Blaze campaign list view */
-"Drive more sales to your store with Blaze" = "Drive more sales to your store with Blaze";
 
 /* Button title to duplicate a product in Product More Options Action Sheet */
 "Duplicate" = "Duplicate";
@@ -4519,9 +4501,6 @@ which should be translated separately and considered part of this sentence. */
 
 /* Button title to explore an extension that isn't installed */
 "Explore" = "Explore";
-
-/* The detailed message shown in the Orders → All Orders tab if the list is empty. */
-"Explore how you can increase your store sales" = "Explore how you can increase your store sales";
 
 /* Display label for affiliate product type. */
 "External/Affiliate" = "External/Affiliate";
@@ -11331,9 +11310,6 @@ which should be translated separately and considered part of this sentence. */
 
 /* Description text for the product discount row informational tooltip */
 "To add a Product Discount, please remove all Coupons from your order" = "To add a Product Discount, please remove all Coupons from your order";
-
-/* Subtitle on the variations list screen when there are no variations and attributes */
-"To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first" = "To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first";
 
 /* Error message displayed when unable to close user account due to having active atomic site. */
 "To close this account now, contact our support team." = "To close this account now, contact our support team.";


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: woocommerce/woomobile-private#412
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR adds periods that were missing in some empty state messages (this was requested here pffQ75-10m-p2#comment-998). I'm not entirely sure I found all the cases here, but this touches on the most important and noticeable ones.

## Steps to reproduce
I think code review and screenshots are enough.

## Testing information
Tested on an iPhone 16 Simulator, iOS 18.1

## Screenshots
I didn't collect all screenshots as it's just text change, please let me know if you prefer me to do so:

<img width=360 src=https://github.com/user-attachments/assets/ac6eac0f-8b74-4253-b98e-6dab35fd9543/>
<img width=360 src=https://github.com/user-attachments/assets/23115ca3-ad05-4ab9-ad7d-d2530b810992/>
<img width=360 src=https://github.com/user-attachments/assets/9124a3a0-0911-4a2a-96e0-1f9198842aff/>
<img width=360 src=https://github.com/user-attachments/assets/b4c33f1f-b45d-401a-ac75-936944e79943/>
<img width=360 src=https://github.com/user-attachments/assets/0bd0467e-3f94-4d7f-940b-875d0e638821/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.