### PR TITLE
[Shipping labels] Add Yosemite support for updating origin address

### DIFF
--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -62,4 +62,11 @@ public enum WooShippingAction: Action {
     case validateAddress(siteID: Int64,
                          address: ShippingLabelAddress,
                          completion: (Result<WooShippingAddressValidationSuccess, Error>) -> Void)
+
+    /// Update an origin address.
+    ///
+    case updateOriginAddress(siteID: Int64,
+                             address: WooShippingOriginAddress,
+                             isVerified: Bool,
+                             completion: (Result<WooShippingOriginAddressUpdate, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -69,6 +69,8 @@ public final class WooShippingStore: Store {
             loadOriginAddresses(siteID: siteID, completion: completion)
         case let .validateAddress(siteID, address, completion):
             validateAddress(siteID: siteID, address: address, completion: completion)
+        case let .updateOriginAddress(siteID, address, isVerified, completion):
+            updateOriginAddress(siteID: siteID, address: address, isVerified: isVerified, completion: completion)
         }
     }
 }
@@ -257,6 +259,13 @@ private extension WooShippingStore {
                          address: ShippingLabelAddress,
                          completion: @escaping (Result<WooShippingAddressValidationSuccess, Error>) -> Void) {
         remote.addressValidation(siteID: siteID, address: address, completion: completion)
+    }
+
+    func updateOriginAddress(siteID: Int64,
+                             address: WooShippingOriginAddress,
+                             isVerified: Bool,
+                             completion: @escaping (Result<WooShippingOriginAddressUpdate, Error>) -> Void) {
+        remote.updateOriginAddress(siteID: siteID, address: address, isVerified: isVerified, completion: completion)
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -116,7 +116,7 @@ final class MockWooShippingRemote {
     }
 
     /// Set the value passed to the `completion` block if `updateOriginAddress` is called.
-    func whenupdatingOriginAddress(siteID: Int64,
+    func whenUpdatingOriginAddress(siteID: Int64,
                                    thenReturn result: Result<WooShippingOriginAddressUpdate, Error>) {
         let key = ResultKey(siteID: siteID)
         updateOriginAddress[key] = result

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -650,6 +650,52 @@ final class WooShippingStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? WooShippingAddressValidationError, expectedError)
     }
+
+    // MARK: `updateOriginAddress`
+
+    func test_updateOriginAddress_returns_success_response() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedAddressUpdate = WooShippingOriginAddressUpdate(address: WooShippingOriginAddress.fake(), isVerified: true)
+        remote.whenUpdatingOriginAddress(siteID: sampleSiteID, thenReturn: .success(expectedAddressUpdate))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingOriginAddressUpdate, Error> = waitFor { promise in
+            let action = WooShippingAction.updateOriginAddress(siteID: self.sampleSiteID,
+                                                               address: WooShippingOriginAddress.fake(),
+                                                               isVerified: false) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let actualAddressUpdate = try XCTUnwrap(result.get())
+        XCTAssertEqual(actualAddressUpdate, expectedAddressUpdate)
+    }
+
+    func test_updateOriginAddress_returns_error_on_failure() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedError = NetworkError.timeout()
+        remote.whenUpdatingOriginAddress(siteID: sampleSiteID, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingOriginAddressUpdate, Error> = waitFor { promise in
+            let action = WooShippingAction.updateOriginAddress(siteID: self.sampleSiteID,
+                                                               address: WooShippingOriginAddress.fake(),
+                                                               isVerified: false) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+    }
 }
 
 private extension WooShippingStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13780
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/14937 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Yosemite layer for updating (saving) an origin address for the Woo Shipping extension.

It updates `WooShippingAction` and `WooShippingStore` to add an action that calls the remote endpoint to update an origin address.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This action isn't yet used; confirm unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.