### PR TITLE
[Woo POS] [Variable Products] Match variation order with wp admin menu order

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -84,6 +84,8 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                                variationIDs: [],
                                                downloadable: false,
                                                status: .published,
+                                               orderBy: .menuOrder,
+                                               order: .ascending,
                                                context: nil,
                                                pageNumber: pageNumber,
                                                pageSize: POSConstants.variationsPerPage)
@@ -105,6 +107,8 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                           variationIDs: [Int64],
                                           downloadable: Bool? = nil,
                                           status: ProductStatus? = nil,
+                                          orderBy: OrderByField? = nil,
+                                          order: OrderDirection? = nil,
                                           context: String?,
                                           pageNumber: Int,
                                           pageSize: Int) -> JetpackRequest {
@@ -116,7 +120,9 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
             ParameterKey.downloadable: downloadable.map { String($0) },
             ParameterKey.contextKey: context ?? Default.context,
             ParameterKey.include: variationIDs.isEmpty ? nil: stringOfVariationIDs,
-            ParameterKey.status: status?.rawValue
+            ParameterKey.status: status?.rawValue,
+            ParameterKey.orderBy: orderBy?.rawValue,
+            ParameterKey.order: order?.rawValue
         ]
             .compactMapValues { $0 }
 
@@ -340,7 +346,20 @@ public extension ProductVariationsRemote {
         static let include: String    = "include"
         static let downloadable: String = "downloadable"
         static let status: String = "status"
+        static let orderBy: String    = "orderby"
+        static let order: String      = "order"
     }
+
+    enum OrderByField: String {
+        case date
+        case menuOrder = "menu_order"
+    }
+
+    enum OrderDirection: String {
+        case ascending = "asc"
+        case descending = "desc"
+    }
+
 }
 
 private extension ProductVariationsRemote {

--- a/WooCommerce/WooCommerceTests/Extensions/VersionHelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/VersionHelpersTests.swift
@@ -1,52 +1,50 @@
-import XCTest
+import Testing
 @testable import WooCommerce
 
 /// VersionHelpers Unit Tests
 ///
-final class VersionHelpersTests: XCTestCase {
-    func test_compare_as_version() {
-        let tests = [
-            VersionTestCase(foundVersion: "2.8", requiredMinimumVersion: "2", meetsMinimum: true),
-            VersionTestCase(foundVersion: "2.9", requiredMinimumVersion: "3", meetsMinimum: false),
-            VersionTestCase(foundVersion: "2.9.1", requiredMinimumVersion: "2", meetsMinimum: true),
-            VersionTestCase(foundVersion: "3.0", requiredMinimumVersion: "3", meetsMinimum: true),
+struct VersionHelpersTests {
+    @Test("Version comparisons match PHP behaviour", arguments: [
+        VersionTestCase(foundVersion: "2.8", requiredMinimumVersion: "2", meetsMinimum: true),
+        VersionTestCase(foundVersion: "2.9", requiredMinimumVersion: "3", meetsMinimum: false),
+        VersionTestCase(foundVersion: "2.9.1", requiredMinimumVersion: "2", meetsMinimum: true),
+        VersionTestCase(foundVersion: "3.0", requiredMinimumVersion: "3", meetsMinimum: true),
 
-            VersionTestCase(foundVersion: "2.8", requiredMinimumVersion: "2.9", meetsMinimum: false),
-            VersionTestCase(foundVersion: "2.9", requiredMinimumVersion: "2.9", meetsMinimum: true),
-            VersionTestCase(foundVersion: "2.9.1", requiredMinimumVersion: "2.9", meetsMinimum: true),
-            VersionTestCase(foundVersion: "3.0", requiredMinimumVersion: "2.9", meetsMinimum: true),
+        VersionTestCase(foundVersion: "2.8", requiredMinimumVersion: "2.9", meetsMinimum: false),
+        VersionTestCase(foundVersion: "2.9", requiredMinimumVersion: "2.9", meetsMinimum: true),
+        VersionTestCase(foundVersion: "2.9.1", requiredMinimumVersion: "2.9", meetsMinimum: true),
+        VersionTestCase(foundVersion: "3.0", requiredMinimumVersion: "2.9", meetsMinimum: true),
 
-            VersionTestCase(foundVersion: "2.9", requiredMinimumVersion: "2.9.0", meetsMinimum: true),
+        VersionTestCase(foundVersion: "2.9", requiredMinimumVersion: "2.9.0", meetsMinimum: true),
 
-            VersionTestCase(foundVersion: "2.9.1", requiredMinimumVersion: "2.9.1", meetsMinimum: true),
-            VersionTestCase(foundVersion: "3.0", requiredMinimumVersion: "2.9.1", meetsMinimum: true),
+        VersionTestCase(foundVersion: "2.9.1", requiredMinimumVersion: "2.9.1", meetsMinimum: true),
+        VersionTestCase(foundVersion: "3.0", requiredMinimumVersion: "2.9.1", meetsMinimum: true),
 
-            VersionTestCase(foundVersion: "3.3.1-test-1", requiredMinimumVersion: "2.9.1", meetsMinimum: true),
-            VersionTestCase(foundVersion: "3.3.1-test-1", requiredMinimumVersion: "3.3", meetsMinimum: true),
-            VersionTestCase(foundVersion: "3.3.1-test-1", requiredMinimumVersion: "3.3.1", meetsMinimum: false),
+        VersionTestCase(foundVersion: "3.3.1-test-1", requiredMinimumVersion: "2.9.1", meetsMinimum: true),
+        VersionTestCase(foundVersion: "3.3.1-test-1", requiredMinimumVersion: "3.3", meetsMinimum: true),
+        VersionTestCase(foundVersion: "3.3.1-test-1", requiredMinimumVersion: "3.3.1", meetsMinimum: false),
 
-            VersionTestCase(foundVersion: "4.3.2RC1", requiredMinimumVersion: "4.3.2RC2", meetsMinimum: false),
-            VersionTestCase(foundVersion: "4.3.2RC2", requiredMinimumVersion: "4.3.2RC1", meetsMinimum: true),
+        VersionTestCase(foundVersion: "4.3.2RC1", requiredMinimumVersion: "4.3.2RC2", meetsMinimum: false),
+        VersionTestCase(foundVersion: "4.3.2RC2", requiredMinimumVersion: "4.3.2RC1", meetsMinimum: true),
 
-            VersionTestCase(foundVersion: "1.0.0beta", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.1beta", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
-            VersionTestCase(foundVersion: "1.0.0beta", requiredMinimumVersion: "1.0.0b", meetsMinimum: true),
+        VersionTestCase(foundVersion: "1.0.0beta", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.1beta", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
+        VersionTestCase(foundVersion: "1.0.0beta", requiredMinimumVersion: "1.0.0b", meetsMinimum: true),
 
-            VersionTestCase(foundVersion: "1.0.0-dev", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.0-alpha", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.0-a", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.0-beta", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.0-b", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.0-RC1", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.0-rc1", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
-            VersionTestCase(foundVersion: "1.0.0-pl", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
-            VersionTestCase(foundVersion: "1.0.0-p1", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
-        ]
-
-        for test in tests {
-            let meetsMinimum = VersionHelpers.compare(test.foundVersion, test.requiredMinimumVersion) != .orderedAscending
-            XCTAssertEqual(test.meetsMinimum, meetsMinimum)
-        }
+        VersionTestCase(foundVersion: "1.0.0-dev", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.0-alpha", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.0-a", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.0-beta", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.0-b", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.0-RC1", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.0-rc1", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
+        VersionTestCase(foundVersion: "1.0.0-pl", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
+        VersionTestCase(foundVersion: "1.0.0-p1", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
+    ])
+    func compareAsVersion(testCase: VersionTestCase) {
+        let meetsMinimum = VersionHelpers.compare(testCase.foundVersion, testCase.requiredMinimumVersion) != .orderedAscending
+        #expect(testCase.meetsMinimum == meetsMinimum,
+                "\(testCase.foundVersion) should \(testCase.meetsMinimum ? "not " : "" )meet minimum \(testCase.requiredMinimumVersion)")
     }
 
     struct VersionTestCase {

--- a/WooCommerce/WooCommerceTests/Extensions/VersionHelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/VersionHelpersTests.swift
@@ -40,6 +40,10 @@ struct VersionHelpersTests {
         VersionTestCase(foundVersion: "1.0.0-rc1", requiredMinimumVersion: "1.0.0", meetsMinimum: false),
         VersionTestCase(foundVersion: "1.0.0-pl", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
         VersionTestCase(foundVersion: "1.0.0-p1", requiredMinimumVersion: "1.0.0", meetsMinimum: true),
+
+        VersionTestCase(foundVersion: "9.6.0-rc.1", requiredMinimumVersion: "9.6.0-rc.2", meetsMinimum: false),
+        VersionTestCase(foundVersion: "9.6.0-rc.1", requiredMinimumVersion: "9.6.0-rc.1", meetsMinimum: true),
+        VersionTestCase(foundVersion: "9.6.0-rc.2", requiredMinimumVersion: "9.6.0-rc.1", meetsMinimum: true),
     ])
     func compareAsVersion(testCase: VersionTestCase) {
         let meetsMinimum = VersionHelpers.compare(testCase.foundVersion, testCase.requiredMinimumVersion) != .orderedAscending


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14945
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the sort order for variations to match WP admin, where they can be reordered, rather than using the default `date` order.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

To test this effectively, your variations should have different creation dates. If you import or generate them, they probably won't, so add them manually!

1. Launch the app, navigate to POS
2. Open a variable product with at least 2 variations – note the order shown
3. Open that variable product in wp-admin on another machine
4. Reorder the variations and save changes
5. Pull to refresh, observe that the updated order is reflected.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Check that the variations list in the Products tab isn't affected by the change, **but be aware:** `menu_order` is used as the tie breaker when variations were created at the same time, which they usually are if they're imported or generated. So unless you have variations with different creation dates in the same variable product, they'll appear to be affected by the change. To confirm, add a new variation in wp-admin and move it down the list, then save. In POS, the re-order will be shown, in the Products tab it'll just stay at the top of the list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/2513b238-087b-4217-ad90-dcfa1cea91ff


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.