### PR TITLE
[Shipping labels] Locally validate the address fields and display validation errors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
@@ -22,13 +22,18 @@ final class WooShippingAddressField: ObservableObject {
     /// Returns an error message if the value is invalid.
     var validate: (String) -> String?
 
+    /// Number of seconds to wait before validating new value input.
+    private let validationDelay: Double
+
     init(type: WooShippingAddressFieldType,
          value: String,
          required: Bool,
+         validationDelayInSeconds: Double = 1,
          validate: @escaping (String) -> String?) {
         self.type = type
         self.value = value
         self.required = required
+        self.validationDelay = validationDelayInSeconds
         self.validate = validate
 
         observeValue()
@@ -36,7 +41,7 @@ final class WooShippingAddressField: ObservableObject {
 
     private func observeValue() {
         $value
-            .debounce(for: 0.5, scheduler: DispatchQueue.main)
+            .debounce(for: .seconds(validationDelay), scheduler: DispatchQueue.main)
             .map { [weak self] newValue in
                 guard let self else { return nil }
                 return validate(newValue)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
@@ -36,6 +36,7 @@ final class WooShippingAddressField: ObservableObject {
 
     private func observeValue() {
         $value
+            .debounce(for: 0.5, scheduler: DispatchQueue.main)
             .map { [weak self] newValue in
                 guard let self else { return nil }
                 return validate(newValue)
@@ -51,6 +52,12 @@ final class WooShippingAddressField: ObservableObject {
     /// Validates the field with the current value.
     func validateField() {
         errorMessage = validate(value)
+    }
+
+    /// Clears the current validation error.
+    /// This can be used to reset an error for later re-validation.
+    func clearError() {
+        errorMessage = nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -19,11 +19,6 @@ struct WooShippingEditAddressView: View {
     /// Used to validate the field when the focus changes.
     @State private var previousFocusedField: WooShippingAddressFieldType?
 
-    /// Tracks the previously focused address field.
-    ///
-    /// Used to validate the field when the focus changes.
-    @State private var previousFocusedField: AddressField?
-
     @Environment(\.dismiss) private var dismiss
 
     @State private var isPresentingCountrySelector: Bool = false
@@ -194,6 +189,9 @@ struct WooShippingEditAddressView: View {
                 .foregroundStyle(Color(.text))
                 TextField(Localization.title(for: field.type), text: $field.value, prompt: Text(field.required ? "" : Localization.optional))
                     .focused($focused, equals: field.type)
+                    .onChange(of: field.value) { _ in
+                        field.clearError()
+                    }
                     .padding()
                     .roundedBorder(cornerRadius: Constants.cornerRadius,
                                    lineColor: Constants.fieldBorderColor(focused: focused == field.type, valid: field.errorMessage == nil),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -19,6 +19,11 @@ struct WooShippingEditAddressView: View {
     /// Used to validate the field when the focus changes.
     @State private var previousFocusedField: WooShippingAddressFieldType?
 
+    /// Tracks the previously focused address field.
+    ///
+    /// Used to validate the field when the focus changes.
+    @State private var previousFocusedField: AddressField?
+
     @Environment(\.dismiss) private var dismiss
 
     @State private var isPresentingCountrySelector: Bool = false
@@ -77,6 +82,12 @@ struct WooShippingEditAddressView: View {
                 }
             }
             .padding()
+            .onChange(of: focusedField) { newField in
+                if let previousFocusedField {
+                    viewModel.validate(previousFocusedField)
+                }
+                previousFocusedField = newField
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Localization.cancel) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -185,8 +185,14 @@ struct WooShippingEditAddressView: View {
                     .focused($focused, equals: field.type)
                     .padding()
                     .roundedBorder(cornerRadius: Constants.cornerRadius,
-                                   lineColor: focused == field.type ? Color(.accent) : Constants.defaultBorderColor,
+                                   lineColor: Constants.fieldBorderColor(focused: focused == field.type, valid: field.errorMessage == nil),
                                    lineWidth: focused == field.type ? 2 : Constants.defaultBorderWidth)
+                if let errorMessage = field.errorMessage {
+                    Text(errorMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(Constants.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
         }
     }
@@ -224,6 +230,12 @@ struct WooShippingEditAddressView: View {
                     .roundedBorder(cornerRadius: Constants.cornerRadius,
                                    lineColor: Constants.defaultBorderColor,
                                    lineWidth: Constants.defaultBorderWidth)
+                }
+                if let errorMessage = field.errorMessage {
+                    Text(errorMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(Constants.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
@@ -295,6 +307,12 @@ private extension WooShippingEditAddressView {
         static let red = Color(UIColor(light: .withColorStudio(.red, shade: .shade60),
                                        dark: .withColorStudio(.red, shade: .shade40)))
         static let requiredLabelSpacing: CGFloat = 4
+        static func fieldBorderColor(focused: Bool, valid: Bool) -> Color {
+            guard valid else {
+                return red
+            }
+            return focused ? Color(.accent) : defaultBorderColor
+        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -49,13 +49,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Whether the address has been remotely verified.
     private var isVerified: Bool
 
+    /// Whether the address is locally validated (there are no validation errors).
+    @Published private var isValid: Bool = false
+
     var allFields: [WooShippingAddressField] {
         [name, company, country, address, city, state, postalCode, email, phone]
-    }
-
-    /// Fields with validation errors based on local validation.
-    var invalidFields: [WooShippingAddressField] {
-        allFields.filter { $0.errorMessage != nil }
     }
 
     /// Whether the phone number is required.
@@ -64,7 +62,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     // TODO: Set status to unverified if the address was verified remotely but there are unsaved changes.
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus {
-        switch (isVerified, invalidFields.isEmpty) {
+        switch (isVerified, isValid) {
         case (true, true):
             return .verified
         case (false, true):
@@ -209,6 +207,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         observeNameAndCompany()
         observeSelectedCountry()
         observeSelectedState()
+        observeFieldErrors()
         fetchCountries()
         validateAddress()
     }
@@ -314,6 +313,16 @@ private extension WooShippingEditAddressViewModel {
                 guard let self else { return }
                 state.value = selectedState?.code ?? ""
                 state.setDisplayValue(selectedState?.name ?? "")
+            }
+            .store(in: &cancellables)
+    }
+
+    func observeFieldErrors() {
+        allFields.map { $0.$errorMessage }
+            .combineLatest()
+            .sink { [weak self] errors in
+                guard let self else { return }
+                isValid = errors.allSatisfy { $0 == nil }
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -207,6 +207,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         observeSelectedCountry()
         observeSelectedState()
         fetchCountries()
+        validateAddress()
     }
 
     convenience init(address: WooShippingOriginAddress,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -9,6 +9,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private let siteID: Int64
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private let debounceDelay: Double
     private var cancellables: Set<AnyCancellable> = []
 
     enum AddressType {
@@ -147,7 +148,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          isVerified: Bool,
          phoneNumberRequired: Bool,
          stores: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         debounceDelayInSeconds: Double = 1) {
         self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
@@ -176,6 +178,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
+        self.debounceDelay = debounceDelayInSeconds
 
         // Set validation rules for fields that rely on instance properties.
         self.name.validate = { [weak self] newName in
@@ -268,7 +271,19 @@ extension WooShippingEditAddressViewModel {
 
 private extension WooShippingEditAddressViewModel {
     func observeNameAndCompany() {
-        (name.$value.removeDuplicates()).combineLatest(company.$value.removeDuplicates())
+        let nameValues = name.$value.removeDuplicates()
+        let companyValues = company.$value.removeDuplicates()
+
+        (nameValues).combineLatest(companyValues)
+            .sink { [weak self] _, _ in
+                guard let self else { return }
+                self.name.clearError()
+                self.company.clearError()
+            }
+            .store(in: &cancellables)
+
+        (nameValues).combineLatest(companyValues)
+            .debounce(for: .seconds(debounceDelay), scheduler: DispatchQueue.main)
             .sink { [weak self] name, company in
                 guard let self else { return }
                 self.name.required = company.isEmpty

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -15,7 +15,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let postalCode = "12883-1487"
         let country = "US"
         let email = "TEST@EXAMPLE.COM"
-        let phone = "123-456-7890"
+        let phone = "1-234-456-7890"
         let saveAsDefault = true
         let showCompanyField = true
         let isVerified = true
@@ -72,12 +72,12 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                state: "NY",
                                                postcode: "12883-1487",
                                                country: "US",
-                                               phone: "123-456-7890",
+                                               phone: "223-456-7890",
                                                firstName: "JANE",
                                                lastName: "DOE",
                                                email: "TEST@EXAMPLE.COM",
                                                defaultAddress: true,
-                                               isVerified: true)
+                                               isVerified: false)
 
         // When
         let viewModel = WooShippingEditAddressViewModel(address: address, storageManager: storageManager)
@@ -95,9 +95,31 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.email.value, address.email)
         XCTAssertTrue(viewModel.isDefaultAddress)
         XCTAssertTrue(viewModel.showCompanyField)
-        XCTAssertEqual(viewModel.status, .verified)
+        XCTAssertEqual(viewModel.status, .unverified)
         XCTAssertTrue(viewModel.showSaveAsDefault)
         XCTAssertEqual(viewModel.countries.count, 1, "Should only include USPS-supported countries for origin addresses")
+    }
+
+    func test_it_validates_address_with_missing_information_and_sets_expected_status_on_init() {
+        // Given & When
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: false,
+                                                        phoneNumberRequired: true)
+
+        // Then
+        XCTAssertEqual(viewModel.status, .missingInformation)
     }
 
     func test_expected_fields_are_required() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -485,7 +485,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        debounceDelayInSeconds: 0)
 
         // When
         viewModel.validateAddress()
@@ -517,7 +518,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        storageManager: storageManager)
+                                                        storageManager: storageManager,
+                                                        debounceDelayInSeconds: 0)
 
         // When
         for field in WooShippingAddressFieldType.allCases {
@@ -545,7 +547,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        debounceDelayInSeconds: 0)
 
         // When
         for field in WooShippingAddressFieldType.allCases {
@@ -579,7 +582,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        storageManager: storageManager)
+                                                        storageManager: storageManager,
+                                                        debounceDelayInSeconds: 0)
 
         // When
         viewModel.validate(.state)
@@ -608,7 +612,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        storageManager: storageManager)
+                                                        storageManager: storageManager,
+                                                        debounceDelayInSeconds: 0)
 
         // When
         viewModel.validate(.phone)
@@ -633,7 +638,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        debounceDelayInSeconds: 0)
         // Precondition check
         viewModel.validate(.name)
         XCTAssertTrue(viewModel.invalidFields.map { $0.type }.contains(.name))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -439,7 +439,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.selectedState)
     }
 
-    func test_validateAddress_sets_expected_properties_when_all_fields_valid() {
+    func test_validateAddress_sets_expected_status_when_all_fields_valid() {
         // Given
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
@@ -465,7 +465,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         viewModel.validateAddress()
 
         // Then
-        XCTAssertTrue(viewModel.invalidFields.isEmpty)
+        XCTAssertTrue(viewModel.invalidFieldTypes.isEmpty)
         XCTAssertEqual(viewModel.status, .verified)
     }
 
@@ -493,12 +493,12 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         // Note that empty state is valid when country is empty (has no states).
-        let expectedInvalidFieldTypes = WooShippingAddressFieldType.allCases.filter { $0 != .state }
-        XCTAssertEqual(viewModel.invalidFields.map { $0.type }, expectedInvalidFieldTypes)
+        let expectedInvalidFieldTypes = viewModel.allFields.filter { $0.type != .state }.map { $0.type }
+        XCTAssertEqual(viewModel.invalidFieldTypes, expectedInvalidFieldTypes)
         XCTAssertEqual(viewModel.status, .missingInformation)
     }
 
-    func test_validate_sets_expected_properties_when_all_fields_valid() {
+    func test_validate_sets_expected_status_when_all_fields_valid() {
         // Given
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
@@ -527,7 +527,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(viewModel.invalidFields.isEmpty)
+        XCTAssertTrue(viewModel.invalidFieldTypes.isEmpty)
         XCTAssertEqual(viewModel.status, .verified)
     }
 
@@ -557,8 +557,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         // Note that empty state is valid when country is empty (has no states).
-        let expectedInvalidFields = WooShippingAddressFieldType.allCases.filter { $0 != .state }
-        XCTAssertEqual(viewModel.invalidFields.map { $0.type }, expectedInvalidFields)
+        let expectedInvalidFieldTypes = viewModel.allFields.filter { $0.type != .state }.map { $0.type }
+        XCTAssertEqual(viewModel.invalidFieldTypes, expectedInvalidFieldTypes)
         XCTAssertEqual(viewModel.status, .missingInformation)
     }
 
@@ -589,7 +589,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         viewModel.validate(.state)
 
         // Then
-        XCTAssertTrue(viewModel.invalidFields.map { $0.type }.contains(.state))
+        XCTAssertTrue(viewModel.invalidFieldTypes.contains(.state))
     }
 
     func test_validate_sets_phone_as_invalid_field_when_invalid_for_US() {
@@ -619,7 +619,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         viewModel.validate(.phone)
 
         // Then
-        XCTAssertTrue(viewModel.invalidFields.map { $0.type }.contains(.phone))
+        XCTAssertTrue(viewModel.invalidFieldTypes.contains(.phone))
     }
 
     func test_validate_removes_valid_field_from_invalidFields() {
@@ -642,13 +642,19 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         debounceDelayInSeconds: 0)
         // Precondition check
         viewModel.validate(.name)
-        XCTAssertTrue(viewModel.invalidFields.map { $0.type }.contains(.name))
+        XCTAssertTrue(viewModel.invalidFieldTypes.contains(.name))
 
         // When
         viewModel.name.value = "JANE DOE"
         viewModel.validate(.name)
 
         // Then
-        XCTAssertFalse(viewModel.invalidFields.map { $0.type }.contains(.name))
+        XCTAssertFalse(viewModel.invalidFieldTypes.contains(.name))
+    }
+}
+
+private extension WooShippingEditAddressViewModel {
+    var invalidFieldTypes: [WooShippingAddressFieldType] {
+        allFields.filter { $0.errorMessage != nil }.map { $0.type }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14943
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/14949 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the address validation behavior and UI to the Woo Shipping flow:

1. When a merchant opens the address form, we will immediately validate the address form and show any errors for invalid fields.
2. When a merchant types in any input fields, we will wait some seconds after the typing stops and perform a validation.
3. If the value of an input field is not valid, we will display an error.
4. When a merchant starts typing again on an input field with an error, we will clear the error and wait for the merchant to stop typing and validate the input as in step 2.
5. When we change focus from one input field to another, we will validate the value of the input field that lost the focus.

### Changes

* We immediately validate all fields in the address when `WooShippingEditAddressViewModel` inits.
* We add a debounce before validating new values for `WooShippingAddressField`, and when cross-validating the name and shipping fields. This allows us to delay validation while a merchant is typing.
* We add a `WooShippingAddressField.clearError()` method and use it to clear any error when new text is being entered in an address text field.
* When observing the company and name fields, we immediately clear both fields when one changes and (after a delay) re-validate them.
* In the view, we add the UI to display the error message for a field. We also observe changes to the focused field and validate the previous field when it changes.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. In the edit address sheet, confirm the address is validated as expected when the sheet opens.
8. Erase the text from a required field, wait a second, and confirm the expected validation error appears.
9. Start typing in the same field and confirm the validation error immediately disappears.
10. Erase the text from a required field, change the focus to a new field, and confirm the previous field is immediately validated.

Confirm that at each step the status label and button at the bottom of the sheet reflect the current validation status.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/cc43d6ec-c3d9-4ed6-8f84-dba9d06d7a7d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.