### PR TITLE
Use latest ci-toolkit, 3.9.1, to print better logs when caching

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -4,7 +4,7 @@
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
 XCODE_VERSION=$(sed 's/^~> *//' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION="3.7.1"
+CI_TOOLKIT_PLUGIN_VERSION="3.9.1"
 
 # Note: `-v4` suffix was added to use xcode-16.1-v4 image; remember to remove that suffix during the next Xcode update
 export IMAGE_ID="xcode-$XCODE_VERSION-v4"


### PR DESCRIPTION
See changes from https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/135

In chatting with @ParaskP7  and @wzieba , we thought it be useful to surface cache performance in CI using the new ci-toolkit version.

See also https://github.com/wordpress-mobile/WordPress-iOS/pull/24002 with more details.