### PR TITLE
[Woo POS][Cash & Receipts] Validate empty cash user input as zero

### DIFF
--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -36,8 +36,10 @@ final class CollectCashViewHelper {
     func validateAmountOnSubmit(orderTotal: String,
                                 textFieldAmountInput: String,
                                 onError: (String) -> Void) -> Bool {
+        let userInput = textFieldAmountInput.isEmpty ? "0" : textFieldAmountInput
+
         guard let orderDecimal = parseCurrency(orderTotal),
-              let inputDecimal = parseCurrency(textFieldAmountInput) else {
+              let inputDecimal = parseCurrency(userInput) else {
             onError(Localization.failedToCollectCashPayment)
             return false
         }

--- a/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CollectCashViewHelper.swift
@@ -36,7 +36,7 @@ final class CollectCashViewHelper {
     func validateAmountOnSubmit(orderTotal: String,
                                 textFieldAmountInput: String,
                                 onError: (String) -> Void) -> Bool {
-        let userInput = textFieldAmountInput.isEmpty ? "0" : textFieldAmountInput
+        let userInput = textFieldAmountInput.isNotEmpty ? textFieldAmountInput : "0"
 
         guard let orderDecimal = parseCurrency(orderTotal),
               let inputDecimal = parseCurrency(userInput) else {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CollectCashViewHelperTests.swift
@@ -207,4 +207,59 @@ struct CollectCashViewHelperTests {
         #expect(result == false)
         #expect(capturedErrorMessage == expectedErrorMessage)
     }
+
+    @Test func validateAmountOnSubmit_when_input_is_empty_then_returns_true() {
+        // Given
+        let orderTotal = "$0.00"
+        let inputAmount = ""
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount,
+            onError: { _ in })
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func validateAmountOnSubmit_when_orderTotal_is_empty_then_returns_false_with_expected_error_message() {
+        // Given
+        let orderTotal = ""
+        let inputAmount = ""
+        let expectedErrorMessage = "Error trying to process payment. Try again."
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount,
+            onError: { error in
+                capturedErrorMessage = error
+            })
+
+        // Then
+        #expect(result == false)
+        #expect(capturedErrorMessage == expectedErrorMessage)
+    }
+
+    @Test func validateAmountOnSubmit_when_inputDecimal_is_empty_and_less_than_orderTotal_then_returns_false_with_expected_error_message() {
+        // Given
+        let orderTotal = "$1.00"
+        let inputAmount = ""
+        let expectedErrorMessage = "Amount must be more or equal to total."
+        var capturedErrorMessage: String?
+
+        // When
+        let result = sut.validateAmountOnSubmit(
+            orderTotal: orderTotal,
+            textFieldAmountInput: inputAmount,
+            onError: { error in
+                capturedErrorMessage = error
+            })
+
+        // Then
+        #expect(result == false)
+        #expect(capturedErrorMessage == expectedErrorMessage)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Ref: pdfdoF-6fr#comment-7372-p2

## Description
This PR updates the submit validation logic when processing cash, so if an empty textfield is submitted for validation, we assume that it's zero. This is done to handle 0-value carts with free products without the user having to specifically type "0" in the textfield.

## Testing information
- Switch `.acceptCashForPointOfSale` on 
- Process a POS transaction with a $0-cart value, select cash payment
- Tap the "Mark as Complete" button without typing anything in the textfield
- Observe that the transaction is processed normally


https://github.com/user-attachments/assets/aeba5f1b-3260-4b92-92ac-ac9f70216c20

Receipts and the rest of the flow works as before, the only difference is we remove the need to type down `0` in the textfield.

<img width="589" alt="Screenshot 2025-01-23 at 08 49 24" src="https://github.com/user-attachments/assets/bbbb48fe-5b3f-498a-b72d-d286c9946bf4" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
