### PR TITLE
[Woo POS] [Variable Products] Only show one ghost cell for next page

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -49,8 +49,12 @@ struct ItemList<HeaderView: View>: View {
 
     @ViewBuilder var footerRows: some View {
         switch state {
-        case .loading:
-            ForEach(0..<8) { _ in
+        case .loading(let items):
+            if items.isEmpty {
+                ForEach(0..<8) { _ in
+                    GhostItemCardView()
+                }
+            } else {
                 GhostItemCardView()
             }
         case .inlineError(_, let errorState):


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14955
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes the loading next page UI for products and variations to match Android.

We now show only one ghost cell when loading the next page, but continue to show 8 when loading the first page of variations.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS
2. Observe that the initial loading state is a spinner.
3. Scroll to the end of the product list; observe that one ghost cell is shown while loading new items.
4. Open a variation; observe that the loading state is a page of ghost cells which all animate.
5. Scroll to the end of the list (min 26 variations); observe that the loading state for the next page is one ghost cell.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/3d9ffc9b-75b0-4e08-9f2d-daaecd626780


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.