### PR TITLE
[Mobile-Payments] Fix Stripe Extension Setup URL

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [Internal] Removed feedback survey for shipping label creation [https://github.com/woocommerce/woocommerce-ios/pull/14889]
 - [Internal] Removed feedback survey for product creation AI [https://github.com/woocommerce/woocommerce-ios/pull/14890]
 - [Internal] Removed feedback survey for coupons list [https://github.com/woocommerce/woocommerce-ios/pull/14891]
+- [*] Updated the Stripe Gateway setup URL to point to the appropriate settings page. [https://github.com/woocommerce/woocommerce-ios/pull/14964]
 
 21.4
 -----

--- a/WooCommerce/Classes/Extensions/Site+URL.swift
+++ b/WooCommerce/Classes/Extensions/Site+URL.swift
@@ -27,11 +27,15 @@ extension Site {
     }
 
     /// Returns the plugin URL from wp-admin that handles pending tasks or requirements during onboarding.
-    /// Both WCPay and Stripe use the same URL.
-    /// Payments Connect page was recommended by the web team over Payments Overview page in pdfdoF-5Bo-p2#comment-6655
     ///
-    func cardPresentPluginHasPendingTasksURL() -> String {
-        return adminURL + "admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+    func cardPresentPluginHasPendingTasksURL(plugin: CardPresentPaymentsPlugin) -> String {
+        switch plugin {
+        case .wcPay:
+            /// Payments Connect page was recommended by the web team over Payments Overview page in pdfdoF-5Bo-p2#comment-6655
+            return adminURL + "admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+        case .stripe:
+            return pluginSettingsSectionURL(from: .stripe) + "&panel=settings"
+        }
     }
 
     /// Returns the WooCommerce admin URL, or attempts to construct it from the site URL.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
@@ -66,9 +66,10 @@ struct CardPresentPaymentsOnboardingView: View {
                     viewModel.refresh)
             case .pluginSetupNotCompleted(let plugin):
                 InPersonPaymentsPluginNotSetup(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
-            case .stripeAccountOverdueRequirement:
+            case .stripeAccountOverdueRequirement(let plugin):
                 InPersonPaymentsStripeAccountOverdue(analyticReason: viewModel.state.reasonForAnalytics,
-                                                     onRefresh: viewModel.refresh)
+                                                     onRefresh: viewModel.refresh,
+                                                     plugin: plugin)
             case .stripeAccountPendingRequirement(_, let deadline):
                 InPersonPaymentsStripeAccountPending(
                     deadline: deadline,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -54,7 +54,7 @@ struct InPersonPaymentsPluginNotSetup: View {
     }
 
     private var setupURL: URL? {
-        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.cardPresentPluginHasPendingTasksURL() else {
+        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.cardPresentPluginHasPendingTasksURL(plugin: plugin) else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -4,9 +4,9 @@ import enum Yosemite.CardPresentPaymentsPlugin
 struct InPersonPaymentsStripeAccountOverdue: View {
     let analyticReason: String
     let onRefresh: () -> Void
+    let plugin: CardPresentPaymentsPlugin
     @State private var presentedSetupURL: URL? = nil
 
-    private let plugin: CardPresentPaymentsPlugin = .stripe
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -36,7 +36,7 @@ struct InPersonPaymentsStripeAccountOverdue: View {
      }
 
     private var setupURL: URL? {
-        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.cardPresentPluginHasPendingTasksURL() else {
+        guard let pluginSectionURL = ServiceLocator.stores.sessionManager.defaultSite?.cardPresentPluginHasPendingTasksURL(plugin: plugin) else {
             return nil
         }
 
@@ -77,6 +77,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountOverdue_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountOverdue(analyticReason: "", onRefresh: { })
+        InPersonPaymentsStripeAccountOverdue(analyticReason: "", onRefresh: { }, plugin: .stripe)
     }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/SitePluginsURLTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/SitePluginsURLTests.swift
@@ -43,4 +43,18 @@ final class Site_PluginsURLTests: XCTestCase {
         // Then
         XCTAssertEqual(site.pluginSettingsSectionURL(from: .stripe), expectedURL)
     }
+
+    func test_cardPresentPluginHasPendingTasksURL_when_plugin_is_wcpay_then_returns_correct_URL() {
+        let expectedURL = adminURL + "admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+
+        // Then
+        XCTAssertEqual(site.cardPresentPluginHasPendingTasksURL(plugin: .wcPay), expectedURL)
+    }
+
+    func test_cardPresentPluginHasPendingTasksURL_when_plugin_is_stripe_then_returns_correct_URL() {
+        let expectedURL = adminURL + "admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings"
+
+        // Then
+        XCTAssertEqual(site.cardPresentPluginHasPendingTasksURL(plugin: .stripe), expectedURL)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14917
Android PR: https://github.com/woocommerce/woocommerce-android/pull/13356
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Thanks https://github.com/woocommerce/woocommerce-ios/pull/14297 for test cases

There are two use cases of the payment setup URL:

- `InPersonPaymentsPluginNotSetup`
- `InPersonPaymentsStripeAccountOverdue`

I recommend testing by hardcoding result of `CardPresentPaymentsOnboardingUseCase.checkOnboardingState`, and testing 4 cases:
- `.stripeAccountOverdueRequirement(plugin: .wcPay)`
- `.stripeAccountOverdueRequirement(plugin: .stripe)`
- `.pluginSetupNotCompleted(plugin: .wcPay)`
- `.pluginSetupNotCompleted(plugin: .stripe)`

### Stripe Account Overdue

Prerequisite: Return `.stripeAccountOverdueRequirement(plugin: .stripe)` / `.stripeAccountOverdueRequirement(plugin: .wcPay)`

1. Log into the store
2. Make an order and collect payment
3. Tap `Card Reader` --> an onboarding modal should be shown. after the loading state, the Stripe overdue UI should be shown
4. Tap `Resolve Now` --> a webview should be shown. log in to wp-admin if needed for WPCOM login. 
5. The web view should open either Stripe or WooPayments page depending on initial setup

### Payments plugin not set up

Prerequisite: return `.pluginSetupNotCompleted(plugin: .stripe)` / `.pluginSetupNotCompleted(plugin: .wcPay)` from `checkOnboardingState`

1. Log into the store
2. Make an order and collect payment
3. Tap `Card Reader` --> an onboarding modal should be shown. after the loading state, the plugin not set up UI should be shown
4. Tap `Finish Setup in Store Admin` --> a webview should be shown. log in to wp-admin if needed for WPCOM login. 
5. The web view should open either Stripe or WooPayments page depending on the initial setup

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested both plugin not setup and stripe account overdue states with Stripe and WCPay on IPP and POS.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.