### PR TITLE
[Brand Updates] Update In-Person mentions to make sure we use non-breaking hyphen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -100,8 +100,13 @@ private enum Localization {
         "Choose your Payment Provider",
         comment: "Title for the screen to select the preferred provider for In-Person Payments")
     static let prompt = NSLocalizedString(
-        "In-Person Payments can be processed through either of these payment providers. Which provider would you like to use?",
-        comment: "Main prompt for the screen to select the preferred provider for In-Person Payments")
+        "In‑Person Payments can be processed through either of these payment providers. Which provider would you like to use?",
+        comment: """
+                 Main prompt for the screen to select the preferred provider for In-Person Payments
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
+    )
     static let confirm = NSLocalizedString(
         "Confirm Payment Method",
         comment: "Button to confirm the preferred provider for In-Person Payments")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -31,13 +31,21 @@ struct InPersonPaymentsCountryNotSupported: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "We don’t support In-Person Payments in %1$@",
-        comment: "Title for the error screen when In-Person Payments is not supported in a specific country"
+        "We don’t support In‑Person Payments in %1$@",
+        comment: """
+                 Title for the error screen when In-Person Payments is not supported in a specific country
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let titleUnknownCountry = NSLocalizedString(
-        "We don’t support In-Person Payments in your country",
-        comment: "Title for the error screen when In-Person Payments is not supported because we don't know the name of the country"
+        "We don’t support In‑Person Payments in your country",
+        comment: """
+                 Title for the error screen when In-Person Payments is not supported because we don't know the name of the country.
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let message = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -31,13 +31,21 @@ struct InPersonPaymentsCountryNotSupportedStripe: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "We don’t support In-Person Payments with Stripe in %1$@",
-        comment: "Title for the error screen when In-Person Payments is not supported in a specific country"
+        "We don’t support In‑Person Payments with Stripe in %1$@",
+        comment: """
+                 Title for the error screen when In-Person Payments is not supported in a specific country
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let titleUnknownCountry = NSLocalizedString(
-        "We don’t support In-Person Payments with Stripe in your country",
-        comment: "Title for the error screen when In-Person Payments is not supported because we don't know the name of the country"
+        "We don’t support In‑Person Payments with Stripe in your country",
+        comment: """
+                 Title for the error screen when In-Person Payments is not supported because we don't know the name of the country
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let message = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -35,9 +35,13 @@ private enum Localization {
     )
 
     static let message = NSLocalizedString(
-        "The %1$@ extension cannot be in test mode for In-Person Payments. "
+        "The %1$@ extension cannot be in test mode for In‑Person Payments. "
             + "Please disable test mode.",
-        comment: "Error message when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name."
+        comment: """
+                 Error message when a card present payments plugin is in test mode on a live site. %1$@ is a placeholder for the plugin name.
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let primaryButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -35,8 +35,12 @@ private enum Localization {
     )
 
     static let message = NSLocalizedString(
-        "The %1$@ extension is installed on your store but not activated. Please activate it to accept In-Person Payments",
-        comment: "Error message when a Card Present Payments extension is not activated"
+        "The %1$@ extension is installed on your store but not activated. Please activate it to accept In‑Person Payments",
+        comment: """
+                 Error message when a Card Present Payments extension is not activated
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let primaryButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -33,8 +33,12 @@ private enum Localization {
     )
 
     static let message = NSLocalizedString(
-        "You’ll need to install the free WooCommerce Payments extension on your store to accept In-Person Payments.",
-        comment: "Error message when WooCommerce Payments is not installed"
+        "You’ll need to install the free WooCommerce Payments extension on your store to accept In‑Person Payments.",
+        comment: """
+                 Error message when WooCommerce Payments is not installed
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
+                 """
     )
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -69,8 +69,12 @@ private enum Localization {
     )
 
     static let message = NSLocalizedString(
-        "You’re almost there! Please finish setting up %1$@ to start accepting In-Person Payments.",
-        comment: "Error message when an in-person payments plugin is activated but not set up. %1$@ contains the plugin name."
+        "You’re almost there! Please finish setting up %1$@ to start accepting In‑Person Payments.",
+        comment: """
+                 Error message when an in-person payments plugin is activated but not set up. %1$@ contains the plugin name.
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let primaryButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -35,9 +35,13 @@ private enum Localization {
     )
 
     static let message = NSLocalizedString(
-        "The %1$@ extension is installed on your store, but needs to be updated for In-Person Payments. "
+        "The %1$@ extension is installed on your store, but needs to be updated for In‑Person Payments. "
             + "Please update it to the most recent version.",
-        comment: "Error message when a Card Present Payments extension is installed but the version is not supported"
+        comment: """
+                Error message when a Card Present Payments extension is installed but the version is not supported
+                The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
+                """
     )
 
     static let primaryButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -56,13 +56,21 @@ private extension InPersonPaymentsStripeAccountOverdue {
 
 private enum Localization {
      static let title = NSLocalizedString(
-         "In-Person Payments is currently unavailable",
-         comment: "Title for the error screen when the Stripe account is restricted because there are overdue requirements."
+         "In‑Person Payments is currently unavailable",
+         comment: """
+                  Title for the error screen when the Stripe account is restricted because there are overdue requirements.
+                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                  If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                  """
      )
 
      static let message = NSLocalizedString(
-         "You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments.",
-         comment: "Error message when WooCommerce Payments is not supported because the Stripe account has overdue requirements"
+         "You have at least one overdue requirement on your account. Please take care of that to resume In‑Person Payments.",
+         comment: """
+                  Error message when WooCommerce Payments is not supported because the Stripe account has overdue requirements
+                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                  If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                  """
      )
 
     static let primaryButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -46,14 +46,23 @@ private enum Localization {
     )
 
     static let messageDeadline = NSLocalizedString(
-        "There are pending requirements for your account. Please complete those requirements by %1$@ to keep accepting In-Person Payments.",
-        comment: "Error message when because there are pending requirements in the merchant's " +
-        "In-Person Payments account. %1$d will contain the localized deadline (e.g. August 11, 2021)"
+        "There are pending requirements for your account. Please complete those requirements by %1$@ to keep accepting In‑Person Payments.",
+        comment: """
+                 Error message when because there are pending requirements in the merchant's
+                 In-Person Payments account.
+                 %1$d will contain the localized deadline (e.g. August 11, 2021)
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let messageUnknownDeadline = NSLocalizedString(
-        "There are pending requirements for your account. Please complete those requirements to keep accepting In-Person Payments.",
-        comment: "Error message when there are pending requirements in the merchant's payment account (without a known deadline)"
+        "There are pending requirements for your account. Please complete those requirements to keep accepting In‑Person Payments.",
+        comment: """
+                 Error message when there are pending requirements in the merchant's payment account (without a known deadline)
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let skipButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -21,13 +21,21 @@ struct InPersonPaymentsStripeAccountReview: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "In-Person Payments is currently unavailable",
-        comment: "Title for the error screen when the merchant's payment account is restricted because it's under reviw"
+        "In‑Person Payments is currently unavailable",
+        comment: """
+                 Title for the error screen when the merchant's payment account is restricted because it's under reviw
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let message = NSLocalizedString(
-        "You'll be able to accept In-Person Payments as soon as we finish reviewing your account.",
-        comment: "Error message when the merchant's payment account is under review"
+        "You'll be able to accept In‑Person Payments as soon as we finish reviewing your account.",
+        comment: """
+                 Error message when the merchant's payment account is under review
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -20,13 +20,21 @@ struct InPersonPaymentsStripeRejected: View {
 
 private enum Localization {
     static let title = NSLocalizedString(
-        "In-Person Payments isn't available for this store",
-        comment: "Title for the error screen when the merchant's payment account has been rejected."
+        "In‑Person Payments isn't available for this store",
+        comment: """
+                 Title for the error screen when the merchant's payment account has been rejected.
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let message = NSLocalizedString(
-        "We are sorry but we can't support In-Person Payments for this store.",
-        comment: "Error message when the merchant's payment account has been rejected"
+        "We are sorry but we can't support In‑Person Payments for this store.",
+        comment: """
+                 Error message when the merchant's payment account has been rejected
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
@@ -21,13 +21,21 @@ struct InPersonPaymentsUnavailable: View {
 
 private enum Localization {
     static let unavailable = NSLocalizedString(
-        "Unable to verify In-Person Payments for this store",
-        comment: "Title for the error screen when In-Person Payments is unavailable"
+        "Unable to verify In‑Person Payments for this store",
+        comment: """
+                 Title for the error screen when In-Person Payments is unavailable
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 
     static let message = NSLocalizedString(
-        "We're sorry, we were unable to verify In-Person Payments for this store.",
-        comment: "Generic error message when In-Person Payments is unavailable"
+        "We're sorry, we were unable to verify In‑Person Payments for this store.",
+        comment: """
+                 Generic error message when In-Person Payments is unavailable
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
+                 """
     )
 }
 


### PR DESCRIPTION
## Description
As part of the design review of the app, we got feedback about `in-person` breaking and pushing person to new line.
This PR updates those cases to use a non-breaking hyphen, and also updates the localizable comment to mention this for translators, this follows the same approach we are [already doing](https://github.com/woocommerce/woocommerce-ios/blame/65a7b39574cae1bf52c01deb13ac877dcbd43a2f/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/LearnMoreViewModel.swift#L84) in other areas.

## Steps to reproduce
I think code review should be enough here.

## Testing information
Tested the plugin not installed case to confirm this works as expected.
Tested using an iPhone 16 simulator, iOS 18.1

## Screenshots
| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 16 12 40](https://github.com/user-attachments/assets/790bb9c0-6930-405f-9a48-9e72b7969712) | ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 15 19 05](https://github.com/user-attachments/assets/9d755cd1-6e5d-4340-beff-c3684d4cb301) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.