### PR TITLE
[Woo POS] [Variable Products] Add empty state for variations

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct PointOfSaleItemListEmptyView: View {
-    let base: ItemListBaseItem
+    private let baseItem: ItemListBaseItem
+
+    init(base: ItemListBaseItem) {
+        self.baseItem = base
+    }
 
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
@@ -11,14 +15,14 @@ struct PointOfSaleItemListEmptyView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: Constants.iconSize, height: Constants.iconSize)
                 .foregroundColor(.posSecondaryText)
-            Text(Localization.emptyProductsTitle)
+            Text(title)
                 .foregroundStyle(Color.posSecondaryText)
                 .font(.posTitleEmphasized)
-            Text(Localization.emptyProductsSubtitle)
+            Text(subtitle)
                 .foregroundStyle(Color.posSecondaryText)
                 .font(.posBodyRegular)
                 .padding([.leading, .trailing])
-            Text(Localization.emptyProductsHint)
+            Text(hint)
                 .foregroundStyle(Color.posSecondaryText)
                 .font(.posBodyRegular)
                 .padding([.leading, .trailing])
@@ -28,6 +32,42 @@ struct PointOfSaleItemListEmptyView: View {
 }
 
 private extension PointOfSaleItemListEmptyView {
+    var title: String {
+        switch baseItem {
+        case .root:
+            return Localization.emptyProductsTitle
+        case .parent(.variableParentProduct):
+            return Localization.emptyVariableParentProductTitle
+        default:
+            assertionFailure("No title defined for \(baseItem)")
+            return Localization.emptyProductsTitle
+        }
+    }
+
+    var subtitle: String {
+        switch baseItem {
+        case .root:
+            return Localization.emptyProductsSubtitle
+        case .parent(.variableParentProduct):
+            return Localization.emptyVariableParentProductSubtitle
+        default:
+            assertionFailure("No subtitle defined for \(baseItem)")
+            return Localization.emptyProductsTitle
+        }
+    }
+
+    var hint: String {
+        switch baseItem {
+        case .root:
+            return Localization.emptyProductsHint
+        case .parent(.variableParentProduct):
+            return Localization.emptyVariableParentProductHint
+        default:
+            assertionFailure("No hint defined for \(baseItem)")
+            return Localization.emptyProductsTitle
+        }
+    }
+
     enum Constants {
         static let iconSystemName: String = "plus.magnifyingglass"
         static let iconSize: CGFloat = 100
@@ -46,6 +86,22 @@ private extension PointOfSaleItemListEmptyView {
         static let emptyProductsHint = NSLocalizedString(
             "pos.pointOfSaleItemListEmptyView.emptyProductsHint",
             value: "To add one, exit POS and go to Products",
+            comment: "Text hinting the merchant to create a product."
+        )
+
+        static let emptyVariableParentProductTitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyVariableParentProductTitle",
+            value: "No supported variations found.",
+            comment: "Text appearing on screen when there are no variations to load."
+        )
+        static let emptyVariableParentProductSubtitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyVariableParentProductSubtitle",
+            value: "POS only supports enabled, non-downloadable variations.",
+            comment: "Subtitle text on screen when there are no products to load."
+        )
+        static let emptyVariableParentProductHint = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyVariableParentProductHint",
+            value: "To add one, exit POS and edit this product in the Products tab.",
             comment: "Text hinting the merchant to create a product."
         )
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -2,27 +2,25 @@ import SwiftUI
 
 struct PointOfSaleItemListEmptyView: View {
     var body: some View {
-        PointOfSaleItemListFullscreenView {
-            VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
-                Spacer()
-                Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: Constants.iconSize, height: Constants.iconSize)
-                    .foregroundColor(.posSecondaryText)
-                Text(Localization.emptyProductsTitle)
-                    .foregroundStyle(Color.posSecondaryText)
-                    .font(.posTitleEmphasized)
-                Text(Localization.emptyProductsSubtitle)
-                    .foregroundStyle(Color.posSecondaryText)
-                    .font(.posBodyRegular)
-                    .padding([.leading, .trailing])
-                Text(Localization.emptyProductsHint)
-                    .foregroundStyle(Color.posSecondaryText)
-                    .font(.posBodyRegular)
-                    .padding([.leading, .trailing])
-                Spacer()
-            }
+        VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
+            Spacer()
+            Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Constants.iconSize, height: Constants.iconSize)
+                .foregroundColor(.posSecondaryText)
+            Text(Localization.emptyProductsTitle)
+                .foregroundStyle(Color.posSecondaryText)
+                .font(.posTitleEmphasized)
+            Text(Localization.emptyProductsSubtitle)
+                .foregroundStyle(Color.posSecondaryText)
+                .font(.posBodyRegular)
+                .padding([.leading, .trailing])
+            Text(Localization.emptyProductsHint)
+                .foregroundStyle(Color.posSecondaryText)
+                .font(.posBodyRegular)
+                .padding([.leading, .trailing])
+            Spacer()
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -74,18 +74,18 @@ private extension PointOfSaleItemListEmptyView {
     }
     enum Localization {
         static let emptyProductsTitle = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.emptyProductsTitle",
-            value: "No supported products found",
+            "pos.pointOfSaleItemListEmptyView.emptyProductsTitle.1",
+            value: "No supported products found.",
             comment: "Text appearing on screen when there are no products to load."
         )
         static let emptyProductsSubtitle = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.emptyProductsSubtitle",
-            value: "POS currently only supports simple products.",
+            "pos.pointOfSaleItemListEmptyView.emptyProductsSubtitle.1",
+            value: "POS currently only supports simple and variable products.",
             comment: "Subtitle text on screen when there are no products to load."
         )
         static let emptyProductsHint = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.emptyProductsHint",
-            value: "To add one, exit POS and go to Products",
+            "pos.pointOfSaleItemListEmptyView.emptyProductsHint.1",
+            value: "To add one, exit POS and go to Products.",
             comment: "Text hinting the merchant to create a product."
         )
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct PointOfSaleItemListEmptyView: View {
+    let base: ItemListBaseItem
+
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
             Spacer()

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -22,6 +22,8 @@ struct ChildItemList: View {
     var body: some View {
         VStack {
             switch state {
+            case .loaded([], _):
+                emptyView
             case .loading, .loaded, .inlineError:
                 listView
             case let .error(error):
@@ -68,6 +70,19 @@ private extension ChildItemList {
             ItemList(state: state,
                      node: .parent(parentItem))
                 .transition(.opacity)
+        }
+    }
+
+    @ViewBuilder
+    var emptyView: some View {
+        ZStack {
+            VStack {
+                headerView
+                Spacer()
+            }
+
+            PointOfSaleItemListEmptyView(base: .parent(parentItem))
+                .zIndex(1)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -16,7 +16,9 @@ struct PointOfSaleDashboardView: View {
                     .transition(.opacity)
                     .ignoresSafeArea()
             case .empty:
-                PointOfSaleItemListEmptyView()
+                PointOfSaleItemListFullscreenView {
+                    PointOfSaleItemListEmptyView()
+                }
             case .error(let errorContents):
                 PointOfSaleItemListFullscreenErrorView(error: errorContents, onRetry: {
                     Task {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleDashboardView: View {
                     .ignoresSafeArea()
             case .empty:
                 PointOfSaleItemListFullscreenView {
-                    PointOfSaleItemListEmptyView()
+                    PointOfSaleItemListEmptyView(base: .root)
                 }
             case .error(let errorContents):
                 PointOfSaleItemListFullscreenErrorView(error: errorContents, onRetry: {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14965
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds an empty state for variations, and updates the strings for the product list empty state to reflect that we now support variable products.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Product List
1. Launch the app on a store with no products, or edit the network response to have no items
2. Open POS
3. Observe that the empty state is shown and mentions support for variable products.

### Empty Variable Product
1. Launch the app on a store with a variable product with no (non-downloadable, enabled) variations, or edit the network response to meet this.
2. Open POS
3. Open the variable parent product
4. Observe that the new empty state is shown and is specific to variations.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested on an iPad Air running iOS 17.7.2


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/8503f644-74bf-4b50-bb86-9a84412bd814



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.