### PR TITLE
[Mobile Payments] Handle Network errors for payments using site credentials

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		077F39E626A5D15800ABEADC /* SystemPluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DB26A58F4800ABEADC /* SystemPluginMapperTests.swift */; };
 		09885C8027C3FFD200910A62 /* product-variations-bulk-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 09885C7F27C3FFD200910A62 /* product-variations-bulk-update.json */; };
 		09EA564B27C75FCE00407D40 /* ProductVariationsBulkUpdateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA564A27C75FCE00407D40 /* ProductVariationsBulkUpdateMapper.swift */; };
+		204CBD2B2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */; };
 		209AD3C32AC196E300825D76 /* WooPaymentsPayoutsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3C22AC196E300825D76 /* WooPaymentsPayoutsOverview.swift */; };
 		209AD3C52AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3C42AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift */; };
 		20D210C32B1780CE0099E517 /* deposits-overview-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 20D210C22B1780CE0099E517 /* deposits-overview-all.json */; };
@@ -1489,6 +1490,7 @@
 		09885C7F27C3FFD200910A62 /* product-variations-bulk-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-bulk-update.json"; sourceTree = "<group>"; };
 		09EA564A27C75FCE00407D40 /* ProductVariationsBulkUpdateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsBulkUpdateMapper.swift; sourceTree = "<group>"; };
 		14CE248C7246705417A41DE1 /* Pods-NetworkingWatchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingWatchOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingWatchOS/Pods-NetworkingWatchOS.release.xcconfig"; sourceTree = "<group>"; };
+		204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error-site-credentials.json"; sourceTree = "<group>"; };
 		209AD3C22AC196E300825D76 /* WooPaymentsPayoutsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverview.swift; sourceTree = "<group>"; };
 		209AD3C42AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewMapper.swift; sourceTree = "<group>"; };
 		20D210C22B1780CE0099E517 /* deposits-overview-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deposits-overview-all.json"; sourceTree = "<group>"; };
@@ -3550,6 +3552,7 @@
 				03E6676827E0F62B00890E6F /* wcpay-charge-interac-present.json */,
 				03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */,
 				0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */,
+				204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */,
 				45CCFCE927A2E59B0012E8CB /* inbox-note-list.json */,
 				4513382727A96DE700AE5E78 /* inbox-note.json */,
 				0205021B27C86B9700FB1C6B /* inbox-note-without-isRead.json */,
@@ -4368,6 +4371,7 @@
 				026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */,
 				02AF07EC27492FDD00B2D81E /* media-library.json in Resources */,
 				CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */,
+				204CBD2B2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json in Resources */,
 				26B15E442A269F79000C35E4 /* ip-location.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */,

--- a/Networking/NetworkingTests/Responses/wcpay-charge-error-site-credentials.json
+++ b/Networking/NetworkingTests/Responses/wcpay-charge-error-site-credentials.json
@@ -1,0 +1,5 @@
+{
+  "code": "wcpay_get_charge",
+  "message": "Error: No such charge: 'ch_3KMVapErrorERROR'",
+  "data": null
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 21.6
 -----
-
+- [*] Payments: Improved error handling during card payments and refunds [https://github.com/woocommerce/woocommerce-ios/pull/14980]
 
 21.5
 -----

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -23,7 +23,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
         switch eventDetails {
         case .paymentError(error: CollectOrderPaymentUseCaseError.orderAlreadyPaid, _, _):
             paymentEventSubject.send(.show(eventDetails: .paymentSuccess(done: {})))
-        case .paymentError(error: ServerSidePaymentCaptureError.paymentGateway(.otherError), _, let cancelPayment):
+        case .paymentError(error: ServerSidePaymentCaptureError.paymentGateway, _, let cancelPayment):
             paymentEventSubject.send(.show(
                 eventDetails: .paymentCaptureError(cancelPayment: { [weak self] in
                     cancelPayment()

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -401,7 +401,7 @@ private extension CollectOrderPaymentUseCase {
                                                       paymentGatewayAccount: PaymentGatewayAccount,
                                                       channel: PaymentChannel,
                                                       onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        guard case ServerSidePaymentCaptureError.paymentGateway(.otherError) = error else {
+        guard case ServerSidePaymentCaptureError.paymentGateway = error else {
             return handlePaymentFailureAndRetryPayment(error,
                                                        alertProvider: paymentAlerts,
                                                        paymentGatewayAccount: paymentGatewayAccount,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		077F39E226A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */; };
 		077F39E526A5C98200ABEADC /* SystemStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
+		204CBD2F2D43C516006FF89A /* WCPayChargesError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CBD2E2D43C516006FF89A /* WCPayChargesError.swift */; };
 		207D2D1B2CFA06BD00F79204 /* POSCartItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */; };
 		207D2D1D2CFA0CEF00F79204 /* MockPOSOrderableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */; };
 		209AD3CC2AC1A68800825D76 /* WooPaymentsPayoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */; };
@@ -689,6 +690,7 @@
 		077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStore.swift; sourceTree = "<group>"; };
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStoreTests.swift; sourceTree = "<group>"; };
+		204CBD2E2D43C516006FF89A /* WCPayChargesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayChargesError.swift; sourceTree = "<group>"; };
 		207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCartItemTests.swift; sourceTree = "<group>"; };
 		207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrderableItem.swift; sourceTree = "<group>"; };
 		209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutService.swift; sourceTree = "<group>"; };
@@ -1724,6 +1726,7 @@
 				2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */,
 				DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */,
 				D83B093825DECFD800B21F45 /* CardPresentPaymentStore.swift */,
+				204CBD2E2D43C516006FF89A /* WCPayChargesError.swift */,
 				741F34812195EA71005F5BD9 /* CommentStore.swift */,
 				03FBDA25263296A100ACE257 /* CouponStore.swift */,
 				45E462132684C92D00011BF2 /* DataStore.swift */,
@@ -2442,6 +2445,7 @@
 				DEA493922B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift in Sources */,
 				45E462122684C7A400011BF2 /* DataAction.swift in Sources */,
 				247CE83C2582F36800F9D9D1 /* MockOrderActionHandler.swift in Sources */,
+				204CBD2F2D43C516006FF89A /* WCPayChargesError.swift in Sources */,
 				453954DA2C9197C900A3E64A /* MetaDataStore.swift in Sources */,
 				45E462142684C92D00011BF2 /* DataStore.swift in Sources */,
 				02FF055423D983F30058E6E7 /* MediaExport.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -147,7 +147,7 @@
 		077F39E226A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */; };
 		077F39E526A5C98200ABEADC /* SystemStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
-		204CBD2F2D43C516006FF89A /* WCPayChargesError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CBD2E2D43C516006FF89A /* WCPayChargesError.swift */; };
+		204CBD2F2D43C516006FF89A /* PaymentsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CBD2E2D43C516006FF89A /* PaymentsError.swift */; };
 		207D2D1B2CFA06BD00F79204 /* POSCartItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */; };
 		207D2D1D2CFA0CEF00F79204 /* MockPOSOrderableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */; };
 		209AD3CC2AC1A68800825D76 /* WooPaymentsPayoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */; };
@@ -690,7 +690,7 @@
 		077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStore.swift; sourceTree = "<group>"; };
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStoreTests.swift; sourceTree = "<group>"; };
-		204CBD2E2D43C516006FF89A /* WCPayChargesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayChargesError.swift; sourceTree = "<group>"; };
+		204CBD2E2D43C516006FF89A /* PaymentsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsError.swift; sourceTree = "<group>"; };
 		207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCartItemTests.swift; sourceTree = "<group>"; };
 		207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrderableItem.swift; sourceTree = "<group>"; };
 		209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutService.swift; sourceTree = "<group>"; };
@@ -1726,7 +1726,7 @@
 				2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */,
 				DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */,
 				D83B093825DECFD800B21F45 /* CardPresentPaymentStore.swift */,
-				204CBD2E2D43C516006FF89A /* WCPayChargesError.swift */,
+				204CBD2E2D43C516006FF89A /* PaymentsError.swift */,
 				741F34812195EA71005F5BD9 /* CommentStore.swift */,
 				03FBDA25263296A100ACE257 /* CouponStore.swift */,
 				45E462132684C92D00011BF2 /* DataStore.swift */,
@@ -2445,7 +2445,7 @@
 				DEA493922B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift in Sources */,
 				45E462122684C7A400011BF2 /* DataAction.swift in Sources */,
 				247CE83C2582F36800F9D9D1 /* MockOrderActionHandler.swift in Sources */,
-				204CBD2F2D43C516006FF89A /* WCPayChargesError.swift in Sources */,
+				204CBD2F2D43C516006FF89A /* PaymentsError.swift in Sources */,
 				453954DA2C9197C900A3E64A /* MetaDataStore.swift in Sources */,
 				45E462142684C92D00011BF2 /* DataStore.swift in Sources */,
 				02FF055423D983F30058E6E7 /* MediaExport.swift in Sources */,

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -3,8 +3,6 @@ import Hardware
 import Networking
 import Combine
 
-
-
 // MARK: CardPresentPaymentStore
 ///
 public final class CardPresentPaymentStore: Store {
@@ -731,97 +729,3 @@ public protocol CardReaderCapableRemote {
 extension WCPayRemote: CardReaderCapableRemote {}
 extension StripeRemote: CardReaderCapableRemote {}
 
-// MARK: - WCPayChargesError
-public enum WCPayChargesError: Error, LocalizedError {
-    case noSuchChargeError(message: String)
-    case otherError(error: AnyError)
-
-    init(underlyingError error: Error) {
-        guard let errorDetails = Self.unwrapError(error: error) else {
-            self = .otherError(error: error.toAnyError)
-            return
-        }
-
-        /// See if we recognize this DotcomError code
-        ///
-        self = errorDetails.asWCPayChargesError() ?? .otherError(error: error.toAnyError)
-    }
-
-    private static func unwrapError(error: Error) -> WCPayChargesErrorConvertible? {
-        switch error {
-        case let DotcomError.unknown(code, message):
-            return WCPayChargesDotcomErrorDetails(code: code, message: message)
-        case let NetworkError.unacceptableStatusCode(_, response):
-            guard let response,
-                  let errorDetails = try? JSONDecoder().decode(WCPayChargesNetworkErrorDetails.self, from: response) else {
-                return nil
-            }
-            return errorDetails
-        default:
-            return nil
-        }
-    }
-
-    private struct WCPayChargesNetworkErrorDetails: Decodable, WCPayChargesErrorConvertible {
-        let code: WCPayChargesErrorCode
-        let message: String?
-
-        enum CodingKeys: CodingKey {
-            case code
-            case message
-        }
-    }
-
-    private struct WCPayChargesDotcomErrorDetails: WCPayChargesErrorConvertible {
-        // The response JSON differs from NetworkError above:
-        // `"error": "wcpay_get_charge", "message": "Error fetching charge:"`
-        // It's also decoded further up the chain.
-        let code: WCPayChargesErrorCode
-        let message: String?
-
-        init?(code: String, message: String?) {
-            guard let errorCode = WCPayChargesErrorCode(rawValue: code) else {
-                return nil
-            }
-
-            self.code = errorCode
-            self.message = message
-        }
-    }
-
-    public var errorDescription: String? {
-        switch self {
-        case .noSuchChargeError(let message):
-            /// Return the message directly from the store
-            /// "Error: No such charge: 'ch_3KMVapErrorERROR'"
-            return message
-        case .otherError(let error):
-            return error.localizedDescription
-        }
-    }
-}
-
-enum WCPayChargesErrorCode: String, Decodable {
-    case getChargeError = "wcpay_get_charge"
-    case unknown
-}
-
-protocol WCPayChargesErrorConvertible {
-    var code: WCPayChargesErrorCode { get }
-    var message: String? { get }
-}
-
-extension WCPayChargesErrorConvertible {
-    func asWCPayChargesError() -> WCPayChargesError? {
-        switch code {
-        case .getChargeError:
-            guard let message,
-                  message.starts(with: "Error: No such charge") else {
-                return nil
-            }
-            return .noSuchChargeError(message: message)
-        default:
-            return nil
-        }
-    }
-}

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -661,9 +661,18 @@ private extension CardPresentPaymentStore {
     }
 }
 
-public enum ServerSidePaymentCaptureError: Error {
+public enum ServerSidePaymentCaptureError: Error, LocalizedError {
     case paymentIntentNotSuccessful
     case paymentGateway(error: PaymentsError)
+
+    public var errorDescription: String? {
+        switch self {
+        case .paymentIntentNotSuccessful:
+            return "Payment intent not successful"
+        case .paymentGateway(error: let error):
+            return error.localizedDescription
+        }
+    }
 }
 
 private extension PaymentGatewayAccount {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -737,25 +737,53 @@ public enum WCPayChargesError: Error, LocalizedError {
     case otherError(error: AnyError)
 
     init(underlyingError error: Error) {
-        guard case let DotcomError.unknown(code, message) = error,
-              let message = message else {
-                  self = .otherError(error: error.toAnyError)
-                  return
-              }
+        guard let errorDetails = Self.unwrapError(error: error) else {
+            self = .otherError(error: error.toAnyError)
+            return
+        }
 
         /// See if we recognize this DotcomError code
         ///
-        self = ErrorCode(rawValue: code)?.error(message: message) ?? .otherError(error: error.toAnyError)
+        self = errorDetails.asWCPayChargesError() ?? .otherError(error: error.toAnyError)
     }
 
-    enum ErrorCode: String {
+    private static func unwrapError(error: Error) -> WCPayChargesNetworkErrorDetails? {
+        switch error {
+        case let DotcomError.unknown(code, message):
+            guard let errorCode = ErrorCode(rawValue: code) else {
+                return nil
+            }
+            return WCPayChargesNetworkErrorDetails(code: errorCode, message: message)
+        case let NetworkError.unacceptableStatusCode(_, response):
+            guard let response,
+                  let errorDetails = try? JSONDecoder().decode(WCPayChargesNetworkErrorDetails.self, from: response) else {
+                return nil
+            }
+            return errorDetails
+        default:
+            return nil
+        }
+    }
+
+    enum ErrorCode: String, Decodable {
         case getChargeError = "wcpay_get_charge"
         case unknown
+    }
 
-        func error(message: String) -> WCPayChargesError? {
-            switch self {
+    private struct WCPayChargesNetworkErrorDetails: Decodable {
+        let code: ErrorCode
+        let message: String?
+
+        enum CodingKeys: CodingKey {
+            case code
+            case message
+        }
+
+        func asWCPayChargesError() -> WCPayChargesError? {
+            switch code {
             case .getChargeError:
-                guard message.starts(with: "Error: No such charge") else {
+                guard let message,
+                      message.starts(with: "Error: No such charge") else {
                     return nil
                 }
                 return .noSuchChargeError(message: message)

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -747,13 +747,10 @@ public enum WCPayChargesError: Error, LocalizedError {
         self = errorDetails.asWCPayChargesError() ?? .otherError(error: error.toAnyError)
     }
 
-    private static func unwrapError(error: Error) -> WCPayChargesNetworkErrorDetails? {
+    private static func unwrapError(error: Error) -> WCPayChargesErrorConvertible? {
         switch error {
         case let DotcomError.unknown(code, message):
-            guard let errorCode = ErrorCode(rawValue: code) else {
-                return nil
-            }
-            return WCPayChargesNetworkErrorDetails(code: errorCode, message: message)
+            return WCPayChargesDotcomErrorDetails(code: code, message: message)
         case let NetworkError.unacceptableStatusCode(_, response):
             guard let response,
                   let errorDetails = try? JSONDecoder().decode(WCPayChargesNetworkErrorDetails.self, from: response) else {
@@ -765,31 +762,30 @@ public enum WCPayChargesError: Error, LocalizedError {
         }
     }
 
-    enum ErrorCode: String, Decodable {
-        case getChargeError = "wcpay_get_charge"
-        case unknown
-    }
-
-    private struct WCPayChargesNetworkErrorDetails: Decodable {
-        let code: ErrorCode
+    private struct WCPayChargesNetworkErrorDetails: Decodable, WCPayChargesErrorConvertible {
+        let code: WCPayChargesErrorCode
         let message: String?
 
         enum CodingKeys: CodingKey {
             case code
             case message
         }
+    }
 
-        func asWCPayChargesError() -> WCPayChargesError? {
-            switch code {
-            case .getChargeError:
-                guard let message,
-                      message.starts(with: "Error: No such charge") else {
-                    return nil
-                }
-                return .noSuchChargeError(message: message)
-            default:
+    private struct WCPayChargesDotcomErrorDetails: WCPayChargesErrorConvertible {
+        // The response JSON differs from NetworkError above:
+        // `"error": "wcpay_get_charge", "message": "Error fetching charge:"`
+        // It's also decoded further up the chain.
+        let code: WCPayChargesErrorCode
+        let message: String?
+
+        init?(code: String, message: String?) {
+            guard let errorCode = WCPayChargesErrorCode(rawValue: code) else {
                 return nil
             }
+
+            self.code = errorCode
+            self.message = message
         }
     }
 
@@ -801,6 +797,31 @@ public enum WCPayChargesError: Error, LocalizedError {
             return message
         case .otherError(let error):
             return error.localizedDescription
+        }
+    }
+}
+
+enum WCPayChargesErrorCode: String, Decodable {
+    case getChargeError = "wcpay_get_charge"
+    case unknown
+}
+
+protocol WCPayChargesErrorConvertible {
+    var code: WCPayChargesErrorCode { get }
+    var message: String? { get }
+}
+
+extension WCPayChargesErrorConvertible {
+    func asWCPayChargesError() -> WCPayChargesError? {
+        switch code {
+        case .getChargeError:
+            guard let message,
+                  message.starts(with: "Error: No such charge") else {
+                return nil
+            }
+            return .noSuchChargeError(message: message)
+        default:
+            return nil
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -558,7 +558,7 @@ private extension CardPresentPaymentStore {
                         completion(.success(charge))
                     }
                 case .failure(let error):
-                    if case .noSuchChargeError = WCPayChargesError(underlyingError: error) {
+                    if case .noSuchChargeError = PaymentsError(underlyingError: error) {
                         self.deleteCharge(siteID: siteID, chargeID: chargeID) {
                             completion(.failure(error))
                         }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -541,7 +541,7 @@ private extension CardPresentPaymentStore {
                     }
                     return .success(())
                 case .failure(let error):
-                    let error = PaymentGatewayAccountError(underlyingError: error)
+                    let error = PaymentsError(underlyingError: error)
                     return .failure(ServerSidePaymentCaptureError.paymentGateway(error: error))
                 }
             }
@@ -663,52 +663,7 @@ private extension CardPresentPaymentStore {
 
 public enum ServerSidePaymentCaptureError: Error {
     case paymentIntentNotSuccessful
-    case paymentGateway(error: PaymentGatewayAccountError)
-}
-
-public enum PaymentGatewayAccountError: Error, LocalizedError {
-    case orderPaymentCaptureError(message: String?)
-    case otherError(error: AnyError)
-
-    init(underlyingError error: Error) {
-        guard case let DotcomError.unknown(code, message) = error else {
-            self = .otherError(error: error.toAnyError)
-            return
-        }
-
-        /// See if we recognize this DotcomError code
-        ///
-        self = ErrorCode(rawValue: code)?.error(message: message ?? Localizations.defaultMessage) ?? .otherError(error: error.toAnyError)
-    }
-
-    enum ErrorCode: String {
-        case wcpayCaptureError = "wcpay_capture_error"
-
-        func error(message: String) -> PaymentGatewayAccountError {
-            switch self {
-            case .wcpayCaptureError:
-                return .orderPaymentCaptureError(message: message)
-            }
-        }
-    }
-
-    public var errorDescription: String? {
-        switch self {
-        case .orderPaymentCaptureError(let message):
-            /// Return the message directly from the store, e.g. in the case of fractional quantities, which are not allowed
-            /// "Payment capture failed to complete with the following message: Error: Invalid integer: 2.5"
-            return message
-        case .otherError(let error):
-            return error.localizedDescription
-        }
-    }
-
-    enum Localizations {
-        static let defaultMessage = NSLocalizedString(
-            "An unexpected error occurred with the store's payment gateway when capturing payment for the order",
-            comment: "Message presented when an unexpected error occurs with the store's payment gateway."
-        )
-    }
+    case paymentGateway(error: PaymentsError)
 }
 
 private extension PaymentGatewayAccount {
@@ -728,4 +683,3 @@ public protocol CardReaderCapableRemote {
 
 extension WCPayRemote: CardReaderCapableRemote {}
 extension StripeRemote: CardReaderCapableRemote {}
-

--- a/Yosemite/Yosemite/Stores/PaymentsError.swift
+++ b/Yosemite/Yosemite/Stores/PaymentsError.swift
@@ -3,6 +3,7 @@ import Networking
 
 public enum PaymentsError: Error, LocalizedError {
     case noSuchChargeError(message: String)
+    case orderPaymentCaptureError(message: String?)
     case otherError(error: AnyError)
 
     init(underlyingError error: Error) {
@@ -64,14 +65,26 @@ public enum PaymentsError: Error, LocalizedError {
             /// Return the message directly from the store
             /// "Error: No such charge: 'ch_3KMVapErrorERROR'"
             return message
+        case .orderPaymentCaptureError(let message):
+            /// Return the message directly from the store, e.g. in the case of fractional quantities, which are not allowed
+            /// "Payment capture failed to complete with the following message: Error: Invalid integer: 2.5"
+            return message ?? Localizations.defaultPaymentCaptureMessage
         case .otherError(let error):
             return error.localizedDescription
         }
+    }
+
+    enum Localizations {
+        static let defaultPaymentCaptureMessage = NSLocalizedString(
+            "An unexpected error occurred with the store's payment gateway when capturing payment for the order",
+            comment: "Message presented when an unexpected error occurs with the store's payment gateway."
+        )
     }
 }
 
 enum PaymentsErrorCode: String, Decodable {
     case getChargeError = "wcpay_get_charge"
+    case wcpayCaptureError = "wcpay_capture_error"
     case unknown
 }
 
@@ -89,7 +102,9 @@ extension PaymentsErrorConvertible {
                 return nil
             }
             return .noSuchChargeError(message: message)
-        default:
+        case .wcpayCaptureError:
+            return .orderPaymentCaptureError(message: message)
+        case .unknown:
             return nil
         }
     }

--- a/Yosemite/Yosemite/Stores/PaymentsError.swift
+++ b/Yosemite/Yosemite/Stores/PaymentsError.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Networking
 
-public enum WCPayChargesError: Error, LocalizedError {
+public enum PaymentsError: Error, LocalizedError {
     case noSuchChargeError(message: String)
     case otherError(error: AnyError)
 
@@ -13,16 +13,16 @@ public enum WCPayChargesError: Error, LocalizedError {
 
         /// See if we recognize this DotcomError code
         ///
-        self = errorDetails.asWCPayChargesError() ?? .otherError(error: error.toAnyError)
+        self = errorDetails.asPaymentsError() ?? .otherError(error: error.toAnyError)
     }
 
-    private static func unwrapError(error: Error) -> WCPayChargesErrorConvertible? {
+    private static func unwrapError(error: Error) -> PaymentsErrorConvertible? {
         switch error {
         case let DotcomError.unknown(code, message):
-            return WCPayChargesDotcomErrorDetails(code: code, message: message)
+            return PaymentsDotcomErrorDetails(code: code, message: message)
         case let NetworkError.unacceptableStatusCode(_, response):
             guard let response,
-                  let errorDetails = try? JSONDecoder().decode(WCPayChargesNetworkErrorDetails.self, from: response) else {
+                  let errorDetails = try? JSONDecoder().decode(PaymentsNetworkErrorDetails.self, from: response) else {
                 return nil
             }
             return errorDetails
@@ -31,8 +31,8 @@ public enum WCPayChargesError: Error, LocalizedError {
         }
     }
 
-    private struct WCPayChargesNetworkErrorDetails: Decodable, WCPayChargesErrorConvertible {
-        let code: WCPayChargesErrorCode
+    private struct PaymentsNetworkErrorDetails: Decodable, PaymentsErrorConvertible {
+        let code: PaymentsErrorCode
         let message: String?
 
         enum CodingKeys: CodingKey {
@@ -41,15 +41,15 @@ public enum WCPayChargesError: Error, LocalizedError {
         }
     }
 
-    private struct WCPayChargesDotcomErrorDetails: WCPayChargesErrorConvertible {
+    private struct PaymentsDotcomErrorDetails: PaymentsErrorConvertible {
         // The response JSON differs from NetworkError above:
         // `"error": "wcpay_get_charge", "message": "Error fetching charge:"`
         // It's also decoded further up the chain.
-        let code: WCPayChargesErrorCode
+        let code: PaymentsErrorCode
         let message: String?
 
         init?(code: String, message: String?) {
-            guard let errorCode = WCPayChargesErrorCode(rawValue: code) else {
+            guard let errorCode = PaymentsErrorCode(rawValue: code) else {
                 return nil
             }
 
@@ -70,18 +70,18 @@ public enum WCPayChargesError: Error, LocalizedError {
     }
 }
 
-enum WCPayChargesErrorCode: String, Decodable {
+enum PaymentsErrorCode: String, Decodable {
     case getChargeError = "wcpay_get_charge"
     case unknown
 }
 
-protocol WCPayChargesErrorConvertible {
-    var code: WCPayChargesErrorCode { get }
+protocol PaymentsErrorConvertible {
+    var code: PaymentsErrorCode { get }
     var message: String? { get }
 }
 
-extension WCPayChargesErrorConvertible {
-    func asWCPayChargesError() -> WCPayChargesError? {
+extension PaymentsErrorConvertible {
+    func asPaymentsError() -> PaymentsError? {
         switch code {
         case .getChargeError:
             guard let message,

--- a/Yosemite/Yosemite/Stores/WCPayChargesError.swift
+++ b/Yosemite/Yosemite/Stores/WCPayChargesError.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Networking
+
+public enum WCPayChargesError: Error, LocalizedError {
+    case noSuchChargeError(message: String)
+    case otherError(error: AnyError)
+
+    init(underlyingError error: Error) {
+        guard let errorDetails = Self.unwrapError(error: error) else {
+            self = .otherError(error: error.toAnyError)
+            return
+        }
+
+        /// See if we recognize this DotcomError code
+        ///
+        self = errorDetails.asWCPayChargesError() ?? .otherError(error: error.toAnyError)
+    }
+
+    private static func unwrapError(error: Error) -> WCPayChargesErrorConvertible? {
+        switch error {
+        case let DotcomError.unknown(code, message):
+            return WCPayChargesDotcomErrorDetails(code: code, message: message)
+        case let NetworkError.unacceptableStatusCode(_, response):
+            guard let response,
+                  let errorDetails = try? JSONDecoder().decode(WCPayChargesNetworkErrorDetails.self, from: response) else {
+                return nil
+            }
+            return errorDetails
+        default:
+            return nil
+        }
+    }
+
+    private struct WCPayChargesNetworkErrorDetails: Decodable, WCPayChargesErrorConvertible {
+        let code: WCPayChargesErrorCode
+        let message: String?
+
+        enum CodingKeys: CodingKey {
+            case code
+            case message
+        }
+    }
+
+    private struct WCPayChargesDotcomErrorDetails: WCPayChargesErrorConvertible {
+        // The response JSON differs from NetworkError above:
+        // `"error": "wcpay_get_charge", "message": "Error fetching charge:"`
+        // It's also decoded further up the chain.
+        let code: WCPayChargesErrorCode
+        let message: String?
+
+        init?(code: String, message: String?) {
+            guard let errorCode = WCPayChargesErrorCode(rawValue: code) else {
+                return nil
+            }
+
+            self.code = errorCode
+            self.message = message
+        }
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .noSuchChargeError(let message):
+            /// Return the message directly from the store
+            /// "Error: No such charge: 'ch_3KMVapErrorERROR'"
+            return message
+        case .otherError(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
+enum WCPayChargesErrorCode: String, Decodable {
+    case getChargeError = "wcpay_get_charge"
+    case unknown
+}
+
+protocol WCPayChargesErrorConvertible {
+    var code: WCPayChargesErrorCode { get }
+    var message: String? { get }
+}
+
+extension WCPayChargesErrorConvertible {
+    func asWCPayChargesError() -> WCPayChargesError? {
+        switch code {
+        case .getChargeError:
+            guard let message,
+                  message.starts(with: "Error: No such charge") else {
+                return nil
+            }
+            return .noSuchChargeError(message: message)
+        default:
+            return nil
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -452,6 +452,38 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         XCTAssertEqual(storageCharge, otherCharge)
     }
 
+    /// Verifies that the store deletes the charge if it's gone from the remote.
+    ///
+    func test_fetchWCPayCharge_deletes_existing_charge_on_no_such_charge_failure_when_using_site_credentials() {
+        // Given
+        let charge = viewStorage.insertNewObject(ofType: Storage.WCPayCharge.self)
+        let networkCharge = WCPayCharge.fake().copy(siteID: sampleSiteID, id: sampleErrorChargeID)
+        charge.update(with: networkCharge)
+        let otherCharge = viewStorage.insertNewObject(ofType: Storage.WCPayCharge.self)
+        let otherNetworkCharge = WCPayCharge.fake().copy(siteID: sampleSiteID, id: sampleChargeID)
+        otherCharge.update(with: otherNetworkCharge)
+
+        XCTAssert(viewStorage.countObjects(ofType: Storage.WCPayCharge.self, matching: nil) == 2)
+
+        let errorResponseData = Loader.contentsOf("wcpay-charge-error-site-credentials")
+        network.simulateError(requestUrlSuffix: "payments/charges/\(sampleErrorChargeID)",
+                              error: NetworkError.unacceptableStatusCode(statusCode: 500, response: errorResponseData))
+
+        // When
+        let _: Result<Yosemite.WCPayCharge, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction.fetchWCPayCharge(siteID: self.sampleSiteID, chargeID: self.sampleErrorChargeID, onCompletion: { result in
+                promise(result)
+            })
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.WCPayCharge.self, matching: nil), 1)
+
+        let storageCharge = viewStorage.firstObject(ofType: Storage.WCPayCharge.self)
+        XCTAssertEqual(storageCharge, otherCharge)
+    }
+
     /// Verifies that the store doesn't delete charges just for any old error.
     ///
     func test_fetchWCPayCharge_does_not_delete_existing_charge_on_unknown_failure() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14409
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures that we decode specific payment-related NetworkErrors, which we receive when using site credentials rather than Jetpack.

Additionally, it resolves an issue that was preventing localized error messages from being shown when payment capture failed. Without fixing this, it would be very difficult to test.

Two payment errors are covered: errors fetching a charge, and errors capturing a payment.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

To cause an error when fetching a charge, replace the path in `WCPayRemote.fetchCharge(for:chargeID:completion:)` with:
```
let path = "\(Path.charges)/\(chargeID.lowercased())"
```

1. Open the orders tab
2. Select an order paid using WooPayments
3. Tap `Issue Refund`
4. Observe that the error is shown.
5. With a breakpoint, observe that a call is made to delete the charge from storage: `CardPresentPaymentStore.fetchCharge(siteID:chargeID:completion:)`


To cause an error when capturing a payment, replace the `minimumAllowedChargeAmount` in `CardPresentPaymentsConfiguration` with a lower number, e.g. 0.1, then try to take payment for an amount between the real minimum and your reduced minimum.

1. Open the orders tab
2. Create an order for an amount below the real minimum
3. Tap Collect Payment
4. Tap a card
5. Observe that the descriptive error from the server is shown

Note that this PR does not fully adopt the new error available in WooPayments – pdfdoF-6h1-p2 for context. To do that, we can add to the decoding of the data returned with the error, which will be easier with `NetworkError` than `DotcomError`. When we do adopt that, we can provide the localization in the app, rather than relying on the server localization as we do in these cases now.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There's no visual difference when refunding a payment, the correct unwrapping of the error triggers a call to delete the charge from storage.

When capturing a payment, you can now see the message from WCPay or the app's localization in the UI, rather than `Yosemite.ServerSideCaptureError 0`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Capture
#### Jetpack login
| Before | After |
| --- | --- |
| ![payment before jetpack](https://github.com/user-attachments/assets/ba112844-7794-43dc-b015-04970a44df96) | ![payment after jetpack](https://github.com/user-attachments/assets/ff749775-9171-4fdb-94ee-02b364dec539) |


#### Site creds login
| Before | After |
| --- | --- |
| ![payment before site creds](https://github.com/user-attachments/assets/df2cb973-520a-4213-ae90-128ef1bc8956) | ![payment after site creds](https://github.com/user-attachments/assets/506ec71d-ab30-4ab6-807c-5c2b1affe8b8) |


### Refund
#### Jetpack login
| Before | After |
| --- | --- |
| ![refund before jetpack](https://github.com/user-attachments/assets/28ff05a5-b7d2-4f39-b078-e4fae7521358) | ![refund after jetpack](https://github.com/user-attachments/assets/82f0d7eb-eeef-454e-943b-01b44ad399c3) |


#### Site creds login
| Before | After |
| --- | --- |
| ![refund before site creds](https://github.com/user-attachments/assets/862920bf-70d5-47bf-a6f0-b4c712afe64e) | ![refund after site creds](https://github.com/user-attachments/assets/3b2e4667-58d9-4bc1-a9f3-f18264cdc675) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.