### PR TITLE
fix: modify `JetpackSetupCoordinator` to dismiss `progressView` upon successful setup completion 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -273,6 +273,7 @@ private extension JetpackSetupCoordinator {
                         }
                     })
                 }
+                progressView.dismiss(animated: true)
 
             case .failure(let error):
                 DDLogError("⛔️ Error fetching sites after Jetpack setup: \(error)")

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -271,9 +271,9 @@ private extension JetpackSetupCoordinator {
                         if site.isJetpackCPConnected {
                             self?.presentJCPJetpackInstallFlow()
                         }
+                        progressView.dismiss(animated: true)
                     })
                 }
-                progressView.dismiss(animated: true)
 
             case .failure(let error):
                 DDLogError("⛔️ Error fetching sites after Jetpack setup: \(error)")


### PR DESCRIPTION

Closes: #14975

## Description
After logging into a store where Jetpack is not connected (whether or not Jetpack is installed), @rachelmcr encountered an issue where the process gets stuck on the "Syncing data" screen after installing or connecting Jetpack.
This happens because there is a `progressView.dismiss(animated: true)` missing if the connection is successful.

## Steps to reproduce
1. Log in to a store where Jetpack is not connected.
2. Go to Menu > Settings > Install Jetpack.
3. Follow the steps to install/connect Jetpack.
4. After the installation is complete, tap the "Go to Store" button.
5. Notice a "Syncing data" progress view appears and is never dismissed.

## Testing information
There are 4 cases that I tested on a Jurassic Ninja store.

#### Case 1
1. Log in to a store where Jetpack is installed but NOT connected.
2. Go to Menu > Settings > Install Jetpack.
3. Follow the steps to install/connect Jetpack.
4. After the installation is complete, tap the "Go to Store" button.
5. Notice a "Syncing data" progress view appears and gets correctly dismissed.

#### Case 2
1. Log in to a store where Jetpack is NOT installed and NOT connected.
2. Go to Menu > Settings > Install Jetpack.
3. Follow the steps to install/connect Jetpack.
4. After the installation is complete, tap the "Go to Store" button.
5. Notice a "Syncing data" progress view appears and gets correctly dismissed.

#### Case 3
1. Log in to a store where Jetpack is installed but NOT connected.
2. From the Dashboard, press the banner to install/connect Jetpack.
3. Follow the steps to install/connect Jetpack.
4. After the installation is complete, tap the "Go to Store" button.
5. Notice a "Syncing data" progress view appears and gets correctly dismissed.

#### Case 4
1. Log in to a store where Jetpack is NOT installed and NOT connected.
2. From the Dashboard, press the banner to install/connect Jetpack.
3. Follow the steps to install/connect Jetpack.
4. After the installation is complete, tap the "Go to Store" button.
5. Notice a "Syncing data" progress view appears and gets correctly dismissed.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
