### PR TITLE
[Revamp Shipping Labels • Customs] Hide/Show Customs row depending on the addresses configuration

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -52,6 +52,7 @@ struct WooShippingCreateLabelsView: View {
                     WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
                                           customsFormViewModel: viewModel.customsFormViewModel)
                         .padding(.bottom, 16)
+                        .renderedIf(viewModel.customsFormRequired)
 
                     if viewModel.canViewLabel {
                         EmptyView()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -126,6 +126,26 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         })
     }()
 
+    /// Check for the need of customs form
+    ///
+    var customsFormRequired: Bool {
+        guard let originAddress = selectedOriginAddress,
+              let destinationAddress = destinationAddress else {
+            return false
+        }
+        // Special case: Any shipment from/to military addresses must have Customs
+        if originAddress.country == Constants.usCountryCode,
+           Constants.usMilitaryStates.contains(where: { $0 == originAddress.state }) {
+            return true
+        }
+        if destinationAddress.country == Constants.usCountryCode,
+           Constants.usMilitaryStates.contains(where: { $0 == destinationAddress.state }) {
+            return true
+        }
+
+        return originAddress.country != destinationAddress.country
+    }
+
     /// Initialize the view model without an existing shipping label.
     init(order: Order,
          selectedOriginAddress: WooShippingOriginAddress? = nil,
@@ -421,6 +441,16 @@ private extension WooShippingCreateLabelsViewModel {
                                                               value: "Adult Signature Required",
                                                               comment: "Label for row showing the additional cost to require an adult signature " +
                                                               "on the shipping label creation screen")
+    }
+
+    enum Constants {
+        /// Country code for US - to check for international shipment
+        ///
+        static let usCountryCode = "US"
+
+        /// These US states are a special case because they represent military bases. They're considered "domestic",
+        /// but they require a Customs form to ship from/to them.
+        static let usMilitaryStates = ["AA", "AE", "AP"]
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -35,7 +35,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingRates.count, 1)
     }
 
-    func test_customsFormRequired_returns_false_for_origin_and_destination_in_US() {
+    func test_customsFormRequired_when_origin_and_destination_in_US_then_returns_false() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",
                                                company: "HEADQUARTERS",
@@ -60,6 +60,87 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.customsFormRequired)
+    }
+
+    func test_customsFormRequired_when_origin_address_is_US_military_then_returns_true() {
+        // Given
+        let originAddress = WooShippingOriginAddress(id: "default_address",
+                                               company: "HEADQUARTERS",
+                                               address1: "15 ALGONKIN ST",
+                                               address2: "STE 100",
+                                               city: "TICONDEROGA",
+                                               state: "AA",
+                                               postcode: "12883-1487",
+                                               country: "US",
+                                               phone: "223-456-7890",
+                                               firstName: "JANE",
+                                               lastName: "DOE",
+                                               email: "TEST@EXAMPLE.COM",
+                                               defaultAddress: true,
+                                               isVerified: false)
+
+        let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
+        let order = Order.fake().copy(shippingAddress: address)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedOriginAddress: originAddress)
+
+        // Then
+        XCTAssertTrue(viewModel.customsFormRequired)
+    }
+
+    func test_customsFormRequired_when_destination_address_is_US_military_then_returns_true() {
+        // Given
+        let originAddress = WooShippingOriginAddress(id: "default_address",
+                                               company: "HEADQUARTERS",
+                                               address1: "15 ALGONKIN ST",
+                                               address2: "STE 100",
+                                               city: "TICONDEROGA",
+                                               state: "NY",
+                                               postcode: "12883-1487",
+                                               country: "US",
+                                               phone: "223-456-7890",
+                                               firstName: "JANE",
+                                               lastName: "DOE",
+                                               email: "TEST@EXAMPLE.COM",
+                                               defaultAddress: true,
+                                               isVerified: false)
+
+        let address = Address.fake().copy(address1: "1 Main Street", city: "Military City", state: "AA", postcode: "12345", country: "US")
+        let order = Order.fake().copy(shippingAddress: address)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedOriginAddress: originAddress)
+
+        // Then
+        XCTAssertTrue(viewModel.customsFormRequired)
+    }
+
+    func test_customsFormRequired_when_destination_address_is_not_in_US_then_returns_true() {
+        // Given
+        let originAddress = WooShippingOriginAddress(id: "default_address",
+                                               company: "HEADQUARTERS",
+                                               address1: "15 ALGONKIN ST",
+                                               address2: "STE 100",
+                                               city: "TICONDEROGA",
+                                               state: "NY",
+                                               postcode: "12883-1487",
+                                               country: "US",
+                                               phone: "223-456-7890",
+                                               firstName: "JANE",
+                                               lastName: "DOE",
+                                               email: "TEST@EXAMPLE.COM",
+                                               defaultAddress: true,
+                                               isVerified: false)
+
+        let address = Address.fake().copy(address1: "1 Main Street", city: "London", state: "LD", postcode: "12345", country: "GB")
+        let order = Order.fake().copy(shippingAddress: address)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedOriginAddress: originAddress)
+
+        // Then
+        XCTAssertTrue(viewModel.customsFormRequired)
     }
 
     func test_origin_addresses_fetched_and_converted_to_originAddresses_view_model() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -35,6 +35,33 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingRates.count, 1)
     }
 
+    func test_customsFormRequired_returns_false_for_origin_and_destination_in_US() {
+        // Given
+        let originAddress = WooShippingOriginAddress(id: "default_address",
+                                               company: "HEADQUARTERS",
+                                               address1: "15 ALGONKIN ST",
+                                               address2: "STE 100",
+                                               city: "TICONDEROGA",
+                                               state: "NY",
+                                               postcode: "12883-1487",
+                                               country: "US",
+                                               phone: "223-456-7890",
+                                               firstName: "JANE",
+                                               lastName: "DOE",
+                                               email: "TEST@EXAMPLE.COM",
+                                               defaultAddress: true,
+                                               isVerified: false)
+
+        let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
+        let order = Order.fake().copy(shippingAddress: address)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedOriginAddress: originAddress)
+
+        // Then
+        XCTAssertFalse(viewModel.customsFormRequired)
+    }
+
     func test_origin_addresses_fetched_and_converted_to_originAddresses_view_model() {
         // Given
         let originAddress = WooShippingOriginAddress.fake().copy(id: "default", defaultAddress: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we hide/show the Customs row depending on the origin/destination addresses configuration.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Tap on Create Shipping Label on an order
2. Check these configurations and verify if the Customs row is shown or hidden:
     a. Both origin and destination address are in the US: Row is hidden
     b. Origin address in the US, destination elsewhere: Row is shown
     c. Origin or destination in any US military state (Codes ["AA", "AE", "AP"]): Row is shown


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
See above

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/fa4c77ad-22f4-43da-b175-1e2899d335bb" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
