### PR TITLE
[Woo POS] Fix try again buttons when payment cancellation fails

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -245,9 +245,13 @@ extension PointOfSaleAggregateModel {
     func cancelThenCollectPayment() {
         Task { [weak self] in
             guard let self else { return }
-            try await cardPresentPaymentService.cancelPayment()
-            await collectCardPayment()
+            await cancelThenCollectPayment()
         }
+    }
+
+    func cancelThenCollectPayment() async {
+        try? await cardPresentPaymentService.cancelPayment()
+        await collectCardPayment()
     }
 
     private func setupReaderReconnectionObservation() {

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
@@ -52,4 +52,10 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
     func cancelPayment() {
         cancelPaymentCalled = true
     }
+
+    var onCancelPaymentCalled: (() async throws -> Void)?
+    func cancelPayment() async throws {
+        cancelPaymentCalled = true
+        try await onCancelPaymentCalled?()
+    }
 }

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -463,6 +463,23 @@ struct PointOfSaleAggregateModelTests {
             }
         }
 
+        @Test func cancelThenCollectPayment_still_collects_payment_when_cancellation_fails() async throws {
+            // Given
+            orderController.orderStateToReturn = makeLoadedOrderState(cartTotal: "$1.00")
+            await orderController.syncOrder(for: [], retryHandler: {})
+
+            struct TestError: Error {}
+            cardPresentPaymentService.onCancelPaymentCalled = {
+                throw TestError()
+            }
+
+            // When
+            await sut.cancelThenCollectPayment()
+
+            // Then
+            #expect(cardPresentPaymentService.collectPaymentWasCalled)
+        }
+
         // MARK: Onboarding
         @Test func cardPresentPaymentOnboardingViewModel_is_non_nil_when_onboarding_is_required() async throws {
             // Given


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14996
Merge after: #14995
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the `Try again` button on some payment errors, so that it does retry even if the cancellation attempt fails.

In the cash collection project, we made `cancelPayment` async, so we could cancel first, then collect the cash payment, so that the cash payment view wouldn't be presented until after the cancellation completed – this avoided having card payment messages interrupt cash payment.

However, in `cancelThenCollectPayment` we didn't account for times when the cancellation fails. In that case, it's more appropriate to continue to try to collect the payment. This case was handled in `startCashPayment`, but not the function used to try a new payment method.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

There are probably other ways to do this, but here's one

1. Launch the app and go to POS
2. Connect your card reader
3. Check out
4. Open control centre
5. As you tap your card, turn off bluetooth
6. Observe that an error's shown saying there's no card reader connected. If this doesn't happen, you weren't quick enough.
7. Tap the button – observe that it restarts the payment (and prompts you to turn bluetooth back on.)

Note that connecting the reader right after disconnecting it with bluetooth isn't the best; I find it works better if you turn the reader off before attempting the connection again.

When it takes you back to the Checkout screen, the `Enable bluetooth` error shows for a few seconds, before it gets dismissed by the preflight handler failing (due to bluetooth being disabled.) This flow isn't perfect, but it's totally recoverable and easy enough to understand. To fix it would mean a significant delve into the existing code, and I don't think it's worth doing for this edge case.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This code doesn't actually change anything to do with Cash payments, despite its proximity, but it's worth checking that they work correctly even when a card reader is connected.

I've tested using an iPad Air on 17.7.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/e81a1f22-6a5e-4bdc-a02e-ebc9f6390e6a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.