### PR TITLE
[Woo POS] Show $0.00 when there’s no price returned

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		09885C8027C3FFD200910A62 /* product-variations-bulk-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 09885C7F27C3FFD200910A62 /* product-variations-bulk-update.json */; };
 		09EA564B27C75FCE00407D40 /* ProductVariationsBulkUpdateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA564A27C75FCE00407D40 /* ProductVariationsBulkUpdateMapper.swift */; };
 		204CBD2B2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */; };
+		207D816C2D4A30A30097012E /* products-load-simple-products-empty-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 207D816B2D4A30A30097012E /* products-load-simple-products-empty-price.json */; };
 		209AD3C32AC196E300825D76 /* WooPaymentsPayoutsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3C22AC196E300825D76 /* WooPaymentsPayoutsOverview.swift */; };
 		209AD3C52AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3C42AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift */; };
 		20D210C32B1780CE0099E517 /* deposits-overview-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 20D210C22B1780CE0099E517 /* deposits-overview-all.json */; };
@@ -1491,6 +1492,7 @@
 		09EA564A27C75FCE00407D40 /* ProductVariationsBulkUpdateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsBulkUpdateMapper.swift; sourceTree = "<group>"; };
 		14CE248C7246705417A41DE1 /* Pods-NetworkingWatchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingWatchOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingWatchOS/Pods-NetworkingWatchOS.release.xcconfig"; sourceTree = "<group>"; };
 		204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error-site-credentials.json"; sourceTree = "<group>"; };
+		207D816B2D4A30A30097012E /* products-load-simple-products-empty-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "products-load-simple-products-empty-price.json"; sourceTree = "<group>"; };
 		209AD3C22AC196E300825D76 /* WooPaymentsPayoutsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverview.swift; sourceTree = "<group>"; };
 		209AD3C42AC19E7500825D76 /* WooPaymentsDepositsOverviewMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewMapper.swift; sourceTree = "<group>"; };
 		20D210C22B1780CE0099E517 /* deposits-overview-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deposits-overview-all.json"; sourceTree = "<group>"; };
@@ -3579,6 +3581,7 @@
 				CE070A2F2BBC527900017578 /* gift-card-stats.json */,
 				CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */,
 				68FBA53B2C290A5F0067B377 /* products-load-all-type-simple.json */,
+				207D816B2D4A30A30097012E /* products-load-simple-products-empty-price.json */,
 				68255E432C60C6AA00090EBD /* products-load-all-for-eligibility-criteria.json */,
 				CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */,
 				CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */,
@@ -4593,6 +4596,7 @@
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				20D210C52B1788E60099E517 /* deposits-overview-all-no-default-currency.json in Resources */,
+				207D816C2D4A30A30097012E /* products-load-simple-products-empty-price.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
 				DEDA8DA52B1839320076BF0F /* theme-list-success.json in Resources */,
 				EE84D62B2B0B46E7008EA80A /* product-variation-subscription-incomplete.json in Resources */,

--- a/Networking/NetworkingTests/Responses/products-load-simple-products-empty-price.json
+++ b/Networking/NetworkingTests/Responses/products-load-simple-products-empty-price.json
@@ -1,0 +1,249 @@
+{
+    "data": [
+        {
+            "id": 208,
+            "name": "Dymo LabelWriter 4XL",
+            "slug": "dymo-labelwriter-4xl",
+            "permalink": "https://example.com/product/dymo-labelwriter-4xl/",
+            "date_created": "2018-05-07T21:02:28",
+            "date_created_gmt": "2018-05-07T21:02:28",
+            "date_modified": "2019-02-19T18:22:50",
+            "date_modified_gmt": "2019-02-19T18:22:50",
+            "type": "simple",
+            "status": "publish",
+            "featured": false,
+            "catalog_visibility": "visible",
+            "description": "<ul class=\"a-unordered-list a-vertical a-spacing-none\">\n<li><span class=\"a-list-item\">Print Extra Large Shipping Labels up to 4” x 6”</span></li>\n<li><span class=\"a-list-item\">Select from over 60 professional label templates and customize text and graphics with free DYMO Label Software</span></li>\n<li><span class=\"a-list-item\">Compatible with Microsoft Office, Quickbooks, and More</span></li>\n<li><span class=\"a-list-item\">Print shipping labels directly from popular online selling platforms such as DYMO Stamps, eBay, Amazon, Etsy, and Iabol</span></li>\n<li><span class=\"a-list-item\">Direct thermal printing eliminates the need for costly ink or toner</span></li>\n<li><span class=\"a-list-item\">Print USPS-approved DYMO Stamps from your desktop - no monthly fee, contracts, or commitments (US only)</span></li>\n<li><span class=\"a-list-item\">System Requirements: Windows 7 or later, Mac OS v10.10 or later</span></li>\n<li><span class=\"a-list-item\">Includes: LabelWriter® 4XL printer, adapter, power cable, USB 2.0 cable, Quick Start guide, and starter roll of 4x6 extra large shipping labels</span></li>\n<li><span class=\"a-list-item\">For best results use DYMO authentic labels only</span></li>\n<li>Bonus: 1 extra roll of labels when you pay with points!</li>\n</ul>\n<div class=\"a-row a-expander-container a-expander-inline-container\" aria-live=\"polite\">\n<div class=\"a-expander-content a-expander-extend-content a-expander-content-expanded\" aria-expanded=\"true\"></div>\n</div>\n",
+            "short_description": "<h4 class=\"a-spacing-mini a-color-secondary a-text-italic\">High Volume Jobs? Not a Problem.</h4>\n<p class=\"a-spacing-base\">The DYMO LabelWriter 4XL is a wide-format label printer that accommodates the entire line of LabelWriter labels for maximum flexibility, and is also compatible with a variety of popular online selling platforms and shipping carriers. It&#8217;s ideal for extra-large shipping and warehouse labels, along with label styles for file folders, name badges, and more. It&#8217;s ideal for extra-large shipping and warehouse labels, including 4 inch international shipping labels, along with label styles for file folders, name badges, online postage, mailing and shipping labels, and more.</p>\n",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "price_html": "<del><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>279.00</span></del> <ins><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>216.00</span></ins>",
+            "on_sale": true,
+            "purchasable": true,
+            "total_sales": 2,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "onbackorder",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": true,
+            "sold_individually": true,
+            "weight": "64",
+            "dimensions": {
+                "length": "10.2",
+                "width": "10",
+                "height": "10"
+            },
+            "shipping_required": true,
+            "shipping_taxable": true,
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "reviews_allowed": true,
+            "average_rating": "0.00",
+            "rating_count": 0,
+            "related_ids": [
+                26,
+                27,
+                28,
+                29
+            ],
+            "upsell_ids": [],
+            "cross_sell_ids": [],
+            "parent_id": 0,
+            "purchase_note": "",
+            "categories": [
+                {
+                    "id": 15,
+                    "name": "Accessories",
+                    "slug": "accessories"
+                }
+            ],
+            "tags": [],
+            "images": [
+                {
+                    "id": 209,
+                    "date_created": "2018-05-07T21:02:45",
+                    "date_created_gmt": "2018-05-07T21:02:45",
+                    "date_modified": "2018-05-07T21:03:04",
+                    "date_modified_gmt": "2018-05-07T21:03:04",
+                    "src": "https://i0.wp.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/05/71PEq6VvFjL._SL1500_.jpg?fit=1500%2C1500&ssl=1",
+                    "name": "Dymo LabelWriter 4XL",
+                    "alt": ""
+                }
+            ],
+            "attributes": [],
+            "default_attributes": [],
+            "variations": [],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 5981,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                },
+                {
+                    "id": 6847,
+                    "key": "_wc_pre_orders_enabled",
+                    "value": "yes"
+                },
+                {
+                    "id": 6848,
+                    "key": "_wc_pre_orders_availability_datetime",
+                    "value": "1587262140"
+                },
+                {
+                    "id": 6849,
+                    "key": "_wc_pre_orders_fee",
+                    "value": "2"
+                },
+                {
+                    "id": 6850,
+                    "key": "_wc_pre_orders_when_to_charge",
+                    "value": "upon_release"
+                }
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/208"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 31,
+            "name": "Hoodie with Pocket",
+            "slug": "hoodie-with-pocket",
+            "permalink": "https://example.com/product/hoodie-with-pocket/",
+            "date_created": "2018-01-26T21:49:46",
+            "date_created_gmt": "2018-01-26T21:49:46",
+            "date_modified": "2018-01-26T21:49:46",
+            "date_modified_gmt": "2018-01-26T21:49:46",
+            "type": "simple",
+            "status": "publish",
+            "featured": true,
+            "catalog_visibility": "visible",
+            "description": "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n",
+            "short_description": "",
+            "sku": "",
+            "price": null,
+            "regular_price": null,
+            "sale_price": null,
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "price_html": "<del><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>45.00</span></del> <ins><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>35.00</span></ins>",
+            "on_sale": true,
+            "purchasable": true,
+            "total_sales": 1,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "sold_individually": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_required": true,
+            "shipping_taxable": true,
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "reviews_allowed": true,
+            "average_rating": "0.00",
+            "rating_count": 0,
+            "related_ids": [
+                32,
+                30,
+                33
+            ],
+            "upsell_ids": [],
+            "cross_sell_ids": [],
+            "parent_id": 0,
+            "purchase_note": "",
+            "categories": [
+                {
+                    "id": 16,
+                    "name": "Hoodies",
+                    "slug": "hoodies"
+                }
+            ],
+            "tags": [],
+            "images": [
+                {
+                    "id": 12,
+                    "date_created": "2018-01-26T21:49:45",
+                    "date_created_gmt": "2018-01-26T21:49:45",
+                    "date_modified": "2018-01-26T21:49:45",
+                    "date_modified_gmt": "2018-01-26T21:49:45",
+                    "src": "https://i0.wp.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/hoodie-with-pocket.jpg?fit=801%2C801&ssl=1",
+                    "name": "Hoodie with Pocket",
+                    "alt": ""
+                }
+            ],
+            "attributes": [],
+            "default_attributes": [],
+            "variations": [],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 92,
+                    "key": "_customize_changeset_uuid",
+                    "value": "e96101a5-dc4f-4cd7-8f38-30db941b1a97"
+                }
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/31"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -75,7 +75,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                 return POSItem
                     .variation(.init(id: UUID(),
                                      name: variationName,
-                                     formattedPrice: currencyFormatter.formatAmount(variation.price) ?? "-",
+                                     formattedPrice: formatPrice(variation.price),
                                      price: variation.price,
                                      productImageSource: variation.image?.src,
                                      productID: variation.productID,
@@ -91,14 +91,13 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     // - Product thumbnail, if any.
     private func mapProductsToPOSItems(products: [Product]) -> [POSItem] {
         return products.compactMap { product in
-            let formattedPrice = currencyFormatter.formatAmount(product.price) ?? "-"
             let thumbnailSource = product.images.first?.src
 
             switch product.productType {
                 case .simple:
                     return .simpleProduct(POSSimpleProduct(id: UUID(),
                                                            name: product.name,
-                                                           formattedPrice: formattedPrice,
+                                                           formattedPrice: formatPrice(product.price),
                                                            productImageSource: thumbnailSource,
                                                            productID: product.productID,
                                                            price: product.price))
@@ -114,5 +113,10 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                     return nil
             }
         }
+    }
+
+    private func formatPrice(_ price: String) -> String {
+        let zeroOrPlaceholder = currencyFormatter.formatAmount("0") ?? "-"
+        return currencyFormatter.formatAmount(price) ?? zeroOrPlaceholder
     }
 }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -154,44 +154,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                 name: "Tea",
                 productImageSource: nil,
                 productID: parentProductID,
-                allAttributes: [
-                        .init(
-                            siteID: siteID,
-                            attributeID: 0,
-                            name: "Shape",
-                            position: 1,
-                            visible: true,
-                            variation: true,
-                            options: ["Marble", "Heart"]
-                        ),
-                        .init(
-                            siteID: siteID,
-                            attributeID: 0,
-                            name: "Flavor",
-                            position: 2,
-                            visible: true,
-                            variation: true,
-                            options: ["fruity", "nuts"]
-                        ),
-                        .init(
-                            siteID: siteID,
-                            attributeID: 0,
-                            name: "Darkness",
-                            position: 3,
-                            visible: true,
-                            variation: true,
-                            options: ["99%", "87%"]
-                        ),
-                        .init(
-                            siteID: siteID,
-                            attributeID: 0,
-                            name: "Size",
-                            position: 4,
-                            visible: true,
-                            variation: true,
-                            options: ["6 piece"]
-                        )
-                    ]
+                allAttributes: teaAttributes
             ),
             pageNumber: 1
         )
@@ -210,7 +173,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
             "Shape: brick, Flavor: nuts, Darkness: 99%, " +
             String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Size")
         )
-        XCTAssertEqual(firstVariation.formattedPrice, "-")
+        XCTAssertEqual(firstVariation.formattedPrice, "$0.00")
         XCTAssertEqual(firstVariation.price, "")
         XCTAssertEqual(firstVariation.productImageSource,
                        "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1")
@@ -282,5 +245,110 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         } catch {
             XCTAssertEqual(error as? PointOfSaleItemServiceError, expectedError)
         }
+    }
+
+    func test_providePointOfSaleVariationItems_formats_empty_prices_as_zero() async throws {
+        // Given
+        let itemProvider = PointOfSaleItemService(siteID: siteID,
+                                                  currencySettings: currencySettings,
+                                                  network: network,
+                                                  isVariableProductsFeatureEnabled: true)
+        let parentProductID: Int64 = 123
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products/\(parentProductID)/variations", filename: "product-variations-load-all")
+        let pagedVariations = try await itemProvider.providePointOfSaleVariationItems(
+            for: .init(
+                id: .init(),
+                name: "Tea",
+                productImageSource: nil,
+                productID: parentProductID,
+                allAttributes: teaAttributes
+            ),
+            pageNumber: 1
+        )
+
+        // Then
+        let variations = pagedVariations.items
+
+        XCTAssertEqual(variations.count, 7)
+        for variationItem in variations {
+            guard case let .variation(variation) = variationItem else {
+                return XCTFail("Variation is expected.")
+            }
+            if variation.price == "" {
+                XCTAssertEqual(variation.formattedPrice, "$0.00")
+            } else {
+                XCTFail("Test does not handle non-empty prices")
+            }
+        }
+    }
+
+    func test_providePointOfSaleSimpleProductItems_formats_empty_prices_as_zero() async throws {
+        // Given
+        let expectedProductPrice = ""
+        let expectedFormattedPrice = "$0.00"
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-simple-products-empty-price")
+        let pagedItems = try await itemProvider.providePointOfSaleItems()
+
+        // Then
+        let items = pagedItems.items
+        XCTAssertEqual(items.count, 2)
+        for item in items {
+            guard case let .simpleProduct(simpleProduct) = item else {
+                return XCTFail("Simple product is expected.")
+            }
+            if simpleProduct.price == "" {
+                XCTAssertEqual(simpleProduct.formattedPrice, expectedFormattedPrice)
+                XCTAssertEqual(simpleProduct.price, expectedProductPrice)
+            } else {
+                XCTFail("Test does not handle non-empty prices")
+            }
+        }
+    }
+}
+
+private extension PointOfSaleItemServiceTests {
+    var teaAttributes: [ProductAttribute] {
+        [
+            .init(
+                siteID: siteID,
+                attributeID: 0,
+                name: "Shape",
+                position: 1,
+                visible: true,
+                variation: true,
+                options: ["Marble", "Heart"]
+            ),
+            .init(
+                siteID: siteID,
+                attributeID: 0,
+                name: "Flavor",
+                position: 2,
+                visible: true,
+                variation: true,
+                options: ["fruity", "nuts"]
+            ),
+            .init(
+                siteID: siteID,
+                attributeID: 0,
+                name: "Darkness",
+                position: 3,
+                visible: true,
+                variation: true,
+                options: ["99%", "87%"]
+            ),
+            .init(
+                siteID: siteID,
+                attributeID: 0,
+                name: "Size",
+                position: 4,
+                visible: true,
+                variation: true,
+                options: ["6 piece"]
+            )
+        ]
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14968
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the item display to use "$0.00" when there's no price provided from the API. This applies to variations and products.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Add a product and a variation to your site without setting a price for either.

1. Launch the app
2. Open POS
3. Scroll to see your new product – observe that the price is displayed as $0.00
4. Open the variable product with your unpriced variation – observe that the price is displayed as $0.00

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Note that you can't currently check out a free order if you have a card reader connected, even using cash. I'll tackle this in a separate PR.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/22b4e056-3fc7-4366-af4f-c462c8a2977e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.