### PR TITLE
[Shipping labels] Add UI for normalizing an origin/destination address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -11,24 +11,10 @@ struct WooShippingNormalizeAddressView: View {
                     Text(Localization.selectAddressPrompt)
                 }
                 .bodyStyle()
-                VStack(alignment: .leading, spacing: Constants.innerVerticalSpacing) {
-                    Text(Localization.enteredAddressLabel.localizedUppercase)
-                        .footnoteStyle()
-                    Text("1234 Main St\nSan Francisco, CA 94104")
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding()
-                        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 0.5)
-                }
-                VStack(alignment: .leading, spacing: Constants.innerVerticalSpacing) {
-                    Text(Localization.suggestedAddressLabel.localizedUppercase)
-                        .footnoteStyle()
-                    Text("1234 Main St\nSan Francisco, CA 94104")
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding()
-                        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 0.5)
-                }
+                AddressView(label: Localization.enteredAddressLabel,
+                            address: "15 Algonkin St, Ticonderogaa, NY 12883-1487, US")
+                AddressView(label: Localization.suggestedAddressLabel,
+                            address: "15 ALGONKIN ST, TICONDEROGA, NY 12883-1487, US")
             }
             .padding()
         }
@@ -52,6 +38,26 @@ struct WooShippingNormalizeAddressView: View {
                 .padding()
             }
             .background(Color(uiColor: .systemBackground))
+        }
+    }
+
+    private struct AddressView: View {
+        /// Label for the address
+        let label: String
+
+        /// Address to display, formatted in a string.
+        let address: String
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: Constants.innerVerticalSpacing) {
+                Text(label.localizedUppercase)
+                    .footnoteStyle()
+                Text(address)
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 0.5)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -11,10 +11,13 @@ struct WooShippingNormalizeAddressView: View {
                     Text(Localization.selectAddressPrompt)
                 }
                 .bodyStyle()
+                // TODO: Replace static data with real data from view model
                 AddressView(label: Localization.enteredAddressLabel,
-                            address: "15 Algonkin St, Ticonderogaa, NY 12883-1487, US")
+                            address: "15 Algonkin St, Ticonderogaa, NY 12883-1487, US",
+                            isSelected: false)
                 AddressView(label: Localization.suggestedAddressLabel,
-                            address: "15 ALGONKIN ST, TICONDEROGA, NY 12883-1487, US")
+                            address: "15 ALGONKIN ST, TICONDEROGA, NY 12883-1487, US",
+                            isSelected: true)
             }
             .padding()
         }
@@ -48,6 +51,9 @@ struct WooShippingNormalizeAddressView: View {
         /// Address to display, formatted in a string.
         let address: String
 
+        /// Whether the address is selected.
+        var isSelected: Bool
+
         var body: some View {
             VStack(alignment: .leading, spacing: Constants.innerVerticalSpacing) {
                 Text(label.localizedUppercase)
@@ -56,7 +62,10 @@ struct WooShippingNormalizeAddressView: View {
                     .font(.subheadline)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
-                    .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 0.5)
+                    .background(isSelected ? Color(.wooCommercePurple(.shade0)) : nil)
+                    .roundedBorder(cornerRadius: 8,
+                                   lineColor: isSelected ? Color(.wooCommercePurple(.shade60)) : Color(.separator),
+                                   lineWidth: isSelected ? 2 : 0.5)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct WooShippingNormalizeAddressView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
+                VStack(alignment: .leading, spacing: Constants.innerVerticalSpacing) {
+                    Text(Localization.modifiedAddressInfo)
+                    Text(Localization.selectAddressPrompt)
+                }
+                .bodyStyle()
+                VStack(alignment: .leading, spacing: Constants.innerVerticalSpacing) {
+                    Text(Localization.enteredAddressLabel.localizedUppercase)
+                        .footnoteStyle()
+                    Text("1234 Main St\nSan Francisco, CA 94104")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 0.5)
+                }
+                VStack(alignment: .leading, spacing: Constants.innerVerticalSpacing) {
+                    Text(Localization.suggestedAddressLabel.localizedUppercase)
+                        .footnoteStyle()
+                    Text("1234 Main St\nSan Francisco, CA 94104")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .roundedBorder(cornerRadius: 8, lineColor: Color(.separator), lineWidth: 0.5)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(Localization.cancel) {
+                    dismiss()
+                }
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: .zero) {
+                Divider().ignoresSafeArea(edges: [.horizontal])
+                Button(Localization.confirmSuggestedAddress) {
+                    // TODO: Update button label based on selected address
+                    // TODO: Confirm selected address
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding()
+            }
+            .background(Color(uiColor: .systemBackground))
+        }
+    }
+}
+
+private extension WooShippingNormalizeAddressView {
+    enum Constants {
+        static let verticalSpacing: CGFloat = 24
+        static let innerVerticalSpacing: CGFloat = 8
+    }
+
+    enum Localization {
+        static let cancel = NSLocalizedString("wooShipping.normalizeAddress.cancel",
+                                            value: "Cancel",
+                                            comment: "Button to cancel normalizing an address for a Woo Shipping label")
+        static let title = NSLocalizedString("wooShipping.normalizeAddress.title",
+                                             value: "Confirm address",
+                                             comment: "Title for the address normalization screen for a Woo Shipping label")
+        static let modifiedAddressInfo = NSLocalizedString("wooShipping.normalizeAddress.modifiedAddressInfo",
+                                                           value: "We have slightly modified the entered address.",
+                                                           comment: "Informational text when normalizing an address for a Woo Shipping label")
+        static let selectAddressPrompt = NSLocalizedString("wooShipping.normalizeAddress.selectAddressPrompt",
+                                                           value: "If correct, please use the suggested address to ensure accurate delivery.",
+                                                           comment: "Prompt to select the suggested address when normalizing an address for a Woo Shipping label")
+        static let enteredAddressLabel = NSLocalizedString("wooShipping.normalizeAddress.enteredAddressLabel",
+                                                           value: "What you entered",
+                                                           comment: "Label for the address the merchant entered " +
+                                                           "when normalizing an address for a Woo Shipping label")
+        static let suggestedAddressLabel = NSLocalizedString("wooShipping.normalizeAddress.suggestedAddressLabel",
+                                                             value: "Suggested",
+                                                             comment: "Label for the suggested address when normalizing an address for a Woo Shipping label")
+        static let confirmSuggestedAddress = NSLocalizedString("wooShipping.normalizeAddress.confirmSuggestedAddress",
+                                                               value: "Confirm Suggested Address",
+                                                               comment: "Button to confirm the suggested address for a Woo Shipping label")
+        static let confirmEnteredAddress = NSLocalizedString("wooShipping.normalizeAddress.confirmEnteredAddress",
+                                                             value: "Confirm Entered Address",
+                                                             comment: "Button to confirm the entered address for a Woo Shipping label")
+    }
+}
+
+#Preview {
+    NavigationView {
+        WooShippingNormalizeAddressView()
+    }
+    .wooNavigationBarStyle()
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2339,6 +2339,7 @@
 		CE6E110D2C91E5FF00563DD4 /* WooShippingItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */; };
 		CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */; };
 		CE7269C82D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7269C72D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift */; };
+		CE755F712D4A4922002539F6 /* WooShippingNormalizeAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE755F702D4A4922002539F6 /* WooShippingNormalizeAddressView.swift */; };
 		CE7B4A582CA191FB00F764EB /* WooShippingItemRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */; };
 		CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
@@ -5491,6 +5492,7 @@
 		CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItems.swift; sourceTree = "<group>"; };
 		CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedBorder.swift"; sourceTree = "<group>"; };
 		CE7269C72D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddPackageViewModelTests.swift; sourceTree = "<group>"; };
+		CE755F702D4A4922002539F6 /* WooShippingNormalizeAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingNormalizeAddressView.swift; sourceTree = "<group>"; };
 		CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModelTests.swift; sourceTree = "<group>"; };
 		CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingHazmat.swift; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
@@ -12143,6 +12145,7 @@
 				CE852E1E2D2EDC4C00C7DBB6 /* WooShippingEditAddressView.swift */,
 				CE5A9BBA2D3137ED00FBADDF /* WooShippingEditAddressViewModel.swift */,
 				CED9BCD02D412E1E00C063B8 /* WooShippingAddressField.swift */,
+				CE755F702D4A4922002539F6 /* WooShippingNormalizeAddressView.swift */,
 			);
 			path = WooShippingAddresses;
 			sourceTree = "<group>";
@@ -15954,6 +15957,7 @@
 				0365986B29AFB11E00F297D3 /* SetUpTapToPayInformationViewController.swift in Sources */,
 				31316F9C25CB20FD00D9F129 /* OrderStatusListViewModel.swift in Sources */,
 				DE6906E727D74A1900735E3B /* WooSplitViewController.swift in Sources */,
+				CE755F712D4A4922002539F6 /* WooShippingNormalizeAddressView.swift in Sources */,
 				0386CFEB2852108B00134466 /* PaymentMethodsHostingController.swift in Sources */,
 				B56DB3CA2049BFAA00D4AA8E /* AppDelegate.swift in Sources */,
 				451750B224470CD5004FDA65 /* EnhancedTextView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14960
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the UI (with static data) for the screen used to normalize an origin or destination address in the Woo Shipping label flow. You can use the SwiftUI preview to view the screen (it isn't used in the app yet).

The UI is designed to show the address the merchant entered and the normalized (suggested) address from the backend. The merchant can then select the address to use and confirm it.

A future PR will add a view model to handle the real address data, selected address, and remote action when the address is confirmed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Design|Actual
-|-
![Confirm address](https://github.com/user-attachments/assets/d43c3013-a675-4707-8ffa-a009f640aa62)|![Screenshot 2025-01-29 at 12 58 37](https://github.com/user-attachments/assets/df29999f-ecb8-4130-a770-9a75e5284e19)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.