### PR TITLE
[Woo POS] Analytics: Decorate POS events with `pos_` prefix

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -12,6 +12,12 @@ public class TracksProvider: NSObject, AnalyticsProvider {
         tracksService.eventNamePrefix = Constants.eventNamePrefix
         return tracksService
     }()
+
+    private static var isPOSModeActive: Bool = false
+
+    public static func setPOSMode(_ active: Bool) {
+        isPOSModeActive = active
+    }
 }
 
 
@@ -28,6 +34,7 @@ public extension TracksProvider {
     }
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
+        let eventName = decorateEventNameForPOSIfNeeded(eventName)
         if let properties {
             guard Self.tracksService.trackEventName(eventName, withCustomProperties: properties) else {
                 return DDLogError("🔴 Error tracking \(eventName) with properties: \(properties)")
@@ -100,6 +107,14 @@ private extension TracksProvider {
             UserDefaults.standard[.analyticsUsername] = nil
             Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
         }
+    }
+
+    private func decorateEventNameForPOSIfNeeded(_ eventName: String) -> String {
+        if Self.isPOSModeActive {
+            let prefix = "pos_"
+            return "\(prefix)\(eventName)"
+        }
+        return eventName
     }
 
     func refreshTracksMetadata() {

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -110,6 +110,18 @@ private extension TracksProvider {
     }
 
     private func decorateEventNameForPOSIfNeeded(_ eventName: String) -> String {
+        // We do not want to track some events that might happen in POS mode as `pos_` events,
+        // for example, when backgrounding the app or finishing async work from the app side.
+        // Ref: https://github.com/woocommerce/woocommerce-ios/pull/15006#issuecomment-2622001706
+        let exemptedEvents: Set<String> = [
+            "application_opened",
+            "application_closed",
+            "dynamic_dashboard_card_data_loading_completed"
+        ]
+        if exemptedEvents.contains(eventName) {
+            return eventName
+        }
+
         if Self.isPOSModeActive {
             let prefix = "pos_"
             return "\(prefix)\(eventName)"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1268,9 +1268,9 @@ enum WooAnalyticsStat: String {
     case backgroundUpdatesDisabled = "background_updates_disabled"
 
     // MARK: Point of Sale events
-    case pointOfSaleAddItemToCart = "pos_item_added_to_cart"
-    case pointOfSalePaymentsOnboardingShown = "pos_payments_onboarding_shown"
-    case pointOfSalePaymentsOnboardingDismissed = "pos_payments_onboarding_dismissed"
+    case pointOfSaleAddItemToCart = "item_added_to_cart"
+    case pointOfSalePaymentsOnboardingShown = "payments_onboarding_shown"
+    case pointOfSalePaymentsOnboardingDismissed = "payments_onboarding_dismissed"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -228,6 +228,7 @@ final class HubMenuViewModel: ObservableObject {
 
     func updateDefaultConfigurationForPointOfSale(_ isPointOfSaleActive: Bool) {
         updateInAppNotifications(isPointOfSaleActive)
+        updateTrackEventPrefix(isPointOfSaleActive)
     }
 
     func trackMenuItemTapEvent(menu: HubMenuItem) {
@@ -274,6 +275,12 @@ private extension HubMenuViewModel {
         } else {
             ServiceLocator.pushNotesManager.enableInAppNotifications()
         }
+    }
+
+    // Decorates track events with a different prefix when Point of Sale is active
+    //
+    func updateTrackEventPrefix(_ isPointOfSaleActive: Bool) {
+        TracksProvider.setPOSMode(isPointOfSaleActive)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -148,7 +148,7 @@ struct PointOfSaleAggregateModelTests {
 
             // Then
             let event = try #require(analyticsProvider.receivedEvents.first)
-            #expect(event == "pos_item_added_to_cart")
+            #expect(event == "item_added_to_cart")
         }
     }
 
@@ -508,7 +508,7 @@ struct PointOfSaleAggregateModelTests {
             sut.cancelCardPaymentsOnboarding()
 
             // Then
-            #expect(analyticsProvider.receivedEvents.first(where: { $0 == "pos_payments_onboarding_dismissed" }) != nil)
+            #expect(analyticsProvider.receivedEvents.first(where: { $0 == "payments_onboarding_dismissed" }) != nil)
             let eventProperties = try #require(analyticsProvider.receivedProperties.first(where: { $0.keys.contains("onboarding_state")
             }))
             #expect(eventProperties["onboarding_state"] as? String == "no_connection_error")
@@ -521,7 +521,7 @@ struct PointOfSaleAggregateModelTests {
             sut.trackCardPaymentsOnboardingShown()
 
             // Then
-            #expect(analyticsProvider.receivedEvents.first(where: { $0 == "pos_payments_onboarding_shown" }) != nil)
+            #expect(analyticsProvider.receivedEvents.first(where: { $0 == "payments_onboarding_shown" }) != nil)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13614
Part of https://github.com/woocommerce/woocommerce-ios/issues/13277

## Description

This PR updates the existing `TracksProvider` to prepend `pos_` to `eventName` when POS mode is active, so existing events that happen when POS mode is active are tracked as `woocommerceios_pos_*`. It will also continue tracking events as always when we exit POS mode.

## Why?

While we can create new events for POS (as we had with adding items to cart, or card onboarding state), handling existing track events -mostly- around payments/reader connection/... is more difficult: POS relies on the existing card payment implementation through the adaptor/façade, which already tracks events as `woocommerceios_` . 

Attempting to create a new `PointOfSaleTracksProvider` and inject this through the POS entry point has proven complex as well due to the static nature of tracks, which didn't allow us to update the `eventNamePrefix` at runtime or when going back and forth between app and POS. (Some context from our previous conversation about trying this solution during the pre-POC phase: https://github.com/woocommerce/woocommerce-ios/pull/13604#pullrequestreview-2238191873 )

I've found a straight-forward solution by following the same pattern we already do when disabling in-app notifications, on entering or existing POS mode we switch a flag that will append a prefix or not to existing events, which comes with minimal changes to the underlying analytics implementation. Happy to discuss this approach further!

## Steps to reproduce
1. Navigate through the app, process a normal Order, pay and collect via card reader. Observe in the console that events are tracked normally. Eg: 

```
🔵 Tracked card_present_collect_payment_success, properties: [country: US, plugin_slug: woocommerce-payments, card_reader_model: STRIPE_M2, is_wpcom_store: false, milliseconds_since_card_collect_payment_flow: 12793, milliseconds_since_order_add_new: 22625, site_id: 215063064, blog_id: 215063064, site_url: https://indiemelon.mystagingwebsite.com, plan: jetpack_security_daily, payment_method_type: card, was_ecommerce_trial: false, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f]
```

2. Enter in POS mode, observe in the console that all events are prepended as `pos_` now. Connect the reader, process a payment, disconnect it, disable it, etc, ... any general payment event that we normally track should continue being tracked with the prefix:
```
🔵 Tracked pos_card_present_collect_payment_success, properties: [card_reader_model: STRIPE_M2, plugin_slug: woocommerce-payments, site_id: 215063064, was_ecommerce_trial: false, blog_id: 215063064, is_wpcom_store: false, plan: jetpack_security_daily, site_url: https://indiemelon.mystagingwebsite.com, payment_method_type: card, country: US, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f]
```

Confirm in Track Events that events are logged as `woocommerceios_pos_%` (this may take a while, 10-20m, is not immediate)

<img width="735" alt="Screenshot 2025-01-29 at 14 38 29" src="https://github.com/user-attachments/assets/5bcdc961-7c34-4583-9859-99548a533032" />

All event validations will be done later on, as we'll need to manually validate in Tracks the `woocommerceios_pos_` versions of any existing event we want to keep an eye on.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
