### PR TITLE
[Revamp Shipping Labels • Customs] Enhance Customs row design

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -10,36 +10,35 @@ struct WooShippingCustomsRow: View {
     @State private var showCustomsForm: Bool = false
 
     var body: some View {
-        Button {
-            showCustomsForm.toggle()
-        } label: {
-            AdaptiveStack {
-                Text(Localization.customsTitle)
-                    .headlineStyle()
-                    .foregroundColor(.primary)
+        AdaptiveStack {
+            Text(Localization.customsTitle)
+                .headlineStyle()
+                .foregroundColor(.primary)
 
-                Spacer()
+            Spacer()
 
-                Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
-                    .foregroundColor(.black)
-                    .captionStyle()
-                    .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
-                    .padding(.vertical, Layout.statusBadgeVerticalPadding)
-                    .background(
-                        RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
-                            .fill(informationIsCompleted ?
-                                  Color.withColorStudio(name: .green, shade: .shade5) :
-                                    Color.withColorStudio(name: .red, shade: .shade10))
-                    )
-                    .padding(.horizontal, 10)
+            Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
+                .foregroundColor(.black)
+                .captionStyle()
+                .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
+                .padding(.vertical, Layout.statusBadgeVerticalPadding)
+                .background(
+                    RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
+                        .fill(informationIsCompleted ?
+                              Color.withColorStudio(name: .green, shade: .shade5) :
+                                Color.withColorStudio(name: .red, shade: .shade10))
+                )
+                .padding(.horizontal, 10)
 
-                Image(systemName: "pencil")
+            PencilEditButton {
+                showCustomsForm.toggle()
             }
-            .padding(Layout.borderPadding)
-            .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
-            .sheet(isPresented: $showCustomsForm) {
-                WooShippingCustomsForm(viewModel: customsFormViewModel)
-            }
+            .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
+        }
+        .padding(Layout.borderPadding)
+        .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+        .sheet(isPresented: $showCustomsForm) {
+            WooShippingCustomsForm(viewModel: customsFormViewModel)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -10,35 +10,36 @@ struct WooShippingCustomsRow: View {
     @State private var showCustomsForm: Bool = false
 
     var body: some View {
-        AdaptiveStack {
-            Text(Localization.customsTitle)
-                .headlineStyle()
-                .foregroundColor(.primary)
+        Button {
+            showCustomsForm.toggle()
+        } label: {
+            AdaptiveStack {
+                Text(Localization.customsTitle)
+                    .headlineStyle()
+                    .foregroundColor(.primary)
 
-            Spacer()
+                Spacer()
 
-            Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
-                .foregroundColor(.black)
-                .captionStyle()
-                .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
-                .padding(.vertical, Layout.statusBadgeVerticalPadding)
-                .background(
-                    RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
-                        .fill(informationIsCompleted ?
-                              Color.withColorStudio(name: .green, shade: .shade5) :
-                                Color.withColorStudio(name: .red, shade: .shade10))
-                )
-                .padding(.horizontal, 10)
+                Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
+                    .foregroundColor(.black)
+                    .captionStyle()
+                    .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
+                    .padding(.vertical, Layout.statusBadgeVerticalPadding)
+                    .background(
+                        RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
+                            .fill(informationIsCompleted ?
+                                  Color.withColorStudio(name: .green, shade: .shade5) :
+                                    Color.withColorStudio(name: .red, shade: .shade10))
+                    )
+                    .padding(.horizontal, 10)
 
-            PencilEditButton {
-                showCustomsForm.toggle()
+                Image(systemName: "pencil")
             }
-            .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
-        }
-        .padding(Layout.borderPadding)
-        .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
-        .sheet(isPresented: $showCustomsForm) {
-            WooShippingCustomsForm(viewModel: customsFormViewModel)
+            .padding(Layout.borderPadding)
+            .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+            .sheet(isPresented: $showCustomsForm) {
+                WooShippingCustomsForm(viewModel: customsFormViewModel)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -49,10 +49,16 @@ struct WooShippingCreateLabelsView: View {
 
                     WooShippingHazmat(enabled: !viewModel.canViewLabel)
 
-                    WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
-                                          customsFormViewModel: viewModel.customsFormViewModel)
-                        .padding(.bottom, 16)
-                        .renderedIf(viewModel.customsFormRequired)
+                    Group {
+                        Divider()
+                            .padding(.trailing, -16)
+                            .padding(.bottom, 16)
+                            .padding(.top, -8)
+                        WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
+                                              customsFormViewModel: viewModel.customsFormViewModel)
+                            .padding(.bottom, 16)
+                    }
+                    .renderedIf(viewModel.customsFormRequired)
 
                     if viewModel.canViewLabel {
                         EmptyView()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of:: #13784 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Here we add a divider on top of the Customs row and make the whole row tappable, and not just the pencil button.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Tap on Create Shipping Label on an order
2. Check that there's a divider on top of the customs row

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
See above

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/9f06a141-a754-43c0-915f-fda5b7afe4aa" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
