### PR TITLE
[Shipping labels] Add view model to provide data and actions for normalizing address UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
@@ -2,7 +2,6 @@ import Foundation
 import Contacts
 import Yosemite
 
-
 // Yosemite.WooShippingAddress Helper Methods
 //
 extension WooShippingAddress {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Contacts
+import Yosemite
+
+
+// Yosemite.WooShippingAddress Helper Methods
+//
+extension WooShippingAddress {
+
+    /// Returns the two Address Lines combined (if there are, effectively, two lines).
+    /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm
+    ///
+    var combinedAddress: String {
+        guard address2.isNotEmpty else {
+            return address1
+        }
+
+        return address1 + " " + address2
+    }
+
+    /// Returns the Postal Address, formatted and ready for display.
+    ///
+    var formattedPostalAddress: String? {
+        return postalAddress.formatted(as: .mailingAddress)?.replacingOccurrences(of: "\n", with: ", ")
+    }
+}
+
+private extension WooShippingAddress {
+
+    /// Returns a CNPostalAddress with the receiver's properties
+    ///
+    var postalAddress: CNPostalAddress {
+        let address = CNMutablePostalAddress()
+        address.street = combinedAddress
+        address.city = city
+        address.state = state
+        address.postalCode = postcode
+        address.country = country
+        address.isoCountryCode = country
+
+        return address
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct WooShippingNormalizeAddressView: View {
     @Environment(\.dismiss) private var dismiss
 
+    @ObservedObject var viewModel: WooShippingNormalizeAddressViewModel
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
@@ -11,13 +13,12 @@ struct WooShippingNormalizeAddressView: View {
                     Text(Localization.selectAddressPrompt)
                 }
                 .bodyStyle()
-                // TODO: Replace static data with real data from view model
                 AddressView(label: Localization.enteredAddressLabel,
-                            address: "15 Algonkin St, Ticonderogaa, NY 12883-1487, US",
-                            isSelected: false)
+                            address: viewModel.enteredAddress.formattedPostalAddress ?? "",
+                            isSelected: viewModel.selectedAddress == .entered)
                 AddressView(label: Localization.suggestedAddressLabel,
-                            address: "15 ALGONKIN ST, TICONDEROGA, NY 12883-1487, US",
-                            isSelected: true)
+                            address: viewModel.suggestedAddress.formattedPostalAddress ?? "",
+                            isSelected: viewModel.selectedAddress == .suggested)
             }
             .padding()
         }
@@ -33,9 +34,15 @@ struct WooShippingNormalizeAddressView: View {
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: .zero) {
                 Divider().ignoresSafeArea(edges: [.horizontal])
-                Button(Localization.confirmSuggestedAddress) {
-                    // TODO: Update button label based on selected address
+                Button {
                     // TODO: Confirm selected address
+                } label: {
+                    switch viewModel.selectedAddress {
+                    case .entered:
+                        Text(Localization.confirmEnteredAddress)
+                    case .suggested:
+                        Text(Localization.confirmSuggestedAddress)
+                    }
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .padding()
@@ -108,7 +115,8 @@ private extension WooShippingNormalizeAddressView {
 
 #Preview {
     NavigationView {
-        WooShippingNormalizeAddressView()
+        WooShippingNormalizeAddressView(viewModel: .init(enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
+                                                         suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress))
     }
     .wooNavigationBarStyle()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -16,9 +16,15 @@ struct WooShippingNormalizeAddressView: View {
                 AddressView(label: Localization.enteredAddressLabel,
                             address: viewModel.enteredAddress.formattedPostalAddress ?? "",
                             isSelected: viewModel.selectedAddress == .entered)
+                .onTapGesture {
+                    viewModel.selectedAddress = .entered
+                }
                 AddressView(label: Localization.suggestedAddressLabel,
                             address: viewModel.suggestedAddress.formattedPostalAddress ?? "",
                             isSelected: viewModel.selectedAddress == .suggested)
+                .onTapGesture {
+                    viewModel.selectedAddress = .suggested
+                }
             }
             .padding()
         }
@@ -73,6 +79,7 @@ struct WooShippingNormalizeAddressView: View {
                     .roundedBorder(cornerRadius: 8,
                                    lineColor: isSelected ? Color(.wooCommercePurple(.shade60)) : Color(.separator),
                                    lineWidth: isSelected ? 2 : 0.5)
+                    .contentShape(Rectangle())
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -41,7 +41,7 @@ struct WooShippingNormalizeAddressView: View {
             VStack(spacing: .zero) {
                 Divider().ignoresSafeArea(edges: [.horizontal])
                 Button {
-                    // TODO: Confirm selected address
+                    viewModel.confirmSelectedAddress()
                 } label: {
                     switch viewModel.selectedAddress {
                     case .entered:
@@ -123,7 +123,8 @@ private extension WooShippingNormalizeAddressView {
 #Preview {
     NavigationView {
         WooShippingNormalizeAddressView(viewModel: .init(enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
-                                                         suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress))
+                                                         suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
+                                                         onConfirm: { address in print(address) }))
     }
     .wooNavigationBarStyle()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -36,7 +36,6 @@ enum WooShippingSelectedAddressType {
 }
 
 // MARK: - Sample Data for SwiftUI Previews
-#if DEBUG
 extension WooShippingNormalizeAddressViewModel {
     static var sampleEnteredAddress: WooShippingAddress {
         WooShippingAddress(company: "",
@@ -62,4 +61,3 @@ extension WooShippingNormalizeAddressViewModel {
                            postcode: "12883-1487")
     }
 }
-#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -9,7 +9,7 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject {
 
     /// The selected address type.
     /// Defaults to the suggested address.
-    @Published private(set) var selectedAddress: WooShippingSelectedAddressType = .suggested
+    @Published var selectedAddress: WooShippingSelectedAddressType = .suggested
 
     init(enteredAddress: WooShippingAddress, suggestedAddress: WooShippingAddress) {
         self.enteredAddress = enteredAddress

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -1,0 +1,53 @@
+import Yosemite
+
+final class WooShippingNormalizeAddressViewModel: ObservableObject {
+    /// The address entered by the merchant.
+    let enteredAddress: WooShippingAddress
+
+    /// The suggested (normalized) address.
+    let suggestedAddress: WooShippingAddress
+
+    /// The selected address type.
+    /// Defaults to the suggested address.
+    @Published private(set) var selectedAddress: WooShippingSelectedAddressType = .suggested
+
+    init(enteredAddress: WooShippingAddress, suggestedAddress: WooShippingAddress) {
+        self.enteredAddress = enteredAddress
+        self.suggestedAddress = suggestedAddress
+    }
+}
+
+/// Represents which address the merchant has selected for the shipping label.
+enum WooShippingSelectedAddressType {
+    case entered
+    case suggested
+}
+
+// MARK: - Sample Data for SwiftUI Previews
+#if DEBUG
+extension WooShippingNormalizeAddressViewModel {
+    static var sampleEnteredAddress: WooShippingAddress {
+        WooShippingAddress(company: "",
+                           name: "",
+                           phone: "",
+                           country: "US",
+                           state: "NY",
+                           address1: "15 Algonkin St",
+                           address2: "",
+                           city: "Ticonderogaa",
+                           postcode: "12883-1487")
+    }
+
+    static var sampleSuggestedAddress: WooShippingAddress {
+        WooShippingAddress(company: "",
+                           name: "",
+                           phone: "",
+                           country: "US",
+                           state: "NY",
+                           address1: "15 ALGONKIN ST",
+                           address2: "",
+                           city: "TICONDEROGA",
+                           postcode: "12883-1487")
+    }
+}
+#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -11,9 +11,21 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject {
     /// Defaults to the suggested address.
     @Published var selectedAddress: WooShippingSelectedAddressType = .suggested
 
-    init(enteredAddress: WooShippingAddress, suggestedAddress: WooShippingAddress) {
+    /// Closure to perform when the address is confirmed.
+    var onConfirm: ((WooShippingAddress) -> Void)
+
+    init(enteredAddress: WooShippingAddress,
+         suggestedAddress: WooShippingAddress,
+         onConfirm: @escaping ((WooShippingAddress) -> Void)) {
         self.enteredAddress = enteredAddress
         self.suggestedAddress = suggestedAddress
+        self.onConfirm = onConfirm
+    }
+
+    /// Confirms the selected address.
+    func confirmSelectedAddress() {
+        let addressToConfirm = selectedAddress == .entered ? enteredAddress : suggestedAddress
+        onConfirm(addressToConfirm)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2340,6 +2340,9 @@
 		CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */; };
 		CE7269C82D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7269C72D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift */; };
 		CE755F712D4A4922002539F6 /* WooShippingNormalizeAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE755F702D4A4922002539F6 /* WooShippingNormalizeAddressView.swift */; };
+		CE755F732D4A5F9D002539F6 /* WooShippingNormalizeAddressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE755F722D4A5F96002539F6 /* WooShippingNormalizeAddressViewModel.swift */; };
+		CE755F752D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE755F742D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift */; };
+		CE755F772D4A79C8002539F6 /* WooShippingAddress+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE755F762D4A79C2002539F6 /* WooShippingAddress+Woo.swift */; };
 		CE7B4A582CA191FB00F764EB /* WooShippingItemRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */; };
 		CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
@@ -5493,6 +5496,9 @@
 		CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedBorder.swift"; sourceTree = "<group>"; };
 		CE7269C72D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CE755F702D4A4922002539F6 /* WooShippingNormalizeAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingNormalizeAddressView.swift; sourceTree = "<group>"; };
+		CE755F722D4A5F96002539F6 /* WooShippingNormalizeAddressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingNormalizeAddressViewModel.swift; sourceTree = "<group>"; };
+		CE755F742D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingNormalizeAddressViewModelTests.swift; sourceTree = "<group>"; };
+		CE755F762D4A79C2002539F6 /* WooShippingAddress+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingAddress+Woo.swift"; sourceTree = "<group>"; };
 		CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModelTests.swift; sourceTree = "<group>"; };
 		CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingHazmat.swift; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
@@ -12139,6 +12145,7 @@
 		CE7FE6922D13249D000F9475 /* WooShippingAddresses */ = {
 			isa = PBXGroup;
 			children = (
+				CE755F762D4A79C2002539F6 /* WooShippingAddress+Woo.swift */,
 				CECAE7102D23168D000AE10B /* WooShippingOriginAddress+Woo.swift */,
 				CE7FE6932D1324BD000F9475 /* WooShippingOriginAddressListView.swift */,
 				CECAE70B2D22EF9B000AE10B /* WooShippingOriginAddressListViewModel.swift */,
@@ -12146,6 +12153,7 @@
 				CE5A9BBA2D3137ED00FBADDF /* WooShippingEditAddressViewModel.swift */,
 				CED9BCD02D412E1E00C063B8 /* WooShippingAddressField.swift */,
 				CE755F702D4A4922002539F6 /* WooShippingNormalizeAddressView.swift */,
+				CE755F722D4A5F96002539F6 /* WooShippingNormalizeAddressViewModel.swift */,
 			);
 			path = WooShippingAddresses;
 			sourceTree = "<group>";
@@ -12283,6 +12291,7 @@
 				CE7269C72D11A99800D565C1 /* WooShippingAddPackageViewModelTests.swift */,
 				CE56C01D2D2431C000EBDE24 /* WooShippingOriginAddressListViewModelTests.swift */,
 				CE5A9BBC2D315E0500FBADDF /* WooShippingEditAddressViewModelTests.swift */,
+				CE755F742D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -16529,6 +16538,7 @@
 				DECEA4472C81778300C28C10 /* ProductImagePickerView.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
+				CE755F732D4A5F9D002539F6 /* WooShippingNormalizeAddressViewModel.swift in Sources */,
 				B90D21782D15B72900ED60ED /* WooShippingCustomsFormViewModel.swift in Sources */,
 				03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,
 				016C6B972C74AB17000D86FD /* POSConnectivityView.swift in Sources */,
@@ -16711,6 +16721,7 @@
 				03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */,
 				458BAC6E2C57CDA6009440EA /* ProductPasswordEligibilityUseCase.swift in Sources */,
 				DEE2152D2D113EF1004A11F3 /* EditStoreListView.swift in Sources */,
+				CE755F772D4A79C8002539F6 /* WooShippingAddress+Woo.swift in Sources */,
 				0388E1A829E04687007DF84D /* DeepLinkNavigator.swift in Sources */,
 				B6A10E9C292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
@@ -17554,6 +17565,7 @@
 				DE7E5E8A2B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift in Sources */,
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
 				262B442E2C77D9B000441FD5 /* OrderDetailsViewControllerTests.swift in Sources */,
+				CE755F752D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift in Sources */,
 				CCCFFC5D2934F0BA006130AF /* StatsIntervalDataParserTests.swift in Sources */,
 				953728F82B23635300FDF1D1 /* UIAlertController+helpers.swift in Sources */,
 				02645D8A27BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
@@ -3,7 +3,6 @@ import XCTest
 import Yosemite
 
 final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
-
     func test_it_inits_with_expected_values() {
         // Given
         let enteredAddress = WooShippingNormalizeAddressViewModel.sampleEnteredAddress

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
@@ -10,7 +10,7 @@ final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
         let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
 
         // When
-        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress, suggestedAddress: suggestedAddress)
+        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress, suggestedAddress: suggestedAddress, onConfirm: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.enteredAddress, enteredAddress)
@@ -18,4 +18,20 @@ final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedAddress, .suggested)
     }
 
+    func test_confirmSelectedAddress_calls_onConfirm_with_expected_address() {
+        // Given
+        let enteredAddress = WooShippingNormalizeAddressViewModel.sampleEnteredAddress
+        let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
+        var confirmedAddress: WooShippingAddress?
+        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress, suggestedAddress: suggestedAddress, onConfirm: { address in
+            confirmedAddress = address
+        })
+
+        // When
+        viewModel.selectedAddress = .entered
+        viewModel.confirmSelectedAddress()
+
+        // Then
+        XCTAssertEqual(confirmedAddress, enteredAddress)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
+
+    func test_it_inits_with_expected_values() {
+        // Given
+        let enteredAddress = WooShippingNormalizeAddressViewModel.sampleEnteredAddress
+        let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
+
+        // When
+        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress, suggestedAddress: suggestedAddress)
+
+        // Then
+        XCTAssertEqual(viewModel.enteredAddress, enteredAddress)
+        XCTAssertEqual(viewModel.suggestedAddress, suggestedAddress)
+        XCTAssertEqual(viewModel.selectedAddress, .suggested)
+    }
+
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -181,6 +181,7 @@ public typealias TopEarnerStats = Networking.TopEarnerStats
 public typealias TopEarnerStatsItem = Networking.TopEarnerStatsItem
 public typealias User = Networking.User
 public typealias WooAPIVersion = Networking.WooAPIVersion
+public typealias WooShippingAddress = Networking.WooShippingAddress
 public typealias WooShippingAddressValidationSuccess = Networking.WooShippingAddressValidationSuccess
 public typealias WooShippingAddressValidationError = Networking.WooShippingAddressValidationError
 public typealias WooShippingCustomPackage = Networking.WooShippingCustomPackage


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14960
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a view model for the view used to normalize an origin or destination address in the Woo Shipping label flow. It provides the address data to display and a confirmation action that uses the selected address.

### Changes

* Adds helpers for `WooShippingAddress` to support displaying a formatted postal address.
* Adds the view model, which inits with the two addresses (entered and suggested) and a closure to perform when the selected address is confirmed. This will be different depending on whether the address is an origin address (which will be updated remotely) or a destination address (which will be updated locally).
* Updates the view to use the view model. You can now select an address and the confirmation button label will be updated to match your selection.
* Adds related unit tests for the view model.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The view is not yet used in the app, but you can try out the behavior in the SwiftUI preview:

1. Confirm the provided addresses are displayed in the view.
2. Tap to select a different address and notice the confirmation button label updates to match your selection.
3. Tap the confirmation button and confirm the selected address is printed to the console.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/986c648c-fe3e-46ff-852a-13b551f5c96e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.960