### PR TITLE
Show cash button when order below card threshold

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel.swift
@@ -2,12 +2,13 @@ import Foundation
 import enum Networking.DotcomError
 
 struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel: Equatable {
-    let title: String = Localization.title
+    let title: String
     let message: String
     let tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel?
 
     init(error: Error,
          retryApproach: CardPresentPaymentRetryApproach) {
+        self.title = Self.title(for: error)
         self.message = Self.message(for: error)
         if case .tryAgain(let retryAction) = retryApproach {
             self.tryAgainButtonViewModel = CardPresentPaymentsModalButtonViewModel(
@@ -18,10 +19,22 @@ struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel: Equata
         }
     }
 
+    private static func title(for error: Error) -> String {
+        switch error {
+        case CollectOrderPaymentUseCaseNotValidAmountError.belowMinimumAmount:
+            return Localization.belowMinimumAmountTitle
+        default:
+            return Localization.title
+        }
+    }
+
     private static func message(for error: Error) -> String {
-        if let error = error as? LocalizedError {
+        switch error {
+        case CollectOrderPaymentUseCaseNotValidAmountError.belowMinimumAmount(let amount):
+            return String(format: Localization.belowMinimumAmount, amount)
+        case let error as LocalizedError:
             return error.errorDescription ?? error.localizedDescription
-        } else {
+        default:
             return error.localizedDescription
         }
     }
@@ -39,6 +52,19 @@ private extension PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewMo
             "pointOfSale.cardPresent.validatingOrderError.retry",
             value: "Retry",
             comment: "Button title to retry order validation."
+        )
+
+        static let belowMinimumAmountTitle = NSLocalizedString(
+            "pointOfSale.cardPresent.validatingOrderError.belowMinimumAmount.title",
+            value: "Unable to take card payment",
+            comment: "Error title when the order amount is below the minimum amount allowed for a card payment on POS."
+        )
+
+        static let belowMinimumAmount = NSLocalizedString(
+            "pointOfSale.cardPresent.validatingOrderError.belowMinimumAmount.description",
+            value: "The order total is below the minimum amount you can charge a card, which is %1$@. " +
+            "You can take a cash payment instead.",
+            comment: "Error message when the order amount is below the minimum amount allowed for a card payment on POS."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -17,12 +17,6 @@ struct TotalsView: View {
         viewHelper.shouldShowTotalsFields(for: posModel.paymentState)
     }
 
-    private var shouldShowCollectCashPaymentButton: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.acceptCashForPointOfSale) &&
-        posModel.orderState != .syncing &&
-        (posModel.paymentState == .card(.idle) || posModel.paymentState == .card(.acceptingCard))
-    }
-
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.colorScheme) var colorScheme
 
@@ -77,7 +71,8 @@ struct TotalsView: View {
                     .buttonStyle(SecondaryButtonStyle())
                     .padding(.horizontal, Constants.buttonHorizontalPadding)
                     .padding(.bottom, Constants.cashButtonBottomPadding)
-                    .renderedIf(shouldShowCollectCashPaymentButton)
+                    .renderedIf(viewHelper.shouldShowCollectCashPaymentButton(orderState: posModel.orderState,
+                                                                              paymentState: posModel.paymentState))
                 }
                 .animation(.default, value: isShowingPaymentView)
             case .error(let viewModel):

--- a/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
@@ -39,4 +39,11 @@ final class TotalsViewHelper {
             return false
         }
     }
+
+    func shouldShowCollectCashPaymentButton(orderState: PointOfSaleOrderState,
+                                            paymentState: PointOfSalePaymentState) -> Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.acceptCashForPointOfSale) &&
+        orderState != .syncing &&
+        (paymentState == .card(.idle) || paymentState == .card(.acceptingCard) || paymentState == .card(.validatingOrderError))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Merge after: #15005
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures that the cash payment button shows even when we fail to validate the order for card payments.

It also updates the message when shown in POS to be a little more specific about next steps.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Connect your card reader
3. Add an item below the card payment threshold, but above 0, to your cart
4. Checkout
5. Observe that you can still pay with cash, but get an explanation for why you can't pay with card.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/67faa977-b32f-4045-9b6b-2cc7b8babb3e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.