### PR TITLE
[Shipping labels] Track when an address being edited has local changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
@@ -4,6 +4,9 @@ import SwiftUI
 final class WooShippingAddressField: ObservableObject {
     let type: WooShippingAddressFieldType
 
+    /// The original value for the field.
+    private let originalValue: String
+
     /// The value for the field.
     @Published var value: String
 
@@ -25,12 +28,18 @@ final class WooShippingAddressField: ObservableObject {
     /// Number of seconds to wait before validating new value input.
     private let validationDelay: Double
 
+    /// Whether the field has changes from the original value.
+    var hasChanges: Bool {
+        value != originalValue
+    }
+
     init(type: WooShippingAddressFieldType,
          value: String,
          required: Bool,
          validationDelayInSeconds: Double = 1,
          validate: @escaping (String) -> String?) {
         self.type = type
+        self.originalValue = value
         self.value = value
         self.required = required
         self.validationDelay = validationDelayInSeconds

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -46,11 +46,16 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     // MARK: Local requirements & validation
 
-    /// Whether the address has been remotely verified.
-    private var isVerified: Bool
+    /// Whether the original (unedited) address has been remotely verified.
+    private var originalAddressIsVerified: Bool
 
     /// Whether the address is locally validated (there are no validation errors).
     @Published private var isValid: Bool = false
+
+    /// Whether there are any local changes to the address fields.
+    var hasChanges: Bool {
+        allFields.contains { $0.hasChanges }
+    }
 
     var allFields: [WooShippingAddressField] {
         [name, company, country, address, city, state, postalCode, email, phone]
@@ -59,15 +64,15 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Whether the phone number is required.
     private let phoneNumberRequired: Bool
 
-    // TODO: Set status to unverified if the address was verified remotely but there are unsaved changes.
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus {
-        switch (isVerified, isValid) {
-        case (true, true):
+        let isRemotelyVerified = originalAddressIsVerified && !hasChanges
+        switch (isRemotelyVerified, isValid) {
+        case (true, true): // Is a valid, remotely verified address.
             return .verified
-        case (false, true):
+        case (false, true): // Is a valid, unverified address.
             return .unverified
-        case (_, false):
+        case (_, false): // Is an invalid address.
             return .missingInformation
         }
     }
@@ -171,7 +176,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.phone = WooShippingAddressField(type: .phone, value: phone, required: phoneNumberRequired, validate: { _ in return nil})
         self.isDefaultAddress = isDefaultAddress
         self.showCompanyField = showCompanyField
-        self.isVerified = isVerified
+        self.originalAddressIsVerified = isVerified
         self.phoneNumberRequired = phoneNumberRequired
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -651,6 +651,38 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.invalidFieldTypes.contains(.name))
     }
+
+    func test_status_is_unverified_when_verified_address_has_changes() {
+        // Given
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "JANE DOE",
+                                                        company: "HEADQUARTERS",
+                                                        country: "US",
+                                                        address: "15 ALGONKIN ST STE 100",
+                                                        city: "TICONDEROGA",
+                                                        state: "NY",
+                                                        postalCode: "12883-1487",
+                                                        email: "TEST@EXAMPLE.COM",
+                                                        phone: "1-234-456-7890",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        storageManager: storageManager)
+
+        // Check precondition
+        XCTAssertEqual(viewModel.status, .verified)
+
+        // When
+        viewModel.name.value = "JANE DOE SMITH"
+
+        // Then
+        XCTAssertEqual(viewModel.status, .unverified)
+    }
 }
 
 private extension WooShippingEditAddressViewModel {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the address status handling when editing an address in the Woo Shipping label flow. With this change, we set the status to unverified if there are unsaved changes.

### Changes

* `WooShippingAddressField` now tracks the original value of the field and has a property `hasChanges` to indicate if the field has changed from its original value.
* `WooShippingEditAddressViewModel` now has a property `hasChanges` to indicate if any of the fields have changes. That is now used to set the `status` property, so that any locally valid address with unsaved changes will have the `unverified` status.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. In the edit address sheet, confirm the address status (at the bottom of the screen) is verified.
8. Make a change to the address and confirm the status is unverified.
9. Make an invalid change (e.g. remove all the information from a required field) and confirm the status is missing information.
10. Re-enter the original address details and confirm the status is verified again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/e7b454b4-eda0-4bbe-997a-2f41664d0ca6


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.