### PR TITLE
[Woo POS] Add celebration UX to cash payments

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -28,12 +28,14 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     init(orderService: POSOrderServiceProtocol,
          receiptService: POSReceiptServiceProtocol,
          stores: StoresManager = ServiceLocator.stores,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         celebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration()) {
         self.orderService = orderService
         self.receiptService = receiptService
         self.stores = stores
         self.storeCurrency = currencySettings.currencyCode
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.celebration = celebration
     }
 
     var orderStatePublisher: AnyPublisher<PointOfSaleInternalOrderState, Never> {
@@ -44,6 +46,7 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     private let receiptService: POSReceiptServiceProtocol
 
     private let currencyFormatter: CurrencyFormatter
+    private let celebration: PaymentCaptureCelebrationProtocol
     private let storeCurrency: CurrencyCode
     private let stores: StoresManager
 
@@ -101,6 +104,10 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
         orderState = .idle
     }
 
+    private func celebrate() {
+        celebration.celebrate()
+    }
+
     @MainActor
     func collectCashPayment() async throws {
         guard let siteID = stores.sessionManager.defaultStoreID else {
@@ -123,7 +130,11 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
                                                  order: updatedOrder,
                                                  giftCard: nil,
                                                  fields: fieldsToUpdate,
-                                                 onCompletion: { result in
+                                                 onCompletion: { [weak self] result in
+                guard let self = self else { return }
+                if case .success = result {
+                    self.celebrate()
+                }
                 continuation.resume(with: result)
             })
             stores.dispatch(action)

--- a/WooCommerce/WooCommerceTests/Mocks/PaymentCaptureCelebration.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/PaymentCaptureCelebration.swift
@@ -1,7 +1,9 @@
 @testable import WooCommerce
 
-struct MockPaymentCaptureCelebration: PaymentCaptureCelebrationProtocol {
+final class MockPaymentCaptureCelebration: PaymentCaptureCelebrationProtocol {
+    private(set) var celebrationWasCalled: Bool = false
+    
     func celebrate() {
-        // no-op
+        celebrationWasCalled = true
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/PaymentCaptureCelebration.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/PaymentCaptureCelebration.swift
@@ -2,7 +2,7 @@
 
 final class MockPaymentCaptureCelebration: PaymentCaptureCelebrationProtocol {
     private(set) var celebrationWasCalled: Bool = false
-    
+
     func celebrate() {
         celebrationWasCalled = true
     }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -5,6 +5,7 @@ import Foundation
 @testable import WooCommerce
 import struct Yosemite.Order
 import struct Yosemite.OrderItem
+import enum Yosemite.OrderAction
 import class WooFoundation.CurrencySettings
 
 struct PointOfSaleOrderControllerTests {
@@ -191,6 +192,48 @@ struct PointOfSaleOrderControllerTests {
             // Then
             #expect(error == .noOrder)
         }
+    }
+
+    @MainActor
+    @Test func collectCashPayment_when_successful_calls_celebrate() async throws {
+        // Given
+        let sampleSiteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.sessionManager.setStoreId(sampleSiteID)
+        let mockPaymentCelebration = MockPaymentCaptureCelebration()
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService,
+                                             stores: mockStores,
+                                             celebration: mockPaymentCelebration)
+
+        let orderItem = OrderItem.fake()
+        let fakeOrder = Order.fake().copy(items: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
+        await sut.syncOrder(for: [makeItem()], retryHandler: {})
+
+        // When
+        let completionResult: Bool = await withCheckedContinuation { continuation in
+            mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(siteID, order, _, _, onCompletion):
+                    onCompletion(.success(order))
+                    continuation.resume(returning: true)
+                default:
+                    #expect(Bool(false), "Unexpected action \(action)")
+                }
+            }
+            Task { @MainActor in
+                do {
+                    try await sut.collectCashPayment()
+                } catch {
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+
+        // Then
+        #expect(completionResult == true)
+        #expect(mockPaymentCelebration.celebrationWasCalled == true)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR adds _chaching_ sound + haptic to cash payment success, which so far we only do via card payments. The feedback/question section below regarding tests can be handled here as well or as a separate PR with more tests around the class.

## Feedback/question:
1. I wasn't sure the best place to add this, I went ahead with the OrderController because:
- AggregateModel feels it shouldn't need to care, and if we handle it here on cash success then we'd need to make the function public and call it from somewhere else, for really no reason.
- OrderService it's in Yosemite, while the PaymentCaptureCelebration is above in WooCommerce.
- We can keep the logic encapsulated in the OrderController and just trigger when the result is success, which seems adequate.

We can move it somewhere else if feels more appropriate 🤔  

2. Testing (we can add those here or separately, I found myself blocked by the tests):

The value of testing the celebration being triggered on success is minimal, but while doing so I found out that we don't really have tests around this bit of logic neither. I seem unable to run the test without crashing the app due the action dispatcher erroring out because it's not running in the Main Thread. I've tried several approaches, but more or less all of them are similar. Some examples:

```
Inject let mockStores = MockStoresManager(sessionManager: .testingInstance), then:

    @Test func collectCashPayment_when_successful_calls_celebrate() async throws {
        // Given
        let orderItem = OrderItem.fake()
        let fakeOrder = Order.fake().copy(items: [orderItem])
        mockOrderService.orderToReturn = fakeOrder
        await sut.syncOrder(for: [makeItem()], retryHandler: {})

        mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
            switch action {
            case let .updateOrder(_, order, _, _, onCompletion):
                onCompletion(.success(order))
            default:
                #expect(Bool(false), "Unexpected action: \(action)")
            }
        }

        let completionResult = await withCheckedContinuation { continuation in
            Task { @MainActor in
                try? await sut.collectCashPayment()
                continuation.resume(returning: true)
            }
        }

        #expect(completionResult == true)
        #expect(mockPaymentCelebration.celebrationWasCalled == true)
}
```

```
@Test func collectCashPayment_when_successful_calls_celebrate() async throws {
        // Given
        let orderItem = OrderItem.fake()
        let fakeOrder = Order.fake().copy(items: [orderItem])
        mockOrderService.orderToReturn = fakeOrder
        await sut.syncOrder(for: [makeItem()], retryHandler: {})

        let completionResult: Bool = await withCheckedContinuation { continuation in
            mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
                switch action {
                case let .updateOrder(_, order, _, _, onCompletion):
                    onCompletion(.success(order))
                default:
                    #expect(Bool(false), "Unexpected action \(action)")
                }
            }
            
            Task { @MainActor in
                try await sut.collectCashPayment()
            }
        }
        
        // Then
        #expect(completionResult == true)
        #expect(mockPaymentCelebration.celebrationWasCalled == true)
    }
```

Specially in the second case I'd expect the logic happens on main, but that's not the case. Any feedback is appreciated here.

## Testing
- In POS, create an pay an order via cash. Note how the "chaching" sounds on success.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
