### PR TITLE
[Shipping labels] Remotely validate edited address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -173,6 +173,11 @@ struct WooShippingEditAddressView: View {
             }
             .background(Color(uiColor: .systemBackground))
         }
+        .sheet(item: $viewModel.normalizeAddressVM) { viewModel in
+            NavigationStack {
+                WooShippingNormalizeAddressView(viewModel: viewModel)
+            }
+        }
     }
 
     private struct AddressTextField: View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -155,13 +155,18 @@ struct WooShippingEditAddressView: View {
                     .font(.subheadline)
                     .foregroundStyle(viewModel.status == .verified ? Constants.green : Constants.red)
                     Button(Localization.Button.label(for: viewModel.status)) {
-                        if viewModel.status == .verified {
+                        switch viewModel.status {
+                        case .verified:
                             dismiss()
-                        } else {
-                            // TODO: Handle remote verification
+                        case .unverified:
+                            Task { @MainActor in
+                                await viewModel.remotelyValidateAddress()
+                            }
+                        case .missingInformation:
+                            break
                         }
                     }
-                    .buttonStyle(PrimaryButtonStyle())
+                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isRemotelyValidating))
                     .disabled(viewModel.status == .missingInformation)
                 }
                 .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -138,6 +138,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     // MARK: Remote validation
 
     /// Whether the address is being remotely validated.
+    /// This property is used to show a loading indicator while the remote validation is in progress.
     @Published private(set) var isRemotelyValidating: Bool = false
 
     /// View model for normalizing the address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -135,6 +135,17 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         statesOfSelectedCountry.isNotEmpty
     }
 
+    // MARK: Remote validation
+
+    /// Whether the address is being remotely validated.
+    @Published private(set) var isRemotelyValidating: Bool = false
+
+    /// View model for normalizing the address.
+    @Published var normalizeAddressVM: WooShippingNormalizeAddressViewModel?
+
+    /// Closure to perform when the address is done being edited.
+    var onAddressEdited: ((WooShippingAddress) -> Void)?
+
     init(type: AddressType,
          id: String,
          name: String,
@@ -152,7 +163,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          phoneNumberRequired: Bool,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         debounceDelayInSeconds: Double = 1) {
+         debounceDelayInSeconds: Double = 1,
+         onAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
         self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
@@ -219,7 +231,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     convenience init(address: WooShippingOriginAddress,
                      stores: StoresManager = ServiceLocator.stores,
-                     storageManager: StorageManagerType = ServiceLocator.storageManager) {
+                     storageManager: StorageManagerType = ServiceLocator.storageManager,
+                     onAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
         self.init(type: .origin,
                   id: address.id,
                   name: address.fullName,
@@ -236,7 +249,31 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   isVerified: address.isVerified,
                   phoneNumberRequired: true,
                   stores: stores,
-                  storageManager: storageManager)
+                  storageManager: storageManager,
+                  onAddressEdited: onAddressEdited)
+    }
+
+    /// Validates the address remotely.
+    @MainActor
+    func remotelyValidateAddress() async {
+        let addressToValidate = ShippingLabelAddress(company: company.value,
+                                                     name: name.value,
+                                                     phone: phone.value,
+                                                     country: country.value,
+                                                     state: state.value,
+                                                     address1: address.value,
+                                                     address2: "",
+                                                     city: city.value,
+                                                     postcode: postalCode.value)
+        do {
+            let validation = try await remotelyValidateAddress(addressToValidate)
+            normalizeAddressVM = WooShippingNormalizeAddressViewModel(enteredAddress: validation.originalAddress,
+                                                                      suggestedAddress: validation.normalizedAddress,
+                                                                      onConfirm: onAddressEdited)
+        } catch {
+            // TODO: Handle `WooShippingAddressValidationError` errors.
+            DDLogError("⛔️ Error validating address for Woo Shipping label: \(error)")
+        }
     }
 }
 
@@ -357,6 +394,26 @@ private extension WooShippingEditAddressViewModel {
         let stateCode = state.value
         selectedCountry = countries.first { $0.code == country.value }
         selectedState = statesOfSelectedCountry.first { $0.code == stateCode }
+    }
+
+    /// Remotely validates the provided address.
+    @MainActor
+    func remotelyValidateAddress(_ address: ShippingLabelAddress) async throws -> WooShippingAddressValidationSuccess {
+        try await withCheckedThrowingContinuation { continuation in
+            isRemotelyValidating = true
+            let action = WooShippingAction.validateAddress(siteID: siteID,
+                                                           address: address) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(validation):
+                    continuation.resume(returning: validation)
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+                self.isRemotelyValidating = false
+            }
+            stores.dispatch(action)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -143,9 +143,6 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// View model for normalizing the address.
     @Published var normalizeAddressVM: WooShippingNormalizeAddressViewModel?
 
-    /// Closure to perform when the address is done being edited.
-    var onAddressEdited: ((WooShippingAddress) -> Void)?
-
     init(type: AddressType,
          id: String,
          name: String,
@@ -163,8 +160,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          phoneNumberRequired: Bool,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         debounceDelayInSeconds: Double = 1,
-         onAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
+         debounceDelayInSeconds: Double = 1) {
         self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
@@ -249,8 +245,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   isVerified: address.isVerified,
                   phoneNumberRequired: true,
                   stores: stores,
-                  storageManager: storageManager,
-                  onAddressEdited: onAddressEdited)
+                  storageManager: storageManager)
     }
 
     /// Validates the address remotely.
@@ -268,8 +263,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         do {
             let validation = try await remotelyValidateAddress(addressToValidate)
             normalizeAddressVM = WooShippingNormalizeAddressViewModel(enteredAddress: validation.originalAddress,
-                                                                      suggestedAddress: validation.normalizedAddress,
-                                                                      onConfirm: onAddressEdited)
+                                                                      suggestedAddress: validation.normalizedAddress)
         } catch {
             // TODO: Handle `WooShippingAddressValidationError` errors.
             DDLogError("⛔️ Error validating address for Woo Shipping label: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -1,6 +1,9 @@
 import Yosemite
 
-final class WooShippingNormalizeAddressViewModel: ObservableObject {
+final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable {
+    /// Unique ID for the view model.
+    let id = UUID()
+
     /// The address entered by the merchant.
     let enteredAddress: WooShippingAddress
 
@@ -12,11 +15,11 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject {
     @Published var selectedAddress: WooShippingSelectedAddressType = .suggested
 
     /// Closure to perform when the address is confirmed.
-    var onConfirm: ((WooShippingAddress) -> Void)
+    var onConfirm: ((WooShippingAddress) -> Void)?
 
     init(enteredAddress: WooShippingAddress,
          suggestedAddress: WooShippingAddress,
-         onConfirm: @escaping ((WooShippingAddress) -> Void)) {
+         onConfirm: ((WooShippingAddress) -> Void)? = nil) {
         self.enteredAddress = enteredAddress
         self.suggestedAddress = suggestedAddress
         self.onConfirm = onConfirm
@@ -25,7 +28,7 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject {
     /// Confirms the selected address.
     func confirmSelectedAddress() {
         let addressToConfirm = selectedAddress == .entered ? enteredAddress : suggestedAddress
-        onConfirm(addressToConfirm)
+        onConfirm?(addressToConfirm)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -56,6 +56,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.isDefaultAddress, saveAsDefault)
         XCTAssertEqual(viewModel.showCompanyField, showCompanyField)
         XCTAssertEqual(viewModel.status, .verified)
+        XCTAssertFalse(viewModel.isRemotelyValidating)
+        XCTAssertNil(viewModel.normalizeAddressVM)
     }
 
     func test_origin_address_inits_with_expected_values() {
@@ -682,6 +684,122 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.status, .unverified)
+    }
+
+    @MainActor
+    func test_isRemotelyValidating_set_during_and_after_remote_validation() async {
+        // Given
+        var isRemotelyValidatingDuringRemoteAction = false
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        debounceDelayInSeconds: 0)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            if case let .validateAddress(_, _, completion) = action {
+                isRemotelyValidatingDuringRemoteAction = viewModel.isRemotelyValidating
+                completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
+            }
+        }
+
+        // When
+        await viewModel.remotelyValidateAddress()
+
+        // Then
+        XCTAssertTrue(isRemotelyValidatingDuringRemoteAction)
+        XCTAssertFalse(viewModel.isRemotelyValidating)
+    }
+
+    @MainActor
+    func test_remotelyValidateAddress_sends_expected_address_to_validate() async {
+        // Given
+        let expectedAddress = ShippingLabelAddress(company: "HEADQUARTERS",
+                                                   name: "JANE DOE",
+                                                   phone: "1-234-456-7890",
+                                                   country: "US",
+                                                   state: "NY",
+                                                   address1: "15 ALGONKIN ST STE 100",
+                                                   address2: "",
+                                                   city: "TICONDEROGA",
+                                                   postcode: "12883-1487")
+        var receivedAddress: ShippingLabelAddress?
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            if case let .validateAddress(_, address, completion) = action {
+                receivedAddress = address
+                completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
+            }
+        }
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: expectedAddress.name,
+                                                        company: expectedAddress.company,
+                                                        country: expectedAddress.country,
+                                                        address: expectedAddress.address1,
+                                                        city: expectedAddress.city,
+                                                        state: expectedAddress.state,
+                                                        postalCode: expectedAddress.postcode,
+                                                        email: "",
+                                                        phone: expectedAddress.phone,
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        debounceDelayInSeconds: 0)
+
+        // When
+        await viewModel.remotelyValidateAddress()
+
+        // Then
+        XCTAssertEqual(receivedAddress, expectedAddress)
+    }
+
+    @MainActor
+    func test_remotelyValidateAddress_sets_normalizeAddressVM_on_success() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        debounceDelayInSeconds: 0)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            if case let .validateAddress(_, _, completion) = action {
+                completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
+            }
+        }
+
+        // When
+        await viewModel.remotelyValidateAddress()
+
+        // Then
+        XCTAssertNotNil(viewModel.normalizeAddressVM)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -736,6 +736,9 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                    city: "TICONDEROGA",
                                                    postcode: "12883-1487")
         var receivedAddress: ShippingLabelAddress?
+        let storageManager = MockStorageManager()
+        let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             if case let .validateAddress(_, address, completion) = action {
@@ -759,6 +762,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
                                                         stores: stores,
+                                                        storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781
⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/15020 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds remote validation to the address editing view in the Woo Shipping label flow.

When the "Validate & Save" button is tapped, it remotely validates the address and opens a sheet to confirm the address. This suggests the normalized address provided by the backend. (Note that we are matching the web behavior and displaying this view even if the entered and suggested addresses match.)

### Changes

* In `WooShippingEditAddressView`:
   * When the status is `unverified` tapping the primary button now calls the view model's `remotelyValidateAddress()` method (and shows a loading indicator while the request is in progress).
   * When the view model's `normalizeAddressVM` is set, it opens a sheet with the normalize address view.
* In `WooShippingEditAddressViewModel`, we prepare the address to be validated with the current field values, call the remote action, and set `normalizeAddressVM` based on the response.
* `WooShippingNormalizeAddressViewModel` is updated to include an ID (so it can be used as a SwiftUI sheet item) and its closure is now optional for convenience.

Notes:

* We don't yet handle an error response from the validation endpoint. For now errors are logged to the console, but a later PR will add them to the UI.
* The full "confirm address" flow isn't finished yet, so the address can't be confirmed after that sheet is opened. That will come in a later PR.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. In the edit address sheet, update the name field.
8. Tap "Validate & Save" and confirm the "Confirm Address" sheet opens with the entered and suggested (normalized) address.
9. Tap "Cancel" to go back and enter a non-existent address.
10. Tap "Validate & Save" and confirm the error from the remote endpoint is logged to the console, and the "Confirm Address" sheet does not open.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/acbf8c6a-1ead-434b-92e8-457e7cd3c582



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.