### PR TITLE
[Shipping labels] Display remote validation errors in address form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddressField.swift
@@ -73,6 +73,12 @@ final class WooShippingAddressField: ObservableObject {
     func clearError() {
         errorMessage = nil
     }
+
+    /// Sets the current validation error.
+    /// This can be used to override the local validation, e.g. when remote validation fails.
+    func setError(_ message: String) {
+        errorMessage = message
+    }
 }
 
 /// Represents the types of fields in a WooCommerce Shipping address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -150,7 +150,7 @@ struct WooShippingEditAddressView: View {
                 VStack(spacing: Constants.verticalSpacing) {
                     HStack {
                         Image(systemName: viewModel.status == .verified ? "checkmark.circle" : "exclamationmark.circle")
-                        Text(Localization.Status.label(for: viewModel.status))
+                        Text(viewModel.statusLabel)
                     }
                     .font(.subheadline)
                     .foregroundStyle(viewModel.status == .verified ? Constants.green : Constants.red)
@@ -390,28 +390,6 @@ private extension WooShippingEditAddressView {
         static let done = NSLocalizedString("wooShipping.createLabels.editAddress.done",
                                             value: "Done",
                                             comment: "Button to dismiss the keyboard")
-
-        enum Status {
-            static func label(for status: WooShippingAddressStatus) -> String {
-                switch status {
-                case .verified:
-                    return verified
-                case .unverified:
-                    return unverified
-                case .missingInformation:
-                    return missingInformation
-                }
-            }
-            static let verified = NSLocalizedString("wooShipping.createLabels.editAddress.verified",
-                                                    value: "Address verified",
-                                                    comment: "Label when the address has been verified in the Woo Shipping label creation flow")
-            static let unverified = NSLocalizedString("wooShipping.createLabels.editAddress.unverified",
-                                                      value: "Unverified address",
-                                                      comment: "Label when the address is unverified in the Woo Shipping label creation flow")
-            static let missingInformation = NSLocalizedString("wooShipping.createLabels.editAddress.missingInformation",
-                                                              value: "Missing information",
-                                                              comment: "Label when the address is missing information in the Woo Shipping label creation flow")
-        }
 
         enum Button {
             static func label(for status: WooShippingAddressStatus) -> String {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -79,7 +79,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Label to describe the status of the address.
     var statusLabel: String {
-        Localization.Status.label(for: status)
+        if let remoteValidationError, hasChanges {
+            return remoteValidationError
+        } else {
+            return Localization.Status.label(for: status)
+        }
     }
 
     // MARK: State/Country
@@ -147,6 +151,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// View model for normalizing the address.
     @Published var normalizeAddressVM: WooShippingNormalizeAddressViewModel?
+
+    /// Error from remote validation, if any.
+    @Published private var remoteValidationError: String?
 
     init(type: AddressType,
          id: String,
@@ -269,8 +276,17 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
             let validation = try await remotelyValidateAddress(addressToValidate)
             normalizeAddressVM = WooShippingNormalizeAddressViewModel(enteredAddress: validation.originalAddress,
                                                                       suggestedAddress: validation.normalizedAddress)
+        } catch let error as WooShippingAddressValidationError {
+            if let nameError = error.nameError {
+                name.setError(nameError)
+            }
+            if let addressError = error.addressError {
+                address.setError(addressError)
+            }
+            if let generalError = error.generalError {
+                remoteValidationError = generalError
+            }
         } catch {
-            // TODO: Handle `WooShippingAddressValidationError` errors.
             DDLogError("⛔️ Error validating address for Woo Shipping label: \(error)")
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -77,6 +77,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         }
     }
 
+    /// Label to describe the status of the address.
+    var statusLabel: String {
+        Localization.Status.label(for: status)
+    }
+
     // MARK: State/Country
 
     /// ResultsController: Loads Countries from the Storage Layer.
@@ -459,6 +464,28 @@ private extension WooShippingEditAddressViewModel {
             static let postalCode = NSLocalizedString("wooShipping.createLabels.editAddress.validation.postalCode",
                                                       value: "Please provide a valid postal code.",
                                                       comment: "Validation message when the postal code field is empty in the Woo Shipping label creation flow")
+        }
+
+        enum Status {
+            static func label(for status: WooShippingAddressStatus) -> String {
+                switch status {
+                case .verified:
+                    return verified
+                case .unverified:
+                    return unverified
+                case .missingInformation:
+                    return missingInformation
+                }
+            }
+            static let verified = NSLocalizedString("wooShipping.createLabels.editAddress.verified",
+                                                    value: "Address verified",
+                                                    comment: "Label when the address has been verified in the Woo Shipping label creation flow")
+            static let unverified = NSLocalizedString("wooShipping.createLabels.editAddress.unverified",
+                                                      value: "Unverified address",
+                                                      comment: "Label when the address is unverified in the Woo Shipping label creation flow")
+            static let missingInformation = NSLocalizedString("wooShipping.createLabels.editAddress.missingInformation",
+                                                              value: "Missing information",
+                                                              comment: "Label when the address is missing information in the Woo Shipping label creation flow")
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -805,6 +805,48 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(viewModel.normalizeAddressVM)
     }
+
+    @MainActor
+    func test_remotelyValidateAddress_sets_status_and_field_errors_on_validation_error() async {
+        // Given
+        let expectedNameError = "Either Name or Company is required"
+        let expectedAddressError = "House number is missing"
+        let expectedGeneralError = "Address not found"
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        debounceDelayInSeconds: 0)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            if case let .validateAddress(_, _, completion) = action {
+                completion(.failure(WooShippingAddressValidationError(addressError: expectedAddressError,
+                                                                      generalError: expectedGeneralError,
+                                                                      nameError: expectedNameError)))
+            }
+        }
+
+        // When
+        viewModel.address.value = "ALGONKIN ST"
+        await viewModel.remotelyValidateAddress()
+
+        // Then
+        XCTAssertEqual(viewModel.name.errorMessage, expectedNameError)
+        XCTAssertEqual(viewModel.address.errorMessage, expectedAddressError)
+        XCTAssertEqual(viewModel.statusLabel, expectedGeneralError)
+    }
 }
 
 private extension WooShippingEditAddressViewModel {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13781 
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/15023 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the Woo Shipping label edit address form to display validation errors from the remote endpoint.

There are two changes in the behavior:

1. If we receive an error specific to an address field (e.g. name or address error) we display it inline, under the field.
2. If we receive a general error, we display it at the bottom of the screen (instead of the verified/unverified status).

### Changes

* Updates `WooShippingAddressField` to include a method to set an error message, so we can set a remote validation error on a field.
* Updates `WooShippingEditAddressView` to get the status label from the view model.
* Updates `WooShippingEditAddressViewModel` with a `statusLabel` property.
   * When an error is received from the remote validation endpoint, and it's a general validation error, we save that error in `remoteValidationError`. If it's a field-specific error, we set the error on the corresponding field.
   * If there are no validation errors, this shows the address status (verified, unverified, missing information).
   * If there is a general error, and there are local changes that need to be validated and saved, this shows the error message.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. In the edit address sheet, update the address fields to a non-existent address. (You can remove the house number from the address field to ensure a field-specific error.)
8. Tap "Validate & Save" and confirm the validation errors are shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/68e07e89-5e22-476a-bd5b-6cd4d997d565



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.