### PR TITLE
Fix: Release POSModalManager after closing the POS

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -30,6 +30,7 @@ struct PointOfSaleEntryPointView: View {
         }
         .onDisappear {
             onPointOfSaleModeActiveStateChange(false)
+            posModalManager.onDisappear()
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -26,6 +26,10 @@ class POSModalManager: ObservableObject {
         allowsInteractiveDismissal = allowed
     }
 
+    func onDisappear() {
+        reset()
+    }
+
     private func reset() {
         onDismiss = nil
         allowsInteractiveDismissal = true

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -1,26 +1,15 @@
 import SwiftUI
-import Combine
 
 class POSModalManager: ObservableObject {
     @Published private(set) var isPresented: Bool = false
     @Published private(set) var allowsInteractiveDismissal: Bool = true
     private var contentBuilder: (() -> AnyView)?
     private var onDismiss: (() -> Void)?
-    private var subscriptions = Set<AnyCancellable>()
 
     func present<Content: View>(onDismiss: @escaping () -> Void, content: @escaping () -> Content) {
         contentBuilder = { AnyView(content()) }
         self.onDismiss = onDismiss
         isPresented = true
-
-        $isPresented
-            .sink { [weak self] _ in
-                guard let self else { return }
-                if !isPresented {
-                    reset()
-                }
-            }
-            .store(in: &subscriptions)
     }
 
     func dismiss() {
@@ -45,6 +34,5 @@ class POSModalManager: ObservableObject {
         onDismiss = nil
         allowsInteractiveDismissal = true
         contentBuilder = nil
-        subscriptions = Set()
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -1,15 +1,26 @@
 import SwiftUI
+import Combine
 
 class POSModalManager: ObservableObject {
     @Published private(set) var isPresented: Bool = false
     @Published private(set) var allowsInteractiveDismissal: Bool = true
     private var contentBuilder: (() -> AnyView)?
     private var onDismiss: (() -> Void)?
+    private var subscriptions = Set<AnyCancellable>()
 
     func present<Content: View>(onDismiss: @escaping () -> Void, content: @escaping () -> Content) {
         contentBuilder = { AnyView(content()) }
         self.onDismiss = onDismiss
         isPresented = true
+
+        $isPresented
+            .sink { [weak self] _ in
+                guard let self else { return }
+                if !isPresented {
+                    reset()
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     func dismiss() {
@@ -34,5 +45,6 @@ class POSModalManager: ObservableObject {
         onDismiss = nil
         allowsInteractiveDismissal = true
         contentBuilder = nil
+        subscriptions = Set()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14593
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When trying to reproduce https://github.com/woocommerce/woocommerce-ios/issues/14593, by closing/reopening POS, connecting/disconnecting the card reader, I managed to get POS into weird states:
- Getting stuck at a payment state (processing, remove card...)
- Finishing payments while being in order view
- Jumping between different payment states
- Stuck at "Disconnecting..." card state

I added many logging statements and inspected memory graphs to understand what was going on. My conclusion so far is that it's more than one issue. Likely contributing to one another. However, I cannot say for sure.

E.g:
- Never-ending “disconnection” is at least partially related to[ this part of the code](https://github.com/woocommerce/woocommerce-ios/blob/9ec2b8d974e15c718aad6bb8db53c7629c4616e7/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift#L433). The problem is that disconnect is never called on the reader since payment cancellation before that never finishes.
- POSModalManager is not released after closing POS, creating retain cycles of the POS resources, including aggregate model, duplicating between launches
- Aggregate model itself is part of other retain cycles unrelated to POSModalManager. Memory graph points to `Task`. `Task` can hold the reference until the async work is complete. If we have methods within services that aren't complete, it can strongly hold the model forever. There may be other issues as well.

## Solution

This is part one of the fixes - addressing `POSModalManager` leaks. `POSModalManager` holds onto dismiss and content closures, which eventually use `POSModalManager`. I spent waaay too much time trying to find a solution but I couldn't.  It has to be one of the toughest reference-cycle challenges I faced, maybe I'm missing something or maybe `reset` within `POSModalManager` exists for a reason.

Eventually, I realized that `POSModalManager` `reset` method is not called when POS is closed, that's what causes the memory leak. I added the call from the entry point.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch POS + Exit POS a few times
2. Open memory debugger 
<img width="359" alt="image" src="https://github.com/user-attachments/assets/9482b6c0-bdba-44ff-a291-ac56f18b3ce9" />

3. Make sure there's no instance of `POSModalManager` 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I cannot tell yet if weird POS behavior is caused because of (these) memory leaks. I want to address the main ones I see:
- `POSModalManager` not reset after pos is closed
- `POSAggregateModel` held by various `Task` closures (??) need to investigate it more

<img width="359" alt="image" src="https://github.com/user-attachments/assets/efc51e8b-5f32-4612-a1a5-3bc2f4850f2a" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.esses