### PR TITLE
[Woo POS] Show payment method name in success screen

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentMethod.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentMethod.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum PointOfSalePaymentMethod {
+    case card
+    case cash
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -189,7 +189,8 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
                     inputMethods: inputMethods)))
         case .paymentSuccess:
             self = .message(.paymentSuccess(viewModel: PointOfSalePaymentSuccessViewModel(
-                formattedOrderTotal: dependencies.formattedOrderTotalPrice)))
+                formattedOrderTotal: dependencies.formattedOrderTotalPrice,
+                paymentMethod: .card)))
         case .paymentError(error: let error, retryApproach: let retryApproach, _):
             switch error {
             case CollectOrderPaymentUseCaseError.couldNotRefreshOrder,

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSalePaymentSuccessViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSalePaymentSuccessViewModel.swift
@@ -4,9 +4,9 @@ struct PointOfSalePaymentSuccessViewModel: Equatable {
     let title: String = Localization.title
     let message: String?
 
-    init(formattedOrderTotal: String?) {
+    init(formattedOrderTotal: String?, paymentMethod: PointOfSalePaymentMethod) {
         if let formattedOrderTotal {
-            self.message = String(format: Localization.message, formattedOrderTotal)
+            self.message = String(format: paymentMethod.paymentSuccessMessageFormatString, formattedOrderTotal)
         } else {
             self.message = nil
         }
@@ -21,11 +21,30 @@ private extension PointOfSalePaymentSuccessViewModel {
             comment: "Title shown to users when payment is made successfully."
         )
 
-        static let message = NSLocalizedString(
-            "pointOfSale.paymentSuccessful.message",
-            value: "A payment of %1$@ was successfully made",
+        static let messageCard = NSLocalizedString(
+            "pointOfSale.paymentSuccessful.message.card",
+            value: "A card payment of %1$@ was successfully made",
             comment: "Message shown to users when payment is made. %1$@ is a placeholder for the order " +
             " total, e.g $10.50. Please include %1$@ in your formatted string"
         )
+
+        static let messageCash = NSLocalizedString(
+            "pointOfSale.paymentSuccessful.message.cash",
+            value: "A cash payment of %1$@ was successfully made",
+            comment: "Message shown to users when payment is made. %1$@ is a placeholder for the order " +
+            " total, e.g $10.50. Please include %1$@ in your formatted string"
+        )
+    }
+}
+
+private extension PointOfSalePaymentMethod {
+    var paymentSuccessMessageFormatString: String {
+        switch self {
+        case .card:
+            return PointOfSalePaymentSuccessViewModel.Localization.messageCard
+
+        case .cash:
+            return PointOfSalePaymentSuccessViewModel.Localization.messageCash
+        }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -104,6 +104,7 @@ private extension PointOfSalePaymentSuccessView {
 
 #Preview {
     return PointOfSalePaymentSuccessView(
-        viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00")
+        viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
+                                                      paymentMethod: .card)
     )
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -243,7 +243,10 @@ private extension TotalsView {
                 if case .loaded(let total) = posModel.orderState {
                     HStack(alignment: .center) {
                         Spacer()
-                        PointOfSaleCardPresentPaymentInLineMessage(messageType: .paymentSuccess(viewModel: .init(formattedOrderTotal: total.orderTotal)))
+                        PointOfSaleCardPresentPaymentInLineMessage(
+                            messageType: .paymentSuccess(
+                                viewModel: .init(formattedOrderTotal: total.orderTotal,
+                                                 paymentMethod: .cash)))
                         Spacer()
                     }
                 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -859,6 +859,7 @@
 		2084B7AE2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7AD2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift */; };
 		208628742D48E4CB003F45DC /* TotalsViewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208628732D48E4CB003F45DC /* TotalsViewHelperTests.swift */; };
 		20897C9E2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20897C9D2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift */; };
+		209566252D4CF00100977124 /* PointOfSalePaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209566242D4CF00100977124 /* PointOfSalePaymentMethod.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -4045,6 +4046,7 @@
 		208628732D48E4CB003F45DC /* TotalsViewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewHelperTests.swift; sourceTree = "<group>"; };
 		20897C9D2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleUnsupportedWidthView.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
+		209566242D4CF00100977124 /* PointOfSalePaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePaymentMethod.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
@@ -9727,6 +9729,7 @@
 				2044158E2CE6181E0070BF54 /* PointOfSaleOrderState.swift */,
 				204415902CE622BA0070BF54 /* PointOfSaleOrderTotals.swift */,
 				209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */,
+				209566242D4CF00100977124 /* PointOfSalePaymentMethod.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -15927,6 +15930,7 @@
 				023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */,
 				2004E2D02C077D2800D62521 /* CardPresentPaymentTransaction.swift in Sources */,
 				0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */,
+				209566252D4CF00100977124 /* PointOfSalePaymentMethod.swift in Sources */,
 				022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */,
 				EEB4E2D629B2063800371C3C /* StoreOnboardingTaskViewModel.swift in Sources */,
 				CED9BCD12D412E2400C063B8 /* WooShippingAddressField.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -93,7 +93,7 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             return XCTFail("Expected payment success message not found")
         }
 
-        XCTAssertEqual(viewModel.message, "A payment of $200.50 was successfully made")
+        XCTAssertEqual(viewModel.message, "A card payment of $200.50 was successfully made")
     }
 
     func test_presentationStyle_for_paymentCaptureError_is_message_paymentCaptureError_with_correctActions() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15011
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds `cash` or `card` in the payment success screen, appropriate for whichever payment method was used.

The new payment method enum could be used in future to improve our state management – i.e. we could keep hold of the card payment state even when we go to cash, and use the payment method enum to declare which is the active payment method.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS
2. Add items and check out
3. Take a payment

Observe that the success screen shows the payment method in the message.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/098d07e5-8217-4cfe-ab20-39ffc9a3a8bf



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.