### PR TITLE
[Brand Updates] Disable automatic publishing of TestFlight build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -684,7 +684,7 @@ platform :ios do
       distribute_external: true,
       # If there is a build waiting for beta review, we want to reject that so the new build can be submitted instead
       reject_build_waiting_for_review: true,
-      groups: ['Internal a8c beta testers', 'Public Beta Testers']
+      groups: ['Internal a8c beta testers']
     )
     sh('cd .. && rm WooCommerce.ipa')
   end


### PR DESCRIPTION
## Description
In order to avoid publishing the 21.6 beta build before the wanted date, this PR disabled the automatic publishing of the TestFlight build to external testers, we'll revert this change after publishing the beta build.

For context, check p1738584139719549/1738314426.603099-slack-C6H8C3G23

## Steps to reproduce
Nothing, this impacts just the release process.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.