### PR TITLE
[Shipping labels] Update origin address remotely

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -166,7 +166,7 @@ struct WooShippingEditAddressView: View {
                             break
                         }
                     }
-                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isRemotelyValidating))
+                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
                     .disabled(viewModel.status == .missingInformation)
                 }
                 .padding()
@@ -175,9 +175,7 @@ struct WooShippingEditAddressView: View {
         }
         .sheet(item: $viewModel.normalizeAddressVM) { viewModel in
             NavigationStack {
-                WooShippingNormalizeAddressView(viewModel: viewModel) {
-                    dismiss()
-                }
+                WooShippingNormalizeAddressView(viewModel: viewModel)
             }
         }
     }
@@ -418,7 +416,8 @@ private extension WooShippingEditAddressView {
 }
 
 #Preview("Without Company") {
-    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
+    WooShippingEditAddressView(viewModel: .init(type: .origin,
+                                                id: UUID().uuidString,
                                                 name: "HEADQUARTERS",
                                                 company: "",
                                                 country: "UNITED STATES",
@@ -431,12 +430,12 @@ private extension WooShippingEditAddressView {
                                                 isDefaultAddress: true,
                                                 showCompanyField: false,
                                                 isVerified: true,
-                                                phoneNumberRequired: true,
-                                                originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin)))
+                                                phoneNumberRequired: true))
 }
 
 #Preview("With Company") {
-    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
+    WooShippingEditAddressView(viewModel: .init(type: .destination,
+                                                id: UUID().uuidString,
                                                 name: "HEADQUARTERS",
                                                 company: "COMPANY",
                                                 country: "UNITED STATES",
@@ -449,6 +448,5 @@ private extension WooShippingEditAddressView {
                                                 isDefaultAddress: false,
                                                 showCompanyField: true,
                                                 isVerified: false,
-                                                phoneNumberRequired: true,
-                                                originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination)))
+                                                phoneNumberRequired: true))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -175,7 +175,9 @@ struct WooShippingEditAddressView: View {
         }
         .sheet(item: $viewModel.normalizeAddressVM) { viewModel in
             NavigationStack {
-                WooShippingNormalizeAddressView(viewModel: viewModel)
+                WooShippingNormalizeAddressView(viewModel: viewModel) {
+                    dismiss()
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -416,8 +416,7 @@ private extension WooShippingEditAddressView {
 }
 
 #Preview("Without Company") {
-    WooShippingEditAddressView(viewModel: .init(type: .origin,
-                                                id: UUID().uuidString,
+    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
                                                 name: "HEADQUARTERS",
                                                 company: "",
                                                 country: "UNITED STATES",
@@ -430,12 +429,12 @@ private extension WooShippingEditAddressView {
                                                 isDefaultAddress: true,
                                                 showCompanyField: false,
                                                 isVerified: true,
-                                                phoneNumberRequired: true))
+                                                phoneNumberRequired: true,
+                                                originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin)))
 }
 
 #Preview("With Company") {
-    WooShippingEditAddressView(viewModel: .init(type: .destination,
-                                                id: UUID().uuidString,
+    WooShippingEditAddressView(viewModel: .init(id: UUID().uuidString,
                                                 name: "HEADQUARTERS",
                                                 company: "COMPANY",
                                                 country: "UNITED STATES",
@@ -448,5 +447,6 @@ private extension WooShippingEditAddressView {
                                                 isDefaultAddress: false,
                                                 showCompanyField: true,
                                                 isVerified: false,
-                                                phoneNumberRequired: true))
+                                                phoneNumberRequired: true,
+                                                originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination)))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -6,14 +6,8 @@ import Combine
 
 /// Represents an editable Woo Shipping address, for either the shipping label origin or destination.
 struct WooShippingEditableAddress: Equatable {
-    enum AddressType {
-        case origin
-        case destination
-    }
-
     let originAddress: WooShippingOriginAddress?
     let destinationAddress: ShippingLabelAddress?
-    let addressType: AddressType
 }
 
 /// View model for editing an address in the Woo Shipping label flow.
@@ -24,8 +18,13 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private let debounceDelay: Double
     private var cancellables: Set<AnyCancellable> = []
 
-    /// Original address being edited.
-    private let originalAddress: WooShippingEditableAddress
+    enum AddressType {
+        case origin
+        case destination
+    }
+
+    /// Type of address being edited.
+    private let addressType: AddressType
 
     // MARK: Address properties
 
@@ -45,7 +44,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Whether to show the "save as default" toggle, to save the address as the default origin address.
     var showSaveAsDefault: Bool {
-        originalAddress.addressType == .origin
+        addressType == .origin
     }
 
     /// Whether to show the company field by default.
@@ -128,7 +127,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// List of countries that can be used as an origin address.
     var countries: [Country] {
-        switch originalAddress.addressType {
+        switch addressType {
         case .origin:
             resultsController.fetchedObjects.filter { Constants.acceptedUSPSCountries.contains($0.code) }
         case .destination:
@@ -153,9 +152,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     // MARK: Remote validation
 
-    /// Whether the address is being remotely validated.
-    /// This property is used to show a loading indicator while the remote validation is in progress.
-    @Published private(set) var isRemotelyValidating: Bool = false
+    /// Whether a remote action is in progress.
+    @Published private(set) var isLoading: Bool = false
 
     /// View model for normalizing the address.
     @Published var normalizeAddressVM: WooShippingNormalizeAddressViewModel?
@@ -166,7 +164,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Closure called when the address is done being edited and the changes are confirmed.
     private(set) var onAddressEdited: ((WooShippingEditableAddress) -> Void)?
 
-    init(id: String,
+    init(type: AddressType,
+         id: String,
          name: String,
          company: String,
          country: String,
@@ -180,11 +179,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          showCompanyField: Bool,
          isVerified: Bool,
          phoneNumberRequired: Bool,
-         originalAddress: WooShippingEditableAddress,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          debounceDelayInSeconds: Double = 1,
          onAddressEdited: ((WooShippingEditableAddress) -> Void)? = nil) {
+        self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
         self.company = WooShippingAddressField(type: .company, value: company, required: name.isEmpty, validate: { _ in return nil })
@@ -209,7 +208,6 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.showCompanyField = showCompanyField
         self.originalAddressIsVerified = isVerified
         self.phoneNumberRequired = phoneNumberRequired
-        self.originalAddress = originalAddress
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
@@ -254,7 +252,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      onAddressEdited: ((WooShippingEditableAddress) -> Void)? = nil) {
-        self.init(id: address.id,
+        self.init(type: .origin,
+                  id: address.id,
                   name: address.fullName,
                   company: address.company,
                   country: address.country,
@@ -268,7 +267,6 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   showCompanyField: address.company.isNotEmpty,
                   isVerified: address.isVerified,
                   phoneNumberRequired: true,
-                  originalAddress: WooShippingEditableAddress(originAddress: address, destinationAddress: nil, addressType: .origin),
                   stores: stores,
                   storageManager: storageManager,
                   onAddressEdited: onAddressEdited)
@@ -288,11 +286,14 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                                                      postcode: postalCode.value)
         do {
             let validation = try await remotelyValidateAddress(addressToValidate)
-            normalizeAddressVM = WooShippingNormalizeAddressViewModel(siteID: siteID,
-                                                                      originalAddress: originalAddress,
-                                                                      enteredAddress: validation.originalAddress,
+            normalizeAddressVM = WooShippingNormalizeAddressViewModel(enteredAddress: validation.originalAddress,
                                                                       suggestedAddress: validation.normalizedAddress,
-                                                                      onConfirm: onAddressEdited)
+                                                                      onConfirm: { [weak self] confirmedAddress in
+                guard let self else { return }
+                if addressType == .origin {
+                    updateConfirmedOriginAddress(confirmedAddress)
+                }
+            })
         } catch let error as WooShippingAddressValidationError {
             if let nameError = error.nameError {
                 name.setError(nameError)
@@ -304,7 +305,42 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                 remoteValidationError = generalError
             }
         } catch {
+            // TODO: Display error if validation request fails.
             DDLogError("⛔️ Error validating address for Woo Shipping label: \(error)")
+        }
+    }
+
+    /// Updates the origin address remotely with the provided (normalized) address and other edits.
+    private func updateConfirmedOriginAddress(_ address: WooShippingAddress) {
+        guard addressType == .origin else {
+            return
+        }
+
+        // Merge the provided (normalized) address with the edited address fields.
+        let address = WooShippingOriginAddress(id: id,
+                                               company: address.company,
+                                               address1: address.address1,
+                                               address2: address.address2,
+                                               city: address.city,
+                                               state: address.state,
+                                               postcode: address.postcode,
+                                               country: address.country,
+                                               phone: address.phone,
+                                               firstName: name.value,
+                                               lastName: "",
+                                               email: email.value,
+                                               defaultAddress: isDefaultAddress,
+                                               isVerified: true)
+
+        Task { @MainActor in
+            do {
+                let updatedOriginAddress = try await updateOriginAddress(with: address)
+                let editableAddress = WooShippingEditableAddress(originAddress: updatedOriginAddress, destinationAddress: nil)
+                onAddressEdited?(editableAddress)
+            } catch {
+                // TODO: Display error if origin address update fails.
+                DDLogError("⛔️ Error updating origin address for Woo Shipping label: \(error)")
+            }
         }
     }
 }
@@ -432,7 +468,7 @@ private extension WooShippingEditAddressViewModel {
     @MainActor
     func remotelyValidateAddress(_ address: ShippingLabelAddress) async throws -> WooShippingAddressValidationSuccess {
         try await withCheckedThrowingContinuation { continuation in
-            isRemotelyValidating = true
+            isLoading = true
             let action = WooShippingAction.validateAddress(siteID: siteID,
                                                            address: address) { [weak self] result in
                 guard let self else { return }
@@ -442,7 +478,28 @@ private extension WooShippingEditAddressViewModel {
                 case let .failure(error):
                     continuation.resume(throwing: error)
                 }
-                self.isRemotelyValidating = false
+                isLoading = false
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Updates an origin address remotely.
+    @MainActor
+    func updateOriginAddress(with address: WooShippingOriginAddress) async throws -> WooShippingOriginAddress {
+        return try await withCheckedThrowingContinuation { continuation in
+            isLoading = true
+            let action = WooShippingAction.updateOriginAddress(siteID: siteID,
+                                                               address: address,
+                                                               isVerified: address.isVerified) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(result):
+                    continuation.resume(returning: result.address)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+                isLoading = false
             }
             stores.dispatch(action)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -5,7 +5,7 @@ import protocol Storage.StorageManagerType
 import Combine
 
 /// Represents an editable Woo Shipping address, for either the shipping label origin or destination.
-struct WooShippingEditableAddress {
+struct WooShippingEditableAddress: Equatable {
     enum AddressType {
         case origin
         case destination
@@ -282,7 +282,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                                                      postcode: postalCode.value)
         do {
             let validation = try await remotelyValidateAddress(addressToValidate)
-            normalizeAddressVM = WooShippingNormalizeAddressViewModel(enteredAddress: validation.originalAddress,
+            normalizeAddressVM = WooShippingNormalizeAddressViewModel(siteID: siteID,
+                                                                      originalAddress: originalAddress,
+                                                                      enteredAddress: validation.originalAddress,
                                                                       suggestedAddress: validation.normalizedAddress)
         } catch let error as WooShippingAddressValidationError {
             if let nameError = error.nameError {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -4,6 +4,18 @@ import Yosemite
 import protocol Storage.StorageManagerType
 import Combine
 
+/// Represents an editable Woo Shipping address, for either the shipping label origin or destination.
+struct WooShippingEditableAddress {
+    enum AddressType {
+        case origin
+        case destination
+    }
+
+    let originAddress: WooShippingOriginAddress?
+    let destinationAddress: ShippingLabelAddress?
+    let addressType: AddressType
+}
+
 /// View model for editing an address in the Woo Shipping label flow.
 final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private let siteID: Int64
@@ -12,13 +24,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private let debounceDelay: Double
     private var cancellables: Set<AnyCancellable> = []
 
-    enum AddressType {
-        case origin
-        case destination
-    }
-
-    /// Type of address being edited.
-    private let addressType: AddressType
+    /// Original address being edited.
+    private let originalAddress: WooShippingEditableAddress
 
     // MARK: Address properties
 
@@ -38,7 +45,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Whether to show the "save as default" toggle, to save the address as the default origin address.
     var showSaveAsDefault: Bool {
-        addressType == .origin
+        originalAddress.addressType == .origin
     }
 
     /// Whether to show the company field by default.
@@ -121,7 +128,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// List of countries that can be used as an origin address.
     var countries: [Country] {
-        switch addressType {
+        switch originalAddress.addressType {
         case .origin:
             resultsController.fetchedObjects.filter { Constants.acceptedUSPSCountries.contains($0.code) }
         case .destination:
@@ -156,8 +163,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Error from remote validation, if any.
     @Published private var remoteValidationError: String?
 
-    init(type: AddressType,
-         id: String,
+    init(id: String,
          name: String,
          company: String,
          country: String,
@@ -171,10 +177,10 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          showCompanyField: Bool,
          isVerified: Bool,
          phoneNumberRequired: Bool,
+         originalAddress: WooShippingEditableAddress,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          debounceDelayInSeconds: Double = 1) {
-        self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
         self.company = WooShippingAddressField(type: .company, value: company, required: name.isEmpty, validate: { _ in return nil })
@@ -199,6 +205,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.showCompanyField = showCompanyField
         self.originalAddressIsVerified = isVerified
         self.phoneNumberRequired = phoneNumberRequired
+        self.originalAddress = originalAddress
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
@@ -242,8 +249,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      onAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
-        self.init(type: .origin,
-                  id: address.id,
+        self.init(id: address.id,
                   name: address.fullName,
                   company: address.company,
                   country: address.country,
@@ -257,6 +263,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   showCompanyField: address.company.isNotEmpty,
                   isVerified: address.isVerified,
                   phoneNumberRequired: true,
+                  originalAddress: WooShippingEditableAddress(originAddress: address, destinationAddress: nil, addressType: .origin),
                   stores: stores,
                   storageManager: storageManager)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -4,12 +4,6 @@ import Yosemite
 import protocol Storage.StorageManagerType
 import Combine
 
-/// Represents an editable Woo Shipping address, for either the shipping label origin or destination.
-struct WooShippingEditableAddress: Equatable {
-    let originAddress: WooShippingOriginAddress?
-    let destinationAddress: ShippingLabelAddress?
-}
-
 /// View model for editing an address in the Woo Shipping label flow.
 final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private let siteID: Int64
@@ -161,8 +155,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Error from remote validation, if any.
     @Published private var remoteValidationError: String?
 
-    /// Closure called when the address is done being edited and the changes are confirmed.
-    private(set) var onAddressEdited: ((WooShippingEditableAddress) -> Void)?
+    /// Closure called when an origin address is done being edited and the changes are confirmed.
+    private(set) var onOriginAddressEdited: ((WooShippingOriginAddress) -> Void)?
 
     init(type: AddressType,
          id: String,
@@ -182,7 +176,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          debounceDelayInSeconds: Double = 1,
-         onAddressEdited: ((WooShippingEditableAddress) -> Void)? = nil) {
+         onOriginAddressEdited: ((WooShippingOriginAddress) -> Void)? = nil) {
         self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
@@ -212,7 +206,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
         self.debounceDelay = debounceDelayInSeconds
-        self.onAddressEdited = onAddressEdited
+        self.onOriginAddressEdited = onOriginAddressEdited
 
         // Set validation rules for fields that rely on instance properties.
         self.name.validate = { [weak self] newName in
@@ -251,7 +245,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     convenience init(address: WooShippingOriginAddress,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
-                     onAddressEdited: ((WooShippingEditableAddress) -> Void)? = nil) {
+                     onAddressEdited: ((WooShippingOriginAddress) -> Void)? = nil) {
         self.init(type: .origin,
                   id: address.id,
                   name: address.fullName,
@@ -269,7 +263,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   phoneNumberRequired: true,
                   stores: stores,
                   storageManager: storageManager,
-                  onAddressEdited: onAddressEdited)
+                  onOriginAddressEdited: onAddressEdited)
     }
 
     /// Validates the address remotely.
@@ -335,8 +329,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         Task { @MainActor in
             do {
                 let updatedOriginAddress = try await updateOriginAddress(with: address)
-                let editableAddress = WooShippingEditableAddress(originAddress: updatedOriginAddress, destinationAddress: nil)
-                onAddressEdited?(editableAddress)
+                onOriginAddressEdited?(updatedOriginAddress)
             } catch {
                 // TODO: Display error if origin address update fails.
                 DDLogError("⛔️ Error updating origin address for Woo Shipping label: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -163,6 +163,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Error from remote validation, if any.
     @Published private var remoteValidationError: String?
 
+    /// Closure called when the address is done being edited and the changes are confirmed.
+    private(set) var onAddressEdited: ((WooShippingEditableAddress) -> Void)?
+
     init(id: String,
          name: String,
          company: String,
@@ -180,7 +183,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          originalAddress: WooShippingEditableAddress,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         debounceDelayInSeconds: Double = 1) {
+         debounceDelayInSeconds: Double = 1,
+         onAddressEdited: ((WooShippingEditableAddress) -> Void)? = nil) {
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
         self.company = WooShippingAddressField(type: .company, value: company, required: name.isEmpty, validate: { _ in return nil })
@@ -210,6 +214,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
         self.debounceDelay = debounceDelayInSeconds
+        self.onAddressEdited = onAddressEdited
 
         // Set validation rules for fields that rely on instance properties.
         self.name.validate = { [weak self] newName in
@@ -248,7 +253,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     convenience init(address: WooShippingOriginAddress,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
-                     onAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
+                     onAddressEdited: ((WooShippingEditableAddress) -> Void)? = nil) {
         self.init(id: address.id,
                   name: address.fullName,
                   company: address.company,
@@ -265,7 +270,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   phoneNumberRequired: true,
                   originalAddress: WooShippingEditableAddress(originAddress: address, destinationAddress: nil, addressType: .origin),
                   stores: stores,
-                  storageManager: storageManager)
+                  storageManager: storageManager,
+                  onAddressEdited: onAddressEdited)
     }
 
     /// Validates the address remotely.
@@ -285,7 +291,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
             normalizeAddressVM = WooShippingNormalizeAddressViewModel(siteID: siteID,
                                                                       originalAddress: originalAddress,
                                                                       enteredAddress: validation.originalAddress,
-                                                                      suggestedAddress: validation.normalizedAddress)
+                                                                      suggestedAddress: validation.normalizedAddress,
+                                                                      onConfirm: onAddressEdited)
         } catch let error as WooShippingAddressValidationError {
             if let nameError = error.nameError {
                 name.setError(nameError)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -5,9 +5,6 @@ struct WooShippingNormalizeAddressView: View {
 
     @ObservedObject var viewModel: WooShippingNormalizeAddressViewModel
 
-    /// Closure to perform when the user successfully confirms the selected address.
-    var onConfirm: () -> Void
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
@@ -44,15 +41,8 @@ struct WooShippingNormalizeAddressView: View {
             VStack(spacing: .zero) {
                 Divider().ignoresSafeArea(edges: [.horizontal])
                 Button {
-                    Task { @MainActor in
-                        do {
-                            try await viewModel.confirmSelectedAddress()
-                            dismiss()
-                            onConfirm()
-                        } catch {
-                            // TODO: Display error notice if remote update fails.
-                        }
-                    }
+                    viewModel.confirmSelectedAddress()
+                    dismiss()
                 } label: {
                     switch viewModel.selectedAddress {
                     case .entered:
@@ -61,7 +51,7 @@ struct WooShippingNormalizeAddressView: View {
                         Text(Localization.confirmSuggestedAddress)
                     }
                 }
-                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isRemotelyUpdating))
+                .buttonStyle(PrimaryButtonStyle())
                 .padding()
             }
             .background(Color(uiColor: .systemBackground))
@@ -133,12 +123,9 @@ private extension WooShippingNormalizeAddressView {
 
 #Preview {
     NavigationView {
-        WooShippingNormalizeAddressView(viewModel: .init(siteID: 12345,
-                                                         originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
-                                                         enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
+        WooShippingNormalizeAddressView(viewModel: .init(enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
                                                          suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
-                                                         onConfirm: { address in print(address) }),
-                                        onConfirm: {})
+                                                         onConfirm: { address in print(address) }))
     }
     .wooNavigationBarStyle()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -5,6 +5,9 @@ struct WooShippingNormalizeAddressView: View {
 
     @ObservedObject var viewModel: WooShippingNormalizeAddressViewModel
 
+    /// Closure to perform when the user successfully confirms the selected address.
+    var onConfirm: () -> Void
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
@@ -45,6 +48,7 @@ struct WooShippingNormalizeAddressView: View {
                         do {
                             try await viewModel.confirmSelectedAddress()
                             dismiss()
+                            onConfirm()
                         } catch {
                             // TODO: Display error notice if remote update fails.
                         }
@@ -133,7 +137,8 @@ private extension WooShippingNormalizeAddressView {
                                                          originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
                                                          enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
                                                          suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
-                                                         onConfirm: { address in print(address) }))
+                                                         onConfirm: { address in print(address) }),
+                                        onConfirm: {})
     }
     .wooNavigationBarStyle()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -42,7 +42,12 @@ struct WooShippingNormalizeAddressView: View {
                 Divider().ignoresSafeArea(edges: [.horizontal])
                 Button {
                     Task { @MainActor in
-                        await viewModel.confirmSelectedAddress()
+                        do {
+                            try await viewModel.confirmSelectedAddress()
+                            dismiss()
+                        } catch {
+                            // TODO: Display error notice if remote update fails.
+                        }
                     }
                 } label: {
                     switch viewModel.selectedAddress {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressView.swift
@@ -41,7 +41,9 @@ struct WooShippingNormalizeAddressView: View {
             VStack(spacing: .zero) {
                 Divider().ignoresSafeArea(edges: [.horizontal])
                 Button {
-                    viewModel.confirmSelectedAddress()
+                    Task { @MainActor in
+                        await viewModel.confirmSelectedAddress()
+                    }
                 } label: {
                     switch viewModel.selectedAddress {
                     case .entered:
@@ -50,7 +52,7 @@ struct WooShippingNormalizeAddressView: View {
                         Text(Localization.confirmSuggestedAddress)
                     }
                 }
-                .buttonStyle(PrimaryButtonStyle())
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isRemotelyUpdating))
                 .padding()
             }
             .background(Color(uiColor: .systemBackground))
@@ -122,7 +124,9 @@ private extension WooShippingNormalizeAddressView {
 
 #Preview {
     NavigationView {
-        WooShippingNormalizeAddressView(viewModel: .init(enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
+        WooShippingNormalizeAddressView(viewModel: .init(siteID: 12345,
+                                                         originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
+                                                         enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
                                                          suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
                                                          onConfirm: { address in print(address) }))
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -43,7 +43,7 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable
 
     /// Confirms the selected address.
     @MainActor
-    func confirmSelectedAddress() async {
+    func confirmSelectedAddress() async throws {
         let addressToConfirm = selectedAddress == .entered ? enteredAddress : suggestedAddress
         do {
             if let originAddress = originalAddress.originAddress {
@@ -54,8 +54,8 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable
                 onConfirm?(updatedEditableAddress)
             }
         } catch {
-            // TODO: Display error notice if remote update fails.
             DDLogError("⛔️ Error updating origin address for Woo Shipping label: \(error)")
+            throw error
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -1,19 +1,13 @@
 import Yosemite
 
 final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable {
-    private let siteID: Int64
-    private let stores: StoresManager
-
-    /// Original address to update.
-    private let originalAddress: WooShippingEditableAddress
-
     /// Unique ID for the view model.
     let id = UUID()
 
-    /// The new address entered by the merchant.
+    /// The address entered by the merchant.
     let enteredAddress: WooShippingAddress
 
-    /// The suggested (normalized) new address.
+    /// The suggested (normalized) address.
     let suggestedAddress: WooShippingAddress
 
     /// The selected address type.
@@ -21,75 +15,20 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable
     @Published var selectedAddress: WooShippingSelectedAddressType = .suggested
 
     /// Closure to perform when the address is confirmed.
-    var onConfirm: ((WooShippingEditableAddress) -> Void)?
+    var onConfirm: ((WooShippingAddress) -> Void)?
 
-    /// Whether the address is being remotely updated.
-    /// This property is used to show a loading indicator while the remote update is in progress.
-    @Published private(set) var isRemotelyUpdating: Bool = false
-
-    init(siteID: Int64,
-         originalAddress: WooShippingEditableAddress,
-         enteredAddress: WooShippingAddress,
+    init(enteredAddress: WooShippingAddress,
          suggestedAddress: WooShippingAddress,
-         stores: StoresManager = ServiceLocator.stores,
-         onConfirm: ((WooShippingEditableAddress) -> Void)? = nil) {
-        self.siteID = siteID
-        self.stores = stores
-        self.originalAddress = originalAddress
+         onConfirm: ((WooShippingAddress) -> Void)? = nil) {
         self.enteredAddress = enteredAddress
         self.suggestedAddress = suggestedAddress
         self.onConfirm = onConfirm
     }
 
     /// Confirms the selected address.
-    @MainActor
-    func confirmSelectedAddress() async throws {
+    func confirmSelectedAddress() {
         let addressToConfirm = selectedAddress == .entered ? enteredAddress : suggestedAddress
-        do {
-            if let originAddress = originalAddress.originAddress {
-                let updatedOriginAddress = try await updateOriginAddress(originAddress, with: addressToConfirm)
-                let updatedEditableAddress = WooShippingEditableAddress(originAddress: updatedOriginAddress,
-                                                                        destinationAddress: originalAddress.destinationAddress,
-                                                                        addressType: originalAddress.addressType)
-                onConfirm?(updatedEditableAddress)
-            }
-        } catch {
-            DDLogError("⛔️ Error updating origin address for Woo Shipping label: \(error)")
-            throw error
-        }
-    }
-}
-
-// MARK: Remote
-private extension WooShippingNormalizeAddressViewModel {
-    /// Updates an origin address remotely.
-    @MainActor
-    func updateOriginAddress(_ originAddress: WooShippingOriginAddress, with address: WooShippingAddress) async throws -> WooShippingOriginAddress {
-        let updatedAddress = originAddress.copy(company: address.company,
-                                                address1: address.address1,
-                                                address2: address.address2,
-                                                city: address.city,
-                                                state: address.state,
-                                                postcode: address.postcode,
-                                                country: address.country,
-                                                phone: address.phone,
-                                                firstName: address.name)
-        return try await withCheckedThrowingContinuation { continuation in
-            isRemotelyUpdating = true
-            let action = WooShippingAction.updateOriginAddress(siteID: siteID,
-                                                               address: updatedAddress,
-                                                               isVerified: updatedAddress.isVerified) { [weak self] result in
-                guard let self else { return }
-                switch result {
-                case let .success(result):
-                    continuation.resume(returning: result.address)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-                isRemotelyUpdating = false
-            }
-            stores.dispatch(action)
-        }
+        onConfirm?(addressToConfirm)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -1,13 +1,19 @@
 import Yosemite
 
 final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable {
+    private let siteID: Int64
+    private let stores: StoresManager
+
+    /// Original address to update.
+    private let originalAddress: WooShippingEditableAddress
+
     /// Unique ID for the view model.
     let id = UUID()
 
-    /// The address entered by the merchant.
+    /// The new address entered by the merchant.
     let enteredAddress: WooShippingAddress
 
-    /// The suggested (normalized) address.
+    /// The suggested (normalized) new address.
     let suggestedAddress: WooShippingAddress
 
     /// The selected address type.
@@ -15,20 +21,75 @@ final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable
     @Published var selectedAddress: WooShippingSelectedAddressType = .suggested
 
     /// Closure to perform when the address is confirmed.
-    var onConfirm: ((WooShippingAddress) -> Void)?
+    var onConfirm: ((WooShippingEditableAddress) -> Void)?
 
-    init(enteredAddress: WooShippingAddress,
+    /// Whether the address is being remotely updated.
+    /// This property is used to show a loading indicator while the remote update is in progress.
+    @Published private(set) var isRemotelyUpdating: Bool = false
+
+    init(siteID: Int64,
+         originalAddress: WooShippingEditableAddress,
+         enteredAddress: WooShippingAddress,
          suggestedAddress: WooShippingAddress,
-         onConfirm: ((WooShippingAddress) -> Void)? = nil) {
+         stores: StoresManager = ServiceLocator.stores,
+         onConfirm: ((WooShippingEditableAddress) -> Void)? = nil) {
+        self.siteID = siteID
+        self.stores = stores
+        self.originalAddress = originalAddress
         self.enteredAddress = enteredAddress
         self.suggestedAddress = suggestedAddress
         self.onConfirm = onConfirm
     }
 
     /// Confirms the selected address.
-    func confirmSelectedAddress() {
+    @MainActor
+    func confirmSelectedAddress() async {
         let addressToConfirm = selectedAddress == .entered ? enteredAddress : suggestedAddress
-        onConfirm?(addressToConfirm)
+        do {
+            if let originAddress = originalAddress.originAddress {
+                let updatedOriginAddress = try await updateOriginAddress(originAddress, with: addressToConfirm)
+                let updatedEditableAddress = WooShippingEditableAddress(originAddress: updatedOriginAddress,
+                                                                        destinationAddress: originalAddress.destinationAddress,
+                                                                        addressType: originalAddress.addressType)
+                onConfirm?(updatedEditableAddress)
+            }
+        } catch {
+            // TODO: Display error notice if remote update fails.
+            DDLogError("⛔️ Error updating origin address for Woo Shipping label: \(error)")
+        }
+    }
+}
+
+// MARK: Remote
+private extension WooShippingNormalizeAddressViewModel {
+    /// Updates an origin address remotely.
+    @MainActor
+    func updateOriginAddress(_ originAddress: WooShippingOriginAddress, with address: WooShippingAddress) async throws -> WooShippingOriginAddress {
+        let updatedAddress = originAddress.copy(company: address.company,
+                                                address1: address.address1,
+                                                address2: address.address2,
+                                                city: address.city,
+                                                state: address.state,
+                                                postcode: address.postcode,
+                                                country: address.country,
+                                                phone: address.phone,
+                                                firstName: address.name)
+        return try await withCheckedThrowingContinuation { continuation in
+            isRemotelyUpdating = true
+            let action = WooShippingAction.updateOriginAddress(siteID: siteID,
+                                                               address: updatedAddress,
+                                                               isVerified: updatedAddress.isVerified) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(result):
+                    continuation.resume(returning: result.address)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+                isRemotelyUpdating = false
+            }
+            stores.dispatch(action)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -32,6 +32,8 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
         onSelect?(address)
     }
 
+    /// Sets the `addressToEdit` property for editing the provided address.
+    /// After the address is edited, the updated address is replaced in the list of addresses.
     func editAddress(_ address: WooShippingOriginAddress) {
         addressToEdit = WooShippingEditAddressViewModel(address: address, onAddressEdited: { [weak self] editedAddress in
             guard let self,
@@ -41,9 +43,11 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
             }
             addresses.remove(at: index)
             addresses.insert(editedAddress, at: index)
+            // If the edited address was the selected address, update the selected address.
             if selectedAddressID == editedAddress.id {
                 onSelect?(editedAddress)
             }
+            addressToEdit = nil // Dismisses address edit screen
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -36,9 +36,7 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
     /// After the address is edited, the updated address is replaced in the list of addresses.
     func editAddress(_ address: WooShippingOriginAddress) {
         addressToEdit = WooShippingEditAddressViewModel(address: address, onAddressEdited: { [weak self] editedAddress in
-            guard let self,
-                  let editedAddress = editedAddress.originAddress,
-                  let index = addresses.firstIndex(where: { $0.id == editedAddress.id }) else {
+            guard let self, let index = addresses.firstIndex(where: { $0.id == editedAddress.id }) else {
                 return
             }
             addresses.remove(at: index)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -41,6 +41,9 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
             }
             addresses.remove(at: index)
             addresses.insert(editedAddress, at: index)
+            if selectedAddressID == editedAddress.id {
+                onSelect?(editedAddress)
+            }
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 
 final class WooShippingOriginAddressListViewModel: ObservableObject {
-    let addresses: [WooShippingOriginAddress]
+    private(set) var addresses: [WooShippingOriginAddress]
     @Published private(set) var selectedAddressID: String?
 
     /// View model for address to edit.
@@ -33,7 +33,15 @@ final class WooShippingOriginAddressListViewModel: ObservableObject {
     }
 
     func editAddress(_ address: WooShippingOriginAddress) {
-        addressToEdit = WooShippingEditAddressViewModel(address: address)
+        addressToEdit = WooShippingEditAddressViewModel(address: address, onAddressEdited: { [weak self] editedAddress in
+            guard let self,
+                  let editedAddress = editedAddress.originAddress,
+                  let index = addresses.firstIndex(where: { $0.id == editedAddress.id }) else {
+                return
+            }
+            addresses.remove(at: index)
+            addresses.insert(editedAddress, at: index)
+        })
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -25,8 +25,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: countries)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: id,
+        let viewModel = WooShippingEditAddressViewModel(id: id,
                                                         name: name,
                                                         company: company,
                                                         country: country,
@@ -40,6 +39,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: showCompanyField,
                                                         isVerified: isVerified,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
                                                         storageManager: storageManager)
 
         // Then
@@ -104,8 +104,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_it_validates_address_with_missing_information_and_sets_expected_status_on_init() {
         // Given & When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -118,7 +117,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: false,
-                                                        phoneNumberRequired: true)
+                                                        phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination))
 
         // Then
         XCTAssertEqual(viewModel.status, .missingInformation)
@@ -128,8 +128,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storageManager = MockStorageManager()
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -143,6 +142,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
                                                         stores: stores,
                                                         storageManager: storageManager)
 
@@ -160,8 +160,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_company_not_required_when_name_is_not_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "JANE DOE",
                                                         company: "",
                                                         country: "",
@@ -174,7 +173,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: false)
+                                                        phoneNumberRequired: false,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin))
 
         // Then
         XCTAssertFalse(viewModel.company.required)
@@ -182,8 +182,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_name_not_required_when_company_is_not_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "HEADQUARTERS",
                                                         country: "",
@@ -196,7 +195,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: false)
+                                                        phoneNumberRequired: false,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin))
 
         // Then
         XCTAssertFalse(viewModel.name.required)
@@ -204,8 +204,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_phone_number_not_required_when_phoneNumberRequired_set_to_false() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -218,7 +217,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: false)
+                                                        phoneNumberRequired: false,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin))
 
         // Then
         XCTAssertFalse(viewModel.phone.required)
@@ -231,8 +231,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: countries)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -246,6 +245,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
                                                         storageManager: storageManager)
 
         // Then
@@ -260,8 +260,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: countries)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -275,6 +274,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Then
@@ -296,8 +296,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -311,6 +310,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         storageManager: storageManager)
 
@@ -324,8 +324,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [.init(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -339,6 +338,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Then
@@ -353,8 +353,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: [country])
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -368,6 +367,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Then
@@ -383,8 +383,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let state = StateOfACountry(code: "NY", name: "New York")
         let country = Country(code: "US", name: "United States", states: [state])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -398,6 +397,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // When
@@ -415,8 +415,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let state = StateOfACountry(code: "NY", name: "New York")
         let country = Country(code: "US", name: "United States", states: [state])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -430,6 +429,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // When
@@ -446,8 +446,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
                                                         country: "US",
@@ -461,6 +460,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // When
@@ -473,8 +473,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validateAddress_sets_expected_properties_when_all_fields_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -488,6 +487,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         debounceDelayInSeconds: 0)
 
         // When
@@ -505,8 +505,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
                                                         country: "US",
@@ -520,6 +519,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -535,8 +535,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validate_sets_expected_properties_when_all_fields_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -550,6 +549,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         debounceDelayInSeconds: 0)
 
         // When
@@ -569,8 +569,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [.fake()])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "US",
@@ -584,6 +583,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -599,8 +599,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "US",
@@ -614,6 +613,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -626,8 +626,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validate_removes_valid_field_from_invalidFields() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -641,6 +640,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         debounceDelayInSeconds: 0)
         // Precondition check
         viewModel.validate(.name)
@@ -659,8 +659,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
                                                         country: "US",
@@ -674,6 +673,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Check precondition
@@ -691,8 +691,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Given
         var isRemotelyValidatingDuringRemoteAction = false
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -706,6 +705,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -746,8 +746,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                 completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
             }
         }
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: expectedAddress.name,
                                                         company: expectedAddress.company,
                                                         country: expectedAddress.country,
@@ -761,6 +760,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
@@ -776,8 +776,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     func test_remotelyValidateAddress_sets_normalizeAddressVM_on_success() async {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -791,6 +790,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -813,8 +813,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let expectedAddressError = "House number is missing"
         let expectedGeneralError = "Address not found"
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
-                                                        id: "",
+        let viewModel = WooShippingEditAddressViewModel(id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -828,6 +827,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
+                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -852,23 +852,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     func test_isLoading_set_during_and_after_remote_origin_address_update() async {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: "",
-                                                        name: "",
-                                                        company: "",
-                                                        country: "",
-                                                        address: "",
-                                                        city: "",
-                                                        state: "",
-                                                        postalCode: "",
-                                                        email: "",
-                                                        phone: "",
-                                                        isDefaultAddress: true,
-                                                        showCompanyField: true,
-                                                        isVerified: true,
-                                                        phoneNumberRequired: true,
-                                                        stores: stores,
-                                                        debounceDelayInSeconds: 0)
+        let viewModel = WooShippingEditAddressViewModel(address: .fake(), stores: stores)
 
         // When
         let isLoadingDuringRemoteAction: Bool = await waitForAsync { promise in
@@ -897,7 +881,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     func test_origin_address_update_sends_expected_origin_address_to_remote() async {
         // Given
         let originAddress = WooShippingOriginAddress.fake().copy(id: "origin",
-                                                                 company: "COMPANY",
                                                                  phone: "123-456-7890",
                                                                  firstName: "JANE",
                                                                  lastName: "DOE",
@@ -912,23 +895,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                   city: "TICONDEROGA",
                                                   postcode: "12883-1487")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: originAddress.id,
-                                                        name: originAddress.fullName,
-                                                        company: originAddress.company,
-                                                        country: originAddress.country,
-                                                        address: originAddress.combinedAddress,
-                                                        city: originAddress.city,
-                                                        state: originAddress.state,
-                                                        postalCode: originAddress.postcode,
-                                                        email: originAddress.email,
-                                                        phone: originAddress.phone,
-                                                        isDefaultAddress: originAddress.defaultAddress,
-                                                        showCompanyField: true,
-                                                        isVerified: originAddress.isVerified,
-                                                        phoneNumberRequired: true,
-                                                        stores: stores,
-                                                        debounceDelayInSeconds: 0)
+        let viewModel = WooShippingEditAddressViewModel(address: originAddress, stores: stores)
 
         // When
         let receivedAddress: WooShippingOriginAddress = await waitForAsync { promise in
@@ -963,6 +930,34 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                        defaultAddress: originAddress.defaultAddress,
                                                        isVerified: true)
         XCTAssertEqual(receivedAddress, expectedAddress)
+    }
+
+    @MainActor
+    func test_origin_address_update_calls_onOriginAddressEdited_closure() async {
+        // Given
+        let expectedAddress = WooShippingOriginAddress.fake().copy(id: "origin")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let editedAddress: WooShippingOriginAddress = await waitForAsync { promise in
+            stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+                switch action {
+                case let .validateAddress(_, _, completion):
+                    completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
+                case let .updateOriginAddress(_, _, _, completion):
+                    completion(.success(WooShippingOriginAddressUpdate(address: expectedAddress, isVerified: true)))
+                default:
+                    XCTFail("Unexpected action received: \(action)")
+                }
+            }
+            // When
+            let viewModel = WooShippingEditAddressViewModel(address: .fake(), stores: stores) { address in
+                promise(address)
+            }
+            await viewModel.remotelyValidateAddress()
+            viewModel.normalizeAddressVM?.confirmSelectedAddress()
+        }
+
+        // Then
+        XCTAssertEqual(editedAddress, expectedAddress)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -25,7 +25,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: countries)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(id: id,
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: id,
                                                         name: name,
                                                         company: company,
                                                         country: country,
@@ -39,7 +40,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: showCompanyField,
                                                         isVerified: isVerified,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
                                                         storageManager: storageManager)
 
         // Then
@@ -56,7 +56,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.isDefaultAddress, saveAsDefault)
         XCTAssertEqual(viewModel.showCompanyField, showCompanyField)
         XCTAssertEqual(viewModel.status, .verified)
-        XCTAssertFalse(viewModel.isRemotelyValidating)
+        XCTAssertFalse(viewModel.isLoading)
         XCTAssertNil(viewModel.normalizeAddressVM)
     }
 
@@ -104,7 +104,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_it_validates_address_with_missing_information_and_sets_expected_status_on_init() {
         // Given & When
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -117,8 +118,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: false,
-                                                        phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination))
+                                                        phoneNumberRequired: true)
 
         // Then
         XCTAssertEqual(viewModel.status, .missingInformation)
@@ -128,7 +128,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let storageManager = MockStorageManager()
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -142,7 +143,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
                                                         stores: stores,
                                                         storageManager: storageManager)
 
@@ -160,7 +160,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_company_not_required_when_name_is_not_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "JANE DOE",
                                                         company: "",
                                                         country: "",
@@ -173,8 +174,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: false,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin))
+                                                        phoneNumberRequired: false)
 
         // Then
         XCTAssertFalse(viewModel.company.required)
@@ -182,7 +182,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_name_not_required_when_company_is_not_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "",
                                                         company: "HEADQUARTERS",
                                                         country: "",
@@ -195,8 +196,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: false,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin))
+                                                        phoneNumberRequired: false)
 
         // Then
         XCTAssertFalse(viewModel.name.required)
@@ -204,7 +204,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_phone_number_not_required_when_phoneNumberRequired_set_to_false() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -217,8 +218,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: false,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin))
+                                                        phoneNumberRequired: false)
 
         // Then
         XCTAssertFalse(viewModel.phone.required)
@@ -231,7 +231,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: countries)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -245,7 +246,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .origin),
                                                         storageManager: storageManager)
 
         // Then
@@ -260,7 +260,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: countries)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -274,7 +275,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Then
@@ -296,7 +296,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -310,7 +311,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         storageManager: storageManager)
 
@@ -324,7 +324,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [.init(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -338,7 +339,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Then
@@ -353,7 +353,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: [country])
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -367,7 +368,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Then
@@ -383,7 +383,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let state = StateOfACountry(code: "NY", name: "New York")
         let country = Country(code: "US", name: "United States", states: [state])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -397,7 +398,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // When
@@ -415,7 +415,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let state = StateOfACountry(code: "NY", name: "New York")
         let country = Country(code: "US", name: "United States", states: [state])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: country.code,
@@ -429,7 +430,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // When
@@ -446,7 +446,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
                                                         country: "US",
@@ -460,7 +461,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // When
@@ -473,7 +473,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validateAddress_sets_expected_properties_when_all_fields_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -487,7 +488,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         debounceDelayInSeconds: 0)
 
         // When
@@ -505,7 +505,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
                                                         country: "US",
@@ -519,7 +520,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -535,7 +535,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validate_sets_expected_properties_when_all_fields_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -549,7 +550,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         debounceDelayInSeconds: 0)
 
         // When
@@ -569,7 +569,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [.fake()])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "US",
@@ -583,7 +584,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -599,7 +599,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "US",
@@ -613,7 +614,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -626,7 +626,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validate_removes_valid_field_from_invalidFields() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -640,7 +641,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         debounceDelayInSeconds: 0)
         // Precondition check
         viewModel.validate(.name)
@@ -659,7 +659,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
                                                         country: "US",
@@ -673,7 +674,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         storageManager: storageManager)
 
         // Check precondition
@@ -687,11 +687,12 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_isRemotelyValidating_set_during_and_after_remote_validation() async {
+    func test_isLoading_set_during_and_after_remote_validation() async {
         // Given
-        var isRemotelyValidatingDuringRemoteAction = false
+        var isLoadingDuringRemoteAction = false
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -705,12 +706,11 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             if case let .validateAddress(_, _, completion) = action {
-                isRemotelyValidatingDuringRemoteAction = viewModel.isRemotelyValidating
+                isLoadingDuringRemoteAction = viewModel.isLoading
                 completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
             }
         }
@@ -719,8 +719,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         await viewModel.remotelyValidateAddress()
 
         // Then
-        XCTAssertTrue(isRemotelyValidatingDuringRemoteAction)
-        XCTAssertFalse(viewModel.isRemotelyValidating)
+        XCTAssertTrue(isLoadingDuringRemoteAction)
+        XCTAssertFalse(viewModel.isLoading)
     }
 
     @MainActor
@@ -746,7 +746,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                 completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
             }
         }
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: expectedAddress.name,
                                                         company: expectedAddress.company,
                                                         country: expectedAddress.country,
@@ -760,7 +761,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
@@ -776,7 +776,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     func test_remotelyValidateAddress_sets_normalizeAddressVM_on_success() async {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -790,7 +791,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -813,7 +813,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let expectedAddressError = "House number is missing"
         let expectedGeneralError = "Address not found"
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(id: "",
+        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+                                                        id: "",
                                                         name: "",
                                                         company: "",
                                                         country: "",
@@ -827,7 +828,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         showCompanyField: true,
                                                         isVerified: true,
                                                         phoneNumberRequired: true,
-                                                        originalAddress: .init(originAddress: nil, destinationAddress: nil, addressType: .destination),
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -846,6 +846,123 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.name.errorMessage, expectedNameError)
         XCTAssertEqual(viewModel.address.errorMessage, expectedAddressError)
         XCTAssertEqual(viewModel.statusLabel, expectedGeneralError)
+    }
+
+    @MainActor
+    func test_isLoading_set_during_and_after_remote_origin_address_update() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: "",
+                                                        name: "",
+                                                        company: "",
+                                                        country: "",
+                                                        address: "",
+                                                        city: "",
+                                                        state: "",
+                                                        postalCode: "",
+                                                        email: "",
+                                                        phone: "",
+                                                        isDefaultAddress: true,
+                                                        showCompanyField: true,
+                                                        isVerified: true,
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        debounceDelayInSeconds: 0)
+
+        // When
+        let isLoadingDuringRemoteAction: Bool = await waitForAsync { promise in
+            stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+                switch action {
+                case let .validateAddress(_, _, completion):
+                    completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
+                case let .updateOriginAddress(_, _, _, completion):
+                    promise(viewModel.isLoading)
+                    completion(.success(WooShippingOriginAddressUpdate(address: .fake(), isVerified: true)))
+                default:
+                    XCTFail("Unexpected action received: \(action)")
+                }
+
+            }
+            await viewModel.remotelyValidateAddress()
+            viewModel.normalizeAddressVM?.confirmSelectedAddress()
+        }
+
+        // Then
+        XCTAssertTrue(isLoadingDuringRemoteAction)
+        XCTAssertFalse(viewModel.isLoading)
+    }
+
+    @MainActor
+    func test_origin_address_update_sends_expected_origin_address_to_remote() async {
+        // Given
+        let originAddress = WooShippingOriginAddress.fake().copy(id: "origin",
+                                                                 company: "COMPANY",
+                                                                 phone: "123-456-7890",
+                                                                 firstName: "JANE",
+                                                                 lastName: "DOE",
+                                                                 email: "TEXT@EXAMPLE.COM")
+        let suggestedAddress = WooShippingAddress(company: "HEADQUARTERS",
+                                                  name: "JANE DOE",
+                                                  phone: "123-456-7890",
+                                                  country: "US",
+                                                  state: "NY",
+                                                  address1: "15 ALGONKIN ST STE 100",
+                                                  address2: "",
+                                                  city: "TICONDEROGA",
+                                                  postcode: "12883-1487")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingEditAddressViewModel(type: .origin,
+                                                        id: originAddress.id,
+                                                        name: originAddress.fullName,
+                                                        company: originAddress.company,
+                                                        country: originAddress.country,
+                                                        address: originAddress.combinedAddress,
+                                                        city: originAddress.city,
+                                                        state: originAddress.state,
+                                                        postalCode: originAddress.postcode,
+                                                        email: originAddress.email,
+                                                        phone: originAddress.phone,
+                                                        isDefaultAddress: originAddress.defaultAddress,
+                                                        showCompanyField: true,
+                                                        isVerified: originAddress.isVerified,
+                                                        phoneNumberRequired: true,
+                                                        stores: stores,
+                                                        debounceDelayInSeconds: 0)
+
+        // When
+        let receivedAddress: WooShippingOriginAddress = await waitForAsync { promise in
+            stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+                switch action {
+                case let .validateAddress(_, _, completion):
+                    completion(.success(.init(normalizedAddress: suggestedAddress, originalAddress: .fake(), isTrivialNormalization: true)))
+                case let .updateOriginAddress(_, address, _, completion):
+                    promise(address)
+                    completion(.success(WooShippingOriginAddressUpdate(address: address, isVerified: true)))
+                default:
+                    XCTFail("Unexpected action received: \(action)")
+                }
+            }
+            await viewModel.remotelyValidateAddress()
+            viewModel.normalizeAddressVM?.confirmSelectedAddress()
+        }
+
+        // Then
+        let expectedAddress = WooShippingOriginAddress(id: originAddress.id,
+                                                       company: suggestedAddress.company,
+                                                       address1: suggestedAddress.address1,
+                                                       address2: suggestedAddress.address2,
+                                                       city: suggestedAddress.city,
+                                                       state: suggestedAddress.state,
+                                                       postcode: suggestedAddress.postcode,
+                                                       country: suggestedAddress.country,
+                                                       phone: originAddress.phone,
+                                                       firstName: suggestedAddress.name,
+                                                       lastName: "",
+                                                       email: originAddress.email,
+                                                       defaultAddress: originAddress.defaultAddress,
+                                                       isVerified: true)
+        XCTAssertEqual(receivedAddress, expectedAddress)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
@@ -3,13 +3,21 @@ import XCTest
 import Yosemite
 
 final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 123
+
     func test_it_inits_with_expected_values() {
         // Given
         let enteredAddress = WooShippingNormalizeAddressViewModel.sampleEnteredAddress
         let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
 
         // When
-        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress, suggestedAddress: suggestedAddress, onConfirm: { _ in })
+        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
+                                                             originalAddress: WooShippingEditableAddress(originAddress: .fake(),
+                                                                                                         destinationAddress: nil,
+                                                                                                         addressType: .origin),
+                                                             enteredAddress: enteredAddress,
+                                                             suggestedAddress: suggestedAddress,
+                                                             onConfirm: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.enteredAddress, enteredAddress)
@@ -17,20 +25,107 @@ final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedAddress, .suggested)
     }
 
-    func test_confirmSelectedAddress_calls_onConfirm_with_expected_address() {
+    @MainActor
+    func test_confirmSelectedAddress_for_origin_address_calls_onConfirm_with_expected_address() async {
         // Given
-        let enteredAddress = WooShippingNormalizeAddressViewModel.sampleEnteredAddress
-        let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
-        var confirmedAddress: WooShippingAddress?
-        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress, suggestedAddress: suggestedAddress, onConfirm: { address in
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .updateOriginAddress(_, _, _, completion):
+                completion(.success(WooShippingOriginAddressUpdate(address: .fake(), isVerified: true)))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        var confirmedAddress: WooShippingEditableAddress?
+        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
+                                                             originalAddress: WooShippingEditableAddress(originAddress: .fake(),
+                                                                                                         destinationAddress: nil,
+                                                                                                         addressType: .origin),
+                                                             enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
+                                                             suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
+                                                             stores: stores,
+                                                             onConfirm: { address in
             confirmedAddress = address
         })
 
         // When
         viewModel.selectedAddress = .entered
-        viewModel.confirmSelectedAddress()
+        await viewModel.confirmSelectedAddress()
 
         // Then
-        XCTAssertEqual(confirmedAddress, enteredAddress)
+        let expectedAddress = WooShippingEditableAddress(originAddress: .fake(), destinationAddress: nil, addressType: .origin)
+        XCTAssertEqual(confirmedAddress, expectedAddress)
+    }
+
+    @MainActor
+    func test_isRemotelyUpdating_set_during_and_after_remote_origin_address_update() async {
+        // Given
+        var isRemotelyUpdatingDuringRemoteAction = false
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
+                                                             originalAddress: WooShippingEditableAddress(originAddress: .fake(),
+                                                                                                         destinationAddress: nil,
+                                                                                                         addressType: .origin),
+                                                             enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
+                                                             suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
+                                                             stores: stores,
+                                                             onConfirm: { _ in })
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            if case let .updateOriginAddress(_, _, _, completion) = action {
+                isRemotelyUpdatingDuringRemoteAction = viewModel.isRemotelyUpdating
+                completion(.success(WooShippingOriginAddressUpdate(address: .fake(), isVerified: true)))
+            }
+        }
+
+        // When
+        await viewModel.confirmSelectedAddress()
+
+        // Then
+        XCTAssertTrue(isRemotelyUpdatingDuringRemoteAction)
+        XCTAssertFalse(viewModel.isRemotelyUpdating)
+    }
+
+    @MainActor
+    func test_confirmSelectedAddress_sends_expected_origin_address_to_remote() async {
+        // Given
+        let originAddress = WooShippingOriginAddress.fake().copy(id: "origin", company: "COMPANY")
+        let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
+        var receivedAddress: WooShippingOriginAddress?
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            if case let .updateOriginAddress(_, address, _, completion) = action {
+                receivedAddress = address
+                completion(.success(WooShippingOriginAddressUpdate(address: address, isVerified: true)))
+            }
+        }
+        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
+                                                             originalAddress: WooShippingEditableAddress(originAddress: originAddress,
+                                                                                                         destinationAddress: nil,
+                                                                                                         addressType: .origin),
+                                                             enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
+                                                             suggestedAddress: suggestedAddress,
+                                                             stores: stores,
+                                                             onConfirm: { _ in })
+
+        // When
+        await viewModel.confirmSelectedAddress()
+
+        // Then
+        let expectedAddress = WooShippingOriginAddress(id: originAddress.id,
+                                                       company: suggestedAddress.company,
+                                                       address1: suggestedAddress.address1,
+                                                       address2: suggestedAddress.address2,
+                                                       city: suggestedAddress.city,
+                                                       state: suggestedAddress.state,
+                                                       postcode: suggestedAddress.postcode,
+                                                       country: suggestedAddress.country,
+                                                       phone: originAddress.phone,
+                                                       firstName: suggestedAddress.name,
+                                                       lastName: "",
+                                                       email: originAddress.email,
+                                                       defaultAddress: originAddress.defaultAddress,
+                                                       isVerified: originAddress.isVerified)
+        XCTAssertEqual(receivedAddress, expectedAddress)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingNormalizeAddressViewModelTests.swift
@@ -11,11 +11,7 @@ final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
         let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
 
         // When
-        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
-                                                             originalAddress: WooShippingEditableAddress(originAddress: .fake(),
-                                                                                                         destinationAddress: nil,
-                                                                                                         addressType: .origin),
-                                                             enteredAddress: enteredAddress,
+        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress,
                                                              suggestedAddress: suggestedAddress,
                                                              onConfirm: { _ in })
 
@@ -25,107 +21,21 @@ final class WooShippingNormalizeAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedAddress, .suggested)
     }
 
-    @MainActor
-    func test_confirmSelectedAddress_for_origin_address_calls_onConfirm_with_expected_address() async {
+    func test_confirmSelectedAddress_for_origin_address_calls_onConfirm_with_expected_address() {
         // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            switch action {
-            case let .updateOriginAddress(_, _, _, completion):
-                completion(.success(WooShippingOriginAddressUpdate(address: .fake(), isVerified: true)))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-        var confirmedAddress: WooShippingEditableAddress?
-        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
-                                                             originalAddress: WooShippingEditableAddress(originAddress: .fake(),
-                                                                                                         destinationAddress: nil,
-                                                                                                         addressType: .origin),
-                                                             enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
+        let enteredAddress = WooShippingNormalizeAddressViewModel.sampleEnteredAddress
+        var confirmedAddress: WooShippingAddress?
+        let viewModel = WooShippingNormalizeAddressViewModel(enteredAddress: enteredAddress,
                                                              suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
-                                                             stores: stores,
                                                              onConfirm: { address in
             confirmedAddress = address
         })
 
         // When
         viewModel.selectedAddress = .entered
-        await viewModel.confirmSelectedAddress()
+        viewModel.confirmSelectedAddress()
 
         // Then
-        let expectedAddress = WooShippingEditableAddress(originAddress: .fake(), destinationAddress: nil, addressType: .origin)
-        XCTAssertEqual(confirmedAddress, expectedAddress)
-    }
-
-    @MainActor
-    func test_isRemotelyUpdating_set_during_and_after_remote_origin_address_update() async {
-        // Given
-        var isRemotelyUpdatingDuringRemoteAction = false
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
-                                                             originalAddress: WooShippingEditableAddress(originAddress: .fake(),
-                                                                                                         destinationAddress: nil,
-                                                                                                         addressType: .origin),
-                                                             enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
-                                                             suggestedAddress: WooShippingNormalizeAddressViewModel.sampleSuggestedAddress,
-                                                             stores: stores,
-                                                             onConfirm: { _ in })
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            if case let .updateOriginAddress(_, _, _, completion) = action {
-                isRemotelyUpdatingDuringRemoteAction = viewModel.isRemotelyUpdating
-                completion(.success(WooShippingOriginAddressUpdate(address: .fake(), isVerified: true)))
-            }
-        }
-
-        // When
-        await viewModel.confirmSelectedAddress()
-
-        // Then
-        XCTAssertTrue(isRemotelyUpdatingDuringRemoteAction)
-        XCTAssertFalse(viewModel.isRemotelyUpdating)
-    }
-
-    @MainActor
-    func test_confirmSelectedAddress_sends_expected_origin_address_to_remote() async {
-        // Given
-        let originAddress = WooShippingOriginAddress.fake().copy(id: "origin", company: "COMPANY")
-        let suggestedAddress = WooShippingNormalizeAddressViewModel.sampleSuggestedAddress
-        var receivedAddress: WooShippingOriginAddress?
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            if case let .updateOriginAddress(_, address, _, completion) = action {
-                receivedAddress = address
-                completion(.success(WooShippingOriginAddressUpdate(address: address, isVerified: true)))
-            }
-        }
-        let viewModel = WooShippingNormalizeAddressViewModel(siteID: sampleSiteID,
-                                                             originalAddress: WooShippingEditableAddress(originAddress: originAddress,
-                                                                                                         destinationAddress: nil,
-                                                                                                         addressType: .origin),
-                                                             enteredAddress: WooShippingNormalizeAddressViewModel.sampleEnteredAddress,
-                                                             suggestedAddress: suggestedAddress,
-                                                             stores: stores,
-                                                             onConfirm: { _ in })
-
-        // When
-        await viewModel.confirmSelectedAddress()
-
-        // Then
-        let expectedAddress = WooShippingOriginAddress(id: originAddress.id,
-                                                       company: suggestedAddress.company,
-                                                       address1: suggestedAddress.address1,
-                                                       address2: suggestedAddress.address2,
-                                                       city: suggestedAddress.city,
-                                                       state: suggestedAddress.state,
-                                                       postcode: suggestedAddress.postcode,
-                                                       country: suggestedAddress.country,
-                                                       phone: originAddress.phone,
-                                                       firstName: suggestedAddress.name,
-                                                       lastName: "",
-                                                       email: originAddress.email,
-                                                       defaultAddress: originAddress.defaultAddress,
-                                                       isVerified: originAddress.isVerified)
-        XCTAssertEqual(receivedAddress, expectedAddress)
+        XCTAssertEqual(confirmedAddress, enteredAddress)
     }
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -194,6 +194,7 @@ public typealias WooShippingPackagesResponse = Networking.WooShippingPackagesRes
 public typealias WooShippingPackagePurchase = Networking.WooShippingPackagePurchase
 public typealias WooShippingPredefinedSavedOption = Networking.WooShippingPredefinedSavedOption
 public typealias WooShippingOriginAddress = Networking.WooShippingOriginAddress
+public typealias WooShippingOriginAddressUpdate = Networking.WooShippingOriginAddressUpdate
 public typealias WPComPlan = Networking.WPComPlan
 public typealias WPComSitePlan = Networking.WPComSitePlan
 public typealias LoadSiteCurrentPlanError = Networking.LoadSiteCurrentPlanError


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13781
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This completes the origin address editing UI in the Woo Shipping labels flow. It updates the edited origin address remotely and in the origin address list.

The remote update action is called after the "Confirm" button is tapped in the "Confirm address" view, but the action itself is part of the edit address view model. This is because we need to merge the normalized, confirmed address with other address edits (that aren't send to the remote normalization endpoint) before updating it remotely.

### Changes

* In `WooShippingNormalizeAddressView`, we now dismiss the view immediately when the selected address is confirmed.
* In `WooShippingEditAddressViewModel`:
   * Renames `isRemotelyValidating` to `isLoading`, to track any remote action in progress (e.g. validating remotely, updating address remotely).
   * Adds a closure property `onOriginAddressEdited` to call when an origin address is done being edited (including the remote update).
   * When `normalizeAddressVM` is set, it now includes an `onConfirm` closure to update an origin address remotely. This merges the normalized/confirmed address with any other changes in the edit address form, and sends it to the remote update endpoint.
* In `WooShippingOriginAddressListViewModel`, we now set the `onOriginAddressEdited` closure. This updates the origin address list with the updated address (and reselects it if it's selected, to ensure the selected address details are updated). It also sets the `addressToEdit` property to nil, which dismisses the edit address form when the edits are complete.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure the latest production version of WooCommerce Shipping (Version 1.3.2) is installed, activated, and set up on your store.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Open the "Shipment details" bottom sheet.
5. Tap the "Ship from" origin address.
6. Tap the edit (pencil) icon on one of the origin addresses.
7. In the edit address sheet, make some edits to the address and tap "Validate & Save."
8. In the confirm address sheet, select and confirm an address.
9. Note that the confirmation sheet is dismissed and you see a loading indicator on the edit address sheet's primary button while the remote action is in progress. Then, the edit address sheet is dismissed.
10. Confirm the origin address list shows the updated address.
11. Close the origin address list and confirm the shipping label bottom sheet shows the updated address.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/9bd4b01a-6626-442f-9011-1ddca8b61b8b




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.