### PR TITLE
[Shipping labels] Add UI to indicate destination address verification status

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -37,6 +37,9 @@ struct WooShippingCreateLabelsView: View {
     /// Whether the origin address list sheet is presented.
     @State private var isOriginAddressListPresented = false
 
+    /// Whether the address verification notice is displayed.
+    @State private var isAddressVerificationNoticePresented = true
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -81,10 +84,12 @@ struct WooShippingCreateLabelsView: View {
                                     .bold()
                                 // TODO: Only display the notice if the address is unverified, or
                                 // if the address was just verified (and then auto-dismiss it after a couple seconds).
-                                addressVerificationNotice
-                                    .onTapGesture {
-                                        // TODO: Start address editing/verification flow if needed (if destination address is unverified).
-                                    }
+                                if isAddressVerificationNoticePresented {
+                                    addressVerificationNotice
+                                        .onTapGesture {
+                                            // TODO: Start address editing/verification flow if needed (if destination address is unverified).
+                                        }
+                                }
                             }
                         }
                         if !viewModel.canViewLabel {
@@ -295,7 +300,9 @@ private extension WooShippingCreateLabelsView {
                  ? Localization.AddressVerification.destinationVerified : Localization.AddressVerification.destinationUnverified)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Button {
-                // TODO: Dismiss the notice.
+                withAnimation {
+                    isAddressVerificationNoticePresented = false
+                }
             } label: {
                 Image(systemName: "xmark")
                     .renderedIf(!viewModel.isDestinationAddressVerified)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -143,6 +143,7 @@ struct WooShippingCreateLabelsView: View {
                                                 line.bold()
                                             }
                                     }
+                                    addressVerificationLabel
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             }
@@ -266,6 +267,17 @@ private extension WooShippingCreateLabelsView {
         .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isPurchasingLabel))
         .disabled(!viewModel.isPurchaseButtonEnabled)
     }
+
+    /// View showing the address verification status.
+    var addressVerificationLabel: some View {
+        HStack(spacing: 4) {
+            Image(systemName: viewModel.isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
+            Text(viewModel.isDestinationAddressVerified
+                 ? Localization.AddressVerification.verified : Localization.AddressVerification.unverified)
+        }
+        .font(.subheadline)
+        .foregroundStyle(viewModel.isDestinationAddressVerified ? Layout.green : Layout.red)
+    }
 }
 
 // MARK: Store Options
@@ -294,6 +306,10 @@ private extension WooShippingCreateLabelsView {
         static let ellipsisWidth: CGFloat = 22
         static let bottomSheetSpacing: CGFloat = 16
         static let bottomSheetPadding: CGFloat = 16
+        static let green = Color(UIColor(light: .withColorStudio(.green, shade: .shade60),
+                                         dark: .withColorStudio(.green, shade: .shade40)))
+        static let red = Color(UIColor(light: .withColorStudio(.red, shade: .shade60),
+                                       dark: .withColorStudio(.red, shade: .shade40)))
     }
 
     enum Localization {
@@ -354,6 +370,15 @@ private extension WooShippingCreateLabelsView {
                                                           value: "Purchase Label · %1$@",
                                                           comment: "Label for button to purchase the shipping label on the shipping label creation screen, " +
                                                           "including the label price. Reads like: 'Purchase Label · $7.63'")
+        }
+
+        enum AddressVerification {
+            static let verified = NSLocalizedString("wooShipping.createLabels.addressVerification.verified",
+                                                    value: "Address verified",
+                                                    comment: "Label when an address is verified on the shipping label creation screen")
+            static let unverified = NSLocalizedString("wooShipping.createLabels.addressVerification.unverified",
+                                                      value: "Unverified address",
+                                                      comment: "Label when an address is unverified on the shipping label creation screen")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -37,9 +37,6 @@ struct WooShippingCreateLabelsView: View {
     /// Whether the origin address list sheet is presented.
     @State private var isOriginAddressListPresented = false
 
-    /// Whether the address verification notice is displayed.
-    @State private var isAddressVerificationNoticePresented = true
-
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -82,9 +79,7 @@ struct WooShippingCreateLabelsView: View {
                                 Text(Localization.BottomSheet.shipmentDetails)
                                     .foregroundStyle(Color(.primary))
                                     .bold()
-                                // TODO: Only display the notice if the address is unverified, or
-                                // if the address was just verified (and then auto-dismiss it after a couple seconds).
-                                if isAddressVerificationNoticePresented {
+                                if viewModel.showAddressVerificationNotice {
                                     addressVerificationNotice
                                         .onTapGesture {
                                             // TODO: Start address editing/verification flow if needed (if destination address is unverified).
@@ -301,7 +296,7 @@ private extension WooShippingCreateLabelsView {
                 .frame(maxWidth: .infinity, alignment: .leading)
             Button {
                 withAnimation {
-                    isAddressVerificationNoticePresented = false
+                    viewModel.showAddressVerificationNotice = false
                 }
             } label: {
                 Image(systemName: "xmark")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -75,9 +75,17 @@ struct WooShippingCreateLabelsView: View {
                 }) {
                     VStack {
                         if !isShipmentDetailsExpanded {
-                            Text(Localization.BottomSheet.shipmentDetails)
-                                .foregroundStyle(Color(.primary))
-                                .bold()
+                            VStack {
+                                Text(Localization.BottomSheet.shipmentDetails)
+                                    .foregroundStyle(Color(.primary))
+                                    .bold()
+                                // TODO: Only display the notice if the address is unverified, or
+                                // if the address was just verified (and then auto-dismiss it after a couple seconds).
+                                addressVerificationNotice
+                                    .onTapGesture {
+                                        // TODO: Start address editing/verification flow if needed (if destination address is unverified).
+                                    }
+                            }
                         }
                         if !viewModel.canViewLabel {
                             if isiPhonePortrait {
@@ -278,6 +286,28 @@ private extension WooShippingCreateLabelsView {
         .font(.subheadline)
         .foregroundStyle(viewModel.isDestinationAddressVerified ? Layout.green : Layout.red)
     }
+
+    /// View showing a notice about the address verification status.
+    var addressVerificationNotice: some View {
+        HStack(spacing: 8) {
+            Image(systemName: viewModel.isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
+            Text(viewModel.isDestinationAddressVerified
+                 ? Localization.AddressVerification.destinationVerified : Localization.AddressVerification.destinationUnverified)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button {
+                // TODO: Dismiss the notice.
+            } label: {
+                Image(systemName: "xmark")
+                    .renderedIf(!viewModel.isDestinationAddressVerified)
+            }
+        }
+        .font(.subheadline)
+        .foregroundStyle(viewModel.isDestinationAddressVerified ? Layout.green : Layout.red)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
+            .fill(Color(uiColor: viewModel.isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
+    }
 }
 
 // MARK: Store Options
@@ -379,6 +409,12 @@ private extension WooShippingCreateLabelsView {
             static let unverified = NSLocalizedString("wooShipping.createLabels.addressVerification.unverified",
                                                       value: "Unverified address",
                                                       comment: "Label when an address is unverified on the shipping label creation screen")
+            static let destinationVerified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationVerified",
+                                                          value: "Verified destination address",
+                                                          comment: "Notice when a destination address is verified on the shipping label creation screen")
+            static let destinationUnverified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationUnverified",
+                                                            value: "Destination address unverified",
+                                                            comment: "Notice when a destination address is unverified on the shipping label creation screen")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -65,6 +65,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         (destinationAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
     }()
 
+    // TODO: Add support for checking if the destination address is verified.
+    /// Whether the destination address is verified.
+    @Published private(set) var isDestinationAddressVerified: Bool = false
+
     /// Shipping lines for the order, with formatted amount.
     let shippingLines: [WooShipping_ShippingLineViewModel]
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -69,6 +69,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Whether the destination address is verified.
     @Published private(set) var isDestinationAddressVerified: Bool = false
 
+    // TODO: Set to false if the destination address is already verified.
+    // TODO: Set to true for a couple seconds after the destination address is verified.
+    /// Whether the destination address verification notice is displayed.
+    @Published var showAddressVerificationNotice = true
+
     /// Shipping lines for the order, with formatted amount.
     let shippingLines: [WooShipping_ShippingLineViewModel]
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13782
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the UI to indicate if a destination address is verified or not. Note: This does not add the logic to check the address verification status or verify an address, only the UI to display the status.

### Changes

* Adds a label below the destination address when the bottom sheet is expanded, showing if the address is verified.
* Adds a notice to the collapsed bottom sheet, showing if the destination address is verified.
* If a destination address is not verified, tapping the "x" button on the notice dismisses it.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

With WooCommerce Shipping installed, activated, and set up on your store:

1. In `WooShippingCreateLabelsViewModel`, set `isDestinationAddressVerified` to true/false to view the different UI states.
2. Create or open an order with at least one physical product and the processing status.
3. Tap "Create Shipping Label" in order details.
4. Confirm the expected address verification notice appears in the "Shipment details" bottom sheet.
5. If the destination address is unverified, tap the "x" on the notice to dismiss it.
6. Open the "Shipment details" bottom sheet and confirm the expected address verification label appears below the destination address.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Verified|Unverified
-|-
![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 06 13](https://github.com/user-attachments/assets/a427b118-e3f2-4dcb-b406-095780ac3f6a)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 09 24](https://github.com/user-attachments/assets/6b617e87-28d9-4790-84cb-c9f83f97ef3c)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 06 17](https://github.com/user-attachments/assets/b0e933d1-27e2-4d30-9809-32f3736d430c)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 09 34](https://github.com/user-attachments/assets/38629b51-48f6-45ae-b23a-020207c85ce1)


https://github.com/user-attachments/assets/d36ce6b8-d67d-489a-87b1-37669a8e2f59



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.