### PR TITLE
Remove WordPressAuthenticator as a testable from `xcschemes`

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/StoreWidgetsExtension.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/StoreWidgetsExtension.xcscheme
@@ -43,17 +43,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3F0904072D26A40800D8ACCE"
-               BuildableName = "WordPressAuthenticatorTests.xctest"
-               BlueprintName = "WordPressAuthenticatorTests"
-               ReferencedContainer = "container:WooCommerce.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/Woo Watch App.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/Woo Watch App.xcscheme
@@ -42,19 +42,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3F0904072D26A40800D8ACCE"
-               BuildableName = "WordPressAuthenticatorTests.xctest"
-               BlueprintName = "WordPressAuthenticatorTests"
-               ReferencedContainer = "container:WooCommerce.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
@@ -48,17 +48,6 @@
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3F0904072D26A40800D8ACCE"
-               BuildableName = "WordPressAuthenticatorTests.xctest"
-               BlueprintName = "WordPressAuthenticatorTests"
-               ReferencedContainer = "container:WooCommerce.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce IAP.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce IAP.xcscheme
@@ -96,17 +96,6 @@
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3F0904072D26A40800D8ACCE"
-               BuildableName = "WordPressAuthenticatorTests.xctest"
-               BlueprintName = "WordPressAuthenticatorTests"
-               ReferencedContainer = "container:WooCommerce.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceScreenshots.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceScreenshots.xcscheme
@@ -32,17 +32,6 @@
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3F0904072D26A40800D8ACCE"
-               BuildableName = "WordPressAuthenticatorTests.xctest"
-               BlueprintName = "WordPressAuthenticatorTests"
-               ReferencedContainer = "container:WooCommerce.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceScreenshots.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceScreenshots.xcscheme
@@ -22,16 +22,6 @@
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CCDC49C923FFFFF4003166BA"
-               BuildableName = "WooCommerceUITests.xctest"
-               BlueprintName = "WooCommerceUITests"
-               ReferencedContainer = "container:WooCommerce.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -67,6 +57,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+            BuildableName = "WooCommerce.app"
+            BlueprintName = "WooCommerce"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceUITests.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceUITests.xcscheme
@@ -107,17 +107,6 @@
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3F0904072D26A40800D8ACCE"
-               BuildableName = "WordPressAuthenticatorTests.xctest"
-               BlueprintName = "WordPressAuthenticatorTests"
-               ReferencedContainer = "container:WooCommerce.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
## Description

WordPressAuthenticator was added automatically by Xcode to various schemes as a "testable" when the WordPressAuthenticator target was created. What was the logic behind it, I don't know..

Hat tip @AliSoftware for pointing this out [during code review](https://github.com/woocommerce/woocommerce-ios/pull/15000#discussion_r1942556348).

## Steps to reproduce
N.A. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I suppose one could inspect the schemes in Xcode and ensure there are no WordPressAuthenticator entries left.

E.g.:

<img width="933" alt="image" src="https://github.com/user-attachments/assets/dd5a03b3-c966-4c40-9e0e-7bbac35739e0" />

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.