### PR TITLE
[Woo POS] Hide cancellation errors when refreshing

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -162,7 +162,7 @@ private extension PointOfSaleItemsController {
     /// - Parameter appendToExistingItems: Default true – set this to false when refreshing to make the new page the only page.
     /// - Returns: A boolean that indicates whether there is next page for the paginated items.
     @MainActor
-    func fetchItems(pageNumber: Int,appendToExistingItems: Bool = true) async throws -> Bool {
+    func fetchItems(pageNumber: Int, appendToExistingItems: Bool = true) async throws -> Bool {
         do {
             let pagedItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
             let newItems = pagedItems.items

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -2,6 +2,7 @@ import Foundation
 import Observation
 import enum Yosemite.POSItem
 import protocol Yosemite.PointOfSaleItemServiceProtocol
+import enum Yosemite.PointOfSaleItemServiceError
 import struct Yosemite.POSVariableParentProduct
 import class Yosemite.Store
 
@@ -161,27 +162,34 @@ private extension PointOfSaleItemsController {
     /// - Parameter appendToExistingItems: Default true – set this to false when refreshing to make the new page the only page.
     /// - Returns: A boolean that indicates whether there is next page for the paginated items.
     @MainActor
-    func fetchItems(pageNumber: Int, appendToExistingItems: Bool = true) async throws -> Bool {
-        let pagedItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
-        let newItems = pagedItems.items
-        var allItems = appendToExistingItems ? itemsViewState.itemsStack.root.items : []
-        let uniqueNewItems = newItems.filter { newItem in
-            // Note that this uniquing won't currently work, as POSItem has a UUID.
-            !allItems.contains(newItem)
-        }
-        allItems.append(contentsOf: uniqueNewItems)
-        if allItems.isEmpty {
-            itemsViewState.containerState = .empty
-            itemsViewState.itemsStack = ItemsStackState(root: .loaded([], hasMoreItems: false),
-                                                               itemStates: [:])
-        } else {
-            let itemStates = itemsViewState.itemsStack.itemStates
-                .filter { allItems.contains($0.key) }
+    func fetchItems(pageNumber: Int,appendToExistingItems: Bool = true) async throws -> Bool {
+        do {
+            let pagedItems = try await itemProvider.providePointOfSaleItems(pageNumber: pageNumber)
+            let newItems = pagedItems.items
+            var allItems = appendToExistingItems ? itemsViewState.itemsStack.root.items : []
+            let uniqueNewItems = newItems.filter { newItem in
+                // Note that this uniquing won't currently work, as POSItem has a UUID.
+                !allItems.contains(newItem)
+            }
+            allItems.append(contentsOf: uniqueNewItems)
+            if allItems.isEmpty {
+                itemsViewState.containerState = .empty
+                itemsViewState.itemsStack = ItemsStackState(root: .loaded([], hasMoreItems: false),
+                                                            itemStates: [:])
+            } else {
+                let itemStates = itemsViewState.itemsStack.itemStates
+                    .filter { allItems.contains($0.key) }
+                itemsViewState.containerState = .content
+                itemsViewState.itemsStack = ItemsStackState(root: .loaded(allItems, hasMoreItems: pagedItems.hasMorePages),
+                                                            itemStates: itemStates)
+            }
+            return pagedItems.hasMorePages
+        } catch PointOfSaleItemServiceError.requestCancelled {
             itemsViewState.containerState = .content
-            itemsViewState.itemsStack = ItemsStackState(root: .loaded(allItems, hasMoreItems: pagedItems.hasMorePages),
-                                                        itemStates: itemStates)
+            itemsViewState.itemsStack.root = .loaded(itemsViewState.itemsStack.root.items, hasMoreItems: true)
+            // Assume that we have more pages since we'd made a request, and it was cancelled
+            return true
         }
-        return pagedItems.hasMorePages
     }
 
     /// Fetches variation items given a page number and appends new unique items to the existing items array.
@@ -192,20 +200,28 @@ private extension PointOfSaleItemsController {
                                      parentItem: POSItem,
                                      pageNumber: Int,
                                      appendToExistingItems: Bool = true) async throws -> Bool {
-        let pagedItems = try await itemProvider.providePointOfSaleVariationItems(
-            for: parentProduct,
-            pageNumber: pageNumber
-        )
-        let newItems = pagedItems.items
-        var allItems: [POSItem] = appendToExistingItems ? (itemsViewState.itemsStack.itemStates[parentItem]?.items ?? []) : []
-        let uniqueNewItems = newItems.filter { newItem in
-            // Note that this uniquing won't currently work, as POSItem has a UUID.
-            !allItems.contains(newItem)
-        }
-        allItems.append(contentsOf: uniqueNewItems)
+        do {
+            let pagedItems = try await itemProvider.providePointOfSaleVariationItems(
+                for: parentProduct,
+                pageNumber: pageNumber
+            )
+            let newItems = pagedItems.items
+            var allItems: [POSItem] = appendToExistingItems ? (itemsViewState.itemsStack.itemStates[parentItem]?.items ?? []) : []
+            let uniqueNewItems = newItems.filter { newItem in
+                // Note that this uniquing won't currently work, as POSItem has a UUID.
+                !allItems.contains(newItem)
+            }
+            allItems.append(contentsOf: uniqueNewItems)
 
-        updateState(for: parentItem, to: .loaded(allItems, hasMoreItems: pagedItems.hasMorePages))
-        return pagedItems.hasMorePages
+            updateState(for: parentItem, to: .loaded(allItems, hasMoreItems: pagedItems.hasMorePages))
+            return pagedItems.hasMorePages
+        } catch PointOfSaleItemServiceError.requestCancelled {
+            itemsViewState.containerState = .content
+            updateState(for: parentItem, to: .loaded(itemsViewState.itemsStack.itemStates[parentItem]?.items ?? [],
+                                                     hasMoreItems: true))
+            // Assume that we have more pages since we'd made a request, and it was cancelled
+            return true
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -3,6 +3,7 @@ import Foundation
 @testable import WooCommerce
 import struct Yosemite.POSVariableParentProduct
 import enum Yosemite.POSItem
+import enum Yosemite.PointOfSaleItemServiceError
 import Observation
 
 final class PointOfSaleItemsControllerTests {
@@ -238,7 +239,7 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadItems(base: .root)
         await sut.loadItems(base: baseItem)
 
-        itemProvider.shouldThrowError = true
+        itemProvider.errorToThrow = MockError.requestFailed
 
         // When
         await sut.loadNextItems(base: baseItem)
@@ -275,7 +276,7 @@ final class PointOfSaleItemsControllerTests {
         let itemProvider = MockPointOfSaleItemService()
         let sut = PointOfSaleItemsController(itemProvider: itemProvider)
 
-        itemProvider.shouldThrowError = true
+        itemProvider.errorToThrow = MockError.requestFailed
         let expectedError = PointOfSaleErrorState(title: "Error loading products",
                                                   subtitle: "Give it another go?",
                                                   buttonText: "Retry")
@@ -299,7 +300,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.shouldSimulateTwoPages = true
         await sut.loadItems(base: .root)
 
-        itemProvider.shouldThrowError = true
+        itemProvider.errorToThrow = MockError.requestFailed
 
         // When
         await sut.loadNextItems(base: .root)
@@ -316,6 +317,57 @@ final class PointOfSaleItemsControllerTests {
     }
 
     @available(iOS 17.0, *)
+    @Test func loadItems_when_request_is_cancelled_then_state_is_loaded() async throws {
+        // Given
+        let itemProvider = MockPointOfSaleItemService()
+        let sut = PointOfSaleItemsController(itemProvider: itemProvider)
+
+        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
+        try #require(sut.itemsViewState.containerState == .loading)
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.root else {
+            Issue.record("Expected loaded ItemList state, but got \(sut.itemsViewState.itemsStack.root)")
+            return
+        }
+        #expect(items.count == 0)
+        #expect(hasMoreItems)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func loadNextItems_when_request_is_cancelled_then_state_is_loaded() async throws {
+        // Given
+        let itemProvider = MockPointOfSaleItemService()
+        let sut = PointOfSaleItemsController(itemProvider: itemProvider)
+
+        itemProvider.shouldSimulateTwoPages = true
+        await sut.loadItems(base: .root)
+
+        guard case .loaded = sut.itemsViewState.itemsStack.root else {
+            Issue.record("Expected loaded ItemList state, but got \(sut.itemsViewState.itemsStack.root)")
+            return
+        }
+
+        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
+
+        // When
+        await sut.loadNextItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .content)
+
+        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.root else {
+            Issue.record("Expected loaded ItemList state, but got \(sut.itemsViewState.itemsStack.root)")
+            return
+        }
+        #expect(items.count == 2)
+        #expect(hasMoreItems)
+    }
+
+    @available(iOS 17.0, *)
     @Test func loadNextItems_after_itemProvider_throws_error_then_the_same_page_is_requested_next() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -324,7 +376,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.shouldSimulateTwoPages = true
         await sut.loadItems(base: .root)
 
-        itemProvider.shouldThrowError = true
+        itemProvider.errorToThrow = MockError.requestFailed
         await sut.loadNextItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
         itemProvider.spyLastRequestedPageNumber = 0
@@ -504,5 +556,68 @@ final class PointOfSaleItemsControllerTests {
             // When
             await sut.loadItems(base: baseItem)
         }
+    }
+
+    @available(iOS 17.0, *)
+    @Test func loadChildItems_when_request_is_cancelled_then_state_is_loaded() async throws {
+        // Given
+        let itemProvider = MockPointOfSaleItemService()
+        let sut = PointOfSaleItemsController(itemProvider: itemProvider)
+
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+                                                                              name: "Parent product",
+                                                                              productImageSource: nil,
+                                                                              productID: 125))
+        let baseItem = ItemListBaseItem.parent(parentItem)
+
+        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
+        try #require(sut.itemsViewState.containerState == .loading)
+
+        // When
+        await sut.loadItems(base: baseItem)
+
+        // Then
+        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.itemStates[parentItem] else {
+            Issue.record("Expected loaded ItemList state, but got \(String(describing: sut.itemsViewState.itemsStack.itemStates[parentItem]))")
+            return
+        }
+        #expect(items.count == 0)
+        #expect(hasMoreItems)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func loadNextChildItems_when_request_is_cancelled_then_state_is_loaded() async throws {
+        // Given
+        let itemProvider = MockPointOfSaleItemService()
+        let sut = PointOfSaleItemsController(itemProvider: itemProvider)
+
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+                                                                              name: "Parent product",
+                                                                              productImageSource: nil,
+                                                                              productID: 125))
+        let baseItem = ItemListBaseItem.parent(parentItem)
+
+        itemProvider.shouldSimulateTwoPagesOfVariations = true
+        await sut.loadItems(base: baseItem)
+
+        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
+
+        // When
+        await sut.loadNextItems(base: baseItem)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .content)
+
+        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.itemStates[parentItem] else {
+            Issue.record("Expected loaded ItemList state, but got \(String(describing: sut.itemsViewState.itemsStack.itemStates[parentItem]))")
+            return
+        }
+        #expect(items.count == 2)
+        #expect(hasMoreItems)
+    }
+
+
+    enum MockError: Error {
+        case requestFailed
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -10,7 +10,7 @@ import struct Yosemite.POSVariableParentProduct
 final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     /// An array of pages of items, returned when other flags are not set.
     var itemPages: [[POSItem]] = []
-    var shouldThrowError = false
+    var errorToThrow: Error?
     var shouldReturnZeroItems = false
     var shouldSimulateTwoPages = false
     var shouldSimulateMorePages = false
@@ -18,8 +18,8 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     var spyLastRequestedPageNumber: Int?
     func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
         spyLastRequestedPageNumber = pageNumber
-        if shouldThrowError {
-            throw MockError.requestFailed
+        if let errorToThrow {
+            throw errorToThrow
         }
         if shouldReturnZeroItems {
             return .init(items: [], hasMorePages: false)
@@ -35,8 +35,8 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
     var shouldSimulateTwoPagesOfVariations = false
     var shouldSimulateMorePagesOfVariations = false
     func providePointOfSaleVariationItems(for parentProduct: POSVariableParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem> {
-        if shouldThrowError {
-            throw MockError.requestFailed
+        if let errorToThrow {
+            throw errorToThrow
         }
         if shouldSimulateTwoPagesOfVariations,
            pageNumber > 1 {
@@ -126,9 +126,5 @@ extension MockPointOfSaleItemService {
                                       variationID: 4,
                                       parentProductName: "Ice cream")
         return [.variation(variation3), .variation(variation4)]
-    }
-
-    enum MockError: Error {
-        case requestFailed
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -728,6 +728,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func connectCardReader_when_tapped_then_tracks_event() {
             // Given
+            let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
                 itemsController: itemsController,
                 cardPresentPaymentService: cardPresentPaymentService,
@@ -744,6 +745,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func disconnectCardReader_when_tapped_then_tracks_event() {
             // Given
+            let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
                 itemsController: itemsController,
                 cardPresentPaymentService: cardPresentPaymentService,

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -4,11 +4,13 @@ import protocol Networking.ProductVariationsRemoteProtocol
 import class Networking.ProductsRemote
 import class Networking.ProductVariationsRemote
 import class Networking.AlamofireNetwork
+import enum Alamofire.AFError
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 
 public enum PointOfSaleItemServiceError: Error, Equatable {
     case requestFailed
+    case requestCancelled
     case unknown
 }
 
@@ -47,43 +49,51 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> PagedItems<POSItem> {
         let productTypes: [ProductType] = isVariableProductsFeatureEnabled ?
         [.simple, .variable] : [.simple]
-        let pagedProducts = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
-        let products = pagedProducts.items
+        do {
+            let pagedProducts = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
+            let products = pagedProducts.items
 
-        if pageNumber != 1 && products.count == 0 {
-            return .init(items: [], hasMorePages: false)
+            if pageNumber != 1 && products.count == 0 {
+                return .init(items: [], hasMorePages: false)
+            }
+
+            return .init(items: mapProductsToPOSItems(products: products), hasMorePages: pagedProducts.hasMorePages)
+        } catch AFError.explicitlyCancelled {
+            throw PointOfSaleItemServiceError.requestCancelled
         }
-
-        return .init(items: mapProductsToPOSItems(products: products), hasMorePages: pagedProducts.hasMorePages)
     }
 
     public func providePointOfSaleVariationItems(for parentProduct: POSVariableParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem> {
-        let pagedVariations = try await variationRemote
-            .loadVariationsForPointOfSale(for: siteID,
-                                          parentProductID: parentProduct.productID,
-                                          pageNumber: pageNumber)
-        let variations = pagedVariations.items
+        do {
+            let pagedVariations = try await variationRemote
+                .loadVariationsForPointOfSale(for: siteID,
+                                              parentProductID: parentProduct.productID,
+                                              pageNumber: pageNumber)
+            let variations = pagedVariations.items
             // Remove this when WC version 9.7 has significant adoption in POS stores.
-            .filter { !$0.downloadable }
-        return .init(
-            items: variations.compactMap({ variation in
-                let variationName = ProductVariationFormatter().generateNameWithAttributeNames(
-                    for: variation,
-                    from: parentProduct.allAttributes,
-                    separator: ", "
-                )
-                return POSItem
-                    .variation(.init(id: UUID(),
-                                     name: variationName,
-                                     formattedPrice: formatPrice(variation.price),
-                                     price: variation.price,
-                                     productImageSource: variation.image?.src,
-                                     productID: variation.productID,
-                                     variationID: variation.productVariationID,
-                                     parentProductName: parentProduct.name))
-            }),
-            hasMorePages: pagedVariations.hasMorePages
-        )
+                .filter { !$0.downloadable }
+            return .init(
+                items: variations.compactMap({ variation in
+                    let variationName = ProductVariationFormatter().generateNameWithAttributeNames(
+                        for: variation,
+                        from: parentProduct.allAttributes,
+                        separator: ", "
+                    )
+                    return POSItem
+                        .variation(.init(id: UUID(),
+                                         name: variationName,
+                                         formattedPrice: formatPrice(variation.price),
+                                         price: variation.price,
+                                         productImageSource: variation.image?.src,
+                                         productID: variation.productID,
+                                         variationID: variation.productVariationID,
+                                         parentProductName: parentProduct.name))
+                }),
+                hasMorePages: pagedVariations.hasMorePages
+            )
+        } catch AFError.explicitlyCancelled {
+            throw PointOfSaleItemServiceError.requestCancelled
+        }
     }
 
     // Maps result to POSItem, and populate the output with:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #14869 
Merge after: #15060
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR prevents us showing an error when the pull to refresh network task is cancelled.

The cancellation can happen when we do something else to change the state of the item list, in particular, loading a new page.

In this case, the cancellation of the refresh is the right thing to do – we want to _only_ complete the next page, not refresh, show the first page _and_ add a random page to the end of the results.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

It's a bit tricky! Easier if you set your page size small.

1. Launch the app and open POS
2. Pull to refresh and quickly scroll to load a new page
3. Load more new pages
4. Pull to refresh and quickly scroll to load a new page
5. Observe that either:
   a. The first page of results is shown (if PTR succeeded), or
   b. The next page of results is shown with all previous pages above it (if PTR was cancelled)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7820110c-6108-4de9-bfe4-421041515ff3


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.