### PR TITLE
[Woo POS] don't set loading state for pull to refresh

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -11,6 +11,8 @@ protocol PointOfSaleItemsControllerProtocol {
     var itemsViewState: ItemsViewState { get }
     /// Loads the first page of items for a given base item.
     func loadItems(base: ItemListBaseItem) async
+    /// Refreshes the items for a given base item – will result in showing only the first page.
+    func refreshItems(base: ItemListBaseItem) async
     /// Loads the next page of items for a given base item.
     func loadNextItems(base: ItemListBaseItem) async
 }
@@ -31,6 +33,16 @@ protocol PointOfSaleItemsControllerProtocol {
 
     @MainActor
     func loadItems(base: ItemListBaseItem) async {
+        setLoadingState(base: base)
+        await loadFirstPage(base: base)
+    }
+
+    @MainActor func refreshItems(base: ItemListBaseItem) async {
+        await loadFirstPage(base: base)
+    }
+
+    @MainActor
+    private func loadFirstPage(base: ItemListBaseItem) async {
         switch base {
         case .root:
             await loadRootItems()
@@ -41,13 +53,6 @@ protocol PointOfSaleItemsControllerProtocol {
 
     @MainActor
     private func loadRootItems() async {
-        let items = itemsViewState.itemsStack.root.items
-        if items.isEmpty {
-            itemsViewState.containerState = .loading
-        } else {
-            itemsViewState.itemsStack.root = .loading(items)
-        }
-
         do {
             try await paginationTracker.resync { [weak self] pageNumber in
                 guard let self else { return true }
@@ -95,9 +100,6 @@ protocol PointOfSaleItemsControllerProtocol {
 
     @MainActor
     private func loadChildItems(for parent: POSItem) async {
-        let items = itemsViewState.itemsStack.itemStates[parent]?.items ?? []
-        updateState(for: parent, to: .loading(items))
-
         let paginationTracker = paginationTracker(for: parent)
         do {
             try await paginationTracker.resync { [weak self] pageNumber in
@@ -152,6 +154,32 @@ protocol PointOfSaleItemsControllerProtocol {
             childPaginationTrackers[parent] = newChildPaginationTracker
             return newChildPaginationTracker
         }
+    }
+}
+
+@available(iOS 17.0, *)
+private extension PointOfSaleItemsController {
+    func setLoadingState(base: ItemListBaseItem) {
+        switch base {
+        case .root:
+            setRootLoadingState()
+        case .parent(let parent):
+            setChildLoadingState(for: parent)
+        }
+    }
+
+    func setRootLoadingState() {
+        let items = itemsViewState.itemsStack.root.items
+        if items.isEmpty {
+            itemsViewState.containerState = .loading
+        } else {
+            itemsViewState.itemsStack.root = .loading(items)
+        }
+    }
+
+    func setChildLoadingState(for parent: POSItem) {
+        let items = itemsViewState.itemsStack.itemStates[parent]?.items ?? []
+        updateState(for: parent, to: .loading(items))
     }
 }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -37,7 +37,8 @@ protocol PointOfSaleItemsControllerProtocol {
         await loadFirstPage(base: base)
     }
 
-    @MainActor func refreshItems(base: ItemListBaseItem) async {
+    @MainActor
+    func refreshItems(base: ItemListBaseItem) async {
         await loadFirstPage(base: base)
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -94,6 +94,11 @@ extension PointOfSaleAggregateModel {
     }
 
     @MainActor
+    func refreshItems(base: ItemListBaseItem) async {
+        await itemsController.refreshItems(base: base)
+    }
+
+    @MainActor
     func loadNextItems(base: ItemListBaseItem) async {
         await itemsController.loadNextItems(base: base)
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -67,6 +67,10 @@ private extension ChildItemList {
             ItemList(state: state,
                      node: .parent(parentItem))
                 .transition(.opacity)
+                .refreshable {
+                    ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)
+                    await posModel.refreshItems(base: .parent(parentItem))
+                }
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -138,6 +138,10 @@ private extension ItemListView {
                 bannerCardView
             }
         }
+        .refreshable {
+            ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
+            await posModel.refreshItems(base: .root)
+        }
     }
 
     @ViewBuilder
@@ -145,10 +149,6 @@ private extension ItemListView {
         switch parentItem {
         case let .variableParentProduct(parentProduct):
             ChildItemList(parentItem: parentItem, title: parentProduct.name)
-                .refreshable {
-                    ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)
-                    await posModel.refreshItems(base: .parent(parentItem))
-                }
         default:
             EmptyView()
         }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -147,7 +147,7 @@ private extension ItemListView {
             ChildItemList(parentItem: parentItem, title: parentProduct.name)
                 .refreshable {
                     ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)
-                    await posModel.loadItems(base: .parent(parentItem))
+                    await posModel.refreshItems(base: .parent(parentItem))
                 }
         default:
             EmptyView()

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -90,7 +90,7 @@ struct PointOfSaleDashboardView: View {
                     ItemListView()
                         .refreshable {
                             ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
-                            await posModel.loadItems(base: .root)
+                            await posModel.refreshItems(base: .root)
                         }
                         .accessibilitySortPriority(2)
                         .transition(.move(edge: .leading))

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -88,10 +88,6 @@ struct PointOfSaleDashboardView: View {
             HStack {
                 if posModel.orderStage == .building {
                     ItemListView()
-                        .refreshable {
-                            ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
-                            await posModel.refreshItems(base: .root)
-                        }
                         .accessibilitySortPriority(2)
                         .transition(.move(edge: .leading))
                 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -75,6 +75,10 @@ final class PointOfSalePreviewItemsController: PointOfSaleItemsControllerProtoco
         }
     }
 
+    func refreshItems(base: ItemListBaseItem) async {
+        await loadItems(base: base)
+    }
+
     func loadNextItems(base: ItemListBaseItem) async {
         itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loading(mockItems),
                                                                                               itemStates: [:]))

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
@@ -11,5 +11,7 @@ final class MockPointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
 
     func loadItems(base: ItemListBaseItem) async { }
 
+    func refreshItems(base: WooCommerce.ItemListBaseItem) async { }
+
     func loadNextItems(base: ItemListBaseItem) async { }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14869 
Merge after: #15077
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR stops us adding a ghost/skeleton cell to the bottom of the item list when we pull to refresh.

When we pull to refresh, the built in controller shows a loading indicator. Previously, we set our state to `loading`, so we also showed a ghost cell at the bottom of the list. 

On a pull to refresh, it’s unlikely that the list is going to get longer – more likely, the full first page of results will be shown, so it’ll be the same length or shorter.

Previously we had to put our refreshable modifiers higher in the heirarchy than the views they were refreshing, because we changed the state to `loading` when we pulled to refresh. This change of state cancelled the pull to refresh network task. Now we can group the refreshable control more closely with the list view it relates to.


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This is easiest to test with a small page size, since you can see whether there's a ghost cell on PTR without scrolling down, then triggering the load next page and (correctly) showing a ghost cell for that. However, if the items don't fill the screen the next page load won't trigger. You can use the dynamic type to get around that.

1. Launch the app and open POS
2. Pull to refresh
3. Observe that the ghost cell is not shown
4. Load more pages
5. Pull to refresh
6. Observe that the refresh worked as expected.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/4ab2be97-2a94-406b-94c2-f999dc8a5d4a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.