### PR TITLE
[Shipping labels] Extract bottom sheet content into sub-views

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -74,44 +74,10 @@ struct WooShippingCreateLabelsView: View {
                     isShipmentDetailsExpanded = isExpanded
                 }) {
                     VStack {
-                        if !isShipmentDetailsExpanded {
-                            VStack {
-                                Text(Localization.BottomSheet.shipmentDetails)
-                                    .foregroundStyle(Color(.primary))
-                                    .bold()
-                                if viewModel.showAddressVerificationNotice {
-                                    addressVerificationNotice
-                                        .onTapGesture {
-                                            // TODO: Start address editing/verification flow if needed (if destination address is unverified).
-                                        }
-                                }
-                            }
-                        }
-                        if !viewModel.canViewLabel {
-                            if isiPhonePortrait {
-                                VStack(spacing: Layout.bottomSheetSpacing) {
-                                    if isShipmentDetailsExpanded {
-                                        Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
-                                            .font(.subheadline)
-                                            .tint(Color(.primary))
-                                    }
-                                    if isShipmentDetailsExpanded || viewModel.selectedPackage != nil {
-                                        purchaseButton
-                                    }
-                                }
-                            }
-                            else {
-                                HStack(spacing: Layout.bottomSheetSpacing) {
-                                    if viewModel.selectedPackage != nil || isShipmentDetailsExpanded {
-                                        Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
-                                            .font(.subheadline)
-                                            .tint(Color(.primary))
-                                            .fixedSize(horizontal: false, vertical: true)
-                                        purchaseButton
-                                    }
-                                }
-                            }
-                        }
+                        collapsedBottomSheet
+                            .renderedIf(!isShipmentDetailsExpanded)
+                        bottomSheetPurchaseActions
+                            .renderedIf(!viewModel.canViewLabel)
                     }
                     .padding(.horizontal, Layout.bottomSheetPadding)
                 } expandableContent: {
@@ -121,41 +87,9 @@ struct WooShippingCreateLabelsView: View {
                                 .footnoteStyle()
                         }
                         CollapsibleHStack(horizontalAlignment: .leading, verticalAlignment: .top, spacing: .zero) {
-                            HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
-                                Text(Localization.BottomSheet.shipFrom)
-                                    .trackSize(size: $shipmentDetailsShipFromSize)
-                                Button {
-                                    isOriginAddressListPresented = true
-                                } label: {
-                                    HStack {
-                                        Text(viewModel.originAddress)
-                                            .lineLimit(1)
-                                            .truncationMode(.tail)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                        Image(systemName: "ellipsis")
-                                            .frame(width: Layout.ellipsisWidth)
-                                            .bold()
-                                    }
-                                }
-                                .buttonStyle(TextButtonStyle())
-                            }
-                            .padding(Layout.bottomSheetPadding)
+                            shipFromAddress
                             Divider()
-                            HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
-                                Text(Localization.BottomSheet.shipTo)
-                                    .frame(width: shipmentDetailsShipFromSize.width, alignment: .leading)
-                                VStack(alignment: .leading) {
-                                    ForEach(viewModel.destinationAddressLines, id: \.self) { addressLine in
-                                        Text(addressLine)
-                                            .if(addressLine == viewModel.destinationAddressLines.first) { line in
-                                                line.bold()
-                                            }
-                                    }
-                                    addressVerificationLabel
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-                            .padding(Layout.bottomSheetPadding)
+                            shipToAddress
                         }
                         .font(.subheadline)
                         .roundedBorder(cornerRadius: Layout.cornerRadius, lineColor: Color(.separator), lineWidth: 0.5)
@@ -203,6 +137,92 @@ struct WooShippingCreateLabelsView: View {
 }
 
 private extension WooShippingCreateLabelsView {
+    /// View for elements only displayed on the collapsed bottom sheet.
+    var collapsedBottomSheet: some View {
+        VStack {
+            Text(Localization.BottomSheet.shipmentDetails)
+                .foregroundStyle(Color(.primary))
+                .bold()
+            if viewModel.showAddressVerificationNotice {
+                addressVerificationNotice
+                    .onTapGesture {
+                        // TODO: Start address editing/verification flow if needed (if destination address is unverified).
+                    }
+            }
+        }
+    }
+
+    /// View for the purchase-related actions, such as "Mark as completed" toggle and purchase button.
+    var bottomSheetPurchaseActions: some View {
+        Group {
+            if isiPhonePortrait {
+                VStack(spacing: Layout.bottomSheetSpacing) {
+                    if isShipmentDetailsExpanded {
+                        Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
+                            .font(.subheadline)
+                            .tint(Color(.primary))
+                    }
+                    if isShipmentDetailsExpanded || viewModel.selectedPackage != nil {
+                        purchaseButton
+                    }
+                }
+            }
+            else {
+                HStack(spacing: Layout.bottomSheetSpacing) {
+                    if viewModel.selectedPackage != nil || isShipmentDetailsExpanded {
+                        Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
+                            .font(.subheadline)
+                            .tint(Color(.primary))
+                            .fixedSize(horizontal: false, vertical: true)
+                        purchaseButton
+                    }
+                }
+            }
+        }
+    }
+
+    /// View showing the origin ("Ship From") address.
+    var shipFromAddress: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
+            Text(Localization.BottomSheet.shipFrom)
+                .trackSize(size: $shipmentDetailsShipFromSize)
+            Button {
+                isOriginAddressListPresented = true
+            } label: {
+                HStack {
+                    Text(viewModel.originAddress)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Image(systemName: "ellipsis")
+                        .frame(width: Layout.ellipsisWidth)
+                        .bold()
+                }
+            }
+            .buttonStyle(TextButtonStyle())
+        }
+        .padding(Layout.bottomSheetPadding)
+    }
+
+    /// View showing the destination ("Ship To") address.
+    var shipToAddress: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
+            Text(Localization.BottomSheet.shipTo)
+                .frame(width: shipmentDetailsShipFromSize.width, alignment: .leading)
+            VStack(alignment: .leading) {
+                ForEach(viewModel.destinationAddressLines, id: \.self) { addressLine in
+                    Text(addressLine)
+                        .if(addressLine == viewModel.destinationAddressLines.first) { line in
+                            line.bold()
+                        }
+                }
+                addressVerificationLabel
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(Layout.bottomSheetPadding)
+    }
+
     /// View showing the order details, such as order items and shipping costs.
     var orderDetails: some View {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13783
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This refactors the bottom sheet view in the Woo Shipping label flow, to extract its contents into the following subviews:

* The "ship from" (origin) address
* The "ship to" (destination) address
* The bottom sheet UI that is always visible when the sheet is collapsed ("Shipment details" label, address verification notice)
* The bottom sheet UI related to purchase actions (the purchase button, "mark order complete" toggle, etc.)

This helps with readability and also compiling the SwiftUI view.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This is a refactor; there should be no changes to the UI:

With WooCommerce Shipping installed, activated, and set up on your store:

1. Create or open an order with at least one physical product and the processing status.
2. Tap "Create Shipping Label" in order details.
3. Confirm the expected details show in the collapsed bottom sheet.
4. Open the "Shipment details" bottom sheet and confirm the expected details show in the expanded bottom sheet.
5. Select a package and confirm the expected details show in the collapsed bottom sheet (e.g. purchase button).
6. Open the "Shipment details" bottom sheet and confirm the expected details show in the bottom sheet.

Repeat steps 3-6 with the device in landscape orientation.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 59 35](https://github.com/user-attachments/assets/4c314802-e0d5-424b-8a54-b6fa937f051a)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 52 01](https://github.com/user-attachments/assets/9820afd4-f66e-4a50-ac84-caf9192aa50e)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 59 37](https://github.com/user-attachments/assets/01ef2dc9-4ed1-4dd8-b986-8f6ffb08287a)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 52 03](https://github.com/user-attachments/assets/19481739-3628-4640-ae4f-7e98bb45bff0)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 59 48](https://github.com/user-attachments/assets/7f14bcdc-11cd-40cf-8378-de3731f7230a)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 52 15](https://github.com/user-attachments/assets/e8494fad-3159-4714-986f-beb25bf0d49f)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 59 50](https://github.com/user-attachments/assets/f6a766f9-e1f6-4474-978f-09c7457bd7c4)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 52 19](https://github.com/user-attachments/assets/5a23ed27-0048-4120-a316-010666f32ca8)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 59 53](https://github.com/user-attachments/assets/0c6c6fb8-7bc9-4667-bbba-e4f03aa9be8f)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 52 23](https://github.com/user-attachments/assets/5b3e171c-4e77-4a90-ae25-94a13cccfc09)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 59 55](https://github.com/user-attachments/assets/1b1de527-a14f-4070-b8d4-6dd6b6365e04)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 11 52 26](https://github.com/user-attachments/assets/15529abc-0332-4ea2-92b8-26c933e97b8b)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.