### PR TITLE
[Shipping labels] Add "missing address" label and notice for destination address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -148,12 +148,10 @@ private extension WooShippingCreateLabelsView {
             Text(Localization.BottomSheet.shipmentDetails)
                 .foregroundStyle(Color(.primary))
                 .bold()
-            if viewModel.showAddressVerificationNotice {
-                addressVerificationNotice
-                    .onTapGesture {
-                        // TODO: Start address editing/verification flow if needed (if destination address is unverified).
-                    }
-            }
+            addressVerificationNotice(with: viewModel.destinationAddressStatusNoticeLabel)
+                .onTapGesture {
+                    // TODO: Start address editing/verification flow if needed (if destination address is unverified).
+                }
         }
     }
 
@@ -314,26 +312,29 @@ private extension WooShippingCreateLabelsView {
     }
 
     /// View showing a notice about the destination address verification status.
-    var addressVerificationNotice: some View {
-        HStack(spacing: 8) {
-            Image(systemName: isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
-            Text(Localization.AddressVerification.noticeLabel(for: viewModel.destinationAddressStatus))
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Button {
-                withAnimation {
-                    viewModel.showAddressVerificationNotice = false
+    @ViewBuilder
+    func addressVerificationNotice(with label: String?) -> some View {
+        if let label = viewModel.destinationAddressStatusNoticeLabel {
+            HStack(spacing: 8) {
+                Image(systemName: isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
+                Text(label)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Button {
+                    withAnimation {
+                        viewModel.destinationAddressStatusNoticeLabel = nil
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .renderedIf(!isDestinationAddressVerified)
                 }
-            } label: {
-                Image(systemName: "xmark")
-                    .renderedIf(!isDestinationAddressVerified)
             }
+            .font(.subheadline)
+            .foregroundStyle(isDestinationAddressVerified ? Layout.green : Layout.red)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(Color(uiColor: isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
         }
-        .font(.subheadline)
-        .foregroundStyle(isDestinationAddressVerified ? Layout.green : Layout.red)
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
-            .fill(Color(uiColor: isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
     }
 }
 
@@ -449,25 +450,6 @@ private extension WooShippingCreateLabelsView {
             static let missing = NSLocalizedString("wooShipping.createLabels.addressVerification.missing",
                                                    value: "Missing address",
                                                    comment: "Label when an address is missing on the shipping label creation screen")
-            static func noticeLabel(for status: WooShippingCreateLabelsViewModel.DestinationAddressStatus) -> String {
-                switch status {
-                case .verified:
-                    return destinationVerified
-                case .unverified:
-                    return destinationUnverified
-                case .missing:
-                    return destinationMissing
-                }
-            }
-            static let destinationVerified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationVerified",
-                                                          value: "Verified destination address",
-                                                          comment: "Notice when a destination address is verified on the shipping label creation screen")
-            static let destinationUnverified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationUnverified",
-                                                            value: "Destination address unverified",
-                                                            comment: "Notice when a destination address is unverified on the shipping label creation screen")
-            static let destinationMissing = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationMissing",
-                                                            value: "Destination address missing",
-                                                            comment: "Notice when a destination address is missing on the shipping label creation screen")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -37,6 +37,11 @@ struct WooShippingCreateLabelsView: View {
     /// Whether the origin address list sheet is presented.
     @State private var isOriginAddressListPresented = false
 
+    /// Whether the destination address is verified.
+    private var isDestinationAddressVerified: Bool {
+        viewModel.destinationAddressStatus == .verified
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -298,23 +303,21 @@ private extension WooShippingCreateLabelsView {
         .disabled(!viewModel.isPurchaseButtonEnabled)
     }
 
-    /// View showing the address verification status.
+    /// View showing the address verification status for a destination address.
     var addressVerificationLabel: some View {
         HStack(spacing: 4) {
-            Image(systemName: viewModel.isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
-            Text(viewModel.isDestinationAddressVerified
-                 ? Localization.AddressVerification.verified : Localization.AddressVerification.unverified)
+            Image(systemName: isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
+            Text(Localization.AddressVerification.label(for: viewModel.destinationAddressStatus))
         }
         .font(.subheadline)
-        .foregroundStyle(viewModel.isDestinationAddressVerified ? Layout.green : Layout.red)
+        .foregroundStyle(isDestinationAddressVerified ? Layout.green : Layout.red)
     }
 
-    /// View showing a notice about the address verification status.
+    /// View showing a notice about the destination address verification status.
     var addressVerificationNotice: some View {
         HStack(spacing: 8) {
-            Image(systemName: viewModel.isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
-            Text(viewModel.isDestinationAddressVerified
-                 ? Localization.AddressVerification.destinationVerified : Localization.AddressVerification.destinationUnverified)
+            Image(systemName: isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
+            Text(Localization.AddressVerification.noticeLabel(for: viewModel.destinationAddressStatus))
                 .frame(maxWidth: .infinity, alignment: .leading)
             Button {
                 withAnimation {
@@ -322,15 +325,15 @@ private extension WooShippingCreateLabelsView {
                 }
             } label: {
                 Image(systemName: "xmark")
-                    .renderedIf(!viewModel.isDestinationAddressVerified)
+                    .renderedIf(!isDestinationAddressVerified)
             }
         }
         .font(.subheadline)
-        .foregroundStyle(viewModel.isDestinationAddressVerified ? Layout.green : Layout.red)
+        .foregroundStyle(isDestinationAddressVerified ? Layout.green : Layout.red)
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
-            .fill(Color(uiColor: viewModel.isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
+            .fill(Color(uiColor: isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
     }
 }
 
@@ -427,18 +430,44 @@ private extension WooShippingCreateLabelsView {
         }
 
         enum AddressVerification {
+            static func label(for status: WooShippingCreateLabelsViewModel.DestinationAddressStatus) -> String {
+                switch status {
+                case .verified:
+                    return verified
+                case .unverified:
+                    return unverified
+                case .missing:
+                    return missing
+                }
+            }
             static let verified = NSLocalizedString("wooShipping.createLabels.addressVerification.verified",
                                                     value: "Address verified",
                                                     comment: "Label when an address is verified on the shipping label creation screen")
             static let unverified = NSLocalizedString("wooShipping.createLabels.addressVerification.unverified",
                                                       value: "Unverified address",
                                                       comment: "Label when an address is unverified on the shipping label creation screen")
+            static let missing = NSLocalizedString("wooShipping.createLabels.addressVerification.missing",
+                                                   value: "Missing address",
+                                                   comment: "Label when an address is missing on the shipping label creation screen")
+            static func noticeLabel(for status: WooShippingCreateLabelsViewModel.DestinationAddressStatus) -> String {
+                switch status {
+                case .verified:
+                    return destinationVerified
+                case .unverified:
+                    return destinationUnverified
+                case .missing:
+                    return destinationMissing
+                }
+            }
             static let destinationVerified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationVerified",
                                                           value: "Verified destination address",
                                                           comment: "Notice when a destination address is verified on the shipping label creation screen")
             static let destinationUnverified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationUnverified",
                                                             value: "Destination address unverified",
                                                             comment: "Notice when a destination address is unverified on the shipping label creation screen")
+            static let destinationMissing = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationMissing",
+                                                            value: "Destination address missing",
+                                                            comment: "Notice when a destination address is missing on the shipping label creation screen")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -210,11 +210,13 @@ private extension WooShippingCreateLabelsView {
             Text(Localization.BottomSheet.shipTo)
                 .frame(width: shipmentDetailsShipFromSize.width, alignment: .leading)
             VStack(alignment: .leading) {
-                ForEach(viewModel.destinationAddressLines, id: \.self) { addressLine in
-                    Text(addressLine)
-                        .if(addressLine == viewModel.destinationAddressLines.first) { line in
-                            line.bold()
-                        }
+                if let addressLines = viewModel.destinationAddressLines {
+                    ForEach(addressLines, id: \.self) { addressLine in
+                        Text(addressLine)
+                            .if(addressLine == addressLines.first) { line in
+                                line.bold()
+                            }
+                    }
                 }
                 addressVerificationLabel
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -76,10 +76,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// The current destination address status.
     @Published private(set) var destinationAddressStatus: DestinationAddressStatus = .unverified
 
-    // TODO: Set to false if the destination address is already verified.
-    // TODO: Set to true for a couple seconds after the destination address is verified.
-    /// Whether the destination address verification notice is displayed.
-    @Published var showAddressVerificationNotice = true
+    /// This property can be set to display a notice with the provided label about the destination address status.
+    @Published var destinationAddressStatusNoticeLabel: String?
 
     /// Shipping lines for the order, with formatted amount.
     let shippingLines: [WooShipping_ShippingLineViewModel]
@@ -191,6 +189,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         destinationAddressStatus = destinationAddressLines == nil ? .missing : .unverified
 
         observeSelectedOriginAddress()
+        observeDestinationAddressStatus()
         observeSelectedPackage()
         observeForLabelRates()
         loadStoreOptions()
@@ -341,6 +340,30 @@ private extension WooShippingCreateLabelsViewModel {
             .store(in: &subscriptions)
     }
 
+    /// Observes the destination address status and updates the notice label.
+    func observeDestinationAddressStatus() {
+        /// Set the notice when the destination address status changes.
+        $destinationAddressStatus
+            .map { status in
+                switch status {
+                case .verified:
+                    return Localization.DestinationAddressStatus.verified
+                case .unverified:
+                    return Localization.DestinationAddressStatus.unverified
+                case .missing:
+                    return Localization.DestinationAddressStatus.missing
+                }
+            }
+            .assign(to: &$destinationAddressStatusNoticeLabel)
+
+        /// Clear the notice after a delay when the address is verified.
+        $destinationAddressStatusNoticeLabel
+            .filter { $0 == Localization.DestinationAddressStatus.verified }
+            .delay(for: .seconds(2), scheduler: RunLoop.current)
+            .map { _ in nil }
+            .assign(to: &$destinationAddressStatusNoticeLabel)
+    }
+
     /// Observes the selected package and shipment weight and requests the available shipping rates.
     func observeForLabelRates() {
         $shipmentWeight
@@ -461,6 +484,18 @@ private extension WooShippingCreateLabelsViewModel {
                                                               value: "Adult Signature Required",
                                                               comment: "Label for row showing the additional cost to require an adult signature " +
                                                               "on the shipping label creation screen")
+
+        enum DestinationAddressStatus {
+            static let verified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationVerified",
+                                                               value: "Verified destination address",
+                                                               comment: "Notice when a destination address is verified on the shipping label creation screen")
+            static let unverified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationUnverified",
+                                                                 value: "Destination address unverified",
+                                                                 comment: "Notice when a destination address is unverified on the shipping label creation screen")
+            static let missing = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationMissing",
+                                                              value: "Destination address missing",
+                                                              comment: "Notice when a destination address is missing on the shipping label creation screen")
+        }
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -65,9 +65,16 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         (destinationAddress?.formattedPostalAddress)?.components(separatedBy: .newlines)
     }()
 
-    // TODO: Add support for checking if the destination address is verified.
-    /// Whether the destination address is verified.
-    @Published private(set) var isDestinationAddressVerified: Bool = false
+    /// Possible statuses for a Woo Shipping destination address.
+    enum DestinationAddressStatus {
+        case verified
+        case unverified
+        case missing
+    }
+
+    // TODO: Add support for updating the destination address status when it is edited or verified remotely.
+    /// The current destination address status.
+    @Published private(set) var destinationAddressStatus: DestinationAddressStatus = .unverified
 
     // TODO: Set to false if the destination address is already verified.
     // TODO: Set to true for a couple seconds after the destination address is verified.
@@ -180,6 +187,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.stores = stores
         self.debounceDuration = debounceDuration
 
+        // TODO: Check remotely to see if the destination address is verified.
+        destinationAddressStatus = destinationAddressLines == nil ? .missing : .unverified
+
         observeSelectedOriginAddress()
         observeSelectedPackage()
         observeForLabelRates()
@@ -202,6 +212,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.originAddress = shippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
         self.destinationAddress = shippingLabel.destinationAddress
+        self.destinationAddressStatus = .verified
         self.onLabelPurchase = nil
         self.stores = stores
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -61,8 +61,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     @Published private(set) var originAddress: String = ""
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
-    private(set) lazy var destinationAddressLines: [String] = {
-        (destinationAddress?.formattedPostalAddress ?? "").components(separatedBy: .newlines)
+    private(set) lazy var destinationAddressLines: [String]? = {
+        (destinationAddress?.formattedPostalAddress)?.components(separatedBy: .newlines)
     }()
 
     // TODO: Add support for checking if the destination address is verified.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -473,6 +473,32 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.customsInformationIsCompleted)
     }
+
+    func test_destinationAddressStatus_unverified_and_noticeLabel_set_for_unverified_address() {
+        // Given
+        let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
+        let order = Order.fake().copy(shippingAddress: address)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order)
+
+        // Then
+        XCTAssertEqual(viewModel.destinationAddressStatus, .unverified)
+        XCTAssertNotNil(viewModel.destinationAddressStatusNoticeLabel)
+    }
+
+    func test_destinationAddressStatus_missing_and_noticeLabel_set_for_empty_address() {
+        // Given
+        let destinationAddress = Address.fake()
+        let order = Order.fake().copy(shippingAddress: destinationAddress)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order)
+
+        // Then
+        XCTAssertEqual(viewModel.destinationAddressStatus, .missing)
+        XCTAssertNotNil(viewModel.destinationAddressStatusNoticeLabel)
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13783
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the destination address label and notice to handle when the destination address is missing.

It also observes the notice to remove it after a delay when the destination address is verified (per the designs), although this isn't used yet.

### Changes

* In the view model:
   * We now have 3 cases for the destination address status (verified, unverified, and missing).
   * For a new shipping label, we set it to `unverified` unless there are no address details to display, in which case it is set to `missing`. (A future task will check the remote status and set it to `verified` if it has been remotely verified.)
   * For an existing shipping label, we set it to `verified`.
   * We observe the status and set the corresponding notice label, which is used in the view to display the notice.
   * We also observe the notice label and unset it after a delay if it is the verified address label; this supports the auto-dismiss behavior in the designs.
* In the view:
   *  We use the view model's notice label to display the notice, if the label is set.
   * We only show the destination address in the "Ship to" section if there are address lines to display.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: WooCommerce Shipping is installed, activated, and set up on your store.

With a destination address:

1. Create or open an order with at least one physical product and the processing status, and a shipping address.
2. Tap "Create Shipping Label" in order details.
3. Confirm the "unverified address" notice appears in the collapsed bottom sheet.
4. Open the bottom sheet and confirm the "unverified address" label appears below the destination address.

Without a destination address:

1. Create or open an order with at least one physical product and the processing status, and **no** shipping address.
2. Tap "Create Shipping Label" in order details.
3. Confirm the "missing address" notice appears in the collapsed bottom sheet.
4. Open the bottom sheet and confirm the "missing address" label appears in place of the destination address.

A purchased shipping label

1. Open an order with a purchased shipping label.
2. Tap "Create Shipping Label" in order details.
3. Confirm no notice appears in the collapsed bottom sheet.
4. Open the bottom sheet and confirm the "verified address" label appears below the destination address.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Missing|Unverified|Existing label (verified)
-|-|-
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 12 19 23](https://github.com/user-attachments/assets/910fe3f0-9e3d-46fe-acb4-4a010eb40dff)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 12 19 35](https://github.com/user-attachments/assets/c86fd19f-25d2-4e20-a4fb-a7823d1c34c4)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 12 20 13](https://github.com/user-attachments/assets/6851d788-fbcd-4499-9482-56307bb8288c)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 12 19 26](https://github.com/user-attachments/assets/746377cc-46aa-4216-88d9-70e33275db03)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 12 19 37](https://github.com/user-attachments/assets/4207d8b3-6f20-477f-b160-3b2af543d5e9)|![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 12 20 15](https://github.com/user-attachments/assets/3d3f8743-bae0-42d1-9fe6-b7ed69eca957)

Although we don't have the logic for it yet, I simulated how the verified address notice will auto-dismiss after it is shown:


https://github.com/user-attachments/assets/94f25e41-2716-4326-a258-dc93b334c43d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.