### PR TITLE
WaitingTimeTracker improvements

### DIFF
--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -5,7 +5,7 @@ import protocol WooFoundation.Analytics
 /// Tracks the waiting time for app startup, allowing to evaluate as analytics
 /// how much time in seconds it took between the init and the final `end(action:)` function call.
 ///
-class AppStartupWaitingTimeTracker: WaitingTimeTracker {
+final class AppStartupWaitingTimeTracker: WaitingTimeTracker {
 
     /// All actions tracked in the app startup waiting time.
     ///
@@ -21,8 +21,8 @@ class AppStartupWaitingTimeTracker: WaitingTimeTracker {
     private(set) var startupActionsPending = StartupAction.allCases
 
     init(analyticsService: Analytics = ServiceLocator.analytics,
-         currentTimeInMillis: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }) {
-        super.init(trackScenario: .appStartup, analyticsService: analyticsService, currentTime: currentTimeInMillis)
+         currentTimestampSeconds: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }) {
+        super.init(trackScenario: .appStartup, analyticsService: analyticsService, currentTimestampSeconds: currentTimestampSeconds)
     }
 
     /// Ends the waiting time for the provided startup action.

--- a/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
@@ -11,6 +11,11 @@ class WaitingTimeTracker {
     private let analyticsService: Analytics
     private let waitingStartedTimestamp: TimeInterval
 
+    enum TrackingUnit {
+        case seconds
+        case milliseconds
+    }
+
     init(trackScenario: WooAnalyticsEvent.WaitingTime.Scenario,
          analyticsService: Analytics = ServiceLocator.analytics,
          currentTimestampSeconds: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }
@@ -21,21 +26,27 @@ class WaitingTimeTracker {
         waitingStartedTimestamp = currentTimestampSeconds()
     }
 
-    /// End the waiting time by evaluating the elapsed time from the init,
-    /// and sending it as an analytics event, in seconds.
+    /// Default `end()` method to preserve interface compatibility. By default, tracks in `.seconds`
     ///
     func end() {
-        let elapsedTime = currentTimestampSeconds() - waitingStartedTimestamp
+        end(using: .seconds)
+    }
+
+    /// End the waiting time by evaluating the elapsed time from the init,
+    /// and sending it as an analytics event.
+    ///
+    /// - Parameter trackingUnit: Defines whether the elapsed time should be tracked in `.seconds` or `.milliseconds` (default is `.seconds`).
+    ///
+    func end(using trackingUnit: TrackingUnit = .seconds) {
+        let elapsedTime = calculateElapsedTime(in: trackingUnit)
         let analyticsEvent = WooAnalyticsEvent.WaitingTime.waitingFinished(scenario: trackScenario, elapsedTime: elapsedTime)
         analyticsService.track(event: analyticsEvent)
     }
 
-    /// End the waiting time by evaluating the elapsed time from the init,
-    /// and sending it as an analytics event, in milliseconds
+    /// Calculates elapsed time in the specified tracking unit.
     ///
-    func endInMilliseconds() {
-        let elapsedTimeMs = (currentTimestampSeconds() - waitingStartedTimestamp) * 1000
-        let analyticsEvent = WooAnalyticsEvent.WaitingTime.waitingFinished(scenario: trackScenario, elapsedTime: elapsedTimeMs)
-        analyticsService.track(event: analyticsEvent)
+    private func calculateElapsedTime(in trackingUnit: TrackingUnit) -> TimeInterval {
+        let elapsedTime = currentTimestampSeconds() - waitingStartedTimestamp
+        return trackingUnit == .milliseconds ? elapsedTime * 1000 : elapsedTime
     }
 }

--- a/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/WaitingTimeTracker.swift
@@ -7,25 +7,25 @@ import protocol WooFoundation.Analytics
 ///
 class WaitingTimeTracker {
     private let trackScenario: WooAnalyticsEvent.WaitingTime.Scenario
-    private let currentTime: () -> TimeInterval
+    private let currentTimestampSeconds: () -> TimeInterval
     private let analyticsService: Analytics
     private let waitingStartedTimestamp: TimeInterval
 
     init(trackScenario: WooAnalyticsEvent.WaitingTime.Scenario,
          analyticsService: Analytics = ServiceLocator.analytics,
-         currentTime: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }
+         currentTimestampSeconds: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }
     ) {
         self.trackScenario = trackScenario
         self.analyticsService = analyticsService
-        self.currentTime = currentTime
-        waitingStartedTimestamp = currentTime()
+        self.currentTimestampSeconds = currentTimestampSeconds
+        waitingStartedTimestamp = currentTimestampSeconds()
     }
 
     /// End the waiting time by evaluating the elapsed time from the init,
     /// and sending it as an analytics event, in seconds.
     ///
     func end() {
-        let elapsedTime = currentTime() - waitingStartedTimestamp
+        let elapsedTime = currentTimestampSeconds() - waitingStartedTimestamp
         let analyticsEvent = WooAnalyticsEvent.WaitingTime.waitingFinished(scenario: trackScenario, elapsedTime: elapsedTime)
         analyticsService.track(event: analyticsEvent)
     }
@@ -34,7 +34,7 @@ class WaitingTimeTracker {
     /// and sending it as an analytics event, in milliseconds
     ///
     func endInMilliseconds() {
-        let elapsedTimeMs = (currentTime() - waitingStartedTimestamp) * 1000
+        let elapsedTimeMs = (currentTimestampSeconds() - waitingStartedTimestamp) * 1000
         let analyticsEvent = WooAnalyticsEvent.WaitingTime.waitingFinished(scenario: trackScenario, elapsedTime: elapsedTimeMs)
         analyticsService.track(event: analyticsEvent)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
@@ -31,7 +31,7 @@ private extension PointOfSaleLoadingView {
 
     func trackElapsedTimeOnDisappear() {
         if let waitingTimeTracker = waitingTimeTracker {
-            waitingTimeTracker.endInMilliseconds()
+            waitingTimeTracker.end(using: .milliseconds)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
@@ -91,6 +91,36 @@ class WaitingTimeTrackerTests: XCTestCase {
         XCTAssertEqual(testAnalytics.lastReceivedEventName, WooAnalyticsStat.applicationOpenedWaitingTimeLoaded.rawValue)
     }
 
+    func test_timeElapsed_evaluation_in_milliseconds_is_correct() {
+        // Given
+        var currentTimeCallCounter = 0.0
+        let expectedReceivedWaitingTime = 10_000.0 // 10s * 1000 ms
+        let waitingTracker = WaitingTimeTracker(trackScenario: .orderDetails,
+                                                analyticsService: testAnalytics) {
+            currentTimeCallCounter += 1
+            return currentTimeCallCounter * 10
+        }
+
+        // When
+        waitingTracker.end(using: .milliseconds)
+
+        // Then
+        XCTAssertEqual(testAnalytics.lastReceivedWaitingTime, expectedReceivedWaitingTime)
+    }
+
+    func test_track_scenario_triggers_expected_analytics_stat_in_milliseconds() {
+        // Given
+        let waitingTracker = WaitingTimeTracker(trackScenario: .pointOfSaleLoaded,
+                                                analyticsService: testAnalytics,
+                                                currentTimestampSeconds: { 0 })
+
+        // When
+        waitingTracker.end(using: .milliseconds)
+
+        // Then
+        XCTAssertEqual(testAnalytics.lastReceivedEventName, WooAnalyticsStat.pointOfSaleLoaded.rawValue)
+    }
+
     class TestAnalytics: Analytics {
         var lastReceivedEventName: String? = nil
         var lastReceivedWaitingTime: TimeInterval? = nil

--- a/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WaitingTimeTrackerTests.swift
@@ -26,7 +26,7 @@ class WaitingTimeTrackerTests: XCTestCase {
 
     func testOrderDetailsTrackScenarioTriggersExpectedAnalyticsStat() {
         // Given
-        let waitingTracker = WaitingTimeTracker(trackScenario: .orderDetails, analyticsService: testAnalytics, currentTime: { 0 })
+        let waitingTracker = WaitingTimeTracker(trackScenario: .orderDetails, analyticsService: testAnalytics, currentTimestampSeconds: { 0 })
 
         // When
         waitingTracker.end()
@@ -39,7 +39,7 @@ class WaitingTimeTrackerTests: XCTestCase {
         // Given
         let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardTopPerformers,
                                                 analyticsService: testAnalytics,
-                                                currentTime: { 0 }
+                                                currentTimestampSeconds: { 0 }
         )
 
         // When
@@ -53,7 +53,7 @@ class WaitingTimeTrackerTests: XCTestCase {
         // Given
         let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats,
                                                 analyticsService: testAnalytics,
-                                                currentTime: { 0 }
+                                                currentTimestampSeconds: { 0 }
         )
 
         // When
@@ -67,7 +67,7 @@ class WaitingTimeTrackerTests: XCTestCase {
         // Given
         let waitingTracker = WaitingTimeTracker(trackScenario: .analyticsHub,
                                                 analyticsService: testAnalytics,
-                                                currentTime: { 0 }
+                                                currentTimestampSeconds: { 0 }
         )
 
         // When
@@ -81,7 +81,7 @@ class WaitingTimeTrackerTests: XCTestCase {
         // Given
         let waitingTracker = WaitingTimeTracker(trackScenario: .appStartup,
                                                 analyticsService: testAnalytics,
-                                                currentTime: { 0 }
+                                                currentTimestampSeconds: { 0 }
         )
 
         // When


### PR DESCRIPTION
## Description
This PR is a side-quest from https://github.com/woocommerce/woocommerce-ios/pull/15047 to improve WaitingTimeTracker's readability. In that PR we reused the existing `WaitingTimeTracker` to capture POS events in milliseconds without realizing the actual elapsed time was being captured in seconds. With these changes we extend the class to allow both, and be more explicit about it.

## Changes:
- Updates `...InMillis` property in the interface to avoid using it incorrectly by mistake, by being explicit about the time unit.
- Updates internals to use seconds (by default) or milliseconds by choice
- Adds additional tests

## Testing information
* Pre-existing `WooAnalyticsEvent.WaitingTime.Scenario` are still tracked in seconds with the key `waiting_time`. For example these two run as soon as we load the app:
```
🔵 Tracked dashboard_main_stats_waiting_time_loaded, properties: [store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, is_wpcom_store: false, blog_id: -1, plan: , site_url: https://indiemelon.mystagingwebsite.com, waiting_time: 2.065809965133667, was_ecommerce_trial: false]
🔵 Tracked dashboard_top_performers_waiting_time_loaded, properties: [store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, plan: , site_url: https://indiemelon.mystagingwebsite.com, was_ecommerce_trial: false, is_wpcom_store: false, blog_id: -1, waiting_time: 7.46925497055054]
```

* In a POS eligible-store, load POS and observe the loading event is tracked in milliseconds with the key `milliseconds_time_elapsed_in_splash_screen`:
```
🔵 Tracked pos_pos_loaded, properties: [is_wpcom_store: false, blog_id: -1, milliseconds_time_elapsed_in_splash_screen: 2152.8499126434326, site_url: https://indiemelon.mystagingwebsite.com, was_ecommerce_trial: false, plan: , store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f]
```

Tested in simulator iPad Air 11 iOS 17.5

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
