### PR TITLE
POS: Fix retain cycles related to payment onboarding view

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentOnboardingAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentOnboardingAdaptor.swift
@@ -9,7 +9,9 @@ final class CardPresentPaymentsOnboardingPresenterAdaptor: CardPresentPaymentsOn
 
     private let readinessUseCase: CardPresentPaymentsReadinessUseCase
 
-    private let onboardingViewModel: CardPresentPaymentsOnboardingViewModel
+    private var onboardingViewModel: CardPresentPaymentsOnboardingViewModel {
+        CardPresentPaymentsOnboardingViewModel(useCase: onboardingUseCase)
+    }
 
     private var readinessSubscription: AnyCancellable?
 
@@ -20,7 +22,6 @@ final class CardPresentPaymentsOnboardingPresenterAdaptor: CardPresentPaymentsOn
     init(stores: StoresManager = ServiceLocator.stores) {
         onboardingUseCase = CardPresentPaymentsOnboardingUseCase(stores: stores)
         readinessUseCase = CardPresentPaymentsReadinessUseCase(onboardingUseCase: onboardingUseCase, stores: stores)
-        onboardingViewModel = CardPresentPaymentsOnboardingViewModel(useCase: onboardingUseCase)
         onboardingScreenViewModelPublisher = onboardingScreenViewModelSubject.eraseToAnyPublisher()
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -167,14 +167,14 @@ extension PointOfSaleAggregateModel {
     }
 
     func connectCardReader() {
-        Task { @MainActor in
-            _ = try await cardPresentPaymentService.connectReader(using: .bluetooth)
+        Task { @MainActor [weak self] in
+            _ = try await self?.cardPresentPaymentService.connectReader(using: .bluetooth)
         }
     }
 
     func disconnectCardReader() {
-        Task { @MainActor in
-            await cardPresentPaymentService.disconnectReader()
+        Task { @MainActor [weak self] in
+            await self?.cardPresentPaymentService.disconnectReader()
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -140,6 +140,9 @@ private extension PointOfSaleDashboardView {
         .onAppear {
             posModel.trackCardPaymentsOnboardingShown()
         }
+        .onDisappear {
+            onboardingViewModel.showSupport = nil
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -133,8 +133,8 @@ private extension PointOfSaleDashboardView {
     }
 
     func paymentsOnboardingView(from onboardingViewModel: CardPresentPaymentsOnboardingViewModel) -> some View {
-        onboardingViewModel.showSupport = {
-            posModel.cancelCardPaymentsOnboarding()
+        onboardingViewModel.showSupport = { [weak posModel] in
+            posModel?.cancelCardPaymentsOnboarding()
             showSupport = true
         }
         return PointOfSaleCardPresentPaymentOnboardingView(viewModel: .init(onboardingViewModel: onboardingViewModel,
@@ -143,9 +143,6 @@ private extension PointOfSaleDashboardView {
         }))
         .onAppear {
             posModel.trackCardPaymentsOnboardingShown()
-        }
-        .onDisappear {
-            onboardingViewModel.showSupport = nil
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
@@ -33,7 +33,9 @@ final class CardPresentPaymentsOnboardingViewModel: ObservableObject, PaymentSet
                 self?.updateLearnMoreURL(state: result)
                 self?.reevaluateShouldShow(onboardingState: result)
             })
-            .handleEvents(receiveOutput: trackState(_:))
+            .handleEvents(receiveOutput: { [weak self] state in
+                self?.trackState(state)
+            })
             .assign(to: &$state)
     }
 


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-ios/issues/14593

<!-- Remember about a good descriptive title. -->

**Note:** One review is enough!

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

https://github.com/woocommerce/woocommerce-ios/pull/15055 PR review @jaclync noticed a memory leak after payment onboarding was presented.

It all pointed out to `showSupport` closure in `PointOfSaleDashboardView`: https://github.com/woocommerce/woocommerce-ios/blob/7e6c816d2b5059a95f2d7d4f8e9859fc61fe061d/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift#L130 

This closure captures `POSAggregateModel`. It creates a strong reference cycle of:

`POSAggregateModel` -> `CardPresentPaymentService` -> `CardPresentPaymentsOnboardingPresenterAdaptor` -> `CardPresentPaymentsOnboardingViewModel` -> `showSupport` -> `POSAggregateModel`.

![image](https://github.com/user-attachments/assets/adc956e2-2610-4355-aee7-a634194ac990)

Unfortunately, simple solutions of applying `weak` to `posModel` didn't work. Other parts of the stack keep holding the onboarding model which holds the support closure that holds the `posModel`. Even when I:
- Stopped holding onboarding model within `CardPresentPaymentsOnboardingPresenterAdaptor`
- Set it to `weak` within `PointOfSaleAggregateModel`

Still, there remained a `Combine` publisher that kept holding the reference:

<img width="931" alt="image" src="https://github.com/user-attachments/assets/faaedbf1-1555-4b15-b976-d96dadacc364" />

When I looked closely, it looked like the onboarding model was caught in a reference cycle:
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/41eb7d46-38be-4dab-9aa4-5826e932be73" />

I realized I spent hours looking at the wrong places. I looked at this observation logic multiple times, but my eyes haven't caught that we call `handleEvents` twice, and once strongly capturing self.  🤦

<img width="776" alt="image" src="https://github.com/user-attachments/assets/5bb28693-ff5b-451c-8a6b-0b8c333c60de" />

At this point, we must leave one strong reference. I think it makes sense for aggregate model to hold onto onboarding view model for the duration of the presentation.

### Another Issue

Even after doing all this, `POSAggregateModel` was still held after closing POS. This fact made me discard a lot of the changes I made, thinking they didn't work.

It turns out that when we try to connect to the reader and onboarding is shown, the card reader connection task never finishes:

```
    func connectCardReader() {
        analytics.track(.pointOfSaleCardReaderConnectionTapped)
        Task { @MainActor in
            _ = try await cardPresentPaymentService.connectReader(using: .bluetooth)
        }
}
```

`CardPresentPaymentPreflightAdaptor` never returns the result from the `attemptConnection` call. Thankfully, putting `[weak self]` within a Task was enough for it not to hold onto the `POSAggregateModel` after `POS` was closed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:
- Return `stripeAccountOverdueRequirement(plugin: .wcPay)` in  `CardPresentPaymentsOnboardingUseCase.checkOnboardingState`

1. Open POS
2. Tap to connect to the card reader
3. Confirm onboarding view opens
4. Close it
5. Open it again
6. Confirm "Contact us" open support
7. Close POS
8. Repeat one or two times
9. Close POS
10. Open Memory Debugger
11. Confirm `POSAggregateModel` is released (or at least not held by `support` closure).

If `POSAggregateModel` is not released for you, could you:
1. Enable `Edit Scheme -> WooCommerce -> Diagnostics -> Malloc Stack Logging`
2. Reproduce memory leak again
3. In the memory debugger select `File -> Export Memory Graph` and share with me
4. Thanks! 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested on an iPad Pro 11-inch M4 18.2 simulator. A couple of times after closing POS, the aggregate model was still held by some `SwiftUI` related properties. However, it's worth waiting a bit or putting the POS in the background and returning it before opening the memory debugger. It worked for me and `POSAggregateModel` was released. I asked Apple engineer about it yesterday:

> Depending on the lifecycle of underlying views and a specific situation, SwiftUI might release the objects not immediately. Among other factors, it may depend on UIKit, AppKit or other frameworks involved. You may notice that the objects owned by recently destroyed views get deallocated after an app goes to the background or when another similar view is constructed.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.