### PR TITLE
[Woo POS] Use Observation for order state

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -14,7 +14,7 @@ import enum WooFoundation.CurrencyCode
 import protocol WooFoundation.Analytics
 
 protocol PointOfSaleOrderControllerProtocol {
-    var orderStatePublisher: AnyPublisher<PointOfSaleInternalOrderState, Never> { get }
+    var orderState: PointOfSaleInternalOrderState { get }
 
     func syncOrder(for cartProducts: [CartItem], retryHandler: @escaping () async -> Void) async
     func sendReceipt(recipientEmail: String) async throws
@@ -22,7 +22,8 @@ protocol PointOfSaleOrderControllerProtocol {
     func collectCashPayment() async throws
 }
 
-final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
+@available(iOS 17.0, *)
+@Observable final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     init(orderService: POSOrderServiceProtocol,
          receiptService: POSReceiptServiceProtocol,
          stores: StoresManager = ServiceLocator.stores,
@@ -38,10 +39,6 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
         self.celebration = celebration
     }
 
-    var orderStatePublisher: AnyPublisher<PointOfSaleInternalOrderState, Never> {
-        $orderState.eraseToAnyPublisher()
-    }
-
     private let orderService: POSOrderServiceProtocol
     private let receiptService: POSReceiptServiceProtocol
 
@@ -51,7 +48,7 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     private let analytics: Analytics
     private let stores: StoresManager
 
-    @Published private var orderState: PointOfSaleInternalOrderState = .idle
+    private(set) var orderState: PointOfSaleInternalOrderState = .idle
     private var order: Order? = nil
 
     @MainActor
@@ -151,7 +148,7 @@ final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     }
 }
 
-
+@available(iOS 17.0, *)
 private extension PointOfSaleOrderController {
     func totals(for order: Order) -> PointOfSaleOrderTotals {
         let totalsCalculator = OrderTotalsCalculator(for: order,
@@ -222,6 +219,7 @@ extension PointOfSaleInternalOrderState: Equatable {
     }
 }
 
+@available(iOS 17.0, *)
 extension PointOfSaleOrderController {
     enum Localization {
         static let cashPaymentMethodTitle = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Combine
+import Observation
 import protocol Yosemite.StoresManager
 import protocol Yosemite.POSOrderServiceProtocol
 import protocol Yosemite.POSReceiptServiceProtocol

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -54,8 +54,8 @@ protocol PointOfSaleAggregateModelProtocol {
 
     private(set) var cart: [CartItem] = []
 
-    private(set) var orderState: PointOfSaleOrderState = .idle
-    private var internalOrderState: PointOfSaleInternalOrderState = .idle
+    var orderState: PointOfSaleOrderState { orderController.orderState.externalState }
+    private var internalOrderState: PointOfSaleInternalOrderState { orderController.orderState }
 
     private let itemsController: PointOfSaleItemsControllerProtocol
 
@@ -80,7 +80,6 @@ protocol PointOfSaleAggregateModelProtocol {
         self.paymentState = paymentState
         publishCardReaderConnectionStatus()
         publishPaymentMessages()
-        publishOrderState()
         setupReaderReconnectionObservation()
     }
 }
@@ -428,21 +427,6 @@ extension PointOfSaleAggregateModel {
             await self?.checkOut()
         })
         await startPaymentWhenCardReaderConnected()
-    }
-
-    func publishOrderState() {
-        orderController.orderStatePublisher
-            .map { $0.externalState }
-            .sink(receiveValue: { [weak self] orderState in
-                self?.orderState = orderState
-            })
-            .store(in: &cancellables)
-
-        orderController.orderStatePublisher
-            .sink(receiveValue: { [weak self] internalOrderState in
-                self?.internalOrderState = internalOrderState
-            })
-            .store(in: &cancellables)
     }
 }
 

--- a/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
+++ b/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
@@ -4,15 +4,13 @@ import struct Yosemite.Order
 import Combine
 
 class PointOfSalePreviewOrderController: PointOfSaleOrderControllerProtocol {
-    var orderStatePublisher: AnyPublisher<PointOfSaleInternalOrderState, Never> = Just(
-        .loaded(
-            .init(cartTotal: "$10.50",
-                  orderTotal: "$12.00",
-                  taxTotal: "$1.50",
-                  orderTotalDecimal: 12.00),
-            OrderFactory.newOrder(currency: .USD)
-        )
-    ).eraseToAnyPublisher()
+    var orderState: PointOfSaleInternalOrderState = .loaded(
+        .init(cartTotal: "$10.50",
+              orderTotal: "$12.00",
+              taxTotal: "$1.50",
+              orderTotalDecimal: 12.00),
+        OrderFactory.newOrder(currency: .USD)
+    )
 
     func syncOrder(for cartProducts: [CartItem],
                    retryHandler: @escaping () async -> Void) async { }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -10,17 +10,14 @@ import class WooFoundation.CurrencySettings
 import protocol WooFoundation.Analytics
 
 struct PointOfSaleOrderControllerTests {
-    let sut: PointOfSaleOrderController
     let mockOrderService = MockPOSOrderService()
     let mockReceiptService = MockReceiptService()
 
-    init() {
-        self.sut = PointOfSaleOrderController(orderService: mockOrderService,
-                                              receiptService: mockReceiptService)
-    }
-
+    @available(iOS 17.0, *)
     @Test func syncOrder_without_items_doesnt_call_orderService() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
 
         // When
         await sut.syncOrder(for: [], retryHandler: {})
@@ -29,8 +26,11 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
+    @available(iOS 17.0, *)
     @Test func syncOrder_with_cart_matching_order_doesnt_call_orderService() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
         let orderItem = OrderItem.fake().copy(quantity: 1)
         let fakeOrder = Order.fake().copy(items: [orderItem])
         let cartItem = makeItem(orderItemsToMatch: [orderItem])
@@ -46,8 +46,11 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
+    @available(iOS 17.0, *)
     @Test func syncOrder_when_already_syncing_doesnt_call_orderService() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
         mockOrderService.simulateSyncing = true
         Task {
             await sut.syncOrder(for: [makeItem(quantity: 1)], retryHandler: {})
@@ -64,6 +67,7 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
+    @available(iOS 17.0, *)
     @Test func syncOrder_with_no_previous_order_calls_orderService() async throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .AUD,
@@ -82,8 +86,11 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.spySyncOrderCurrency == .AUD)
     }
 
+    @available(iOS 17.0, *)
     @Test func syncOrder_with_changes_from_previous_order_calls_orderService() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
         let cartItem = makeItem(quantity: 1)
         let orderItem = OrderItem.fake().copy(quantity: 1)
         let fakeOrder = Order.fake().copy(items: [orderItem])
@@ -100,24 +107,34 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled)
     }
 
+    @available(iOS 17.0, *)
     @Test func syncOrder_with_no_previous_order_sets_orderState_syncing_then_loaded() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
         let fakeOrder = Order.fake()
         mockOrderService.orderToReturn = fakeOrder
-        var cancellables = Set<AnyCancellable>()
-        var orderStates: [PointOfSaleInternalOrderState] = []
-        await confirmation() { confirmation in
-            // We can use `withObservationTracking` when we move to @Observable
-            sut.orderStatePublisher.collect(3)
-                .sink { orderState in
-                    orderStates.append(contentsOf: orderState)
+        var orderStates: [PointOfSaleInternalOrderState] = [sut.orderState]
+        var orderStateAppendTask: Task<Void, Never>? = nil
+        await confirmation(expectedCount: 2) { confirmation in
+            @Sendable func observeOrderState() {
+                withObservationTracking {
+                    _ = sut.orderState
+                } onChange: {
+                    orderStateAppendTask = Task { @MainActor in
+                        orderStates.append(sut.orderState)
+                    }
                     confirmation()
+                    observeOrderState()
                 }
-                .store(in: &cancellables)
+            }
+            observeOrderState()
 
             // When
             await sut.syncOrder(for: [makeItem()], retryHandler: {})
         }
+
+        await orderStateAppendTask?.value
 
         // Then
         #expect(orderStates == [
@@ -128,24 +145,34 @@ struct PointOfSaleOrderControllerTests {
         ])
     }
 
+    @available(iOS 17.0, *)
     @Test func syncOrder_with_order_sync_failure_sets_orderState_syncing_then_error() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
         mockOrderService.orderToReturn = nil
 
-        var cancellables = Set<AnyCancellable>()
-        var orderStates: [PointOfSaleInternalOrderState] = []
-        await confirmation() { confirmation in
-            // We can use `withObservationTracking` when we move to @Observable
-            sut.orderStatePublisher.collect(3)
-                .sink { orderState in
-                    orderStates.append(contentsOf: orderState)
+        var orderStates: [PointOfSaleInternalOrderState] = [sut.orderState]
+        var orderStateAppendTask: Task<Void, Never>? = nil
+        await confirmation(expectedCount: 2) { confirmation in
+            @Sendable func observeOrderState() {
+                withObservationTracking {
+                    _ = sut.orderState
+                } onChange: {
+                    orderStateAppendTask = Task { @MainActor in
+                        orderStates.append(sut.orderState)
+                    }
                     confirmation()
+                    observeOrderState()
                 }
-                .store(in: &cancellables)
+            }
+            observeOrderState()
 
             // When
             await sut.syncOrder(for: [makeItem()], retryHandler: {})
         }
+
+        await orderStateAppendTask?.value
 
         // Then
         #expect(orderStates == [
@@ -157,8 +184,11 @@ struct PointOfSaleOrderControllerTests {
         ])
     }
 
+    @available(iOS 17.0, *)
     @Test func sendReceipt_when_there_is_no_order_then_will_not_trigger() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
         let email = "test@example.com"
 
         // When
@@ -169,8 +199,11 @@ struct PointOfSaleOrderControllerTests {
         #expect(!mockReceiptService.sendReceiptWasCalled)
     }
 
+    @available(iOS 17.0, *)
     @Test func sendReceipt_calls_both_updateOrder_and_sendReceipt() async throws {
         // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
         let order = Order.fake()
         let recipientEmail = "test@fake.com"
         mockOrderService.orderToReturn = order
@@ -187,9 +220,12 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockReceiptService.sendReceiptWasCalled)
     }
 
+    @available(iOS 17.0, *)
     @Test func collectCashPayment_when_no_order_then_fails_with_noOrder_error() async throws {
         do {
             // Given/When
+            let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                                 receiptService: mockReceiptService)
             try await sut.collectCashPayment()
         } catch let error as PointOfSaleOrderController.PointOfSaleOrderControllerError {
             // Then
@@ -198,6 +234,7 @@ struct PointOfSaleOrderControllerTests {
     }
 
     @MainActor
+    @available(iOS 17.0, *)
     @Test func collectCashPayment_when_successful_calls_celebrate() async throws {
         // Given
         let sampleSiteID: Int64 = 1234
@@ -218,7 +255,7 @@ struct PointOfSaleOrderControllerTests {
         let completionResult: Bool = await withCheckedContinuation { continuation in
             mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
                 switch action {
-                case let .updateOrder(siteID, order, _, _, onCompletion):
+                case let .updateOrder(_, order, _, _, onCompletion):
                     onCompletion(.success(order))
                     continuation.resume(returning: true)
                 default:
@@ -244,17 +281,17 @@ struct PointOfSaleOrderControllerTests {
         private let analyticsProvider = MockAnalyticsProvider()
         private let orderService = MockPOSOrderService()
         private let receiptService = MockReceiptService()
-        private let sut: PointOfSaleOrderController
 
         init() {
             analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-            sut = PointOfSaleOrderController(orderService: orderService,
-                                             receiptService: receiptService,
-                                             analytics: analytics)
         }
 
+        @available(iOS 17.0, *)
         @Test func syncOrder_when_create_order_then_tracks_order_creation_success_event() async throws {
             // Given
+            let sut = PointOfSaleOrderController(orderService: orderService,
+                                                 receiptService: receiptService,
+                                                 analytics: analytics)
             let fakeOrderItem = OrderItem.fake().copy(quantity: 1)
             let fakeOrder = Order.fake()
             let fakeCartItem = makeItem(orderItemsToMatch: [fakeOrderItem])
@@ -267,23 +304,16 @@ struct PointOfSaleOrderControllerTests {
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "order_creation_success" }) != nil)
         }
 
+        @available(iOS 17.0, *)
         @Test func syncOrder_when_create_order_fails_with_order_service_error_then_tracks_order_creation_failure_event() async throws {
             // Given
-            // 3 states are expected to be confirmed before returning orderState: .idle, .syncing. .error
-            let confirmationOrderStates = 3
-            var cancellables = Set<AnyCancellable>()
+            let sut = PointOfSaleOrderController(orderService: orderService,
+                                                 receiptService: receiptService,
+                                                 analytics: analytics)
             orderService.orderToReturn = nil
 
-            await confirmation() { confirmation in
-                sut.orderStatePublisher.collect(confirmationOrderStates)
-                    .sink { orderState in
-                        confirmation()
-                    }
-                    .store(in: &cancellables)
-
-                // When
-                await sut.syncOrder(for: [makeItem()], retryHandler: {})
-            }
+            // When
+            await sut.syncOrder(for: [makeItem()], retryHandler: {})
 
             // Then
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "order_creation_failed" }) != nil)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -1,5 +1,5 @@
 import Testing
-import Combine
+import Observation
 import Foundation
 
 @testable import WooCommerce


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes the Combine publishers for the POS Order controller, switching to Observation instead.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This change affects the `orderState`, which is used to determine how the screen split is set, which views are shown, and all the order totals used for payments. General testing of the POS flows is worthwhile, but the logic behind these things hasn't changed at all, only the way we track changes to the model.

Unit testing streams of values with Observation isn't fun. I can't do it without adding warnings about Swift 6 language mode, and to wait for more than one value we need to wait for the `didSet` to finish slightly later than when the `confirmation` is done. We can't just call `confirmation()` in the task; in that case, we go out of the confirmation block's scope and fail to call it enough times.

Keeping hold of the task from inside the `onChange` and waiting for that seems a bit nicer than sleeping in the same place.

Generally speaking, it might be better to avoid these sorts of tests and structure our code in smaller units that we can test a single state with.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/c53256ff-08e8-4c07-97a2-072ff0f38fb7


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.