### PR TITLE
Remove variableProductsInPointOfSale flag and related code

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,8 +91,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .acceptCashForPointOfSale:
             return true
-        case .variableProductsInPointOfSale:
-            return true
         case .hideSitesInStorePicker:
             return true
         case .filterHistoryOnOrderAndProductLists:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -197,10 +197,6 @@ public enum FeatureFlag: Int {
     ///
     case acceptCashForPointOfSale
 
-    /// Supports variable products in POS.
-    ///
-    case variableProductsInPointOfSale
-
     /// Supports hiding sites from the store picker
     ///
     case hideSitesInStorePicker

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -236,20 +236,16 @@ private extension ItemListView {
         static let isSimpleProductsOnlyBannerDismissedKey = "isSimpleProductsOnlyBannerDismissed"
     }
 
-    var variableProductsEnabled: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale)
-    }
-
     var headerBannerTitle: String {
-        variableProductsEnabled ? Localization.headerBannerTitleSimpleAndVariable : Localization.headerBannerTitle
+        Localization.headerBannerTitleSimpleAndVariable
     }
 
     var headerBannerSubtitle: String {
-        variableProductsEnabled ? Localization.headerBannerSubtitleSimpleAndVariable : Localization.headerBannerSubtitle
+        Localization.headerBannerSubtitleSimpleAndVariable
     }
 
     var headerBannerHint: String {
-        variableProductsEnabled ? Localization.headerBannerHintSimpleAndVariable : Localization.headerBannerHint
+        Localization.headerBannerHintSimpleAndVariable
     }
 
     enum Localization {
@@ -257,24 +253,6 @@ private extension ItemListView {
             "pos.itemlistview.title",
             value: "Products",
             comment: "Title at the top of the Point of Sale product selector screen."
-        )
-
-        static let headerBannerTitle = NSLocalizedString(
-            "pos.itemlistview.headerBanner.title",
-            value: "Showing simple products only",
-            comment: "Title of the product selector header banner, which explains current POS limitations"
-        )
-
-        static let headerBannerSubtitle = NSLocalizedString(
-            "pos.itemlistview.headerBanner.subtitle",
-            value: "Only simple physical products are available with POS right now.",
-            comment: "Subtitle of the product selector header banner, which explains current POS limitations"
-        )
-
-        static let headerBannerHint = NSLocalizedString(
-            "pos.itemlistview.headerBanner.hint",
-            value: "Other product types, such as variable and virtual, will become available in future updates.",
-            comment: "Additional text within the product selector header banner, which explains current POS limitations"
         )
 
         static let headerBannerTitleSimpleAndVariable = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
@@ -2,9 +2,6 @@ import SwiftUI
 
 struct SimpleProductsOnlyInformation: View {
     @Binding var isPresented: Bool
-    private var variableProductsEnabled: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale)
-    }
     let deepLinkNavigator: DeepLinkNavigator?
 
     init(isPresented: Binding<Bool>,
@@ -57,15 +54,15 @@ struct SimpleProductsOnlyInformation: View {
     }
 
     private var issueMessage: String {
-        variableProductsEnabled ? Localization.variableAndSimpleProductsOnlyIssueMessage : Localization.simpleProductsOnlyIssueMessage
+        Localization.variableAndSimpleProductsOnlyIssueMessage
     }
 
     private var futureMessage: String {
-        variableProductsEnabled ? Localization.variableAndSimpleProductsOnlyFutureMessage : Localization.simpleProductsOnlyFutureMessage
+        Localization.variableAndSimpleProductsOnlyFutureMessage
     }
 
     private var hintMessage: String {
-        variableProductsEnabled ? Localization.variableAndSimpleProdustsOnlyHint : Localization.modalHint
+        Localization.variableAndSimpleProdustsOnlyHint
     }
 }
 
@@ -88,30 +85,16 @@ private extension SimpleProductsOnlyInformation {
             value: "Why can't I see my products?",
             comment: "Title of the simple products information modal in POS"
         )
-        static let simpleProductsOnlyIssueMessage = NSLocalizedString(
-            "pos.simpleProductsModal.message.issue",
-            value: "Only simple physical products can be used with POS right now.",
-            comment: "Message in the simple products information modal in POS"
-        )
+
         static let variableAndSimpleProductsOnlyIssueMessage = NSLocalizedString(
             "pos.simpleProductsModal.message.issue.variableAndSimple",
             value: "Only simple and variable non-downloadable products can be used with POS right now.",
             comment: "Message in the simple products information modal in POS when variable products are supported"
         )
-        static let simpleProductsOnlyFutureMessage = NSLocalizedString(
-            "pos.simpleProductsModal.message.future",
-            value: "Other product types, such as variable and virtual, will be available in future updates.",
-            comment: "Message in the simple products information modal in POS, explaining future plans"
-        )
         static let variableAndSimpleProductsOnlyFutureMessage = NSLocalizedString(
             "pos.simpleProductsModal.message.future.variableAndSimple",
             value: "Other product types will be available in future updates.",
             comment: "Message in the simple products information modal in POS, explaining future plans when variable products are supported"
-        )
-        static let modalHint = NSLocalizedString(
-            "pos.simpleProductsModal.hint",
-            value: "To take payment for a non-simple product, exit POS and create a new order from the orders tab.",
-            comment: "Hint in the simple products information modal in POS"
         )
         static let variableAndSimpleProdustsOnlyHint = NSLocalizedString(
             "pos.simpleProductsModal.hint.variableAndSimple",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -66,7 +66,7 @@ private extension POSEligibilityChecker {
                 return
             }
 
-            let wcPluginMinimumVersion = wcPluginMinimumVersion
+            let wcPluginMinimumVersion = Constants.wcPluginMinimumVersion
 
             let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
                 guard let wcPlugin = wcPlugin, wcPlugin.active else {
@@ -119,19 +119,11 @@ private extension POSEligibilityChecker {
                 return false
         }
     }
-
-    private var wcPluginMinimumVersion: String {
-        guard featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale) else {
-            return Constants.legacyWcPluginMinimumVersion
-        }
-        return Constants.wcPluginMinimumVersion
-    }
 }
 
 private extension POSEligibilityChecker {
     enum Constants {
         static let wcPluginName = "WooCommerce"
         static let wcPluginMinimumVersion = "9.6.0-beta"
-        static let legacyWcPluginMinimumVersion = "6.6.0"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -99,8 +99,7 @@ final class HubMenuViewModel: ObservableObject {
 
         return PointOfSaleItemService(siteID: siteID,
                                       currencySettings: currencySettings,
-                                      credentials: credentials,
-                                      isVariableProductsFeatureEnabled: featureFlagService.isFeatureFlagEnabled(.variableProductsInPointOfSale))
+                                      credentials: credentials)
     }()
 
     private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -24,7 +24,6 @@ final class MockFeatureFlagService: FeatureFlagService {
     var isProductGlobalUniqueIdentifierSupported: Bool
     var receiptsForPOS: Bool
     var hideSitesInStorePicker: Bool
-    var isVariableProductsInPOSEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -47,8 +46,7 @@ final class MockFeatureFlagService: FeatureFlagService {
          favoriteProducts: Bool = false,
          isProductGlobalUniqueIdentifierSupported: Bool = false,
          receiptsForPOS: Bool = false,
-         hideSitesInStorePicker: Bool = false,
-         isVariableProductsInPOSEnabled: Bool = false) {
+         hideSitesInStorePicker: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -71,7 +69,6 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.isProductGlobalUniqueIdentifierSupported = isProductGlobalUniqueIdentifierSupported
         self.receiptsForPOS = receiptsForPOS
         self.hideSitesInStorePicker = hideSitesInStorePicker
-        self.isVariableProductsInPOSEnabled = isVariableProductsInPOSEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -120,8 +117,6 @@ final class MockFeatureFlagService: FeatureFlagService {
             return receiptsForPOS
         case .hideSitesInStorePicker:
             return hideSitesInStorePicker
-        case .variableProductsInPointOfSale:
-            return isVariableProductsInPOSEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -146,8 +146,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
 
     func test_is_eligible_when_WooCommerce_version_is_below_9_6_then_returns_false() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true,
-                                                        isVariableProductsInPOSEnabled: true)
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
 
         // Unsupported WooCommerce version
@@ -167,56 +166,12 @@ final class POSEligibilityCheckerTests: XCTestCase {
 
     func test_is_eligible_when_WooCommerce_version_is_at_least_9_6_then_returns_true() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true,
-                                                        isVariableProductsInPOSEnabled: true)
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
         accountWhitelistedInBackend(true)
 
         // Supported WooCommerce version
         setupWooCommerceVersion("9.6.0-beta1")
-
-        // When
-        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            siteSettings: siteSettings,
-                                            currencySettings: Fixtures.usdCurrencySettings,
-                                            stores: stores,
-                                            featureFlagService: featureFlagService)
-        checker.isEligible.assign(to: &$isEligible)
-
-        // Then
-        XCTAssertTrue(isEligible)
-    }
-
-    func test_is_eligible_when_WooCommerce_version_is_below_6_6_and_variable_products_disabled_then_returns_false() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true,
-                                                        isVariableProductsInPOSEnabled: false)
-        setupCountry(country: .us)
-
-        // Unsupported WooCommerce version
-        setupWooCommerceVersion("6.5.2")
-
-        // When
-        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
-                                            siteSettings: siteSettings,
-                                            currencySettings: Fixtures.usdCurrencySettings,
-                                            stores: stores,
-                                            featureFlagService: featureFlagService)
-        checker.isEligible.assign(to: &$isEligible)
-
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
-    func test_is_eligible_when_WooCommerce_version_is_at_least_6_6_and_variable_products_disabled_then_returns_true() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true,
-                                                        isVariableProductsInPOSEnabled: false)
-        setupCountry(country: .us)
-        accountWhitelistedInBackend(true)
-
-        // Supported WooCommerce version
-        setupWooCommerceVersion("6.6.0")
 
         // When
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -21,24 +21,20 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     private let currencyFormatter: CurrencyFormatter
     private let productsRemote: ProductsRemote
     private let variationRemote: ProductVariationsRemoteProtocol
-    private let isVariableProductsFeatureEnabled: Bool
 
-    public init(siteID: Int64, currencySettings: CurrencySettings, network: Network, isVariableProductsFeatureEnabled: Bool) {
+    public init(siteID: Int64, currencySettings: CurrencySettings, network: Network) {
         self.siteID = siteID
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.productsRemote = ProductsRemote(network: network)
         self.variationRemote = ProductVariationsRemote(network: network)
-        self.isVariableProductsFeatureEnabled = isVariableProductsFeatureEnabled
     }
 
     public convenience init(siteID: Int64,
                             currencySettings: CurrencySettings,
-                            credentials: Credentials?,
-                            isVariableProductsFeatureEnabled: Bool) {
+                            credentials: Credentials?) {
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
-                  network: AlamofireNetwork(credentials: credentials),
-                  isVariableProductsFeatureEnabled: isVariableProductsFeatureEnabled)
+                  network: AlamofireNetwork(credentials: credentials))
     }
 
     /// Provides a list of products for the Point of Sale, by fetching simple products from the remote, applying any eligibility criteria,
@@ -47,8 +43,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     /// - pageNumber: Number of the page that should be retrieved. If none given, defaults to 1
     ///
     public func providePointOfSaleItems(pageNumber: Int = 1) async throws -> PagedItems<POSItem> {
-        let productTypes: [ProductType] = isVariableProductsFeatureEnabled ?
-        [.simple, .variable] : [.simple]
+        let productTypes: [ProductType] = [.simple, .variable]
         do {
             let pagedProducts = try await productsRemote.loadProductsForPointOfSale(for: siteID, productTypes: productTypes, pageNumber: pageNumber)
             let products = pagedProducts.items

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -15,8 +15,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         currencySettings = CurrencySettings()
         itemProvider = PointOfSaleItemService(siteID: siteID,
                                                  currencySettings: currencySettings,
-                                                 network: network,
-                                                 isVariableProductsFeatureEnabled: false)
+                                                 network: network)
     }
 
     override func tearDown() {
@@ -110,26 +109,11 @@ final class PointOfSaleItemServiceTests: XCTestCase {
 
     // MARK: - Query Parameters
 
-    func test_providePointOfSaleItems_sets_types_parameters_to_simple_only() async throws {
+    func test_providePointOfSaleItems_sets_types_parameters_correctly() async throws {
         // Given
         let itemProvider = PointOfSaleItemService(siteID: siteID,
                                                      currencySettings: currencySettings,
-                                                     network: network,
-                                                     isVariableProductsFeatureEnabled: false)
-
-        // When
-        _ = try? await itemProvider.providePointOfSaleItems()
-
-        // Then
-        XCTAssertEqual(network.queryParametersDictionary?["include_types"] as? String, "simple")
-    }
-
-    func test_providePointOfSaleItems_sets_types_parameters_correctly_when_variable_products_feature_is_enabled() async throws {
-        // Given
-        let itemProvider = PointOfSaleItemService(siteID: siteID,
-                                                     currencySettings: currencySettings,
-                                                     network: network,
-                                                     isVariableProductsFeatureEnabled: true)
+                                                     network: network)
 
         // When
         _ = try? await itemProvider.providePointOfSaleItems()
@@ -142,8 +126,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let itemProvider = PointOfSaleItemService(siteID: siteID,
                                                   currencySettings: currencySettings,
-                                                  network: network,
-                                                  isVariableProductsFeatureEnabled: true)
+                                                  network: network)
         let parentProductID: Int64 = 123
 
         // When
@@ -185,8 +168,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let itemProvider = PointOfSaleItemService(siteID: siteID,
                                                   currencySettings: currencySettings,
-                                                  network: network,
-                                                  isVariableProductsFeatureEnabled: true)
+                                                  network: network)
         let parentProductID: Int64 = 123
 
         // When
@@ -221,8 +203,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let itemProvider = PointOfSaleItemService(siteID: siteID,
                                             currencySettings: currencySettings,
-                                            network: network,
-                                            isVariableProductsFeatureEnabled: true)
+                                            network: network)
         let parentProductID: Int64 = 123
         let expectedError = PointOfSaleItemServiceError.requestFailed
 
@@ -251,8 +232,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let itemProvider = PointOfSaleItemService(siteID: siteID,
                                                   currencySettings: currencySettings,
-                                                  network: network,
-                                                  isVariableProductsFeatureEnabled: true)
+                                                  network: network)
         let parentProductID: Int64 = 123
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Removing variableProductsInPointOfSale flag and related code

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:
- WooCommerce >=9.6
- Store with variable products

1. Open Woo app
2. Menu
3. Confirm POS option appears
4. Open POS
5. Confirm variable products appear in the list

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Unit tests confirm the existing functionality continues to work. 
- Tested POS on iPad Pro 11 inch M4 simulator

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.