### PR TITLE
[Woo POS][Design System] Update skeleton design for item list

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -20,6 +20,9 @@ struct GhostItemCardView: View {
                 .frame(width: dimension, height: dimension)
         }
         .shimmering()
+        .frame(maxWidth: .infinity, idealHeight: dimension)
+        .background(Color.posSurfaceBright)
+        .posItemCardBorderStyles()
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct GhostItemCardView: View {
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    private var dimension: CGFloat {
+        min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
+    }
+
+    var body: some View {
+        HStack(spacing: Constants.cardSpacing) {
+            Spacer()
+                .frame(width: dimension, height: dimension)
+            Rectangle()
+                .foregroundColor(.posOnSurfaceVariantLowest)
+                .frame(height: 36 * scale)
+                .cornerRadius(8)
+                .padding(.horizontal, Constants.horizontalTextPadding)
+            Spacer()
+                .frame(width: dimension, height: dimension)
+        }
+        .shimmering()
+    }
+}
+
+private extension GhostItemCardView {
+    typealias Constants = PointOfSaleItemListCardConstants
+}
+
+#Preview {
+    GhostItemCardView()
+}

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -13,8 +13,8 @@ struct GhostItemCardView: View {
                 .frame(width: dimension, height: dimension)
             Rectangle()
                 .foregroundColor(.posOnSurfaceVariantLowest)
-                .frame(height: 36 * scale)
-                .cornerRadius(8)
+                .frame(height: Layout.placeholderHeight * scale)
+                .cornerRadius(Layout.cornerRadius)
                 .padding(.horizontal, Constants.horizontalTextPadding)
             Spacer()
                 .frame(width: dimension, height: dimension)
@@ -25,6 +25,11 @@ struct GhostItemCardView: View {
 
 private extension GhostItemCardView {
     typealias Constants = PointOfSaleItemListCardConstants
+
+    enum Layout {
+        static let placeholderHeight: CGFloat = 36
+        static let cornerRadius: CGFloat = 8
+    }
 }
 
 #Preview {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -175,45 +175,6 @@ private extension ItemListState {
     }
 }
 
-struct GhostItemCardView: View {
-    @ScaledMetric private var scale: CGFloat = 1.0
-
-    var body: some View {
-        HStack(spacing: 0) {
-            Rectangle()
-                .frame(width: Constants.productCardSize * scale, height: Constants.productCardSize * scale)
-            HStack {
-                Rectangle()
-                    .foregroundColor(Constants.textForegroundColor)
-                    .frame(width: Constants.textWidth * 2 * scale, height: Constants.textHeight * scale)
-                    .padding(.horizontal)
-                Spacer()
-                Rectangle()
-                    .foregroundColor(Constants.textForegroundColor)
-                    .frame(width: Constants.textWidth * scale, height: Constants.textHeight * scale)
-                    .padding(.horizontal)
-            }
-            .frame(height: Constants.productCardSize * scale)
-        }
-        .overlay {
-            RoundedRectangle(cornerRadius: Constants.cornerRadius)
-        }
-        .foregroundColor(Constants.cardForegroundColor)
-        .shimmering()
-    }
-}
-
-private extension GhostItemCardView {
-    enum Constants {
-        static let cornerRadius: CGFloat = 8
-        static let cardForegroundColor: Color = Color.gray.opacity(0.5)
-        static let textForegroundColor: Color = Color.gray.opacity(0.8)
-        static let productCardSize: CGFloat = 112
-        static let textWidth: CGFloat = 112
-        static let textHeight: CGFloat = 32
-    }
-}
-
 /// Constants
 ///
 @available(iOS 17.0, *)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -116,7 +116,7 @@ private extension ItemListView {
         .fixedSize(horizontal: false, vertical: true)
         .background(Color.posSurfaceBright)
         .cornerRadius(Constants.bannerCornerRadius)
-        .shadow(color: Color.black.opacity(0.08), radius: 4, y: 2)
+        .shadow(color: Color.posShadow.opacity(0.08), radius: 4, y: 2)
         .accessibilityAddTraits(.isButton)
         .onTapGesture {
             showSimpleProductsModal = true
@@ -128,7 +128,7 @@ private extension ItemListView {
         Text(headerBannerHint + " ") +
         Text(Localization.headerBannerLearnMoreHint)
             .font(POSFontStyle.posBodySmallBold.font())
-            .foregroundColor(Color(.accent))
+            .foregroundColor(Color(.posPrimary))
     }
 
     @ViewBuilder

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		0204E3622B8CD40B00F1B5FD /* WooAnalyticsEvent+Products.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0204E3612B8CD40B00F1B5FD /* WooAnalyticsEvent+Products.swift */; };
 		0204F0CA29C047A400CFC78F /* SelfSizingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0204F0C929C047A400CFC78F /* SelfSizingHostingController.swift */; };
 		0205021E27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0205021D27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift */; };
+		020556512D5DA45500E51059 /* GhostItemCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020556502D5DA45500E51059 /* GhostItemCardView.swift */; };
 		0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206483923FA4160008441BB /* OrdersRootViewController.swift */; };
 		0206E296299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */; };
 		020732042988AB7B000A53C2 /* DomainContactInfoForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020732032988AB7B000A53C2 /* DomainContactInfoForm.swift */; };
@@ -3285,6 +3286,7 @@
 		0204E3612B8CD40B00F1B5FD /* WooAnalyticsEvent+Products.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Products.swift"; sourceTree = "<group>"; };
 		0204F0C929C047A400CFC78F /* SelfSizingHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSizingHostingController.swift; sourceTree = "<group>"; };
 		0205021D27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxEligibilityUseCase.swift; sourceTree = "<group>"; };
+		020556502D5DA45500E51059 /* GhostItemCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostItemCardView.swift; sourceTree = "<group>"; };
 		0206483923FA4160008441BB /* OrdersRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRootViewController.swift; sourceTree = "<group>"; };
 		0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+DomainSettings.swift"; sourceTree = "<group>"; };
 		020732032988AB7B000A53C2 /* DomainContactInfoForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainContactInfoForm.swift; sourceTree = "<group>"; };
@@ -7489,6 +7491,7 @@
 				027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */,
 				029149772D26658A00F7B3B3 /* VariationCardView.swift */,
 				0291497C2D26CB2500F7B3B3 /* ChildItemList.swift */,
+				020556502D5DA45500E51059 /* GhostItemCardView.swift */,
 			);
 			path = "Item Selector";
 			sourceTree = "<group>";
@@ -15934,6 +15937,7 @@
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,
 				CE1EC8F120B8A408009762BF /* OrderNoteTableViewCell.swift in Sources */,
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
+				020556512D5DA45500E51059 /* GhostItemCardView.swift in Sources */,
 				D8B4D5F226C2CF5B00F34E94 /* InPersonPaymentsStripeAccountOverdueView.swift in Sources */,
 				EE46CEDF29CB31DF004E4524 /* StoreOnboardingStoreDetailsCoordinator.swift in Sources */,
 				025CA1A62887D17A00CCBB25 /* LoggedOutAppSettingsProtocol.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15120

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request focuses on updating the `GhostItemCardView` to match the latest skeleton component in design 1qcjzXitBHU7xPnpCOWnNM-fi-846_21698:

<img width="645" alt="Image" src="https://github.com/user-attachments/assets/a8441308-db47-4fda-994f-1f7250252dbf" />

This has also been implemented on Android (in the screencast) https://github.com/woocommerce/woocommerce-android/pull/13522.

* Extracted `GhostItemCardView` to its own file to display a placeholder card with a shimmering effect following the layout in the item card. (`WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift`)
* Updated `ItemListView` to remove the extracted `GhostItemCardView` and replace color references for shadow and text to use the POS-specific colors. (`WooCommerce/Classes/POS/Presentation/ItemListView.swift`) [[1]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L119-R119) [[2]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L131-R131) [[3]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L178-L216)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites: the store has more than one page of products, and at least one variable product with more than one page of variations

- Enter POS
- Scroll to the bottom of the list --> the loading row should match the design
- Tap on the variable product in the prerequisites --> the loading rows should match the design (there's no design for this specific state, I decided not to touch the display of 10 placeholder rows in case it was discussed with design before)
- Scroll to the bottom of the variations list --> the loading row should match the design

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-14 at 10 18 51](https://github.com/user-attachments/assets/77cab6e9-e434-47ed-83f2-0252a8924f69) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-14 at 10 19 18](https://github.com/user-attachments/assets/a9cd9ad2-0783-4d63-9c49-fe4e610e5fc7)


variations list | variations infinite scroll
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-14 at 10 19 56](https://github.com/user-attachments/assets/11cdf218-c69c-409f-9103-b86b4a2e8be7) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-14 at 10 20 00](https://github.com/user-attachments/assets/ad91490a-f552-4249-a034-50fed73bba0a)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.