### PR TITLE
[Woo POS][Design System] Update skeleton design for totals view

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -135,6 +135,7 @@ private extension TotalsView {
             Spacer().frame(height: Constants.totalVerticalSpacing)
             Divider()
                 .overlay(Constants.separatorColor)
+                .renderedIf(!totalsLoading)
             Spacer().frame(height: Constants.totalVerticalSpacing)
             totalFieldView(formattedPrice: orderTotals?.orderTotal,
                            shimmeringActive: totalsLoading,
@@ -193,10 +194,9 @@ private extension TotalsView {
     }
 
     func shimmeringLineView(width: CGFloat, height: CGFloat) -> some View {
-        Constants.separatorColor
+        Color.posOnSurfaceVariantLowest
             .frame(width: width, height: height)
             .fixedSize(horizontal: true, vertical: true)
-            .redacted(reason: [.placeholder])
             .shimmering(active: true)
             .cornerRadius(Constants.shimmeringCornerRadius)
     }
@@ -356,10 +356,10 @@ private extension TotalsView {
         static let totalAmountFont: POSFontStyle = .posHeading
         static let separatorColor: Color = Color.posOutlineVariant
 
-        static let shimmeringCornerRadius: CGFloat = 4
-        static let shimmeringWidth: CGFloat = 334
+        static let shimmeringCornerRadius: CGFloat = 8
+        static let shimmeringWidth: CGFloat = 342
         static let subtotalsShimmeringHeight: CGFloat = 36
-        static let totalShimmeringHeight: CGFloat = 40
+        static let totalShimmeringHeight: CGFloat = 46
 
         /// Used for synchronizing animations of shimmeringLine and textField
         static let matchedGeometrySubtotalId: String = "pos_totals_view_subtotal_matched_geometry_id"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15120
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-247_26291

<img width="777" alt="Screenshot 2025-02-13 at 3 38 49 PM" src="https://github.com/user-attachments/assets/2ca8524b-1911-4741-816f-28b16420ac53" />

This pull request includes several updates to the `TotalsView` in the `WooCommerce/Classes/POS/Presentation/TotalsView.swift` file. The changes aim to match the design above.

* Added a condition to render the divider only when `totalsLoading` is false. (`WooCommerce/Classes/POS/Presentation/TotalsView.swift`)
* Updated the color used in the `shimmeringLineView` method from `Constants.separatorColor` to `Color.posOnSurfaceVariantLowest`. (`WooCommerce/Classes/POS/Presentation/TotalsView.swift`)
* Increased the `shimmeringCornerRadius` from 4 to 8 and the `shimmeringWidth` from 334 to 342. Also, increased the `totalShimmeringHeight` from 40 to 46. (`WooCommerce/Classes/POS/Presentation/TotalsView.swift`)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Enter POS
- Add item(s) to cart
- Check out --> the totals loading view should match the design
- Repeat above in a different color scheme

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-13 at 15 35 42](https://github.com/user-attachments/assets/2428b729-48a9-4361-bd72-1079f1b64593) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-13 at 15 36 02](https://github.com/user-attachments/assets/46f02594-8c01-4052-a795-cace7ef57182)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.