### PR TITLE
Background image upload: Show a notice when the user leaves product details while uploads are pending

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Improved image loading in Blaze Campaign Creation: displays a redacted and shimmering effects when loading product image and falls back to a placeholder if no image is available. [https://github.com/woocommerce/woocommerce-ios/pull/15098]
 - [*] Product List: Display syncing animation on items with image upload in progress [https://github.com/woocommerce/woocommerce-ios/pull/15052]
 - [*] Background image upload: Fix missing error notice in iPhones [https://github.com/woocommerce/woocommerce-ios/pull/15117]
+- [*] Background image upload: Show a notice when the user leaves product details while uploads are pending [https://github.com/woocommerce/woocommerce-ios/pull/15134]
 
 21.7
 -----

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import struct Yosemite.ProductImage
 import enum Yosemite.ProductAction
 import protocol Yosemite.StoresManager
@@ -78,6 +79,11 @@ protocol ProductImageUploaderProtocol {
     /// - Parameters:
     ///   - key: identifiable information about the product.
     func startEmittingErrors(key: ProductImageUploaderKey)
+
+    /// Triggers a notice about background image upload for a product if needed.
+    /// - Parameter key: identifiable information about the product.
+    ///
+    func sendBackgroundUploadNoticeIfNeeded(key: ProductImageUploaderKey, using noticePresenter: NoticePresenter)
 
     /// Determines whether there are unsaved changes on a product's images.
     /// If the product had any save request before, it checks whether the image statuses to save match the latest image statuses.
@@ -165,6 +171,18 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
 
     func startEmittingErrors(key: ProductImageUploaderKey) {
         statusUpdatesExcludedProductKeys.remove(key)
+    }
+
+    func sendBackgroundUploadNoticeIfNeeded(key: ProductImageUploaderKey, using noticePresenter: NoticePresenter) {
+        if activeUploadsPublisher.contains(key) {
+            let title = NSLocalizedString(
+                "productImageUploader.backgroundUploadNotice.title",
+                value: "Image uploading will continue in the background",
+                comment: ""
+            )
+            let notice = Notice(title: title)
+            noticePresenter.enqueue(notice: notice)
+        }
     }
 
     func hasUnsavedChangesOnImages(key: ProductImageUploaderKey, originalImages: [ProductImage]) -> Bool {

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -173,12 +173,7 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
 
     func sendBackgroundUploadNoticeIfNeeded(key: ProductImageUploaderKey, using noticePresenter: NoticePresenter) {
         if activeUploadsPublisher.contains(key) {
-            let title = NSLocalizedString(
-                "productImageUploader.backgroundUploadNotice.title",
-                value: "Image uploading will continue in the background",
-                comment: ""
-            )
-            let notice = Notice(title: title)
+            let notice = Notice(title: Localization.backgroundUploadNoticeTitle)
             noticePresenter.enqueue(notice: notice)
         }
     }
@@ -315,4 +310,12 @@ enum ProductImageUploaderError: Error {
     case noRemoteProductIDFound
     case failedSavingProductAfterImageUpload(error: Error)
     case failedUploadingImage(error: Error)
+}
+
+private enum Localization {
+    static let backgroundUploadNoticeTitle = NSLocalizedString(
+        "productImageUploader.backgroundUploadNotice.title",
+        value: "Image uploading will continue in the background",
+        comment: ""
+    )
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -196,9 +196,11 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         view.endEditing(true)
 
         if isBeingDismissedInAnyWay {
-            productImageUploader.startEmittingErrors(key: .init(siteID: viewModel.productModel.siteID,
-                                                                productOrVariationID: productOrVariationID,
-                                                                isLocalID: !viewModel.productModel.existsRemotely))
+            let key = ProductImageUploaderKey(siteID: viewModel.productModel.siteID,
+                                              productOrVariationID: productOrVariationID,
+                                              isLocalID: !viewModel.productModel.existsRemotely)
+            productImageUploader.startEmittingErrors(key: key)
+            productImageUploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: ServiceLocator.noticePresenter)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -195,7 +195,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
         view.endEditing(true)
         prepareForBackgroundUploadsUponDismissal()
-        
     }
 
     override var shouldShowOfflineBanner: Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -194,14 +194,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         super.viewWillDisappear(animated)
 
         view.endEditing(true)
-
-        if isBeingDismissedInAnyWay {
-            let key = ProductImageUploaderKey(siteID: viewModel.productModel.siteID,
-                                              productOrVariationID: productOrVariationID,
-                                              isLocalID: !viewModel.productModel.existsRemotely)
-            productImageUploader.startEmittingErrors(key: key)
-            productImageUploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: ServiceLocator.noticePresenter)
-        }
+        prepareForBackgroundUploadsUponDismissal()
+        
     }
 
     override var shouldShowOfflineBanner: Bool {
@@ -1339,6 +1333,16 @@ private extension ProductFormViewController {
 // MARK: - Navigation actions handling
 //
 private extension ProductFormViewController {
+    func prepareForBackgroundUploadsUponDismissal() {
+        guard isBeingDismissedInAnyWay else { return }
+
+        let key = ProductImageUploaderKey(siteID: viewModel.productModel.siteID,
+                                          productOrVariationID: productOrVariationID,
+                                          isLocalID: !viewModel.productModel.existsRemotely)
+        productImageUploader.startEmittingErrors(key: key)
+        productImageUploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: ServiceLocator.noticePresenter)
+    }
+
     func presentBackNavigationActionSheet(onDiscard: @escaping () -> Void = {}, onCancel: @escaping () -> Void = {}) {
         let exitForm: () -> Void = {
             presentationStyle.createExitForm(viewController: navigationController ?? self, completion: onDiscard)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -231,12 +231,7 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if didNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode(navigationController, didShow: viewController) {
             if let contentType = contentTypes.last, case let .productForm(product) = contentType, let product {
-                let uploader = ServiceLocator.productImageUploader
-                let key = ProductImageUploaderKey(siteID: product.siteID,
-                                                  productOrVariationID: .product(id: product.productID),
-                                                  isLocalID: false)
-                uploader.startEmittingErrors(key: key)
-                uploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: ServiceLocator.noticePresenter)
+                didDismissProductForm(product: product)
             }
             contentTypes = []
             secondaryNavigationController.viewControllers = []
@@ -276,6 +271,15 @@ private extension ProductsSplitViewCoordinator {
         viewController is SearchViewController<ProductsTabProductTableViewCell, ProductSearchUICommand>
         return splitViewController.isCollapsed && navigationController == primaryNavigationController
             && contentTypes.isNotEmpty && isNavigatingToProductList
+    }
+
+    func didDismissProductForm(product: Product) {
+        let uploader = ServiceLocator.productImageUploader
+        let key = ProductImageUploaderKey(siteID: product.siteID,
+                                          productOrVariationID: .product(id: product.productID),
+                                          isLocalID: false)
+        uploader.startEmittingErrors(key: key)
+        uploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: ServiceLocator.noticePresenter)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -231,10 +231,12 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if didNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode(navigationController, didShow: viewController) {
             if let contentType = contentTypes.last, case let .productForm(product) = contentType, let product {
-                ServiceLocator.productImageUploader.startEmittingErrors(
-                    key: .init(siteID: product.siteID,
-                               productOrVariationID: .product(id: product.productID),
-                               isLocalID: false))
+                let uploader = ServiceLocator.productImageUploader
+                let key = ProductImageUploaderKey(siteID: product.siteID,
+                                                  productOrVariationID: .product(id: product.productID),
+                                                  isLocalID: false)
+                uploader.startEmittingErrors(key: key)
+                uploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: ServiceLocator.noticePresenter)
             }
             contentTypes = []
             secondaryNavigationController.viewControllers = []

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductImageUploader.swift
@@ -63,6 +63,10 @@ extension MockProductImageUploader: ProductImageUploaderProtocol {
         hasUnsavedChangesOnImages
     }
 
+    func sendBackgroundUploadNoticeIfNeeded(key: ProductImageUploaderKey, using noticePresenter: NoticePresenter) {
+        // no-op
+    }
+
     func reset() {
         resetWasCalled = true
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -617,6 +617,7 @@ final class ProductImageUploaderTests: XCTestCase {
     }
 
     func test_product_is_removed_from_activeUploads_when_upload_is_cancelled() {
+        // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let imageUploader = ProductImageUploader(stores: stores)
         let key = ProductImageUploaderKey(siteID: siteID,
@@ -647,6 +648,45 @@ final class ProductImageUploaderTests: XCTestCase {
         waitUntil {
             activeUploads == []
         }
+    }
+
+    func test_background_upload_notice_is_sent_when_there_are_active_uploads() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let imageUploader = ProductImageUploader(stores: stores)
+        let key = ProductImageUploaderKey(siteID: siteID,
+                                          productOrVariationID: .product(id: productID),
+                                          isLocalID: false)
+        let actionHandler = imageUploader.actionHandler(key: key, originalStatuses: [])
+
+        let noticePresenter = MockNoticePresenter()
+        var isNoticeTriggered = false
+        noticePresenter.onNoticeQueued = { _ in
+            isNoticeTriggered = true
+        }
+
+        var activeUploads: [ProductImageUploaderKey] = []
+        activeUploadsSubscription = imageUploader.activeUploads
+            .sink { keys in
+                activeUploads = keys
+            }
+
+        // When
+        imageUploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: noticePresenter)
+
+        // Then
+        XCTAssertFalse(isNoticeTriggered)
+
+        // When
+        let asset = PHAsset()
+        actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: .phAsset(asset: asset))
+        waitUntil {
+            activeUploads == [key]
+        }
+
+        // Then
+        imageUploader.sendBackgroundUploadNoticeIfNeeded(key: key, using: noticePresenter)
+        XCTAssertTrue(isNoticeTriggered)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7315 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a notice to be displayed when dismissing the product form while there are pending image uploads.

The change includes a new helper method in `ProductImageUploader` to display this notice for better reusability.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Open an existing product or create a new one.
- Add one or more image to the product, save the changes and navigate back to the product list. If you're using an iPad, select a different product in the product list instead.
- Confirm that a notice is displayed regarding the background image upload.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 16 Pro and iPad Mini and confirmed that the notice is displayed on both iPhone and iPad.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

iPhone:


https://github.com/user-attachments/assets/7ae457ae-d78f-4c7e-a1e7-d140037cbeb0

iPad:


https://github.com/user-attachments/assets/1f9798bb-c6ff-40ef-b3b8-eac06f43dba8



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.