### PR TITLE
[Brand Updates] Remove underline from links in the login screens

### DIFF
--- a/WooCommerce/WordPressAuthenticator/Extensions/String+Underline.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/String+Underline.swift
@@ -1,24 +1,24 @@
 extension String {
-    /// Creates an attributed string from one underlined section that's surrounded by underscores
+    /// Creates an attributed string from one link section that's surrounded by underscores
     ///
     /// - Parameters:
     ///   - color: foreground color to use for the string (optional)
-    ///   - underlineColor: foreground color to use for the underlined section (optional)
+    ///   - linkColor: foreground color to use for the link (optional)
     /// - Returns: Attributed string
-    /// - Note: "this _is_ underlined" would under the "is"
-    func underlined(color: UIColor? = nil, underlineColor: UIColor? = nil) -> NSAttributedString {
+    /// - Note: "this _is_ an example" would color the "is" using the linkColor
+    func withColor(color: UIColor? = nil, linkColor: UIColor? = nil) -> NSAttributedString {
         let labelParts = self.components(separatedBy: "_")
         let firstPart = labelParts[0]
-        let underlinePart = labelParts.indices.contains(1) ? labelParts[1] : ""
+        let linkParts = labelParts.indices.contains(1) ? labelParts[1] : ""
         let lastPart = labelParts.indices.contains(2) ? labelParts[2] : ""
 
         let foregroundColor = color ?? UIColor.black
-        let underlineForegroundColor = underlineColor ?? foregroundColor
+        let linkSectionColor = linkColor ?? foregroundColor
 
-        let underlinedString = NSMutableAttributedString(string: firstPart, attributes: [.foregroundColor: foregroundColor])
-        underlinedString.append(NSAttributedString(string: underlinePart, attributes: [.underlineStyle: NSUnderlineStyle.single.rawValue, .foregroundColor: underlineForegroundColor]))
-        underlinedString.append(NSAttributedString(string: lastPart, attributes: [.foregroundColor: foregroundColor]))
+        let result = NSMutableAttributedString(string: firstPart, attributes: [.foregroundColor: foregroundColor])
+        result.append(NSAttributedString(string: linkParts, attributes: [.foregroundColor: linkSectionColor]))
+        result.append(NSAttributedString(string: lastPart, attributes: [.foregroundColor: foregroundColor]))
 
-        return underlinedString
+        return result
     }
 }

--- a/WooCommerce/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -175,8 +175,8 @@ extension WPStyleGuide {
         if WordPressAuthenticator.shared.configuration.showLoginOptions {
             let baseString =  NSLocalizedString("Or log in by _entering your site address_.", comment: "Label for button to log in using site address. Underscores _..._ denote underline.")
 
-            let attrStrNormal = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonColor)
-            let attrStrHighlight = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonHighlightColor)
+            let attrStrNormal = baseString.withColor(color: style.subheadlineColor, linkColor: style.textButtonColor)
+            let attrStrHighlight = baseString.withColor(color: style.subheadlineColor, linkColor: style.textButtonHighlightColor)
             let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 
             button = textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: alignment)
@@ -203,8 +203,8 @@ extension WPStyleGuide {
     class func wpcomSignupButton() -> UIButton {
         let style = WordPressAuthenticator.shared.style
         let baseString = NSLocalizedString("Don't have an account? _Sign up_", comment: "Label for button to log in using your site address. The underscores _..._ denote underline")
-        let attrStrNormal = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonColor)
-        let attrStrHighlight = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonHighlightColor)
+        let attrStrNormal = baseString.withColor(color: style.subheadlineColor, linkColor: style.textButtonColor)
+        let attrStrHighlight = baseString.withColor(color: style.subheadlineColor, linkColor: style.textButtonHighlightColor)
         let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 
         return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font)
@@ -219,8 +219,8 @@ extension WPStyleGuide {
 
         let baseString =  NSLocalizedString("By signing up, you agree to our _Terms of Service_.", comment: "Legal disclaimer for signup buttons, the underscores _..._ denote underline")
 
-        let attrStrNormal = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonColor)
-        let attrStrHighlight = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonHighlightColor)
+        let attrStrNormal = baseString.withColor(color: style.subheadlineColor, linkColor: style.textButtonColor)
+        let attrStrHighlight = baseString.withColor(color: style.subheadlineColor, linkColor: style.textButtonHighlightColor)
         let font = WPStyleGuide.mediumWeightFont(forStyle: .footnote)
 
         return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: .center)
@@ -237,8 +237,8 @@ extension WPStyleGuide {
         let textColor = unifiedStyle?.textSubtleColor ?? originalStyle.subheadlineColor
         let linkColor = unifiedStyle?.textButtonColor ?? originalStyle.textButtonColor
 
-        let attrStrNormal = baseString.underlined(color: textColor, underlineColor: linkColor)
-        let attrStrHighlight = baseString.underlined(color: textColor, underlineColor: linkColor)
+        let attrStrNormal = baseString.withColor(color: textColor, linkColor: linkColor)
+        let attrStrHighlight = baseString.withColor(color: textColor, linkColor: linkColor)
         let font = WPStyleGuide.mediumWeightFont(forStyle: .footnote)
 
         let button = textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: .center, forUnified: true)

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
@@ -33,8 +33,8 @@ class TextWithLinkTableViewCell: UITableViewCell {
         let linkColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
         let linkHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
 
-        let attributedString = text.underlined(color: textColor, underlineColor: linkColor)
-        let highlightAttributedString = text.underlined(color: textColor, underlineColor: linkHighlightColor)
+        let attributedString = text.withColor(color: textColor, linkColor: linkColor)
+        let highlightAttributedString = text.withColor(color: textColor, linkColor: linkHighlightColor)
 
         button.setAttributedTitle(attributedString, for: .normal)
         button.setAttributedTitle(highlightAttributedString, for: .highlighted)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: woocommerce/woomobile-private#413
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR is just a last step on the top issue, it removes the underline from the links in the login screens, for our login flow, it's just one occasion: the TOS section in the WordPress.com login view.

## Steps to reproduce
1. Sign out if needed.
2. Enter the address of a Jetpack connected site.
3. Check the wordpress.com login screen.

## Testing information
Confirm the Terms of Service is not underlined.

## Screenshots
| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-02-13 at 12 37 03](https://github.com/user-attachments/assets/d65ffa92-dee1-453b-9365-8b2bd3287648) | ![Simulator Screenshot - iPhone 16 Pro - 2025-02-13 at 12 37 49](https://github.com/user-attachments/assets/01ed1076-6851-4293-b4f3-168bf4829ed4) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.t