### PR TITLE
[Woo POS] MVP Analytics: Card payment success event properties

### DIFF
--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -6,6 +6,7 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     private var customerInteractionStarted: Double = 0
     private var orderCreated: Double = 0
     private var cardReaderReady: Double = 0
+    private var cardReaderTapped: Double = 0
 
     func preflightResultReceived(_ result: CardReaderPreflightResult?) { }
     func trackProcessingCompletion(intent: Yosemite.PaymentIntent) { }
@@ -22,10 +23,17 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
         // 3. milliseconds_since_reader_ready_to_collect_payment
         let elapsedTimeSinceCardReaderReady = calculateElapsedTimeInMilliseconds(start: cardReaderReady,
                                                                                  end: Date().timeIntervalSince1970)
+
+        // 4. milliseconds_since_card_tapped
+        let elapsedTimeSinceCardTapped = calculateElapsedTimeInMilliseconds(start: cardReaderTapped,
+                                                                            end: Date().timeIntervalSince1970)
+
         ServiceLocator.analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
             millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
             millisecondsSinceOrderCreationSuccess: elapsedTimeSinceOrderCreation,
-            millisecondsSinceReaderReadyToCollect: elapsedTimeSinceCardReaderReady)
+            millisecondsSinceReaderReadyToCollect: elapsedTimeSinceCardReaderReady,
+            millisecondsSinceCardTapped: elapsedTimeSinceCardTapped
+        )
         )
     }
 
@@ -47,6 +55,10 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
 
     func trackCardReaderReady() {
         cardReaderReady = Date().timeIntervalSince1970
+    }
+
+    func trackCardReaderTapped() {
+        cardReaderTapped = Date().timeIntervalSince1970
     }
 
     private func calculateElapsedTimeInMilliseconds(start: Double, end: Double) -> Double {

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -9,6 +9,7 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     private var cardReaderReady: Double = 0
     private var cardReaderTapped: Double = 0
     private var checkoutTapCount: Int = 0
+    private var hasTrackedProcessingPayment = false
 
     private let analytics: Analytics
 
@@ -41,6 +42,7 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
         ))
 
         resetCheckoutTapCountTracker()
+        resetProcessingPaymentTracking()
     }
 
     func trackPaymentFailure(with error: any Error) { }
@@ -63,8 +65,13 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
         cardReaderReady = trackCurrentTime()
     }
 
+    // The Stripe SDK returns multiple `.processing` events, but we want to capture the first one in the stream only.
+    // This flag is reset as soon as the payment has been successful
     func trackCardReaderTapped() {
-        cardReaderTapped = trackCurrentTime()
+        if !hasTrackedProcessingPayment {
+            hasTrackedProcessingPayment = true
+            cardReaderTapped = trackCurrentTime()
+        }
     }
 
     func trackCheckoutTapped() {
@@ -73,6 +80,10 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
 
     func resetCheckoutTapCountTracker() {
         checkoutTapCount = 0
+    }
+
+    private func resetProcessingPaymentTracking() {
+        hasTrackedProcessingPayment = false
     }
 }
 

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -5,6 +5,7 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
 
     private var customerInteractionStarted: Double = 0
     private var orderCreated: Double = 0
+    private var cardReaderReady: Double = 0
 
     func preflightResultReceived(_ result: CardReaderPreflightResult?) { }
     func trackProcessingCompletion(intent: Yosemite.PaymentIntent) { }
@@ -18,9 +19,13 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
         let elapsedTimeSinceOrderCreation = calculateElapsedTimeInMilliseconds(start: orderCreated,
                                                                                end: Date().timeIntervalSince1970)
 
+        // 3. milliseconds_since_reader_ready_to_collect_payment
+        let elapsedTimeSinceCardReaderReady = calculateElapsedTimeInMilliseconds(start: cardReaderReady,
+                                                                                 end: Date().timeIntervalSince1970)
         ServiceLocator.analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
             millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
-            millisecondsSinceOrderCreationSuccess: elapsedTimeSinceOrderCreation)
+            millisecondsSinceOrderCreationSuccess: elapsedTimeSinceOrderCreation,
+            millisecondsSinceReaderReadyToCollect: elapsedTimeSinceCardReaderReady)
         )
     }
 
@@ -38,6 +43,10 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
 
     func trackOrderCreationSuccess() {
         orderCreated = Date().timeIntervalSince1970
+    }
+
+    func trackCardReaderReady() {
+        cardReaderReady = Date().timeIntervalSince1970
     }
 
     private func calculateElapsedTimeInMilliseconds(start: Double, end: Double) -> Double {

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -54,6 +54,8 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     func trackReceiptPrintFailed(error: any Error) { }
 
     func trackCustomerInteractionStarted() {
+        // Any action that is considered as user starting an iteraction resets any ongoing counter
+        resetAllCountersOnInteractionStarted()
         customerInteractionStarted = Date().timeIntervalSince1970
     }
 
@@ -81,10 +83,6 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     func resetCheckoutTapCountTracker() {
         checkoutTapCount = 0
     }
-
-    private func resetProcessingPaymentTracking() {
-        hasTrackedProcessingPayment = false
-    }
 }
 
 // Helpers
@@ -96,6 +94,18 @@ private extension POSCollectOrderPaymentAnalytics {
     func calculateElapsedTimeInMilliseconds(since start: Double) -> Double {
         let end = Date().timeIntervalSince1970
         return floor((end - start) * 1000)
+    }
+
+    private func resetProcessingPaymentTracking() {
+        hasTrackedProcessingPayment = false
+    }
+
+    private func resetAllCountersOnInteractionStarted() {
+        orderCreated = 0
+        cardReaderReady = 0
+        cardReaderTapped = 0
+        resetCheckoutTapCountTracker()
+        resetProcessingPaymentTracking()
     }
 }
 

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -24,7 +24,6 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
 
         // Property: milliseconds_since_card_tapped
         let elapsedTimeSinceCardTapped = calculateElapsedTimeInMilliseconds(since: cardReaderTapped)
-        
 
         ServiceLocator.analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
             millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
@@ -48,15 +47,15 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     }
 
     func trackOrderCreationSuccess() {
-        orderCreated = Date().timeIntervalSince1970
+        orderCreated = trackCurrentTime()
     }
 
     func trackCardReaderReady() {
-        cardReaderReady = Date().timeIntervalSince1970
+        cardReaderReady = trackCurrentTime()
     }
 
     func trackCardReaderTapped() {
-        cardReaderTapped = Date().timeIntervalSince1970
+        cardReaderTapped = trackCurrentTime()
     }
 
     func trackCheckoutTapped() {
@@ -66,14 +65,27 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     func resetCheckoutTapCountTracker() {
         checkoutTapCount = 0
     }
+}
 
-    private func calculateElapsedTimeInMilliseconds(since start: Double) -> Double {
+// Helpers
+private extension POSCollectOrderPaymentAnalytics {
+    func trackCurrentTime() -> Double {
+        Date().timeIntervalSince1970
+    }
+
+    func calculateElapsedTimeInMilliseconds(since start: Double) -> Double {
         let end = Date().timeIntervalSince1970
         return floor((end - start) * 1000)
     }
 }
 
 // Protocol conformance. These events are not needed for IPP, only for POS.
+// https://github.com/woocommerce/woocommerce-ios/issues/15149
 extension CollectOrderPaymentAnalytics {
     func trackCustomerInteractionStarted() { }
+    func trackOrderCreationSuccess() { }
+    func trackCardReaderReady() { }
+    func trackCardReaderTapped() { }
+    func trackCheckoutTapped() { }
+    func resetCheckoutTapCountTracker() { }
 }

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -1,3 +1,4 @@
+import protocol WooFoundation.Analytics
 import Yosemite
 
 final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTracking {
@@ -8,6 +9,12 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     private var cardReaderReady: Double = 0
     private var cardReaderTapped: Double = 0
     private var checkoutTapCount: Int = 0
+
+    private let analytics: Analytics
+
+    init(analytics: Analytics = ServiceLocator.analytics) {
+        self.analytics = analytics
+    }
 
     func preflightResultReceived(_ result: CardReaderPreflightResult?) { }
     func trackProcessingCompletion(intent: Yosemite.PaymentIntent) { }
@@ -25,7 +32,7 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
         // Property: milliseconds_since_card_tapped
         let elapsedTimeSinceCardTapped = calculateElapsedTimeInMilliseconds(since: cardReaderTapped)
 
-        ServiceLocator.analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
+        analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
             millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
             millisecondsSinceOrderCreationSuccess: elapsedTimeSinceOrderCreation,
             millisecondsSinceReaderReadyToCollect: elapsedTimeSinceCardReaderReady,

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -4,14 +4,24 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     var connectedReaderModel: String?
 
     private var customerInteractionStarted: Double = 0
+    private var orderCreated: Double = 0
 
     func preflightResultReceived(_ result: CardReaderPreflightResult?) { }
     func trackProcessingCompletion(intent: Yosemite.PaymentIntent) { }
 
     func trackSuccessfulPayment(capturedPaymentData: CardPresentCapturedPaymentData) {
-        let elapsedTime = calculateElapsedTimeInMilliseconds(start: customerInteractionStarted, end: Date().timeIntervalSince1970)
-        ServiceLocator.analytics.track(event:
-                .PointOfSale.cardPresentCollectPaymentSuccess(millisecondsSinceCustomerIteractionStated: elapsedTime))
+        // 1. milliseconds_since_customer_interaction_started
+        let elapsedTimeSinceCustomerInteraction = calculateElapsedTimeInMilliseconds(start: customerInteractionStarted,
+                                                                                     end: Date().timeIntervalSince1970)
+
+        // 2. milliseconds_since_order_creation_success
+        let elapsedTimeSinceOrderCreation = calculateElapsedTimeInMilliseconds(start: orderCreated,
+                                                                               end: Date().timeIntervalSince1970)
+
+        ServiceLocator.analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
+            millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
+            millisecondsSinceOrderCreationSuccess: elapsedTimeSinceOrderCreation)
+        )
     }
 
     func trackPaymentFailure(with error: any Error) { }
@@ -24,6 +34,10 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
 
     func trackCustomerInteractionStarted() {
         customerInteractionStarted = Date().timeIntervalSince1970
+    }
+
+    func trackOrderCreationSuccess() {
+        orderCreated = Date().timeIntervalSince1970
     }
 
     private func calculateElapsedTimeInMilliseconds(start: Double, end: Double) -> Double {

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -39,6 +39,8 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
             millisecondsSinceCardTapped: elapsedTimeSinceCardTapped,
             checkoutTapCount: checkoutTapCount
         ))
+
+        resetCheckoutTapCountTracker()
     }
 
     func trackPaymentFailure(with error: any Error) { }

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -7,34 +7,32 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
     private var orderCreated: Double = 0
     private var cardReaderReady: Double = 0
     private var cardReaderTapped: Double = 0
+    private var checkoutTapCount: Int = 0
 
     func preflightResultReceived(_ result: CardReaderPreflightResult?) { }
     func trackProcessingCompletion(intent: Yosemite.PaymentIntent) { }
 
     func trackSuccessfulPayment(capturedPaymentData: CardPresentCapturedPaymentData) {
-        // 1. milliseconds_since_customer_interaction_started
-        let elapsedTimeSinceCustomerInteraction = calculateElapsedTimeInMilliseconds(start: customerInteractionStarted,
-                                                                                     end: Date().timeIntervalSince1970)
+        // Property: milliseconds_since_customer_interaction_started
+        let elapsedTimeSinceCustomerInteraction = calculateElapsedTimeInMilliseconds(since: customerInteractionStarted)
 
-        // 2. milliseconds_since_order_creation_success
-        let elapsedTimeSinceOrderCreation = calculateElapsedTimeInMilliseconds(start: orderCreated,
-                                                                               end: Date().timeIntervalSince1970)
+        // Property: milliseconds_since_order_creation_success
+        let elapsedTimeSinceOrderCreation = calculateElapsedTimeInMilliseconds(since: orderCreated)
 
-        // 3. milliseconds_since_reader_ready_to_collect_payment
-        let elapsedTimeSinceCardReaderReady = calculateElapsedTimeInMilliseconds(start: cardReaderReady,
-                                                                                 end: Date().timeIntervalSince1970)
+        // Property: milliseconds_since_reader_ready_to_collect_payment
+        let elapsedTimeSinceCardReaderReady = calculateElapsedTimeInMilliseconds(since: cardReaderReady)
 
-        // 4. milliseconds_since_card_tapped
-        let elapsedTimeSinceCardTapped = calculateElapsedTimeInMilliseconds(start: cardReaderTapped,
-                                                                            end: Date().timeIntervalSince1970)
+        // Property: milliseconds_since_card_tapped
+        let elapsedTimeSinceCardTapped = calculateElapsedTimeInMilliseconds(since: cardReaderTapped)
+        
 
         ServiceLocator.analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
             millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
             millisecondsSinceOrderCreationSuccess: elapsedTimeSinceOrderCreation,
             millisecondsSinceReaderReadyToCollect: elapsedTimeSinceCardReaderReady,
-            millisecondsSinceCardTapped: elapsedTimeSinceCardTapped
-        )
-        )
+            millisecondsSinceCardTapped: elapsedTimeSinceCardTapped,
+            checkoutTapCount: checkoutTapCount
+        ))
     }
 
     func trackPaymentFailure(with error: any Error) { }
@@ -61,8 +59,17 @@ final class POSCollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTrackin
         cardReaderTapped = Date().timeIntervalSince1970
     }
 
-    private func calculateElapsedTimeInMilliseconds(start: Double, end: Double) -> Double {
-        floor((end - start) * 1000)
+    func trackCheckoutTapped() {
+        checkoutTapCount += 1
+    }
+
+    func resetCheckoutTapCountTracker() {
+        checkoutTapCount = 0
+    }
+
+    private func calculateElapsedTimeInMilliseconds(since start: Double) -> Double {
+        let end = Date().timeIntervalSince1970
+        return floor((end - start) * 1000)
     }
 }
 

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -13,6 +13,7 @@ extension WooAnalyticsEvent {
             static let itemType = "product_type"
             static let itemsInCart = "items_in_cart"
             static let millisecondsSinceCustomerInteractionStarted = "milliseconds_since_customer_interaction_started"
+            static let millisecondsSinceOrderCreationSuccess = "milliseconds_since_order_creation_success"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -33,10 +34,12 @@ extension WooAnalyticsEvent {
                               properties: [Key.itemsInCart: itemsInCart])
         }
 
-        static func cardPresentCollectPaymentSuccess(millisecondsSinceCustomerIteractionStated: Double) -> WooAnalyticsEvent {
+        static func cardPresentCollectPaymentSuccess(millisecondsSinceCustomerIteractionStarted: Double,
+                                                     millisecondsSinceOrderCreationSuccess: Double) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess, properties: [
-                Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStated)"]
-            )
+                Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
+                Key.millisecondsSinceOrderCreationSuccess : "\(millisecondsSinceOrderCreationSuccess)"
+            ])
         }
     }
 }

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -14,6 +14,7 @@ extension WooAnalyticsEvent {
             static let itemsInCart = "items_in_cart"
             static let millisecondsSinceCustomerInteractionStarted = "milliseconds_since_customer_interaction_started"
             static let millisecondsSinceOrderCreationSuccess = "milliseconds_since_order_creation_success"
+            static let millisecondsSinceReaderReadyToCollect = "milliseconds_since_reader_ready_to_collect_payment"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -35,10 +36,12 @@ extension WooAnalyticsEvent {
         }
 
         static func cardPresentCollectPaymentSuccess(millisecondsSinceCustomerIteractionStarted: Double,
-                                                     millisecondsSinceOrderCreationSuccess: Double) -> WooAnalyticsEvent {
+                                                     millisecondsSinceOrderCreationSuccess: Double,
+                                                     millisecondsSinceReaderReadyToCollect: Double) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess, properties: [
                 Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
-                Key.millisecondsSinceOrderCreationSuccess : "\(millisecondsSinceOrderCreationSuccess)"
+                Key.millisecondsSinceOrderCreationSuccess : "\(millisecondsSinceOrderCreationSuccess)",
+                Key.millisecondsSinceReaderReadyToCollect : "\(millisecondsSinceReaderReadyToCollect)"
             ])
         }
     }

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -16,6 +16,7 @@ extension WooAnalyticsEvent {
             static let millisecondsSinceOrderCreationSuccess = "milliseconds_since_order_creation_success"
             static let millisecondsSinceReaderReadyToCollect = "milliseconds_since_reader_ready_to_collect_payment"
             static let millisecondsSinceCardTapped = "milliseconds_since_card_tapped"
+            static let checkoutTapCount = "checkout_tap_count"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -39,12 +40,14 @@ extension WooAnalyticsEvent {
         static func cardPresentCollectPaymentSuccess(millisecondsSinceCustomerIteractionStarted: Double,
                                                      millisecondsSinceOrderCreationSuccess: Double,
                                                      millisecondsSinceReaderReadyToCollect: Double,
-                                                     millisecondsSinceCardTapped: Double) -> WooAnalyticsEvent {
+                                                     millisecondsSinceCardTapped: Double,
+                                                     checkoutTapCount: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess, properties: [
                 Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
                 Key.millisecondsSinceOrderCreationSuccess: "\(millisecondsSinceOrderCreationSuccess)",
                 Key.millisecondsSinceReaderReadyToCollect: "\(millisecondsSinceReaderReadyToCollect)",
-                Key.millisecondsSinceCardTapped: "\(millisecondsSinceCardTapped)"
+                Key.millisecondsSinceCardTapped: "\(millisecondsSinceCardTapped)",
+                Key.checkoutTapCount: "\(checkoutTapCount)"
             ])
         }
     }

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -15,6 +15,7 @@ extension WooAnalyticsEvent {
             static let millisecondsSinceCustomerInteractionStarted = "milliseconds_since_customer_interaction_started"
             static let millisecondsSinceOrderCreationSuccess = "milliseconds_since_order_creation_success"
             static let millisecondsSinceReaderReadyToCollect = "milliseconds_since_reader_ready_to_collect_payment"
+            static let millisecondsSinceCardTapped = "milliseconds_since_card_tapped"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -37,11 +38,13 @@ extension WooAnalyticsEvent {
 
         static func cardPresentCollectPaymentSuccess(millisecondsSinceCustomerIteractionStarted: Double,
                                                      millisecondsSinceOrderCreationSuccess: Double,
-                                                     millisecondsSinceReaderReadyToCollect: Double) -> WooAnalyticsEvent {
+                                                     millisecondsSinceReaderReadyToCollect: Double,
+                                                     millisecondsSinceCardTapped: Double) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess, properties: [
                 Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
-                Key.millisecondsSinceOrderCreationSuccess : "\(millisecondsSinceOrderCreationSuccess)",
-                Key.millisecondsSinceReaderReadyToCollect : "\(millisecondsSinceReaderReadyToCollect)"
+                Key.millisecondsSinceOrderCreationSuccess: "\(millisecondsSinceOrderCreationSuccess)",
+                Key.millisecondsSinceReaderReadyToCollect: "\(millisecondsSinceReaderReadyToCollect)",
+                Key.millisecondsSinceCardTapped: "\(millisecondsSinceCardTapped)"
             ])
         }
     }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -13,10 +13,20 @@ import class WooFoundation.CurrencySettings
 import enum WooFoundation.CurrencyCode
 import protocol WooFoundation.Analytics
 
+enum SyncOrderState {
+    case newOrder
+    case orderUpdated
+}
+
+enum SyncOrderStateError: Error {
+    case syncFailure
+}
+
 protocol PointOfSaleOrderControllerProtocol {
     var orderState: PointOfSaleInternalOrderState { get }
 
-    func syncOrder(for cartProducts: [CartItem], retryHandler: @escaping () async -> Void) async
+    @discardableResult
+    func syncOrder(for cartProducts: [CartItem], retryHandler: @escaping () async -> Void) async -> Result<SyncOrderState, Error>
     func sendReceipt(recipientEmail: String) async throws
     func clearOrder()
     func collectCashPayment() async throws
@@ -51,16 +61,16 @@ protocol PointOfSaleOrderControllerProtocol {
     private(set) var orderState: PointOfSaleInternalOrderState = .idle
     private var order: Order? = nil
 
-    @MainActor
+    @MainActor @discardableResult
     func syncOrder(for cartItems: [CartItem],
-                   retryHandler: @escaping () async -> Void) async {
+                   retryHandler: @escaping () async -> Void) async -> Result<SyncOrderState, Error> {
         let posCartItems = cartItems.map {
             POSCartItem(item: $0.item, quantity: Decimal($0.quantity))
         }
 
         guard !orderState.isSyncing,
               !posCartItems.matches(order: order) else {
-            return
+            return .failure(SyncOrderStateError.syncFailure)
         }
 
         orderState = .syncing
@@ -74,6 +84,9 @@ protocol PointOfSaleOrderControllerProtocol {
             orderState = .loaded(totals(for: syncedOrder), syncedOrder)
             if isNewOrder {
                 analytics.track(.orderCreationSuccess)
+                return .success(.newOrder)
+            } else {
+                return .success(.orderUpdated)
             }
         } catch {
             if isNewOrder {
@@ -83,6 +96,7 @@ protocol PointOfSaleOrderControllerProtocol {
                     errorDescription: error.localizedDescription))
             }
             setOrderStateToError(error, retryHandler: retryHandler)
+            return .failure(SyncOrderStateError.syncFailure)
         }
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -16,6 +16,7 @@ import protocol WooFoundation.Analytics
 enum SyncOrderState {
     case newOrder
     case orderUpdated
+    case orderNotChanged
 }
 
 enum SyncOrderStateError: Error {
@@ -68,9 +69,8 @@ protocol PointOfSaleOrderControllerProtocol {
             POSCartItem(item: $0.item, quantity: Decimal($0.quantity))
         }
 
-        guard !orderState.isSyncing,
-              !posCartItems.matches(order: order) else {
-            return .failure(SyncOrderStateError.syncFailure)
+        guard !orderState.isSyncing, !posCartItems.matches(order: order) else {
+            return .success(.orderNotChanged)
         }
 
         orderState = .syncing

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -227,7 +227,6 @@ extension PointOfSaleAggregateModel {
         }
         do {
             try await collectPayment(for: order)
-            collectOrderPaymentAnalyticsTracker.resetCheckoutTapCountTracker()
         } catch {
             DDLogError("Error taking payment: \(error)")
         }
@@ -251,6 +250,7 @@ extension PointOfSaleAggregateModel {
 
     private func cashPaymentSuccess() {
         paymentState = .cash(.paymentSuccess)
+        // TODO: Move to trackSuccessfulCashPayment() on #15151
         collectOrderPaymentAnalyticsTracker.resetCheckoutTapCountTracker()
     }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -227,6 +227,7 @@ extension PointOfSaleAggregateModel {
         }
         do {
             try await collectPayment(for: order)
+            collectOrderPaymentAnalyticsTracker.resetCheckoutTapCountTracker()
         } catch {
             DDLogError("Error taking payment: \(error)")
         }
@@ -250,6 +251,7 @@ extension PointOfSaleAggregateModel {
 
     private func cashPaymentSuccess() {
         paymentState = .cash(.paymentSuccess)
+        collectOrderPaymentAnalyticsTracker.resetCheckoutTapCountTracker()
     }
 
     @MainActor
@@ -446,6 +448,7 @@ private extension PointOfSaleAggregateModel {
 extension PointOfSaleAggregateModel {
     @MainActor
     func checkOut() async {
+        collectOrderPaymentAnalyticsTracker.trackCheckoutTapped()
         orderStage = .finalizing
         await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
             await self?.checkOut()

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -450,10 +450,12 @@ extension PointOfSaleAggregateModel {
     func checkOut() async {
         collectOrderPaymentAnalyticsTracker.trackCheckoutTapped()
         orderStage = .finalizing
-        await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
+        let syncOrderResult = await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
             await self?.checkOut()
         })
-        collectOrderPaymentAnalyticsTracker.trackOrderCreationSuccess()
+        if case .success(.newOrder) = syncOrderResult {
+            collectOrderPaymentAnalyticsTracker.trackOrderCreationSuccess()
+        }
         await startPaymentWhenCardReaderConnected()
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -442,6 +442,7 @@ extension PointOfSaleAggregateModel {
         await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
             await self?.checkOut()
         })
+        collectOrderPaymentAnalyticsTracker.trackOrderCreationSuccess()
         await startPaymentWhenCardReaderConnected()
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -369,6 +369,10 @@ private extension PointOfSaleAggregateModel {
                     collectOrderPaymentAnalyticsTracker.trackCardReaderReady()
                 }
 
+                if case .card(.processingPayment) = newPaymentState {
+                    collectOrderPaymentAnalyticsTracker.trackCardReaderTapped()
+                }
+
                 return newPaymentState
             }
             .sink(receiveValue: { [weak self] paymentState in

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -365,6 +365,10 @@ private extension PointOfSaleAggregateModel {
                 let newPaymentState = PointOfSalePaymentState(from: paymentEvent,
                                                               using: presentationStyleDeterminerDependencies)
 
+                if case .card(.acceptingCard) = newPaymentState {
+                    collectOrderPaymentAnalyticsTracker.trackCardReaderReady()
+                }
+
                 return newPaymentState
             }
             .sink(receiveValue: { [weak self] paymentState in

--- a/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
+++ b/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
@@ -12,8 +12,9 @@ class PointOfSalePreviewOrderController: PointOfSaleOrderControllerProtocol {
         OrderFactory.newOrder(currency: .USD)
     )
 
-    func syncOrder(for cartProducts: [CartItem],
-                   retryHandler: @escaping () async -> Void) async { }
+    func syncOrder(for cartProducts: [CartItem], retryHandler: @escaping () async -> Void) async -> Result<SyncOrderState, Error> {
+        return .success(.newOrder)
+    }
 
     func sendReceipt(recipientEmail: String) async throws { }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -33,14 +33,6 @@ protocol CollectOrderPaymentAnalyticsTracking {
     func resetCheckoutTapCountTracker()
 }
 
-extension CollectOrderPaymentAnalytics {
-    func trackOrderCreationSuccess() { }
-    func trackCardReaderReady() { }
-    func trackCardReaderTapped() { }
-    func trackCheckoutTapped() { }
-    func resetCheckoutTapCountTracker() { }
-}
-
 final class CollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTracking {
 
     private let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -26,6 +26,11 @@ protocol CollectOrderPaymentAnalyticsTracking {
     func trackReceiptPrintFailed(error: Error)
 
     func trackCustomerInteractionStarted()
+    func trackOrderCreationSuccess()
+}
+
+extension CollectOrderPaymentAnalytics {
+    func trackOrderCreationSuccess() { }
 }
 
 final class CollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTracking {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -27,10 +27,12 @@ protocol CollectOrderPaymentAnalyticsTracking {
 
     func trackCustomerInteractionStarted()
     func trackOrderCreationSuccess()
+    func trackCardReaderReady()
 }
 
 extension CollectOrderPaymentAnalytics {
     func trackOrderCreationSuccess() { }
+    func trackCardReaderReady() { }
 }
 
 final class CollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTracking {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -28,11 +28,13 @@ protocol CollectOrderPaymentAnalyticsTracking {
     func trackCustomerInteractionStarted()
     func trackOrderCreationSuccess()
     func trackCardReaderReady()
+    func trackCardReaderTapped()
 }
 
 extension CollectOrderPaymentAnalytics {
     func trackOrderCreationSuccess() { }
     func trackCardReaderReady() { }
+    func trackCardReaderTapped() { }
 }
 
 final class CollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTracking {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -29,12 +29,16 @@ protocol CollectOrderPaymentAnalyticsTracking {
     func trackOrderCreationSuccess()
     func trackCardReaderReady()
     func trackCardReaderTapped()
+    func trackCheckoutTapped()
+    func resetCheckoutTapCountTracker()
 }
 
 extension CollectOrderPaymentAnalytics {
     func trackOrderCreationSuccess() { }
     func trackCardReaderReady() { }
     func trackCardReaderTapped() { }
+    func trackCheckoutTapped() { }
+    func resetCheckoutTapCountTracker() { }
 }
 
 final class CollectOrderPaymentAnalytics: CollectOrderPaymentAnalyticsTracking {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1589,6 +1589,7 @@
 		68709D3D2A2ED94900A7FA6C /* UpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */; };
 		68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
+		687C006F2D6346E300F832FC /* POSCollectOrderPaymentAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687C006E2D6346E300F832FC /* POSCollectOrderPaymentAnalyticsTests.swift */; };
 		6881CCC42A5EE6BF00AEDE36 /* WooPlanCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */; };
 		6885E2CC2C32B14B004C8D70 /* TotalsViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */; };
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
@@ -4737,6 +4738,7 @@
 		68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesView.swift; sourceTree = "<group>"; };
 		68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
+		687C006E2D6346E300F832FC /* POSCollectOrderPaymentAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCollectOrderPaymentAnalyticsTests.swift; sourceTree = "<group>"; };
 		6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPlanCardView.swift; sourceTree = "<group>"; };
 		6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewHelper.swift; sourceTree = "<group>"; };
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
@@ -9843,6 +9845,14 @@
 			path = InAppPurchases;
 			sourceTree = "<group>";
 		};
+		687C006C2D63469F00F832FC /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				687C006E2D6346E300F832FC /* POSCollectOrderPaymentAnalyticsTests.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		68DF5A8B2CB38EC5000154C9 /* Coupons */ = {
 			isa = PBXGroup;
 			children = (
@@ -12986,6 +12996,7 @@
 		DABF35242C11B40C006AF826 /* POS */ = {
 			isa = PBXGroup;
 			children = (
+				687C006C2D63469F00F832FC /* Analytics */,
 				200BA15C2CF0A9D90006DC5B /* Controllers */,
 				20ADE9442C6B361500C91265 /* Card Present Payments */,
 				DAD988C72C4A9D49009DE9E3 /* Models */,
@@ -17244,6 +17255,7 @@
 				DA24152B2D116EAE0008F69A /* WooShippingAddPackageViewModelTests.swift in Sources */,
 				DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */,
 				D449C52C26E02F2F00D75B02 /* WhatsNewFactoryTests.swift in Sources */,
+				687C006F2D6346E300F832FC /* POSCollectOrderPaymentAnalyticsTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				EE19058A2B590FF800617C53 /* BlazePaymentMethodsViewModelTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCollectOrderPaymentAnalyticsTracker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCollectOrderPaymentAnalyticsTracker.swift
@@ -57,4 +57,24 @@ final class MockCollectOrderPaymentAnalyticsTracker: CollectOrderPaymentAnalytic
     func trackCustomerInteractionStarted() {
         // no-op
     }
+
+    func trackOrderCreationSuccess() {
+        // no-op
+    }
+
+    func trackCardReaderReady() {
+        // no-op
+    }
+
+    func trackCardReaderTapped() {
+        // no-op
+    }
+
+    func trackCheckoutTapped() {
+        // no-op
+    }
+
+    func resetCheckoutTapCountTracker() {
+        // no-op
+    }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCollectOrderPaymentAnalyticsTracker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCollectOrderPaymentAnalyticsTracker.swift
@@ -70,8 +70,9 @@ final class MockCollectOrderPaymentAnalyticsTracker: CollectOrderPaymentAnalytic
         // no-op
     }
 
+    var didCallTrackCheckoutTapped = false
     func trackCheckoutTapped() {
-        // no-op
+        didCallTrackCheckoutTapped = true
     }
 
     func resetCheckoutTapCountTracker() {

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -1,0 +1,36 @@
+@testable import WooCommerce
+import protocol WooFoundation.Analytics
+import Testing
+
+struct POSCollectOrderPaymentAnalyticsTests {
+    private let analytics: Analytics
+    private let analyticsProvider: MockAnalyticsProvider
+
+    init() {
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    @Test func POSCollectOrderPaymentAnalyticsTests_when_successful_payment_then_tracks_event_and_properties() {
+        // Given
+        let sut = POSCollectOrderPaymentAnalytics(analytics: analytics)
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
+        let expectedEvent = "card_present_collect_payment_success"
+        let expectedProperties = [
+            "milliseconds_since_order_creation_success",
+            "milliseconds_since_reader_ready_to_collect_payment",
+            "milliseconds_since_card_tapped",
+            "milliseconds_since_customer_interaction_started",
+            "checkout_tap_count"
+        ]
+
+        // When
+        sut.trackSuccessfulPayment(capturedPaymentData: capturedPaymentData)
+
+        // Then
+        #expect(analyticsProvider.receivedEvents.first(where: { $0 == expectedEvent }) != nil)
+        #expect(expectedProperties.allSatisfy { key in
+            analyticsProvider.receivedProperties.contains(where: { $0.keys.contains(key) })
+        })
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -276,6 +276,77 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockPaymentCelebration.celebrationWasCalled == true)
     }
 
+    @available(iOS 17.0, *)
+    @Test func syncOrder_when_successful_returns_newOrder_result() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
+        let fakeOrderItem = OrderItem.fake().copy(quantity: 1)
+        let fakeOrder = Order.fake()
+        let fakeCartItem = makeItem(orderItemsToMatch: [fakeOrderItem])
+        mockOrderService.orderToReturn = fakeOrder
+
+        // When
+        let result = await sut.syncOrder(for: [fakeCartItem], retryHandler: { })
+
+        // Then
+        if case .success(let state) = result {
+            #expect(state == .newOrder)
+        } else {
+            #expect(Bool(false), "Expected success with new order result")
+        }
+    }
+
+    @available(iOS 17.0, *)
+    @Test func syncOrder_when_updating_existing_order_returns_orderUpdated_result() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
+        let fakeOrderItem = OrderItem.fake().copy(quantity: 1)
+        let fakeOrder = Order.fake()
+        let fakeCartItem = makeItem(orderItemsToMatch: [fakeOrderItem])
+        mockOrderService.orderToReturn = fakeOrder
+
+        // When
+        // 1. Initial order
+        _ = await sut.syncOrder(for: [makeItem()], retryHandler: {})
+
+        // 2. Sync existing order
+        let result = await sut.syncOrder(for: [makeItem(), makeItem()], retryHandler: {})
+
+        // Then
+        if case .success(let state) = result {
+            #expect(state == .orderUpdated)
+        } else {
+            #expect(Bool(false), "Expected success with order updated result")
+        }
+    }
+
+    @available(iOS 17.0, *)
+        @Test func syncOrder_when_cart_matching_order_returns_syncFailure() async throws {
+            // Given
+            let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                                 receiptService: mockReceiptService)
+            let orderItem = OrderItem.fake().copy(quantity: 1)
+            let fakeOrder = Order.fake().copy(items: [orderItem])
+            let cartItem = makeItem(orderItemsToMatch: [orderItem])
+            mockOrderService.orderToReturn = fakeOrder
+
+            // When
+            // 1. Initial order
+            _ = await sut.syncOrder(for: [cartItem], retryHandler: {})
+
+            // 2. Syncing existing order with same cart should fail
+            let result = await sut.syncOrder(for: [cartItem], retryHandler: {})
+
+            // Then
+            if case .failure(let error) = result {
+                #expect(error as? SyncOrderStateError == .syncFailure)
+            } else {
+                #expect(Bool(false), "Expected error with syncFailure result")
+            }
+        }
+
     struct AnalyticsTests {
         private let analytics: WooAnalytics
         private let analyticsProvider = MockAnalyticsProvider()

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -293,7 +293,7 @@ struct PointOfSaleOrderControllerTests {
         if case .success(let state) = result {
             #expect(state == .newOrder)
         } else {
-            #expect(Bool(false), "Expected success with new order result")
+            #expect(Bool(false), "Expected success result with new order")
         }
     }
 
@@ -304,7 +304,6 @@ struct PointOfSaleOrderControllerTests {
                                              receiptService: mockReceiptService)
         let fakeOrderItem = OrderItem.fake().copy(quantity: 1)
         let fakeOrder = Order.fake()
-        let fakeCartItem = makeItem(orderItemsToMatch: [fakeOrderItem])
         mockOrderService.orderToReturn = fakeOrder
 
         // When
@@ -318,34 +317,52 @@ struct PointOfSaleOrderControllerTests {
         if case .success(let state) = result {
             #expect(state == .orderUpdated)
         } else {
-            #expect(Bool(false), "Expected success with order updated result")
+            #expect(Bool(false), "Expected success result with order updated")
         }
     }
 
     @available(iOS 17.0, *)
-        @Test func syncOrder_when_cart_matching_order_returns_syncFailure() async throws {
-            // Given
-            let sut = PointOfSaleOrderController(orderService: mockOrderService,
-                                                 receiptService: mockReceiptService)
-            let orderItem = OrderItem.fake().copy(quantity: 1)
-            let fakeOrder = Order.fake().copy(items: [orderItem])
-            let cartItem = makeItem(orderItemsToMatch: [orderItem])
-            mockOrderService.orderToReturn = fakeOrder
+    @Test func syncOrder_when_cart_matching_order_then_returns_orderNotChanged_result() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
+        let orderItem = OrderItem.fake().copy(quantity: 1)
+        let fakeOrder = Order.fake().copy(items: [orderItem])
+        let cartItem = makeItem(orderItemsToMatch: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
 
-            // When
-            // 1. Initial order
-            _ = await sut.syncOrder(for: [cartItem], retryHandler: {})
+        // When
+        // 1. Initial order
+        _ = await sut.syncOrder(for: [cartItem], retryHandler: {})
 
-            // 2. Syncing existing order with same cart should fail
-            let result = await sut.syncOrder(for: [cartItem], retryHandler: {})
+        // 2. Syncing existing order with same cart should not update order
+        let result = await sut.syncOrder(for: [cartItem], retryHandler: {})
 
-            // Then
-            if case .failure(let error) = result {
-                #expect(error as? SyncOrderStateError == .syncFailure)
-            } else {
-                #expect(Bool(false), "Expected error with syncFailure result")
-            }
+        // Then
+        if case .success(let state) = result {
+            #expect(state == .orderNotChanged)
+        } else {
+            #expect(Bool(false), "Expected success result with no changes to existing order")
         }
+    }
+
+    @available(iOS 17.0, *)
+    @Test func syncOrder_when_orderService_fails_then_returns_syncOrderState_failure() async throws {
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
+        let cartItem = makeItem(quantity: 1)
+
+        // When
+        mockOrderService.orderToReturn = nil
+        let result = await sut.syncOrder(for: [cartItem], retryHandler: {})
+
+        // Then
+        if case .failure(let error) = result {
+            #expect(error as? SyncOrderStateError == .syncFailure)
+        } else {
+            #expect(Bool(false), "Expected sync failure but got \(result)")
+        }
+    }
 
     struct AnalyticsTests {
         private let analytics: WooAnalytics

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderController.swift
@@ -18,18 +18,22 @@ final class MockPointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     var syncOrderWasCalled: Bool = false
     var spyCartProducts: [CartItem]?
     var spyRetryHandler: (() async -> Void)?
+    var syncOrderResultToReturn: Result<SyncOrderState, Error> = .success(.newOrder)
+
+    @discardableResult
     func syncOrder(for cartProducts: [CartItem],
-                   retryHandler: @escaping () async -> Void) async {
+                   retryHandler: @escaping () async -> Void) async -> Result<SyncOrderState, Error> {
         syncOrderWasCalled = true
         spyCartProducts = cartProducts
         spyRetryHandler = retryHandler
 
         guard let orderStateToReturn else {
             orderState = .syncing
-            return
+            return syncOrderResultToReturn
         }
 
         orderState = orderStateToReturn
+        return syncOrderResultToReturn
     }
 
     var clearOrderWasCalled: Bool = false

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -794,6 +794,22 @@ struct PointOfSaleAggregateModelTests {
             // Then
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "card_reader_disconnect_tapped" }) != nil)
         }
+
+        @available(iOS 17.0, *)
+        @Test func checkout_when_invoked_then_tracks_trackCheckoutTapped() async throws {
+            // Given
+            let analyticsTracker = MockCollectOrderPaymentAnalyticsTracker()
+            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+                                                cardPresentPaymentService: cardPresentPaymentService,
+                                                orderController: orderController,
+                                                collectOrderPaymentAnalyticsTracker: analyticsTracker)
+
+            // When
+            await sut.checkOut()
+
+            // Then
+            #expect(analyticsTracker.didCallTrackCheckoutTapped == true)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
This PR it's a continuation of https://github.com/woocommerce/woocommerce-ios/pull/15138, and adds the following missing properties to `pos_card_present_collect_payment_success` event:

```
milliseconds_since_order_creation_success
milliseconds_since_reader_ready_to_collect_payment
milliseconds_since_card_tapped
checkout_tap_count
```
In order to track these we follow the same design that the existing `milliseconds_since_customer_interaction_started` property, as we need to keep track of the elapsed time between the action starts and ends, before sending the event.

## Testing information
- In POS, add some items to cart, tap checkout, go back to the cart (make some edits or not) and tap checkout again, then follow the card payment flow. At the end, observe that the event has been tracked with elapsed times and a correct number of `checkout_tap_count`. 
```
🔵 Tracked pos_card_present_collect_payment_success, properties: [is_wpcom_store: false, milliseconds_since_card_tapped: 5625.0, plan: , site_url: https://indiemelon.mystagingwebsite.com, checkout_tap_count: 3, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, was_ecommerce_trial: false, milliseconds_since_customer_interaction_started: 27118.0, milliseconds_since_order_creation_success: 19099.0, blog_id: -1, milliseconds_since_reader_ready_to_collect_payment: 9861.0]
```
- Repeat the flow just tapping checkout once, observe the count is 1.

While I have a specific issue logged for adding more testing around tracks, in general I found very tricky to add unit tests due to how "invasive" these are in POS, and how much we'd need to mock.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
