### PR TITLE
[Woo POS][Design System] Update cash payment CTA bottom padding to respect safe area

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -33,7 +33,6 @@ struct PointOfSaleDashboardView: View {
                 case .content:
                     contentView
                         .accessibilitySortPriority(2)
-                        .ignoresSafeArea(edges: .bottom)
                 }
             } else {
                 PointOfSaleUnsupportedWidthView()

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -44,6 +44,7 @@ struct PointOfSaleDashboardView: View {
                                    showSupport: $showSupport,
                                    showDocumentation: $showDocumentation)
             .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
+            .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
             .accessibilitySortPriority(1)
             .renderedIf(posModel.itemsViewState.containerState != .loading)
@@ -167,6 +168,7 @@ private extension PointOfSaleDashboardView {
         // For the moment we're just considering landscape for the POS mode
         // https://github.com/woocommerce/woocommerce-ios/issues/13251
         static let cartWidth: CGFloat = 0.35
+        static let floatingControlBottomPadding: CGFloat = 16
         static let floatingControlHorizontalOffset: CGFloat = 16
         static let floatingControlVerticalOffset: CGFloat = 0
         static let exitPOSSheetMaxWidth: CGFloat = 900.0

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -100,7 +100,6 @@ struct PointOfSaleDashboardView: View {
                     CartView()
                         .accessibilitySortPriority(1)
                         .frame(width: geometry.size.width * Constants.cartWidth)
-                        .ignoresSafeArea(edges: .bottom)
                 }
 
                 if posModel.orderStage == .finalizing {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -348,7 +348,7 @@ private extension TotalsView {
         static let pricesIdealWidth: CGFloat = 382
         static let verticalSpacing: CGFloat = 56
         static let buttonHorizontalPadding: CGFloat = 48
-        static let cashButtonBottomPadding: CGFloat = 24
+        static let cashButtonBottomPadding: CGFloat = 16
 
         static let totalsLineViewPadding: EdgeInsets = .init(top: 20, leading: 24, bottom: 20, trailing: 24)
         static let subtotalsVerticalSpacing: CGFloat = 8


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15144
 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the design for the totals view 1qcjzXitBHU7xPnpCOWnNM-fi-247_27739, the cash payment CTA has a 16px bottom padding to the screen but this doesn't account for the safe area. Placing CTAs too close to the bottom safe area could result in interactions with the bottom slider triggering button tap actions unintentionally. This PR updates the bottom CTAs to respect the safe area so that the padding is 16px above the safe area bottom.

Changes to `PointOfSaleDashboardView`:

* Removed the `ignoresSafeArea` modifier from the `contentView` (otherwise, all subviews ignore the safe area) and `CartView` (`ignoresSafeArea` is already implemented in its background) to avoid ignoring safe area insets at the bottom for the totals view. [[1]](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL36) [[2]](diffhunk://#diff-1069a53acabb24cae728a9d5f67de8766ab4ef606dc97df121c2aac09844fdfcL103)
* Added bottom padding to the floating control to have consistent spacing.

Changes to `TotalsView`:

* Adjusted the bottom padding of the `cashButton` from 24 to 16 to match the design.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Enter POS --> the floating control and Checkout CTA should be aligned at the bottom
- Add items to cart and check out --> the floating control and Cash payment CTA should be aligned at the bottom, 16px above the safe area

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-17 at 21 04 12](https://github.com/user-attachments/assets/702320e7-130e-4aca-ab3d-8e4ddfe0fdc5) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-17 at 21 09 23](https://github.com/user-attachments/assets/b671d9de-d5c5-4d24-acfc-578aed2df550)
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-17 at 21 04 16](https://github.com/user-attachments/assets/8b673f2f-75b0-45b2-bdbc-67ec7901b12d) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-17 at 21 11 26](https://github.com/user-attachments/assets/93d76ba3-d542-4066-99cf-2e7db0c0f0b5)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.