### PR TITLE
[Woo POS][Design System] Update design in cash and receipt views

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -18,7 +18,7 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -11,7 +11,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView: View {
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -11,7 +11,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
                     .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
 
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -18,7 +18,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleCardPresentPaymentConnectingToReaderView: View {
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
@@ -16,7 +16,7 @@ struct PointOfSaleCardPresentPaymentConnectionSuccessAlertView: View {
                 .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
 
             Text(viewModel.title)
-                .font(POSFontStyle.posHeading)
+                .font(POSFontStyle.posHeadingBold)
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityAddTraits(.isHeader)
                 .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
@@ -18,7 +18,7 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersView: View {
     var body: some View {
         VStack {
             Text(Localization.headline)
-                .font(.posHeading)
+                .font(.posHeadingBold)
                 .padding(Layout.headerPadding)
                 .accessibilityAddTraits(.isHeader)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
@@ -18,7 +18,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionView: View {
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
@@ -19,7 +19,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView: View {
                     .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
 
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
                     .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
 
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView: View {
 
                 VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                     Text(viewModel.title)
-                        .font(POSFontStyle.posHeading)
+                        .font(POSFontStyle.posHeadingBold)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityAddTraits(.isHeader)
                         .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleCardPresentPaymentScanningForReadersView: View {
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
                 Text(viewModel.title)
-                    .font(POSFontStyle.posHeading)
+                    .font(POSFontStyle.posHeadingBold)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleItemListEmptyView: View {
                 .foregroundColor(.posOnSurfaceVariantHighest)
             Text(title)
                 .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                .font(.posHeading)
+                .font(.posHeadingBold)
             Text(subtitle)
                 .foregroundStyle(Color.posOnSurfaceVariantHighest)
                 .font(.posBodyLargeRegular())

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -19,7 +19,7 @@ struct PointOfSaleItemListErrorView: View {
                 Text(error.title)
                     .accessibilityAddTraits(.isHeader)
                     .foregroundStyle(Color.posOnSurface)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
                 Text(error.subtitle)
                     .foregroundStyle(Color.posOnSurface)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
@@ -21,7 +21,7 @@ struct PointOfSaleCardPresentPaymentActivityIndicatingMessageView: View {
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 
                 Text(message)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .foregroundStyle(Color(.neutral(.shade60)))
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.messageTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
@@ -7,7 +7,7 @@ struct PointOfSaleCardPresentPaymentCancelledOnReaderMessageView: View {
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
             Text(viewModel.title)
-                .font(.posHeading)
+                .font(.posHeadingBold)
                 .foregroundStyle(Color.posOnSurface)
                 .accessibilityAddTraits(.isHeader)
                 .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -18,7 +18,7 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
                 Text(viewModel.title)
                     .accessibilityAddTraits(.isHeader)
                     .foregroundStyle(Color.posOnSurface)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 
                 VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.smallTextSpacing) {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -14,7 +14,7 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
 
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .foregroundStyle(Color.posOnSurface)
                     .accessibilityAddTraits(.isHeader)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView: View {
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 
                 Text(viewModel.message)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .foregroundColor(.posOnPrimary)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.messageTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
                     .foregroundStyle(Color.posOnSurface)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCardPresentPaymentIntentCreationErrorMessageView: View {
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
                     .foregroundStyle(Color.posOnSurface)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
                     .foregroundStyle(Color.posOnSurface)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageView.swift
@@ -19,7 +19,7 @@ struct PointOfSaleCardPresentPaymentProcessingMessageView: View {
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 
                 Text(viewModel.message)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .foregroundStyle(Color.posOnPrimaryContainer)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.messageTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
@@ -21,7 +21,7 @@ struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView: View {
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 
                 Text(viewModel.message)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .foregroundStyle(Color.posOnSurface)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.messageTransitionId, in: animation.namespace, properties: .position)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView: View {
             VStack(alignment: .center, spacing: Constants.textSpacing) {
                 Text(viewModel.title)
                     .foregroundStyle(Color.posOnSurface)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .accessibilityAddTraits(.isHeader)
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -27,7 +27,7 @@ struct PointOfSalePaymentSuccessView: View {
 
                         VStack(alignment: .center, spacing: Constants.textSpacing) {
                             Text(viewModel.title)
-                                .font(.posHeading)
+                                .font(.posHeadingBold)
                                 .foregroundStyle(Color.posOnSurface)
                                 .accessibilityAddTraits(.isHeader)
                                 .offset(y: isViewLoaded ? 0 : Constants.animationOffset)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/Presented Views/PointOfSaleCardPresentPaymentCaptureFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/Presented Views/PointOfSaleCardPresentPaymentCaptureFailedView.swift
@@ -11,7 +11,7 @@ struct PointOfSaleCardPresentPaymentCaptureFailedView: View {
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(Localization.title)
                     .foregroundStyle(Color.posOnSurface)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
 
                 VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.smallTextSpacing) {
                     Text(Localization.message)

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -202,7 +202,7 @@ private extension CartView {
 @available(iOS 17.0, *)
 private extension CartView {
     enum Constants {
-        static let primaryFont: POSFontStyle = .posHeading
+        static let primaryFont: POSFontStyle = .posHeadingBold
         static let secondaryFont: POSFontStyle = .posBodyLargeRegular()
         static let itemsFont: POSFontStyle = .posBodySmallRegular()
         static let itemHorizontalPadding: CGFloat = 8

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleOrderSyncErrorMessageView: View {
                 VStack(alignment: .center, spacing: Constants.textSpacing) {
                     Text(viewModel.title)
                         .foregroundStyle(Color.posOnSurface)
-                        .font(.posHeading)
+                        .font(.posHeadingBold)
 
                     Text(viewModel.message)
                         .foregroundStyle(Color.posOnSurface)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -57,14 +57,14 @@ struct PointOfSaleCollectCashView: View {
 
                 if let changeDue = changeDueMessage {
                     Text(changeDue)
-                        .font(.posBodyLargeRegular())
+                        .font(.posBodySmallRegular())
                         .foregroundColor(.posOnSurfaceVariantHighest)
                 }
 
                 if let errorMessage = errorMessage {
                     Text(errorMessage)
-                        .font(POSFontStyle.posBodyLargeRegular())
-                        .foregroundColor(.red)
+                        .font(POSFontStyle.posBodySmallRegular())
+                        .foregroundColor(.posError)
                         .padding(.bottom, Constants.errorMessagePadding)
                 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -108,7 +108,7 @@ private extension PointOfSaleCollectCashView {
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
             DynamicVStack(horizontalAlignment: .leading, spacing: Constants.navigationButtonSpacing) {
                 Text(Localization.backNavigationTitle)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .accessibilityAddTraits(.isHeader)
                 if dynamicTypeSize.isAccessibilitySize {
                     Spacer()

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -26,7 +26,7 @@ struct PointOfSaleCollectCashView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .center, spacing: conditionalPadding(8)) {
+            VStack(alignment: .center, spacing: conditionalPadding(13)) {
                 POSPageHeaderView(title: Localization.backNavigationTitle,
                                   subtitle: formattedOrderTotal,
                                   backButtonConfiguration: .init(state: isLoading ? .disabled: .enabled,
@@ -37,31 +37,33 @@ struct PointOfSaleCollectCashView: View {
                     }
                 }))
 
-                VStack(alignment: .center, spacing: conditionalPadding(8)) {
-                    FormattableAmountTextField(viewModel: textFieldViewModel, style: .pos)
-                        .focused($isTextFieldFocused)
-                        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-                        .onSubmit {
-                            Task { @MainActor in
-                                await submitCashAmount()
+                VStack(alignment: .center, spacing: conditionalPadding(62)) {
+                    VStack(alignment: .center, spacing: conditionalPadding(4)) {
+                        FormattableAmountTextField(viewModel: textFieldViewModel, style: .pos)
+                            .focused($isTextFieldFocused)
+                            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+                            .onSubmit {
+                                Task { @MainActor in
+                                    await submitCashAmount()
+                                }
                             }
-                        }
-                        .onChange(of: textFieldViewModel.amount) { newValue in
-                            textFieldAmountInput = newValue
-                            updateChangeDueMessage()
+                            .onChange(of: textFieldViewModel.amount) { newValue in
+                                textFieldAmountInput = newValue
+                                updateChangeDueMessage()
+                            }
+
+                        if let changeDue = changeDueMessage {
+                            Text(changeDue)
+                                .font(.posBodySmallRegular())
+                                .foregroundColor(.posOnSurfaceVariantLowest)
                         }
 
-                    if let changeDue = changeDueMessage {
-                        Text(changeDue)
-                            .font(.posBodySmallRegular())
-                            .foregroundColor(.posOnSurfaceVariantHighest)
-                    }
-
-                    if let errorMessage = errorMessage {
-                        Text(errorMessage)
-                            .font(.posBodySmallRegular())
-                            .foregroundColor(.posError)
-                            .padding(.bottom, Constants.errorMessagePadding)
+                        if let errorMessage = errorMessage {
+                            Text(errorMessage)
+                                .font(.posBodySmallRegular())
+                                .foregroundColor(.posError)
+                                .padding(.bottom, Constants.errorMessagePadding)
+                        }
                     }
 
                     Button(action: {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleExitPosAlertView.swift
@@ -21,7 +21,7 @@ struct PointOfSaleExitPosAlertView: View {
                 .foregroundColor(Color.posOnSurfaceVariantLowest)
             }
             Text(Localization.exitTitle)
-                .font(.posHeading)
+                .font(.posHeadingBold)
                 .padding(.bottom, Constants.titleBottomPadding)
             Text(Localization.exitBody)
                 .font(.posBodyLargeRegular())

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
@@ -13,7 +13,7 @@ struct POSHeaderTitleView: View {
         Text(title)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(Constants.padding)
-            .font(.posHeading)
+            .font(.posHeadingBold)
             .foregroundColor(foregroundColor)
             .accessibilityAddTraits(.isHeader)
     }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -48,7 +48,7 @@ struct POSPageHeaderView<TrailingContent: View>: View {
 
             VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
                 Text(title)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
                     .dynamicTypeSize(...DynamicTypeSize.accessibility2)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -28,7 +28,10 @@ struct POSSendReceiptView: View {
             }))
 
             VStack(alignment: .center, spacing: conditionalPadding(8)) {
-                TextField(Localization.textfieldPlaceholder, text: $textFieldInput)
+                TextField("",
+                          text: $textFieldInput,
+                          prompt: Text(Localization.textfieldPlaceholder).foregroundColor(.posOnDisabledContainer))
+                    .foregroundStyle(Color.posOnSurface)
                     .dynamicTypeSize(...DynamicTypeSize.accessibility1)
                     .keyboardType(.emailAddress)
                     .textInputAutocapitalization(.never)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -29,7 +29,7 @@ struct POSSendReceiptView: View {
                         Image(systemName: "chevron.backward")
                         Text(Localization.emailReceiptNavigationText)
                     }
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                     .foregroundColor(.posOnSurface)
                     .dynamicTypeSize(...DynamicTypeSize.accessibility3)
                     .accessibilityAddTraits(.isHeader)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -55,8 +55,8 @@ struct POSSendReceiptView: View {
 
             if let errorMessage = errorMessage {
                 Text(errorMessage)
-                    .font(POSFontStyle.posBodyLargeRegular())
-                    .foregroundColor(.red)
+                    .font(POSFontStyle.posBodySmallRegular())
+                    .foregroundColor(.posError)
                     .padding(.bottom, Constants.errorMessagePadding)
             }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -45,7 +45,7 @@ struct POSSendReceiptView: View {
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .multilineTextAlignment(.center)
-                .font(POSFontStyle.posBodyXLarge)
+                .font(POSFontStyle.posHeadingRegular)
                 .focused()
                 .focused($isTextFieldFocused)
                 .padding()

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
@@ -14,7 +14,7 @@ struct SimpleProductsOnlyInformation: View {
         VStack(spacing: Constants.contentBlockSpacing) {
             VStack(spacing: Constants.textSpacing) {
                 Text(Localization.modalTitle)
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
 
                 Group {
                     Text(issueMessage)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -356,8 +356,8 @@ private extension TotalsView {
         static let totalsHorizontalSpacing: CGFloat = 24
         static let subtotalTitleFont: POSFontStyle = .posBodyLargeRegular()
         static let subtotalAmountFont: POSFontStyle = .posBodyLargeRegular()
-        static let totalTitleFont: POSFontStyle = .posHeading
-        static let totalAmountFont: POSFontStyle = .posHeading
+        static let totalTitleFont: POSFontStyle = .posHeadingBold
+        static let totalAmountFont: POSFontStyle = .posHeadingBold
         static let separatorColor: Color = Color.posOutlineVariant
 
         static let shimmeringCornerRadius: CGFloat = POSCornerRadiusStyle.medium.value

--- a/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
+++ b/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// iOS type style definitions for POS
 /// 1qcjzXitBHU7xPnpCOWnNM-fi-23_7310
 enum POSFontStyle {
-    case posHeading
+    case posHeadingBold
     case posBodyXLarge
     case posBodyLargeBold
     case posBodyLargeRegular(underline: Bool = false)
@@ -19,7 +19,7 @@ enum POSFontStyle {
 
     fileprivate func font(maximumContentSizeCategory: UIContentSizeCategory? = nil) -> Font {
         switch self {
-        case .posHeading:
+        case .posHeadingBold:
             Font.system(size: scaledValue(FontSize.heading, maximumContentSizeCategory: maximumContentSizeCategory ?? .accessibilityLarge), weight: .bold)
         case .posBodyXLarge:
             Font.system(
@@ -138,7 +138,7 @@ extension UIContentSizeCategory {
         VStack(alignment: .leading, spacing: 20) {
             Group {
                 Text("Title Emphasized")
-                    .font(.posHeading)
+                    .font(.posHeadingBold)
                 Text("Body Extra Large")
                     .font(.posBodyXLarge)
                 Text("Body Large Bold")

--- a/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
+++ b/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// 1qcjzXitBHU7xPnpCOWnNM-fi-23_7310
 enum POSFontStyle {
     case posHeadingBold
+    case posHeadingRegular
     case posBodyXLarge
     case posBodyLargeBold
     case posBodyLargeRegular(underline: Bool = false)
@@ -21,6 +22,8 @@ enum POSFontStyle {
         switch self {
         case .posHeadingBold:
             Font.system(size: scaledValue(FontSize.heading, maximumContentSizeCategory: maximumContentSizeCategory ?? .accessibilityLarge), weight: .bold)
+        case .posHeadingRegular:
+            Font.system(size: scaledValue(FontSize.heading, maximumContentSizeCategory: maximumContentSizeCategory ?? .accessibilityLarge), weight: .regular)
         case .posBodyXLarge:
             Font.system(
                 size: scaledValue(FontSize.bodyXLarge, maximumContentSizeCategory: maximumContentSizeCategory ?? .accessibilityLarge),

--- a/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
+++ b/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
@@ -140,8 +140,10 @@ extension UIContentSizeCategory {
     ScrollView {
         VStack(alignment: .leading, spacing: 20) {
             Group {
-                Text("Title Emphasized")
+                Text("Heading Bold")
                     .font(.posHeadingBold)
+                Text("Heading Regular")
+                    .font(.posHeadingRegular)
                 Text("Body Extra Large")
                     .font(.posBodyXLarge)
                 Text("Body Large Bold")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
@@ -25,6 +25,9 @@ struct FormattableAmountTextField: View {
                 .opacity(0)
 
             Text(viewModel.formattedAmount)
+                .if(style == .pos) {
+                    $0.font(.posHeadingRegular)
+                }
                 .font(.system(size: Layout.amountFontSize(size: viewModel.amountTextSize.fontSize, scale: scale), weight: .bold))
                 .foregroundColor(Color(viewModel.amountTextColor))
                 .minimumScaleFactor(0.1)
@@ -80,5 +83,12 @@ private extension FormattableAmountTextField {
                                                         locale: .current,
                                                         storeCurrencySettings: .init(),
                                                         allowNegativeNumber: false)
-    FormattableAmountTextField(viewModel: viewModel, style: .pos)
+    VStack {
+        Text("Default style")
+        FormattableAmountTextField(viewModel: viewModel, style: .default)
+    }
+    VStack {
+        Text("POS style")
+        FormattableAmountTextField(viewModel: viewModel, style: .pos)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15144 
Part of #15145

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request includes misc design changes to cash and receipt views. A new font style was added, Heading Regular, and the previous Heading was renamed to Heading Bold.

* Renamed text font style from `POSFontStyle.posHeading` to `POSFontStyle.posHeadingBold` for the all use cases.
* Added a new font style `POSFontStyle.posHeadingRegular`.
* Receipt view updates:
  * Updated font and color for various components in `POSSendReceiptView`.
  * ⚠️ Because the receipt view is currently embedded in the payment success view with spacers in the `TotalsView`, vertical spacing will be updated separately to keep the PR changes small.
* Cash view updates:
  * Updated font and color for various components and adjusted vertical spacing in `PointOfSaleCollectCashView`.
  * Updated text field color in `FormattableAmountTextField`. Because the POS font style isn't a Font type, an `if` modifier was used.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Enter POS
- Add item(s) to cart and check out
- Tap `Cash payment` --> the view should match the design
- Enter an invalid amount and submit --> the error state should match the design
- Enter a valid amount that is greater --> the change due state should match the design
- Submit to get to the success view
- Tap to send receipt --> the fonts and colors should match the design (note that the vertical spacing and background color will be updated separately)
- Enter an invalid email and submit --> the error state color should match the design

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Cash

placeholder | change due | error
-- | -- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-18 at 15 50 03](https://github.com/user-attachments/assets/c3f69b2c-690e-42d5-bfc0-d4ed3fcbac06) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-18 at 15 22 16](https://github.com/user-attachments/assets/3c45d468-1555-4822-85fe-1e8bc173a626) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-18 at 15 22 24](https://github.com/user-attachments/assets/faa7487a-c386-4bd8-bcbc-0818f9ad9fd6)

### Receipt

placeholder | normal | error
-- | -- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-18 at 15 49 54](https://github.com/user-attachments/assets/c5d0823b-3afd-4205-b215-9b73cea6e00d) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-18 at 15 24 56](https://github.com/user-attachments/assets/ce8f72a9-e808-4172-aefa-4f8087a62c49) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-18 at 15 24 59](https://github.com/user-attachments/assets/f8bf345c-10a1-407e-92f5-a3fc3f0b1e61)

Dark mode:


https://github.com/user-attachments/assets/6c0317fc-801c-4c80-a9ee-f29e08810f06



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.