### PR TITLE
[Woo POS][Design System] Extract notice to a component to match design

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -73,6 +73,7 @@ private extension ItemListView {
         POSNoticeView(
             title: headerBannerTitle,
             subtitle: headerBannerSubtitle,
+            icon: Image(systemName: "info.circle"),
             onDismiss: {
                 isHeaderBannerDismissed = true
             },

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -70,51 +70,17 @@ private extension ItemListView {
     }
 
     var bannerCardView: some View {
-        HStack(alignment: .top, spacing: 0) {
-            VStack {
-                Spacer()
-                Text(Image(systemName: "info.circle"))
-                    .font(.posButtonSymbolLarge)
-                    .padding(Constants.iconPadding)
-                    .foregroundColor(Color.posOnSurface)
-                    .accessibilityHidden(true)
-                Spacer()
+        POSNoticeView(
+            title: headerBannerTitle,
+            subtitle: headerBannerSubtitle,
+            onDismiss: {
+                isHeaderBannerDismissed = true
+            },
+            onTap: {
+                showSimpleProductsModal = true
             }
-            VStack(alignment: .leading, spacing: Constants.bannerTitleSpacing) {
-                Text(headerBannerTitle)
-                    .font(Constants.bannerTitleFont)
-                    .accessibilityAddTraits(.isHeader)
-                VStack(alignment: .leading, spacing: Constants.bannerTextSpacing) {
-                    Text(headerBannerSubtitle)
-                    bannerHintAndLearnMoreText
-                }
-                .font(Constants.bannerSubtitleFont)
-                .lineSpacing(Constants.bannerTextSpacing)
-                .accessibilityElement(children: .combine)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, Constants.bannerVerticalPadding)
-            VStack {
-                Button(action: {
-                    isHeaderBannerDismissed = true
-                }, label: {
-                    Text(Image(systemName: "xmark"))
-                        .font(.posButtonSymbolSmall)
-                        .foregroundColor(Color.posOnSurfaceVariantLowest)
-                        .accessibilityLabel(Localization.dismissBannerAccessibilityLabel)
-                })
-                .padding(Constants.iconPadding)
-                Spacer()
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .fixedSize(horizontal: false, vertical: true)
-        .background(Color.posSurfaceBright)
-        .cornerRadius(Constants.bannerCornerRadius)
-        .posShadow(.medium)
-        .accessibilityAddTraits(.isButton)
-        .onTapGesture {
-            showSimpleProductsModal = true
+        ) {
+            bannerHintAndLearnMoreText
         }
         .padding(.bottom, Constants.bannerCardPadding)
     }
@@ -174,14 +140,7 @@ private extension ItemListState {
 @available(iOS 17.0, *)
 private extension ItemListView {
     enum Constants {
-        static let bannerTitleFont: POSFontStyle = .posBodyLargeBold
-        static let bannerSubtitleFont: POSFontStyle = .posBodySmallRegular()
-        static let bannerCornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
-        static let bannerVerticalPadding: CGFloat = 26
-        static let bannerTextSpacing: CGFloat = 4
-        static let bannerTitleSpacing: CGFloat = 8
         static let infoIconInset: EdgeInsets = .init(top: 8, leading: 6, bottom: 8, trailing: 6)
-        static let iconPadding: CGFloat = 26
         static let itemListPadding: CGFloat = 16
         static let bannerCardPadding: CGFloat = 16
     }
@@ -231,13 +190,6 @@ private extension ItemListView {
             "pos.itemlistview.headerBanner.learnMoreHint",
             value: "Learn More",
             comment: "Link to more information within the product selector header banner, which explains current POS limitations"
-        )
-
-        static let dismissBannerAccessibilityLabel = NSLocalizedString(
-            "pos.itemListView.headerBanner.dismiss.button.accessibiltyLabel",
-            value: "Dismiss",
-            comment: "Accessibility label for button to dismiss the product selector header banner. " +
-            "The banner explains current POS limitations. Tapping the button prevents it being shown again."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -72,7 +72,6 @@ private extension ItemListView {
     var bannerCardView: some View {
         POSNoticeView(
             title: headerBannerTitle,
-            subtitle: headerBannerSubtitle,
             icon: Image(systemName: "info.circle"),
             onDismiss: {
                 isHeaderBannerDismissed = true
@@ -81,7 +80,10 @@ private extension ItemListView {
                 showSimpleProductsModal = true
             }
         ) {
-            bannerHintAndLearnMoreText
+            VStack(alignment: .leading, spacing: Constants.bannerTextSpacing) {
+                Text(headerBannerSubtitle)
+                bannerHintAndLearnMoreText
+            }
         }
         .padding(.bottom, Constants.bannerCardPadding)
     }
@@ -144,6 +146,7 @@ private extension ItemListView {
         static let infoIconInset: EdgeInsets = .init(top: 0, leading: 6, bottom: 0, trailing: 6)
         static let itemListPadding: CGFloat = 16
         static let bannerCardPadding: CGFloat = 16
+        static let bannerTextSpacing: CGFloat = 4
     }
 
     enum BannerState {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -65,6 +65,7 @@ private extension ItemListView {
             if !dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView
                     .padding(.horizontal, Constants.bannerCardPadding)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             }
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
-/// A reusable notice view component that displays information with an icon, title, subtitle, optional dismiss button, and optional hint view.
+/// A reusable notice view component that displays information with an icon, title, optional subtitle, optional dismiss button, and optional hint view.
 /// Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-67_18935
 struct POSNoticeView<HintContent: View>: View {
     private let title: String
-    private let subtitle: String
+    private let subtitle: String?
     private let icon: Image
     private let onDismiss: (() -> Void)?
     private let onTap: (() -> Void)?
@@ -14,7 +14,7 @@ struct POSNoticeView<HintContent: View>: View {
 
     init(
         title: String,
-        subtitle: String,
+        subtitle: String? = nil,
         icon: Image,
         onDismiss: (() -> Void)? = nil,
         onTap: (() -> Void)? = nil,
@@ -29,10 +29,10 @@ struct POSNoticeView<HintContent: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: Constants.padding) {
+        HStack(alignment: .center, spacing: Constants.padding) {
             VStack {
                 Spacer()
-                Text(icon)
+                Text(icon.resizable())
                     .font(.posButtonSymbolLarge)
                     .padding(.horizontal, Constants.iconHorizontalPadding)
                     .foregroundColor(Color.posOnSurface)
@@ -44,7 +44,9 @@ struct POSNoticeView<HintContent: View>: View {
                     .font(Constants.titleFont)
                     .accessibilityAddTraits(.isHeader)
                 VStack(alignment: .leading, spacing: Constants.textSpacing) {
-                    Text(subtitle)
+                    if let subtitle {
+                        Text(subtitle)
+                    }
                     if let hintContent {
                         hintContent
                     }
@@ -52,6 +54,7 @@ struct POSNoticeView<HintContent: View>: View {
                 .font(Constants.subtitleFont)
                 .lineSpacing(Constants.textSpacing)
                 .accessibilityElement(children: .combine)
+                .renderedIf(subtitle != nil || hintContent != nil)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -134,11 +137,11 @@ private enum Localization {
     .padding()
 }
 
-#Preview("Basic") {
+#Preview("Banner that fits to width") {
     POSNoticeView<AnyView>(
         title: "Example Notice",
-        subtitle: "This is a subtitle that explains more about the notice.",
         icon: Image(systemName: "info.circle")
     )
+    .fixedSize(horizontal: true, vertical: true)
     .padding()
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct POSNoticeView<HintContent: View>: View {
     let title: String
     let subtitle: String
+    let icon: Image
     let onDismiss: (() -> Void)?
     let onTap: (() -> Void)?
     let hintContent: HintContent?
@@ -14,12 +15,14 @@ struct POSNoticeView<HintContent: View>: View {
     init(
         title: String,
         subtitle: String,
+        icon: Image,
         onDismiss: (() -> Void)? = nil,
         onTap: (() -> Void)? = nil,
         @ViewBuilder hintContent: () -> HintContent? = { nil }
     ) {
         self.title = title
         self.subtitle = subtitle
+        self.icon = icon
         self.onDismiss = onDismiss
         self.onTap = onTap
         self.hintContent = hintContent()
@@ -29,7 +32,7 @@ struct POSNoticeView<HintContent: View>: View {
         HStack(alignment: .top, spacing: 0) {
             VStack {
                 Spacer()
-                Text(Image(systemName: "info.circle"))
+                Text(icon)
                     .font(.posButtonSymbolLarge)
                     .padding(Constants.iconPadding)
                     .foregroundColor(Color.posOnSurface)
@@ -106,6 +109,7 @@ private enum Localization {
     POSNoticeView(
         title: "Example Notice",
         subtitle: "This is a subtitle that explains more about the notice.",
+        icon: Image(systemName: "exclamationmark.triangle"),
         onDismiss: {},
         onTap: {}
     ) {
@@ -120,6 +124,7 @@ private enum Localization {
     POSNoticeView(
         title: "Example Notice",
         subtitle: "This is a subtitle that explains more about the notice.",
+        icon: Image(systemName: "bell"),
         onTap: {}
     ) {
         Text("Here's a hint about what to do next. Learn More")
@@ -132,7 +137,8 @@ private enum Localization {
 #Preview("Basic") {
     POSNoticeView<AnyView>(
         title: "Example Notice",
-        subtitle: "This is a subtitle that explains more about the notice."
+        subtitle: "This is a subtitle that explains more about the notice.",
+        icon: Image(systemName: "info.circle")
     )
     .padding()
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
@@ -10,8 +10,6 @@ struct POSNoticeView<HintContent: View>: View {
     private let onTap: (() -> Void)?
     private let hintContent: HintContent?
 
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
     init(
         title: String,
         subtitle: String? = nil,

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// A reusable notice view component that displays information with an icon, title, subtitle, optional dismiss button, and optional hint view.
+/// Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-67_18935
+struct POSNoticeView<HintContent: View>: View {
+    let title: String
+    let subtitle: String
+    let onDismiss: (() -> Void)?
+    let onTap: (() -> Void)?
+    let hintContent: HintContent?
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    init(
+        title: String,
+        subtitle: String,
+        onDismiss: (() -> Void)? = nil,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder hintContent: () -> HintContent? = { nil }
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.onDismiss = onDismiss
+        self.onTap = onTap
+        self.hintContent = hintContent()
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            VStack {
+                Spacer()
+                Text(Image(systemName: "info.circle"))
+                    .font(.posButtonSymbolLarge)
+                    .padding(Constants.iconPadding)
+                    .foregroundColor(Color.posOnSurface)
+                    .accessibilityHidden(true)
+                Spacer()
+            }
+            VStack(alignment: .leading, spacing: Constants.titleSpacing) {
+                Text(title)
+                    .font(Constants.titleFont)
+                    .accessibilityAddTraits(.isHeader)
+                VStack(alignment: .leading, spacing: Constants.textSpacing) {
+                    Text(subtitle)
+                    if let hintContent {
+                        hintContent
+                    }
+                }
+                .font(Constants.subtitleFont)
+                .lineSpacing(Constants.textSpacing)
+                .accessibilityElement(children: .combine)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, Constants.verticalPadding)
+
+            if let onDismiss {
+                VStack {
+                    Button(action: onDismiss, label: {
+                        Text(Image(systemName: "xmark"))
+                            .font(.posButtonSymbolSmall)
+                            .foregroundColor(Color.posOnSurfaceVariantLowest)
+                            .accessibilityLabel(Localization.dismissAccessibilityLabel)
+                    })
+                    .padding(Constants.iconPadding)
+                    Spacer()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(Color.posSurfaceBright)
+        .cornerRadius(Constants.cornerRadius)
+        .posShadow(.medium)
+        .if(onTap != nil) { view in
+            view.accessibilityAddTraits(.isButton)
+        }
+        .if(onTap != nil) { view in
+            view.onTapGesture {
+                onTap?()
+            }
+        }
+    }
+}
+
+// MARK: - Constants
+
+private enum Constants {
+    static let titleFont: POSFontStyle = .posBodyLargeBold
+    static let subtitleFont: POSFontStyle = .posBodySmallRegular()
+    static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
+    static let verticalPadding: CGFloat = 26
+    static let textSpacing: CGFloat = 4
+    static let titleSpacing: CGFloat = 8
+    static let iconPadding: CGFloat = 26
+}
+
+private enum Localization {
+    static let dismissAccessibilityLabel = NSLocalizedString(
+        "pos.noticeView.dismiss.button.accessibiltyLabel",
+        value: "Dismiss",
+        comment: "Accessibility label for button to dismiss a notice banner"
+    )
+}
+
+#Preview("With all options") {
+    POSNoticeView(
+        title: "Example Notice",
+        subtitle: "This is a subtitle that explains more about the notice.",
+        onDismiss: {},
+        onTap: {}
+    ) {
+        Text("Here's a hint about what to do next. Learn More")
+            .font(.posBodySmallBold)
+            .foregroundColor(Color(.posPrimary))
+    }
+    .padding()
+}
+
+#Preview("Without dismiss") {
+    POSNoticeView(
+        title: "Example Notice",
+        subtitle: "This is a subtitle that explains more about the notice.",
+        onTap: {}
+    ) {
+        Text("Here's a hint about what to do next. Learn More")
+            .font(.posBodySmallBold)
+            .foregroundColor(Color(.posPrimary))
+    }
+    .padding()
+}
+
+#Preview("Basic") {
+    POSNoticeView<AnyView>(
+        title: "Example Notice",
+        subtitle: "This is a subtitle that explains more about the notice."
+    )
+    .padding()
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 /// A reusable notice view component that displays information with an icon, title, subtitle, optional dismiss button, and optional hint view.
 /// Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-67_18935
 struct POSNoticeView<HintContent: View>: View {
-    let title: String
-    let subtitle: String
-    let icon: Image
-    let onDismiss: (() -> Void)?
-    let onTap: (() -> Void)?
-    let hintContent: HintContent?
+    private let title: String
+    private let subtitle: String
+    private let icon: Image
+    private let onDismiss: (() -> Void)?
+    private let onTap: (() -> Void)?
+    private let hintContent: HintContent?
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -29,12 +29,12 @@ struct POSNoticeView<HintContent: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
+        HStack(alignment: .top, spacing: Constants.padding) {
             VStack {
                 Spacer()
                 Text(icon)
                     .font(.posButtonSymbolLarge)
-                    .padding(Constants.iconPadding)
+                    .padding(.horizontal, Constants.iconHorizontalPadding)
                     .foregroundColor(Color.posOnSurface)
                     .accessibilityHidden(true)
                 Spacer()
@@ -54,7 +54,6 @@ struct POSNoticeView<HintContent: View>: View {
                 .accessibilityElement(children: .combine)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, Constants.verticalPadding)
 
             if let onDismiss {
                 VStack {
@@ -64,23 +63,23 @@ struct POSNoticeView<HintContent: View>: View {
                             .foregroundColor(Color.posOnSurfaceVariantLowest)
                             .accessibilityLabel(Localization.dismissAccessibilityLabel)
                     })
-                    .padding(Constants.iconPadding)
+                    .padding(Constants.dismissIconPadding)
                     Spacer()
                 }
             }
         }
+        .padding(Constants.padding)
         .frame(maxWidth: .infinity)
         .fixedSize(horizontal: false, vertical: true)
         .background(Color.posSurfaceBright)
         .cornerRadius(Constants.cornerRadius)
         .posShadow(.medium)
         .if(onTap != nil) { view in
-            view.accessibilityAddTraits(.isButton)
-        }
-        .if(onTap != nil) { view in
-            view.onTapGesture {
-                onTap?()
-            }
+            view
+                .accessibilityAddTraits(.isButton)
+                .onTapGesture {
+                    onTap?()
+                }
         }
     }
 }
@@ -91,10 +90,11 @@ private enum Constants {
     static let titleFont: POSFontStyle = .posBodyLargeBold
     static let subtitleFont: POSFontStyle = .posBodySmallRegular()
     static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
-    static let verticalPadding: CGFloat = 26
     static let textSpacing: CGFloat = 4
     static let titleSpacing: CGFloat = 8
-    static let iconPadding: CGFloat = 26
+    static let iconHorizontalPadding: CGFloat = 8
+    static let dismissIconPadding: CGFloat = 6
+    static let padding: CGFloat = 16
 }
 
 private enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift
@@ -1,29 +1,26 @@
 import SwiftUI
 
-/// A reusable notice view component that displays information with an icon, title, optional subtitle, optional dismiss button, and optional hint view.
+/// A reusable notice view component that displays information with an icon, title, optional dismiss button, and optional content view.
 /// Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-67_18935
-struct POSNoticeView<HintContent: View>: View {
+struct POSNoticeView<Content: View>: View {
     private let title: String
-    private let subtitle: String?
     private let icon: Image
     private let onDismiss: (() -> Void)?
     private let onTap: (() -> Void)?
-    private let hintContent: HintContent?
+    private let content: Content?
 
     init(
         title: String,
-        subtitle: String? = nil,
         icon: Image,
         onDismiss: (() -> Void)? = nil,
         onTap: (() -> Void)? = nil,
-        @ViewBuilder hintContent: () -> HintContent? = { nil }
+        @ViewBuilder content: () -> Content? = { nil }
     ) {
         self.title = title
-        self.subtitle = subtitle
         self.icon = icon
         self.onDismiss = onDismiss
         self.onTap = onTap
-        self.hintContent = hintContent()
+        self.content = content()
     }
 
     var body: some View {
@@ -41,29 +38,26 @@ struct POSNoticeView<HintContent: View>: View {
                 Text(title)
                     .font(Constants.titleFont)
                     .accessibilityAddTraits(.isHeader)
-                VStack(alignment: .leading, spacing: Constants.textSpacing) {
-                    if let subtitle {
-                        Text(subtitle)
-                    }
-                    if let hintContent {
-                        hintContent
-                    }
+                if let content {
+                    content
+                        .font(Constants.contentFont)
+                        .lineSpacing(Constants.textSpacing)
+                        .accessibilityElement(children: .combine)
                 }
-                .font(Constants.subtitleFont)
-                .lineSpacing(Constants.textSpacing)
-                .accessibilityElement(children: .combine)
-                .renderedIf(subtitle != nil || hintContent != nil)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
             if let onDismiss {
                 VStack {
-                    Button(action: onDismiss, label: {
-                        Text(Image(systemName: "xmark"))
-                            .font(.posButtonSymbolSmall)
-                            .foregroundColor(Color.posOnSurfaceVariantLowest)
-                            .accessibilityLabel(Localization.dismissAccessibilityLabel)
-                    })
+                    Button(
+                        action: onDismiss,
+                        label: {
+                            Text(Image(systemName: "xmark"))
+                                .font(.posButtonSymbolSmall)
+                                .foregroundColor(Color.posOnSurfaceVariantLowest)
+                                .accessibilityLabel(Localization.dismissAccessibilityLabel)
+                        }
+                    )
                     .padding(Constants.dismissIconPadding)
                     Spacer()
                 }
@@ -89,7 +83,7 @@ struct POSNoticeView<HintContent: View>: View {
 
 private enum Constants {
     static let titleFont: POSFontStyle = .posBodyLargeBold
-    static let subtitleFont: POSFontStyle = .posBodySmallRegular()
+    static let contentFont: POSFontStyle = .posBodySmallRegular()
     static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
     static let textSpacing: CGFloat = 4
     static let titleSpacing: CGFloat = 8
@@ -109,14 +103,16 @@ private enum Localization {
 #Preview("With all options") {
     POSNoticeView(
         title: "Example Notice",
-        subtitle: "This is a subtitle that explains more about the notice.",
         icon: Image(systemName: "exclamationmark.triangle"),
         onDismiss: {},
         onTap: {}
     ) {
-        Text("Here's a hint about what to do next. Learn More")
-            .font(.posBodySmallBold)
-            .foregroundColor(Color(.posPrimary))
+        VStack(alignment: .leading, spacing: Constants.textSpacing) {
+            Text("This is a subtitle that explains more about the notice.")
+            Text("Here's a hint about what to do next. Learn More")
+                .font(.posBodySmallBold)
+                .foregroundColor(Color(.posPrimary))
+        }
     }
     .padding()
 }
@@ -124,13 +120,15 @@ private enum Localization {
 #Preview("Without dismiss") {
     POSNoticeView(
         title: "Example Notice",
-        subtitle: "This is a subtitle that explains more about the notice.",
         icon: Image(systemName: "bell"),
         onTap: {}
     ) {
-        Text("Here's a hint about what to do next. Learn More")
-            .font(.posBodySmallBold)
-            .foregroundColor(Color(.posPrimary))
+        VStack(alignment: .leading, spacing: Constants.textSpacing) {
+            Text("This is a subtitle that explains more about the notice.")
+            Text("Here's a hint about what to do next. Learn More")
+                .font(.posBodySmallBold)
+                .foregroundColor(Color(.posPrimary))
+        }
     }
     .padding()
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 		02952B5127808B08008E9BA3 /* StoreStatsPeriodViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02952B5027808B08008E9BA3 /* StoreStatsPeriodViewModelTests.swift */; };
 		0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295355A245ADF8100BDC42B /* FilterType+Products.swift */; };
 		0295736B2D62B93300865E27 /* POSPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295736A2D62B93300865E27 /* POSPageHeaderView.swift */; };
+		0295CDC02D6477C400865E27 /* POSNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295CDBF2D6477C400865E27 /* POSNoticeView.swift */; };
 		029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EB24FE38C900D242F8 /* ScrollWatcher.swift */; };
 		029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */; };
 		029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029A9C662535873000BECEC5 /* AppCoordinatorTests.swift */; };
@@ -3653,6 +3654,7 @@
 		02952B5027808B08008E9BA3 /* StoreStatsPeriodViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsPeriodViewModelTests.swift; sourceTree = "<group>"; };
 		0295355A245ADF8100BDC42B /* FilterType+Products.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterType+Products.swift"; sourceTree = "<group>"; };
 		0295736A2D62B93300865E27 /* POSPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPageHeaderView.swift; sourceTree = "<group>"; };
+		0295CDBF2D6477C400865E27 /* POSNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSNoticeView.swift; sourceTree = "<group>"; };
 		029700EB24FE38C900D242F8 /* ScrollWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcher.swift; sourceTree = "<group>"; };
 		029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcherTests.swift; sourceTree = "<group>"; };
 		029A9C662535873000BECEC5 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -6492,6 +6494,7 @@
 				027ADB722D21812D009608DB /* POSItemImageView.swift */,
 				027ADB742D218A8D009608DB /* POSItemCardBorderStylesModifier.swift */,
 				0295736A2D62B93300865E27 /* POSPageHeaderView.swift */,
+				0295CDBF2D6477C400865E27 /* POSNoticeView.swift */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -16498,6 +16501,7 @@
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */,
 				0373A12F2A1D1F2100731236 /* DotView.swift in Sources */,
+				0295CDC02D6477C400865E27 /* POSNoticeView.swift in Sources */,
 				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,
 				01F42C162CE34AB8003D0A5A /* CardPresentModalBuiltInSuccessEmailSent.swift in Sources */,
 				028FF8E32AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15071 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request focuses on refactoring the banner header view in `ItemListView` to use a new reusable component, `POSNoticeView`. The most important changes include the replacement of the banner card view, and the addition of the new `POSNoticeView` component.

🗒️ I spent some time using the notice component in two other banner use cases, but decided not to commit them for the following reasons:

- `POSReceiptEligibilityBanner`: the image is a Woo icon image clipped to circle shape, but because the clip shape modifier erases the `Image` type, the image cannot be passed to `POSNoticeView.icon` as an `Image` anymore. We could explore other workarounds like to apply the circle shape at `UIImage` level, but I don't think the effort is worthwhile for this edge case.

<img width="223" alt="Screenshot 2025-02-19 at 10 41 40 AM" src="https://github.com/user-attachments/assets/24e1d622-5d76-410b-bfad-c5920b3f7fc5" />

- `POSConnectivityView`: the background colors are inverted from the original design, and the notice component looks too big on top of the screen:

<img src="https://github.com/user-attachments/assets/0f10683a-3e90-49b0-8798-12f75a3d5525" width="300" />

**Refactoring and Component Addition:**

* [`WooCommerce/Classes/POS/Presentation/ItemListView.swift`](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L73-R85): Replaced the existing banner card view with the new `POSNoticeView` component to simplify and standardize the notice view implementation.
* [`WooCommerce/Classes/POS/Presentation/Reusable Views/POSNoticeView.swift`](diffhunk://#diff-d3d9104145f8c2373272ecf2ebb9c770c2952db9baf91cbf33c902f04e20fbd3R1-R147): Added a new reusable `POSNoticeView` component that displays information with an icon, title, optional subtitle, optional dismiss button, and optional hint view.

**Constants and Localization Cleanup:**

* [`WooCommerce/Classes/POS/Presentation/ItemListView.swift`](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L177-L184): Removed unused constants and localization strings related to the old banner view implementation. [[1]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L177-L184) [[2]](diffhunk://#diff-7348f0411ea3b05ba08687e582f83a4e93265bb61ff7c7302f398953dd954071L235-L241)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->


- If you've dismissed the notice before, it's the easiest to hard code the notice to show up by updating `ItemListView.isHeaderBannerDismissed` variable from `@AppStorage` to `@State`
- Enter POS --> the notice view should match the design (please note that there is no hint content in the design, the original layout was applied)
- Tap on the notice --> the modal about product types should be shown
- Dismiss the modal
- Tap on the dismiss icon on the notice --> the notice should be dismissed, and an `i` icon should be shown on the page header

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-19 at 10 51 05](https://github.com/user-attachments/assets/dd8bbb0e-c27a-411d-9841-ed5fa1bc7f52) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-19 at 10 51 11](https://github.com/user-attachments/assets/07794a81-3989-412e-950a-5476f3b113f0)


https://github.com/user-attachments/assets/f1f82e2d-d441-472f-9200-1c37c3475b78



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.15

