### PR TITLE
[Woo POS][Design System] Receipt view: remove extra padding, update background color

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -23,6 +23,7 @@ struct PointOfSalePaymentSuccessView: View {
                     successView
                     Spacer()
                 }
+                .padding([.leading, .trailing], dynamicTypeSize.isAccessibilitySize ? nil : 8)
             }
         }
         .onAppear {
@@ -36,6 +37,8 @@ struct PointOfSalePaymentSuccessView: View {
     private var successView: some View {
         ZStack {
             VStack(alignment: .center, spacing: Constants.headerSpacing) {
+                Spacer()
+
                 successIcon
                     .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                     .scaleEffect(isViewLoaded ? 1 : 0)
@@ -64,6 +67,8 @@ struct PointOfSalePaymentSuccessView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
                 .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
                 .opacity(isViewLoaded ? 1 : 0)
+
+                Spacer()
             }
             .multilineTextAlignment(.center)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -23,6 +23,7 @@ struct PointOfSalePaymentSuccessView: View {
                     successView
                     Spacer()
                 }
+                .background(Color.posSurface)
                 .padding([.leading, .trailing], dynamicTypeSize.isAccessibilitySize ? nil : 8)
             }
         }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -23,8 +23,8 @@ struct PointOfSalePaymentSuccessView: View {
                     successView
                     Spacer()
                 }
-                .background(Color.posSurface)
                 .padding([.leading, .trailing], dynamicTypeSize.isAccessibilitySize ? nil : 8)
+                .background(Color.posSurface)
             }
         }
         .onAppear {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -18,48 +18,10 @@ struct PointOfSalePaymentSuccessView: View {
                         insertion: .move(edge: .trailing).combined(with: .opacity),
                         removal: .move(edge: .trailing).combined(with: .opacity)))
             } else {
-                ZStack {
-                    VStack(alignment: .center, spacing: Constants.headerSpacing) {
-                        successIcon
-                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
-                            .scaleEffect(isViewLoaded ? 1 : 0)
-                            .opacity(isViewLoaded ? 1 : 0)
-
-                        VStack(alignment: .center, spacing: Constants.textSpacing) {
-                            Text(viewModel.title)
-                                .font(.posHeadingBold)
-                                .foregroundStyle(Color.posOnSurface)
-                                .accessibilityAddTraits(.isHeader)
-                                .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                                .opacity(isViewLoaded ? 1 : 0)
-
-                            if let message = viewModel.message {
-                                Text(message)
-                                    .font(.posBodyLargeRegular())
-                                    .foregroundStyle(Color.posOnSurface)
-                                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                                    .opacity(isViewLoaded ? 1 : 0)
-                            }
-                        }
-
-                        PaymentsActionButtons(isShowingSendReceiptView: $isShowingSendReceiptView,
-                                              isShowingReceiptNotEligibleBanner: $isShowingReceiptNotEligibleBanner)
-                        .containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: 0)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
-                        .opacity(isViewLoaded ? 1 : 0)
-                    }
-                    .multilineTextAlignment(.center)
-
-                    if isShowingReceiptNotEligibleBanner {
-                        VStack {
-                            Spacer()
-                            POSReceiptEligibilityBanner(isVisible: $isShowingReceiptNotEligibleBanner)
-                                .transition(.move(edge: .bottom))
-                                .padding(.bottom)
-                        }
-                        .edgesIgnoringSafeArea(.bottom)
-                    }
+                HStack(alignment: .center) {
+                    Spacer()
+                    successView
+                    Spacer()
                 }
             }
         }
@@ -69,6 +31,52 @@ struct PointOfSalePaymentSuccessView: View {
             }
         }
         .animation(.default, value: isShowingSendReceiptView)
+    }
+
+    private var successView: some View {
+        ZStack {
+            VStack(alignment: .center, spacing: Constants.headerSpacing) {
+                successIcon
+                    .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+                    .scaleEffect(isViewLoaded ? 1 : 0)
+                    .opacity(isViewLoaded ? 1 : 0)
+
+                VStack(alignment: .center, spacing: Constants.textSpacing) {
+                    Text(viewModel.title)
+                        .font(.posHeadingBold)
+                        .foregroundStyle(Color.posOnSurface)
+                        .accessibilityAddTraits(.isHeader)
+                        .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
+                        .opacity(isViewLoaded ? 1 : 0)
+
+                    if let message = viewModel.message {
+                        Text(message)
+                            .font(.posBodyLargeRegular())
+                            .foregroundStyle(Color.posOnSurface)
+                            .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
+                            .opacity(isViewLoaded ? 1 : 0)
+                    }
+                }
+
+                PaymentsActionButtons(isShowingSendReceiptView: $isShowingSendReceiptView,
+                                      isShowingReceiptNotEligibleBanner: $isShowingReceiptNotEligibleBanner)
+                .containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: 0)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
+                .opacity(isViewLoaded ? 1 : 0)
+            }
+            .multilineTextAlignment(.center)
+
+            if isShowingReceiptNotEligibleBanner {
+                VStack {
+                    Spacer()
+                    POSReceiptEligibilityBanner(isVisible: $isShowingReceiptNotEligibleBanner)
+                        .transition(.move(edge: .bottom))
+                        .padding(.bottom)
+                }
+                .edgesIgnoringSafeArea(.bottom)
+            }
+        }
     }
 
     private var successIcon: some View {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -66,7 +66,7 @@ struct POSSendReceiptView: View {
             }
             .padding([.horizontal, .bottom])
         }
-        .background(Color.posSurfaceBright.ignoresSafeArea(.all))
+        .background(Color.posSurfaceBright)
         .animation(.easeInOut, value: errorMessage)
         .onChange(of: textFieldInput) { _ in
             errorMessage = nil

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -66,6 +66,7 @@ struct POSSendReceiptView: View {
             }
             .padding([.horizontal, .bottom])
         }
+        .background(Color.posSurfaceBright.ignoresSafeArea(.all))
         .animation(.easeInOut, value: errorMessage)
         .onChange(of: textFieldInput) { _ in
             errorMessage = nil

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -19,7 +19,6 @@ struct TotalsView: View {
     }
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
-    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         HStack {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -231,10 +231,15 @@ private extension TotalsView {
                     posModel.connectCardReader()
                 }
             } else if let inlinePaymentMessage = posModel.cardPresentPaymentInlineMessage {
-                HStack(alignment: .center) {
-                    Spacer()
+                switch inlinePaymentMessage {
+                case .paymentSuccess:
                     PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
-                    Spacer()
+                default:
+                    HStack(alignment: .center) {
+                        Spacer()
+                        PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
+                        Spacer()
+                    }
                 }
             }
         case .cash(let cashPaymentState):

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -246,14 +246,10 @@ private extension TotalsView {
                 }
             case .paymentSuccess:
                 if case .loaded(let total) = posModel.orderState {
-                    HStack(alignment: .center) {
-                        Spacer()
-                        PointOfSaleCardPresentPaymentInLineMessage(
-                            messageType: .paymentSuccess(
-                                viewModel: .init(formattedOrderTotal: total.orderTotal,
-                                                 paymentMethod: .cash)))
-                        Spacer()
-                    }
+                    PointOfSaleCardPresentPaymentInLineMessage(
+                        messageType: .paymentSuccess(
+                            viewModel: .init(formattedOrderTotal: total.orderTotal,
+                                             paymentMethod: .cash)))
                 }
             }
         }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -32,6 +32,9 @@ struct TotalsView: View {
                         if isShowingPaymentView {
                             paymentView
                                 .font(.title)
+                                .if(viewHelper.shouldApplyPadding(paymentState: posModel.paymentState)) {
+                                    $0.paymentViewPadding(layout: cardReaderViewLayout)
+                                }
                                 .transition(.opacity)
                                 .accessibilityShowsLargeContentViewer()
                                 .background(backgroundColor)
@@ -52,6 +55,7 @@ struct TotalsView: View {
                     .animation(.default, value: posModel.cardPresentPaymentInlineMessage)
 
                     Spacer()
+                        .renderedIf(viewHelper.shouldApplyPadding(paymentState: posModel.paymentState))
 
                     Button(action: {
                         Task { @MainActor in
@@ -220,7 +224,6 @@ private extension TotalsView {
                 PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
                     posModel.connectCardReader()
                 }
-                .paymentViewPadding(layout: cardReaderViewLayout)
             } else if let inlinePaymentMessage = posModel.cardPresentPaymentInlineMessage {
                 switch inlinePaymentMessage {
                 case .paymentSuccess:
@@ -231,7 +234,6 @@ private extension TotalsView {
                         PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
                         Spacer()
                     }
-                    .paymentViewPadding(layout: cardReaderViewLayout)
                 }
             }
         case .cash(let cashPaymentState):
@@ -240,7 +242,6 @@ private extension TotalsView {
                 if case .loaded(let total) = posModel.orderState {
                     PointOfSaleCollectCashView(orderTotal: total.orderTotal)
                         .transition(.move(edge: .trailing))
-                        .paymentViewPadding(layout: cardReaderViewLayout)
                 }
             case .paymentSuccess:
                 if case .loaded(let total) = posModel.orderState {
@@ -322,12 +323,16 @@ private extension TotalsView {
                 return .outlined
             case .paymentError:
                 return .topAligned
+            case .cardPaymentSuccessful:
+                return PaymentViewLayout(backgroundColor: backgroundColor,
+                                         topPadding: 0,
+                                         bottomPadding: 0,
+                                         sidePadding: 0)
             case .idle,
                     .acceptingCard,
                     .validatingOrder,
                     .preparingReader,
-                    .processingPayment,
-                    .cardPaymentSuccessful:
+                    .processingPayment:
                 if TotalsViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: posModel.cardReaderConnectionStatus,
                                                                     paymentState: cardPaymentState) {
                     return .outlined
@@ -345,7 +350,7 @@ private extension TotalsView {
             case .paymentSuccess:
                 return PaymentViewLayout(backgroundColor: backgroundColor,
                                          topPadding: 0,
-                                         bottomPadding: nil,
+                                         bottomPadding: 0,
                                          sidePadding: 0)
             }
         }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -88,8 +88,6 @@ struct TotalsView: View {
 
     private var backgroundColor: Color {
         switch posModel.paymentState {
-        case .card(.cardPaymentSuccessful), .cash(.paymentSuccess):
-            .posSurfaceContainerLowest
         case .card(.processingPayment):
             .posPrimary
         case .cash(.collectingCash):

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -346,8 +346,9 @@ private extension TotalsView {
                                          sidePadding: 0)
             case .paymentSuccess:
                 return PaymentViewLayout(backgroundColor: backgroundColor,
-                                         topPadding: nil,
-                                         bottomPadding: nil)
+                                         topPadding: 0,
+                                         bottomPadding: nil,
+                                         sidePadding: 0)
             }
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -33,13 +33,6 @@ struct TotalsView: View {
                         if isShowingPaymentView {
                             paymentView
                                 .font(.title)
-                                .padding([.leading, .trailing],
-                                         dynamicTypeSize.isAccessibilitySize ? nil :
-                                            cardReaderViewLayout.sidePadding)
-                                .padding(.bottom,
-                                         dynamicTypeSize.isAccessibilitySize ? nil :
-                                            cardReaderViewLayout.bottomPadding)
-                                .padding(.top, dynamicTypeSize.isAccessibilitySize ? nil : cardReaderViewLayout.topPadding)
                                 .transition(.opacity)
                                 .accessibilityShowsLargeContentViewer()
                                 .background(backgroundColor)
@@ -230,6 +223,7 @@ private extension TotalsView {
                 PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
                     posModel.connectCardReader()
                 }
+                .paymentViewPadding(layout: cardReaderViewLayout)
             } else if let inlinePaymentMessage = posModel.cardPresentPaymentInlineMessage {
                 switch inlinePaymentMessage {
                 case .paymentSuccess:
@@ -240,6 +234,7 @@ private extension TotalsView {
                         PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
                         Spacer()
                     }
+                    .paymentViewPadding(layout: cardReaderViewLayout)
                 }
             }
         case .cash(let cashPaymentState):
@@ -248,6 +243,7 @@ private extension TotalsView {
                 if case .loaded(let total) = posModel.orderState {
                     PointOfSaleCollectCashView(orderTotal: total.orderTotal)
                         .transition(.move(edge: .trailing))
+                        .paymentViewPadding(layout: cardReaderViewLayout)
                 }
             case .paymentSuccess:
                 if case .loaded(let total) = posModel.orderState {
@@ -356,6 +352,30 @@ private extension TotalsView {
                                          sidePadding: 0)
             }
         }
+    }
+}
+
+@available(iOS 17.0, *)
+extension TotalsView {
+    fileprivate struct PaymentViewPaddingModifier: ViewModifier {
+        @Environment(\.dynamicTypeSize) var dynamicTypeSize
+        let layout: PaymentViewLayout
+
+        func body(content: Content) -> some View {
+            content.padding(
+                [.leading, .trailing],
+                dynamicTypeSize.isAccessibilitySize ? nil : layout.sidePadding
+            )
+            .padding(.bottom, dynamicTypeSize.isAccessibilitySize ? nil : layout.bottomPadding)
+            .padding(.top, dynamicTypeSize.isAccessibilitySize ? nil : layout.topPadding)
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+fileprivate extension View {
+    func paymentViewPadding(layout: TotalsView.PaymentViewLayout) -> some View {
+        modifier(TotalsView.PaymentViewPaddingModifier(layout: layout))
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
@@ -58,4 +58,13 @@ final class TotalsViewHelper {
             return false
         }
     }
+
+    func shouldApplyPadding(paymentState: PointOfSalePaymentState) -> Bool {
+        switch paymentState {
+        case .card(.cardPaymentSuccessful), .cash(.paymentSuccess):
+            return false
+        default:
+            return true
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #15145 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request focus on updating the receipt view, which also means refactoring the payment success view because the two views are in the same `PointOfSalePaymentSuccessView` with animated transition between the two. Important changes include the padding and background color adjustments, so that the success/receipt view can be shown without any of extra padding set in `TotalsView` for all the payment + order states because the page header component already includes the padding. In the future, I think having padding/background color/layout set in individual views of various states of the same view would make any customizations easier.

* [`WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift`](diffhunk://#diff-cd0c091402bbc3872c96560b87876d953d70ed5492de7c63dead45cc32dd7b23R21-R42): Added a `HStack` to center the success view, applied padding that are originally in `TotalsView`, and background color. [[1]](diffhunk://#diff-cd0c091402bbc3872c96560b87876d953d70ed5492de7c63dead45cc32dd7b23R21-R42) [[2]](diffhunk://#diff-cd0c091402bbc3872c96560b87876d953d70ed5492de7c63dead45cc32dd7b23R71-R72) [[3]](diffhunk://#diff-cd0c091402bbc3872c96560b87876d953d70ed5492de7c63dead45cc32dd7b23L65-L72)

* [`WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift`](diffhunk://#diff-cf5f00f880910c1ca657ce7da8f46d52516787931be43c64c6bcb6712e25f009R69): Added a background color to the `POSSendReceiptView` to match the design.

Refinements to payment success views:

* [`WooCommerce/Classes/POS/Presentation/TotalsView.swift`](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65L22): Introduced a new view modifier `PaymentViewPaddingModifier` to handle padding dynamically based on the payment state. Updated the `TotalsView` to use this modifier and adjusted padding logic accordingly. [[1]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65L22) [[2]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65L36-R37) [[3]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65R58) [[4]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65L98-L99) [[5]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65R228-R238) [[6]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65L249-L256) [[7]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65R326-R335) [[8]](diffhunk://#diff-5313bc77e0f9c678577da2c032a0f5f253602d7494cea659dc8d0f1a1e2cad65L353-R381)

* [`WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift`](diffhunk://#diff-0d6421c76ec884732002fb188134df2ede141528606c9ad47db9c37eefbe81d0R61-R69): Added a new method `shouldApplyPadding` to determine if padding should be applied based on the payment state. It should not be applied to payment success states because the success UI includes the receipt view that does not need the padding.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: card payment is available

- Enter POS
- Add item(s) to cart and check out
- Tap `Cash payment` and enter a valid amount --> the success view shouldn't have any visual issues
- Tap `Email receipt` --> notice the background color is different, and there is no longer extra padding around the page header
- Go back and create a new order
- Add item(s) to cart and check out
- Connect to reader and pay with card --> the success view shouldn't have any visual issues
- Tap `Email receipt` --> notice the background color is different, and there is no longer extra padding around the page header

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


success view | receipt view
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-19 at 17 07 13](https://github.com/user-attachments/assets/39e7c318-72c2-4591-970a-c65c7e4b9e2d) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-19 at 17 07 19](https://github.com/user-attachments/assets/ef3156cd-9c7d-44e2-b39b-b53fe9feeb18)

https://github.com/user-attachments/assets/dc6e8477-8704-4660-9d82-2c5c1d111d46


https://github.com/user-attachments/assets/ebd41304-70db-4e1c-aa55-87ebfbad0b37



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.