### PR TITLE
[Woo POS] Analytics: Fix clear cart event called incorrectly

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -135,7 +135,6 @@ extension PointOfSaleAggregateModel {
 
     func removeAllItemsFromCart() {
         cart.removeAll()
-        analytics.track(.pointOfSaleClearCartTapped)
     }
 
     func addMoreToCart() {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -47,6 +47,7 @@ struct CartView: View {
 
                     Button {
                         posModel.removeAllItemsFromCart()
+                        ServiceLocator.analytics.track(.pointOfSaleClearCartTapped)
                     } label: {
                         Text(Localization.clearButtonTitle)
                     }


### PR DESCRIPTION
Closes: #15194 

## Description
This PR fixes the problem with the `pos_clear_cart_tapped` event discovered during testing, where this event would also be wrongly tracked when the merchant starts a new order from the success view.

This is a side-effect of calling the event in the `removeAllItemsFromCart()` function within the aggregate model, as this function is also used for other logic, like emptying the existing cart before proceeding to start a new order.

I've moved the track event closer to where it actually happens, which is in the view when the button is tapped.

## Testing
1. In POS, add `pos_clear_cart_tapped` to the console's search
2. Add some items to the cart, tap "Clear", and observe the event is tracked:
```
🔵 Tracked pos_clear_cart_tapped, properties: [store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, was_ecommerce_trial: false, site_url: https://indiemelon.mystagingwebsite.com, is_wpcom_store: false, blog_id: -1, plan: ]
```
3. Go through the payment flow, and on the success view tap on "new order"
4. Observe the event is no longer tracked.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
