### PR TITLE
[Shipping labels] Networking & Yosemite support for verifying destination address

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1169,6 +1169,11 @@
 		EE078D912AD2EFBA00C1199E /* JWTokenMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE078D902AD2EFBA00C1199E /* JWTokenMapper.swift */; };
 		EE078D932AD2F1E500C1199E /* JWTokenMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE078D922AD2F1E500C1199E /* JWTokenMapperTests.swift */; };
 		EE078D952AD2FCFA00C1199E /* jwt-token-expired-token.json in Resources */ = {isa = PBXBuildFile; fileRef = EE078D942AD2FCFA00C1199E /* jwt-token-expired-token.json */; };
+		EE1042AD2D65CE61005AB07F /* WooShippingVerifyDestinationAddressMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1042AC2D65CE5E005AB07F /* WooShippingVerifyDestinationAddressMapper.swift */; };
+		EE1042AF2D65CED8005AB07F /* WooShippingVerifyDestinationAddressResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1042AE2D65CED7005AB07F /* WooShippingVerifyDestinationAddressResponse.swift */; };
+		EE1042B12D65CF9D005AB07F /* WooShippingVerifyDestinationAddressSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1042B02D65CF9A005AB07F /* WooShippingVerifyDestinationAddressSuccess.swift */; };
+		EE1042B42D65DF9B005AB07F /* wooshipping-verify-destination-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE1042B32D65DF9B005AB07F /* wooshipping-verify-destination-success.json */; };
+		EE1042B52D65DF9B005AB07F /* wooshipping-verify-destination-error.json in Resources */ = {isa = PBXBuildFile; fileRef = EE1042B22D65DF9B005AB07F /* wooshipping-verify-destination-error.json */; };
 		EE1217DC2AFE04A500E6CAB1 /* ProductVariationEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1217DB2AFE04A500E6CAB1 /* ProductVariationEncoderTests.swift */; };
 		EE1CB9002B4BC85B00AD24D5 /* BlazeTargetOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1CB8FC2B4BC85B00AD24D5 /* BlazeTargetOptions.swift */; };
 		EE1CB9012B4BC85B00AD24D5 /* CreateBlazeCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1CB8FD2B4BC85B00AD24D5 /* CreateBlazeCampaign.swift */; };
@@ -2382,6 +2387,11 @@
 		EE078D902AD2EFBA00C1199E /* JWTokenMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTokenMapper.swift; sourceTree = "<group>"; };
 		EE078D922AD2F1E500C1199E /* JWTokenMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTokenMapperTests.swift; sourceTree = "<group>"; };
 		EE078D942AD2FCFA00C1199E /* jwt-token-expired-token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "jwt-token-expired-token.json"; sourceTree = "<group>"; };
+		EE1042AC2D65CE5E005AB07F /* WooShippingVerifyDestinationAddressMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingVerifyDestinationAddressMapper.swift; sourceTree = "<group>"; };
+		EE1042AE2D65CED7005AB07F /* WooShippingVerifyDestinationAddressResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingVerifyDestinationAddressResponse.swift; sourceTree = "<group>"; };
+		EE1042B02D65CF9A005AB07F /* WooShippingVerifyDestinationAddressSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingVerifyDestinationAddressSuccess.swift; sourceTree = "<group>"; };
+		EE1042B22D65DF9B005AB07F /* wooshipping-verify-destination-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-verify-destination-error.json"; sourceTree = "<group>"; };
+		EE1042B32D65DF9B005AB07F /* wooshipping-verify-destination-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wooshipping-verify-destination-success.json"; sourceTree = "<group>"; };
 		EE1217DB2AFE04A500E6CAB1 /* ProductVariationEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationEncoderTests.swift; sourceTree = "<group>"; };
 		EE1CB8FC2B4BC85B00AD24D5 /* BlazeTargetOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlazeTargetOptions.swift; sourceTree = "<group>"; };
 		EE1CB8FD2B4BC85B00AD24D5 /* CreateBlazeCampaign.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateBlazeCampaign.swift; sourceTree = "<group>"; };
@@ -2564,6 +2574,7 @@
 		02C2548225635BB500A04423 /* ShippingLabel */ = {
 			isa = PBXGroup;
 			children = (
+				EE1042AB2D64E409005AB07F /* VerifyDestinationAddress */,
 				02C254B525637A8300A04423 /* Enums */,
 				029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */,
 				02C254A7256373AB00A04423 /* ShippingLabel.swift */,
@@ -3610,6 +3621,8 @@
 				CED9BCBA2D3EAC5E00C063B8 /* wooshipping-address-validation-success.json */,
 				CED9BCBC2D3EAE4400C063B8 /* wooshipping-address-validation-error.json */,
 				CED9BCC82D3FDFCC00C063B8 /* wooshipping-update-origin-success.json */,
+				EE1042B22D65DF9B005AB07F /* wooshipping-verify-destination-error.json */,
+				EE1042B32D65DF9B005AB07F /* wooshipping-verify-destination-success.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -3723,6 +3736,7 @@
 				DAEE64292D104B720031DCDC /* WooShippingOriginAddressesMapper.swift */,
 				CED9BCCA2D3FE0E400C063B8 /* WooShippingOriginAddressMapper.swift */,
 				CED9BCC42D3EBD0D00C063B8 /* WooShippingAddressValidationSuccessMapper.swift */,
+				EE1042AC2D65CE5E005AB07F /* WooShippingVerifyDestinationAddressMapper.swift */,
 				CE90E99D2CEFCB100068D852 /* WooShippingStatusMapper.swift */,
 				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
@@ -4052,6 +4066,15 @@
 			path = SystemStatusDetails;
 			sourceTree = "<group>";
 		};
+		EE1042AB2D64E409005AB07F /* VerifyDestinationAddress */ = {
+			isa = PBXGroup;
+			children = (
+				EE1042B02D65CF9A005AB07F /* WooShippingVerifyDestinationAddressSuccess.swift */,
+				EE1042AE2D65CED7005AB07F /* WooShippingVerifyDestinationAddressResponse.swift */,
+			);
+			path = VerifyDestinationAddress;
+			sourceTree = "<group>";
+		};
 		EE1CB8F22B4BC7F300AD24D5 /* Blaze */ = {
 			isa = PBXGroup;
 			children = (
@@ -4347,6 +4370,8 @@
 				DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */,
 				D865CE5F278CA183002C8520 /* stripe-payment-intent-requires-action.json in Resources */,
 				DE2004662BF7499600660A72 /* product-stock-decimal-sku.json in Resources */,
+				EE1042B42D65DF9B005AB07F /* wooshipping-verify-destination-success.json in Resources */,
+				EE1042B52D65DF9B005AB07F /* wooshipping-verify-destination-error.json in Resources */,
 				CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */,
 				31A451D927863A2E00FE81AA /* stripe-account-live-test.json in Resources */,
 				DE42F9602967C88400D514C2 /* report-orders-total-without-data.json in Resources */,
@@ -5117,6 +5142,7 @@
 				CE12AE9729F2AB3F0056DD17 /* SubscriptionMapper.swift in Sources */,
 				025CA2C2238EBBAA00B05C81 /* ProductShippingClassListMapper.swift in Sources */,
 				CED9BCC72D3FAD1500C063B8 /* WooShippingAddress.swift in Sources */,
+				EE1042B12D65CF9D005AB07F /* WooShippingVerifyDestinationAddressSuccess.swift in Sources */,
 				74ABA1CD213F1B6B00FFAD30 /* TopEarnerStats.swift in Sources */,
 				CCAAD10F2683974000909664 /* ShippingLabelPackagePurchase.swift in Sources */,
 				265EFBDC285257950033BD33 /* Order+Fallbacks.swift in Sources */,
@@ -5161,6 +5187,7 @@
 				3178A49F2703E5CF00A8B4CA /* RemoteReaderLocationMapper.swift in Sources */,
 				45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
+				EE1042AD2D65CE61005AB07F /* WooShippingVerifyDestinationAddressMapper.swift in Sources */,
 				CC01CE5A29B0FD61004FF537 /* ProductBundleItem.swift in Sources */,
 				DAEE642A2D104B7C0031DCDC /* WooShippingOriginAddressesMapper.swift in Sources */,
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,
@@ -5472,6 +5499,7 @@
 				B59325C7217E22FC000B0E8E /* Note.swift in Sources */,
 				CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */,
 				D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */,
+				EE1042AF2D65CED8005AB07F /* WooShippingVerifyDestinationAddressResponse.swift in Sources */,
 				029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */,
 				0359EA0D27AAC5F80048DE2D /* WCPayChargeStatus.swift in Sources */,
 				CE430674234BA6AD0073CBFF /* RefundMapper.swift in Sources */,

--- a/Networking/Networking/Mapper/WooShippingVerifyDestinationAddressMapper.swift
+++ b/Networking/Networking/Mapper/WooShippingVerifyDestinationAddressMapper.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Mapper: Verify Destination Address Response from WooCommerce Shipping extension
+///
+struct WooShippingVerifyDestinationAddressMapper: Mapper {
+    /// (Attempts) to convert a dictionary into WooShippingVerifyDestinationAddressResponse.
+    ///
+    func map(response: Data) throws -> WooShippingVerifyDestinationAddressSuccess {
+        let decoder = JSONDecoder()
+        let data: WooShippingVerifyDestinationAddressResponse = try {
+            if hasDataEnvelope(in: response) {
+                return try decoder.decode(WooShippingVerifyDestinationAddressResponseEnvelope.self, from: response).data
+            } else {
+                return try decoder.decode(WooShippingVerifyDestinationAddressResponse.self, from: response)
+            }
+        }()
+        return try data.result.get()
+    }
+}
+
+/// WooShippingVerifyDestinationAddressResponseEnvelope Disposable Entity:
+/// `Veridy Destination Address` endpoint returns the shipping label address document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct WooShippingVerifyDestinationAddressResponseEnvelope: Decodable {
+    let data: WooShippingVerifyDestinationAddressResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case data = "data"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressResponse.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Represents Shipping Label Destination Address that has been validated or that generated an error from the WooCommerce Shipping Extension.
+///
+/// Only used internally for JSON decoding since the response might contain validation errors.
+/// For public consumption, we'll convert those to a `WooShippingAddressValidationError`, and expose
+/// a `WooShippingVerifyDestinationAddressSuccess` instead if there were no errors.
+///
+internal struct WooShippingVerifyDestinationAddressResponse: Equatable {
+    let result: Result<WooShippingVerifyDestinationAddressSuccess, WooShippingAddressValidationError>
+
+    init(normalizedAddress: WooShippingAddress?,
+         isTrivialNormalization: Bool?,
+         isVerified: Bool?,
+         errors: WooShippingAddressValidationError?) {
+        if let errors {
+            result = .failure(errors)
+        } else if let normalizedAddress,
+                  let isTrivialNormalization,
+                  let isVerified {
+            result = .success(.init(normalizedAddress: normalizedAddress,
+                                    isTrivialNormalization: isTrivialNormalization,
+                                    isVerified: isVerified))
+        } else {
+            // This case should never happen, but that's not guaranteed.
+            // We'll treat the absence of both the addresses and errors as an error with no message.
+            result = .failure(.init(addressError: nil, generalError: nil, nameError: nil))
+        }
+    }
+}
+
+extension WooShippingVerifyDestinationAddressResponse: Decodable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let normalizedAddress = try container.decodeIfPresent(WooShippingAddress.self, forKey: .normalized)
+        let isTrivialNormalization = try container.decodeIfPresent(Bool.self, forKey: .isTrivialNormalization)
+        let isVerified = try container.decodeIfPresent(Bool.self, forKey: .isVerified)
+        let errors = try container.decodeIfPresent(WooShippingAddressValidationError.self, forKey: .errors)
+        self.init(normalizedAddress: normalizedAddress,
+                  isTrivialNormalization: isTrivialNormalization,
+                  isVerified: isVerified,
+                  errors: errors)
+    }
+}
+
+/// Defines all of the WooShippingVerifyDestinationAddressResponse CodingKeys
+///
+private extension WooShippingVerifyDestinationAddressResponse {
+    enum CodingKeys: String, CodingKey {
+        case normalized = "normalizedAddress"
+        case errors = "errors"
+        case isTrivialNormalization = "isTrivialNormalization"
+        case isVerified = "isVerified"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressSuccess.swift
+++ b/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressSuccess.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Codegen
+
+/// Represents Shipping Label Destination Address that has been verified by the WooCommerce Shipping extension.
+///
+public struct WooShippingVerifyDestinationAddressSuccess: Equatable {
+    public let normalizedAddress: WooShippingAddress
+
+    /// When sending an address to normalize to the server, if the response has the is_trivial_normalization property set to true,
+    /// then the normalized address will be automatically accepted without user intervention.
+    /// As its name indicates, that flag will be set when the changes made by the address normalizator were trivial,
+    /// such as adding the +4 portion to a ZIP code, or changing capitalization, or changing street to st for example.
+    ///
+    public let isTrivialNormalization: Bool
+
+    public let isVerified: Bool
+
+    public init(normalizedAddress: WooShippingAddress,
+                isTrivialNormalization: Bool,
+                isVerified: Bool) {
+        self.normalizedAddress = normalizedAddress
+        self.isTrivialNormalization = isTrivialNormalization
+        self.isVerified = isVerified
+    }
+}

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -351,7 +351,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             completion(.failure(error))
         }
     }
-    
+
     /// Verifies the destination address of an order.
     /// - Parameters:
     ///   - siteID: Remote ID of the site.

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -42,6 +42,9 @@ public protocol WooShippingRemoteProtocol {
                              address: WooShippingOriginAddress,
                              isVerified: Bool,
                              completion: @escaping (Result<WooShippingOriginAddressUpdate, Error>) -> Void)
+    func verifyDestinationAddress(siteID: Int64,
+                                  orderID: Int64,
+                                  completion: @escaping (Result<WooShippingVerifyDestinationAddressSuccess, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -348,6 +351,19 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    public func verifyDestinationAddress(siteID: Int64,
+                                         orderID: Int64,
+                                         completion: @escaping (Result<WooShippingVerifyDestinationAddressSuccess, Error>) -> Void) {
+        let path = Path.verifyOrder(orderID: orderID)
+        let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     availableAsRESTRequest: true)
+        let mapper = WooShippingVerifyDestinationAddressMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: Constants
@@ -362,6 +378,9 @@ private extension WooShippingRemote {
         static let originAddresses = "address/origins"
         static let normalizeAddress = "address/normalize"
         static let updateOrigin = "address/update_origin"
+        static func verifyOrder(orderID: Int64) -> String {
+            "address/\(orderID)/verify_order"
+        }
     }
 
     enum ParameterKey {

--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -351,7 +351,12 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
             completion(.failure(error))
         }
     }
-
+    
+    /// Verifies the destination address of an order.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site.
+    ///   - orderID: Remote ID of the order.
+    ///   - completion: Closure to be executed upon completion.
     public func verifyDestinationAddress(siteID: Int64,
                                          orderID: Int64,
                                          completion: @escaping (Result<WooShippingVerifyDestinationAddressSuccess, Error>) -> Void) {

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -514,6 +514,67 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         XCTAssertNotNil(result.failure)
     }
+
+    // MARK: verifyDestinationAddress
+
+    func test_verifyDestinationAddress_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/\(sampleOrderID)/verify_order", filename: "wooshipping-verify-destination-success")
+
+        // When
+        let result: Result<WooShippingVerifyDestinationAddressSuccess, Error> = waitFor { promise in
+            remote.verifyDestinationAddress(siteID: self.sampleSiteID,
+                                            orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let validationResponse = try XCTUnwrap(result.get())
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(validationResponse.normalizedAddress)
+        XCTAssertFalse(validationResponse.isTrivialNormalization)
+        XCTAssertFalse(validationResponse.isTrivialNormalization)
+    }
+
+    func test_verifyDestinationAddress_returns_errors_on_failure() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/\(sampleOrderID)/verify_order", filename: "wooshipping-verify-destination-error")
+
+        // When
+        let result: Result<WooShippingVerifyDestinationAddressSuccess, Error> = waitFor { promise in
+            remote.verifyDestinationAddress(siteID: self.sampleSiteID,
+                                            orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure as? WooShippingAddressValidationError)
+        XCTAssertEqual(error.addressError, "House number is missing")
+        XCTAssertEqual(error.generalError, "Address not found")
+        XCTAssertEqual(error.nameError, "Either Name or Company is required")
+    }
+
+    func test_verifyDestinationAddress_returns_error_on_network_failure() {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "address/\(sampleOrderID)/verify_order", filename: "generic_error")
+
+        // When
+        let result: Result<WooShippingVerifyDestinationAddressSuccess, Error> = waitFor { promise in
+            remote.verifyDestinationAddress(siteID: self.sampleSiteID,
+                                            orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension WooShippingRemoteTests {

--- a/Networking/NetworkingTests/Responses/wooshipping-verify-destination-error.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-verify-destination-error.json
@@ -1,0 +1,11 @@
+{
+    "data": {
+        "success": false,
+        "errors": {
+            "address": "House number is missing",
+            "name": "Either Name or Company is required",
+            "general": "Address not found"
+        },
+        "isVerified": false
+    }
+}

--- a/Networking/NetworkingTests/Responses/wooshipping-verify-destination-success.json
+++ b/Networking/NetworkingTests/Responses/wooshipping-verify-destination-success.json
@@ -1,0 +1,20 @@
+{
+    "data": {
+        "success": true,
+        "normalizedAddress": {
+            "company": "",
+            "address_2": "",
+            "city": "NEW YORK",
+            "state": "NY",
+            "postcode": "10118-0114",
+            "country": "US",
+            "phone": "555-1234",
+            "address_1": "20 W 34TH ST STE 100",
+            "first_name": "NEW",
+            "last_name": "YORK STORE",
+            "email": "john.doe@example.com"
+        },
+        "isTrivialNormalization": false,
+        "isVerified": false
+    }
+}

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -69,4 +69,10 @@ public enum WooShippingAction: Action {
                              address: WooShippingOriginAddress,
                              isVerified: Bool,
                              completion: (Result<WooShippingOriginAddressUpdate, Error>) -> Void)
+
+    /// Verify destination address of an order.
+    ///
+    case verifyDestinationAddress(siteID: Int64,
+                                  orderID: Int64,
+                                  completion: (Result<WooShippingVerifyDestinationAddressSuccess, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -195,6 +195,7 @@ public typealias WooShippingPackagePurchase = Networking.WooShippingPackagePurch
 public typealias WooShippingPredefinedSavedOption = Networking.WooShippingPredefinedSavedOption
 public typealias WooShippingOriginAddress = Networking.WooShippingOriginAddress
 public typealias WooShippingOriginAddressUpdate = Networking.WooShippingOriginAddressUpdate
+public typealias WooShippingVerifyDestinationAddressSuccess = Networking.WooShippingVerifyDestinationAddressSuccess
 public typealias WPComPlan = Networking.WPComPlan
 public typealias WPComSitePlan = Networking.WPComSitePlan
 public typealias LoadSiteCurrentPlanError = Networking.LoadSiteCurrentPlanError

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -71,6 +71,8 @@ public final class WooShippingStore: Store {
             validateAddress(siteID: siteID, address: address, completion: completion)
         case let .updateOriginAddress(siteID, address, isVerified, completion):
             updateOriginAddress(siteID: siteID, address: address, isVerified: isVerified, completion: completion)
+        case let .verifyDestinationAddress(siteID, orderID, completion):
+            verifyDestinationAddress(siteID: siteID, orderID: orderID, completion: completion)
         }
     }
 }
@@ -266,6 +268,12 @@ private extension WooShippingStore {
                              isVerified: Bool,
                              completion: @escaping (Result<WooShippingOriginAddressUpdate, Error>) -> Void) {
         remote.updateOriginAddress(siteID: siteID, address: address, isVerified: isVerified, completion: completion)
+    }
+
+    func verifyDestinationAddress(siteID: Int64,
+                                  orderID: Int64,
+                                  completion: @escaping (Result<WooShippingVerifyDestinationAddressSuccess, Error>) -> Void) {
+        remote.verifyDestinationAddress(siteID: siteID, orderID: orderID, completion: completion)
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -45,6 +45,9 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `updateOriginAddress`
     private var updateOriginAddress = [ResultKey: Result<WooShippingOriginAddressUpdate, Error>]()
 
+    /// The results to return based on the given arguments in `verifyDestinationAddress`
+    private var verifyDestinationAddress = [ResultKey: Result<WooShippingVerifyDestinationAddressSuccess, Error>]()
+
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
                            thenReturn result: Result<WooShippingCreatePackageResponse, Error>) {
@@ -120,6 +123,13 @@ final class MockWooShippingRemote {
                                    thenReturn result: Result<WooShippingOriginAddressUpdate, Error>) {
         let key = ResultKey(siteID: siteID)
         updateOriginAddress[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `verifyDestinationAddress` is called.
+    func whenVerifyDestinationAddress(siteID: Int64,
+                                      thenReturn result: Result<WooShippingVerifyDestinationAddressSuccess, Error>) {
+        let key = ResultKey(siteID: siteID)
+        verifyDestinationAddress[key] = result
     }
 }
 
@@ -290,6 +300,21 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
             let key = ResultKey(siteID: siteID)
             if let result = self.updateOriginAddress[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func verifyDestinationAddress(siteID: Int64,
+                                  orderID: Int64,
+                                  completion: @escaping (Result<WooShippingVerifyDestinationAddressSuccess, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = ResultKey(siteID: siteID)
+            if let result = self.verifyDestinationAddress[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -696,6 +696,52 @@ final class WooShippingStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? NetworkError, expectedError)
     }
+
+    // MARK: `verifyDestinationAddress`
+
+    func test_verifyDestinationAddress_returns_WooShippingVerifyDestinationAddressSuccess_on_success() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedResult = WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingAddress.fake(),
+                                                                        isTrivialNormalization: true,
+                                                                        isVerified: true)
+        remote.whenVerifyDestinationAddress(siteID: sampleSiteID, thenReturn: .success(expectedResult))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingVerifyDestinationAddressSuccess, Error> = waitFor { promise in
+            let action = WooShippingAction.verifyDestinationAddress(siteID: self.sampleSiteID,
+                                                                    orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let validationSuccess = try XCTUnwrap(result.get())
+        XCTAssertEqual(validationSuccess, expectedResult)
+    }
+
+    func test_verifyDestinationAddress_returns_error_on_failure() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedError = WooShippingAddressValidationError(addressError: "House number not found", generalError: nil, nameError: nil)
+        remote.whenVerifyDestinationAddress(siteID: sampleSiteID, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingVerifyDestinationAddressSuccess, Error> = waitFor { promise in
+            let action = WooShippingAction.verifyDestinationAddress(siteID: self.sampleSiteID,
+                                                                    orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? WooShippingAddressValidationError, expectedError)
+    }
 }
 
 private extension WooShippingStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15174 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds support in the Networking and Yosemite layer for [the verify destination address endpoint](https://github.com/woocommerce/woocommerce-shipping/blob/trunk/docs/api/address.md#verify-destination-address). 

Changes
- Added a new action in `WooShippingStore` to support the verify destination address endpoint.
- Added a new method in `WooShippingRemote.swift`. 
- New mapper and model classes for parsing the response.
- The parsing code follows the pattern from [WooShippingAddressValidationResponse](https://github.com/woocommerce/woocommerce-ios/blob/675b9ddede367e278afb8ec277ec1deac36a5761/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift). 
    - This is because [the verify destination address](https://github.com/woocommerce/woocommerce-ios/blob/675b9ddede367e278afb8ec277ec1deac36a5761/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift) and [the normalize endpoint](https://github.com/woocommerce/woocommerce-shipping/blob/trunk/docs/api/address.md#normalize-address) use the same high level pattern for sending success and error responses. 
- Mock JSON files and unit tests.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
This endpoint is not used yet. Unit tests should pass. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
NA

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added4