### PR TITLE
[Woo POS] Analytics: Make allowed event list for POS when decorating

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -141,7 +141,11 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleReaderReadyForCardPayment,
             WooAnalyticsStat.pointOfSaleCashCollectPaymentSuccess,
 
-            // Shared events - Card Reader Connection
+            // Order
+            WooAnalyticsStat.orderCreationSuccess,
+            WooAnalyticsStat.orderCreationFailed,
+
+            // Card Reader Connection
             WooAnalyticsStat.cardReaderSelectTypeShown,
             WooAnalyticsStat.cardReaderSelectTypeBuiltInTapped,
             WooAnalyticsStat.cardReaderSelectTypeBluetoothTapped,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -171,16 +171,7 @@ private extension TracksProvider {
             WooAnalyticsStat.cardPresentOnboardingCtaFailed,
 
             // Receipts
-            WooAnalyticsStat.receiptViewTapped,
-            WooAnalyticsStat.receiptEmailTapped,
-            WooAnalyticsStat.receiptEmailFailed,
-            WooAnalyticsStat.receiptEmailCanceled,
-            WooAnalyticsStat.receiptEmailSuccess,
-            WooAnalyticsStat.receiptPrintTapped,
-            WooAnalyticsStat.receiptPrintFailed,
-            WooAnalyticsStat.receiptPrintCanceled,
-            WooAnalyticsStat.receiptPrintSuccess,
-            WooAnalyticsStat.receiptFetchFailed,
+            // TODO: 15058-gh
 
             // Payments
             WooAnalyticsStat.collectPaymentCanceled,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -110,25 +110,99 @@ private extension TracksProvider {
     }
 
     private func decorateEventNameForPOSIfNeeded(_ eventName: String) -> String {
-        // We do not want to track some events that might happen in POS mode as `pos_` events,
-        // for example, when backgrounding the app or finishing async work from the app side.
-        // Ref: https://github.com/woocommerce/woocommerce-ios/pull/15006#issuecomment-2622001706
-        let exemptedEvents: Set<String> = [
-            "application_opened",
-            "application_closed",
-            "orders_add_new",
-            "support_new_request_viewed",
-            "dynamic_dashboard_card_data_loading_completed"
-        ]
-        if exemptedEvents.contains(eventName) {
+        guard let event = WooAnalyticsStat(rawValue: eventName) else {
+            DDLogWarn("⚠️ Event not found in WooAnalyticsStat list")
             return eventName
         }
 
-        if Self.isPOSModeActive {
-            let prefix = "pos_"
-            return "\(prefix)\(eventName)"
+        let pointOfSaleEventList: Set<WooAnalyticsStat> = [
+            // POS-specific events
+            WooAnalyticsStat.pointOfSaleLoaded,
+            WooAnalyticsStat.pointOfSaleProductsPullToRefresh,
+            WooAnalyticsStat.pointOfSaleVariationsPullToRefresh,
+            WooAnalyticsStat.pointOfSaleAddItemToCart,
+            WooAnalyticsStat.pointOfSaleItemRemovedFromCart,
+            WooAnalyticsStat.pointOfSaleCheckoutTapped,
+            WooAnalyticsStat.pointOfSaleBackToCartTapped,
+            WooAnalyticsStat.pointOfSaleBackToCheckoutFromCashTapped,
+            WooAnalyticsStat.pointOfSaleClearCartTapped,
+            WooAnalyticsStat.pointOfSaleExitMenuItemTapped,
+            WooAnalyticsStat.pointOfSaleExitConfirmed,
+            WooAnalyticsStat.pointOfSaleGetSupportTapped,
+            WooAnalyticsStat.pointOfSaleSimpleProductsExplanationDialogShown,
+            WooAnalyticsStat.pointOfSaleCreateNewOrderTapped,
+            WooAnalyticsStat.pointOfSaleEmailReceiptTapped,
+            WooAnalyticsStat.pointOfSaleEmailReceiptSendTapped,
+            WooAnalyticsStat.pointOfSalePaymentsOnboardingShown,
+            WooAnalyticsStat.pointOfSalePaymentsOnboardingDismissed,
+            WooAnalyticsStat.pointOfSaleCardReaderConnectionTapped,
+            WooAnalyticsStat.pointOfSaleInteractionWithCustomerStarted,
+            WooAnalyticsStat.pointOfSaleViewDocsTapped,
+            WooAnalyticsStat.pointOfSaleReaderReadyForCardPayment,
+            WooAnalyticsStat.pointOfSaleCashCollectPaymentSuccess,
+
+            // Shared events - Card Reader Connection
+            WooAnalyticsStat.cardReaderSelectTypeShown,
+            WooAnalyticsStat.cardReaderSelectTypeBuiltInTapped,
+            WooAnalyticsStat.cardReaderSelectTypeBluetoothTapped,
+            WooAnalyticsStat.cardReaderDiscoveryFailed,
+            WooAnalyticsStat.cardReaderConnectionFailed,
+            WooAnalyticsStat.cardReaderConnectionSuccess,
+            WooAnalyticsStat.cardReaderDisconnectTapped,
+            WooAnalyticsStat.manageCardReadersBuiltInReaderAutoDisconnect,
+            WooAnalyticsStat.cardReaderAutomaticDisconnect,
+            WooAnalyticsStat.cardReaderLocationPermissionPreAlertShown,
+            WooAnalyticsStat.cardReaderLocationPermissionRequiredShown,
+
+            // Card Reader Software Update
+            WooAnalyticsStat.cardReaderSoftwareUpdateTapped,
+            WooAnalyticsStat.cardReaderSoftwareUpdateStarted,
+            WooAnalyticsStat.cardReaderSoftwareUpdateSuccess,
+            WooAnalyticsStat.cardReaderSoftwareUpdateFailed,
+            WooAnalyticsStat.cardReaderSoftwareUpdateCancelTapped,
+            WooAnalyticsStat.cardReaderSoftwareUpdateCanceled,
+
+            // Card-Present Payments Onboarding
+            WooAnalyticsStat.cardPresentOnboardingLearnMoreTapped,
+            WooAnalyticsStat.cardPresentOnboardingCompleted,
+            WooAnalyticsStat.cardPresentOnboardingNotCompleted,
+            WooAnalyticsStat.cardPresentOnboardingStepSkipped,
+            WooAnalyticsStat.cardPresentOnboardingCtaTapped,
+            WooAnalyticsStat.cardPresentOnboardingCtaFailed,
+
+            // Receipts
+            WooAnalyticsStat.receiptViewTapped,
+            WooAnalyticsStat.receiptEmailTapped,
+            WooAnalyticsStat.receiptEmailFailed,
+            WooAnalyticsStat.receiptEmailCanceled,
+            WooAnalyticsStat.receiptEmailSuccess,
+            WooAnalyticsStat.receiptPrintTapped,
+            WooAnalyticsStat.receiptPrintFailed,
+            WooAnalyticsStat.receiptPrintCanceled,
+            WooAnalyticsStat.receiptPrintSuccess,
+            WooAnalyticsStat.receiptFetchFailed,
+
+            // Payments
+            WooAnalyticsStat.collectPaymentCanceled,
+            WooAnalyticsStat.collectPaymentFailed,
+            WooAnalyticsStat.collectPaymentSuccess,
+            WooAnalyticsStat.collectInteracPaymentSuccess,
+            WooAnalyticsStat.interacRefundSuccess,
+            WooAnalyticsStat.interacRefundFailed,
+            WooAnalyticsStat.interacRefundCanceled,
+
+            // Payment Methods
+            WooAnalyticsStat.paymentsFlowCompleted,
+            WooAnalyticsStat.paymentsFlowCanceled,
+            WooAnalyticsStat.paymentsFlowFailed,
+            WooAnalyticsStat.paymentsFlowCollect,
+        ]
+
+        guard Self.isPOSModeActive, pointOfSaleEventList.contains(event) else {
+            return eventName
         }
-        return eventName
+        let prefix = "pos_"
+        return "\(prefix)\(eventName)"
     }
 
     func refreshTracksMetadata() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15058
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR switches from a `exemptedEventList` to an `allowedEventList` for events that we decorate with `pos_` prefix for POS, so we are sure that no sneaky events pass through the decorator if they shouldn't.

I've moved all the shared events with IPP that are currently [in Android](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt) for simplicity, and all payment/card-related. We can reduce the list a bit as some are not really used (printing receipts, COD, ...). Possibly can be reduced further, but we do not have a real list asides from the Android's file referenced above.

Ref: p1739367957933319-slack-C070SJRA8DP

## Caveat

I've noticed we do not track `receipt_email_success` and `receipt_email_failed` in POS, I've asked in the same thread above if we want to do so, and if we do, I'll tackle it separately from this issue.

## Testing
- In POS, test through the normal flow, you should see no difference in the `pos_`-specific events tracked.
- To test shared events you can go through some action we do in both app and POS, for example connecting the reader. Connect the reader in POS, observe the event is tracked with the prefix, disconnect, go back to app's order creation, reconnect the reader, and observe how the event is not decorated anymore.

Eg:
- IPP
```
🔵 Tracked card_reader_connection_success, properties: [country: US, plan: , battery_level: 0.85, connection_type: user_initiated, was_ecommerce_trial: false, is_wpcom_store: false, card_reader_model: CHIPPER_2X, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, plugin_slug: woocommerce-payments, blog_id: -1, site_url: https://indiemelon.mystagingwebsite.com]
```
- POS:
```
🔵 Tracked pos_card_reader_connection_success, properties: [card_reader_model: CHIPPER_2X, plugin_slug: woocommerce-payments, country: US, connection_type: user_initiated, plan: , is_wpcom_store: false, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, was_ecommerce_trial: false, blog_id: -1, battery_level: 0.85, site_url: https://indiemelon.mystagingwebsite.com]
```


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
