### PR TITLE
[Woo POS] MVP Analytics: Update receipt-related events

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -87,8 +87,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productGlobalUniqueIdentifierSupport:
             return true
-        case .sendReceiptsForPointOfSale:
-            return true
         case .hideSitesInStorePicker:
             return true
         case .filterHistoryOnOrderAndProductLists:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -189,10 +189,6 @@ public enum FeatureFlag: Int {
     ///
     case productGlobalUniqueIdentifierSupport
 
-    /// Adds support for  sending receipts after the payment for POS
-    ///
-    case sendReceiptsForPointOfSale
-
     /// Supports hiding sites from the store picker
     ///
     case hideSitesInStorePicker

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -131,7 +131,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleGetSupportTapped,
             WooAnalyticsStat.pointOfSaleSimpleProductsExplanationDialogShown,
             WooAnalyticsStat.pointOfSaleCreateNewOrderTapped,
-            WooAnalyticsStat.pointOfSaleEmailReceiptSendTapped,
+            WooAnalyticsStat.pointOfSaleReceiptEmailSendTapped,
             WooAnalyticsStat.pointOfSalePaymentsOnboardingShown,
             WooAnalyticsStat.pointOfSalePaymentsOnboardingDismissed,
             WooAnalyticsStat.pointOfSaleCardReaderConnectionTapped,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -131,7 +131,6 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleGetSupportTapped,
             WooAnalyticsStat.pointOfSaleSimpleProductsExplanationDialogShown,
             WooAnalyticsStat.pointOfSaleCreateNewOrderTapped,
-            WooAnalyticsStat.pointOfSaleEmailReceiptTapped,
             WooAnalyticsStat.pointOfSaleEmailReceiptSendTapped,
             WooAnalyticsStat.pointOfSalePaymentsOnboardingShown,
             WooAnalyticsStat.pointOfSalePaymentsOnboardingDismissed,
@@ -171,7 +170,7 @@ private extension TracksProvider {
             WooAnalyticsStat.cardPresentOnboardingCtaFailed,
 
             // Receipts
-            // TODO: 15058-gh
+            WooAnalyticsStat.receiptEmailTapped,
 
             // Payments
             WooAnalyticsStat.collectPaymentCanceled,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -171,6 +171,8 @@ private extension TracksProvider {
 
             // Receipts
             WooAnalyticsStat.receiptEmailTapped,
+            WooAnalyticsStat.receiptEmailSuccess,
+            WooAnalyticsStat.receiptEmailFailed,
 
             // Payments
             WooAnalyticsStat.collectPaymentCanceled,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1283,7 +1283,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleGetSupportTapped = "get_support_tapped"
     case pointOfSaleSimpleProductsExplanationDialogShown = "simple_products_explanation_dialog_shown"
     case pointOfSaleCreateNewOrderTapped = "create_new_order_tapped"
-    case pointOfSaleEmailReceiptSendTapped = "email_receipt_send_tapped"
+    case pointOfSaleReceiptEmailSendTapped = "receipt_email_send_tapped"
     case pointOfSalePaymentsOnboardingShown = "payments_onboarding_shown"
     case pointOfSalePaymentsOnboardingDismissed = "payments_onboarding_dismissed"
     case pointOfSaleCardReaderConnectionTapped = "card_reader_connection_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1283,7 +1283,6 @@ enum WooAnalyticsStat: String {
     case pointOfSaleGetSupportTapped = "get_support_tapped"
     case pointOfSaleSimpleProductsExplanationDialogShown = "simple_products_explanation_dialog_shown"
     case pointOfSaleCreateNewOrderTapped = "create_new_order_tapped"
-    case pointOfSaleEmailReceiptTapped = "email_receipt_tapped"
     case pointOfSaleEmailReceiptSendTapped = "email_receipt_send_tapped"
     case pointOfSalePaymentsOnboardingShown = "payments_onboarding_shown"
     case pointOfSalePaymentsOnboardingDismissed = "payments_onboarding_dismissed"

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -278,7 +278,14 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func sendReceipt(to emailAddress: String) async throws {
-        try await orderController.sendReceipt(recipientEmail: emailAddress)
+        do {
+            try await orderController.sendReceipt(recipientEmail: emailAddress)
+            analytics.track(.receiptEmailSuccess)
+        } catch {
+            // Catch and re-throw in order to capture the error event, but still allow the UI to handle the error state.
+            analytics.track(.receiptEmailFailed)
+            throw error
+        }
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -8,16 +8,11 @@ struct PaymentsActionButtons: View {
 
     private let receiptEligibilityUseCase = ReceiptEligibilityUseCase()
 
-    private var shouldShowSendReceiptButton: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sendReceiptsForPointOfSale)
-    }
-
     var body: some View {
         ZStack {
             VStack {
                 newOrderButton
                 sendReceiptButton
-                    .renderedIf(shouldShowSendReceiptButton)
             }
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -28,7 +28,7 @@ private extension PaymentsActionButtons {
     var sendReceiptButton: some View {
         Button(action: {
             Task { @MainActor in
-                ServiceLocator.analytics.track(.pointOfSaleEmailReceiptTapped)
+                ServiceLocator.analytics.track(.receiptEmailTapped)
                 await handleSendReceiptAction()
             }
         }, label: {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -73,7 +73,7 @@ struct POSSendReceiptView: View {
     }
 
     private func sendReceipt() {
-        ServiceLocator.analytics.track(.pointOfSaleEmailReceiptSendTapped)
+        ServiceLocator.analytics.track(.pointOfSaleReceiptEmailSendTapped)
         Task { @MainActor in
             guard isEmailValid else {
                 errorMessage = Localization.emailValidationErrorText

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -83,12 +83,14 @@ struct POSSendReceiptView: View {
             do {
                 errorMessage = nil
                 try await posModel.sendReceipt(to: textFieldInput)
+                ServiceLocator.analytics.track(.receiptEmailSuccess)
                 withAnimation {
                     isShowingSendReceiptView = false
                     isTextFieldFocused = false
                 }
             } catch {
                 errorMessage = Localization.sendReceiptErrorText
+                ServiceLocator.analytics.track(.receiptEmailFailed)
             }
             isLoading = false
         }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -83,14 +83,12 @@ struct POSSendReceiptView: View {
             do {
                 errorMessage = nil
                 try await posModel.sendReceipt(to: textFieldInput)
-                ServiceLocator.analytics.track(.receiptEmailSuccess)
                 withAnimation {
                     isShowingSendReceiptView = false
                     isTextFieldFocused = false
                 }
             } catch {
                 errorMessage = Localization.sendReceiptErrorText
-                ServiceLocator.analytics.track(.receiptEmailFailed)
             }
             isLoading = false
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -44,11 +44,6 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
     /// WooCommerce 9.5 allows to attach a customer email after payment is made and send email receipt via the API.
     ///
     func isEligibleForPointOfSaleReceipts(onCompletion: @escaping (Bool) -> Void) {
-        guard featureFlagService.isFeatureFlagEnabled(.sendReceiptsForPointOfSale) else {
-            onCompletion(false)
-            return
-        }
-
         Task { @MainActor in
             let isWooCommerceSupported = await isPluginSupported(Constants.wcPluginName,
                                                                  minimumVersion: Constants.PointOfSaleReceipts.wcPluginMinimumVersion)

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,7 +22,6 @@ final class MockFeatureFlagService: FeatureFlagService {
     var viewEditCustomFieldsInProductsAndOrders: Bool
     var favoriteProducts: Bool
     var isProductGlobalUniqueIdentifierSupported: Bool
-    var receiptsForPOS: Bool
     var hideSitesInStorePicker: Bool
 
     init(isInboxOn: Bool = false,
@@ -45,7 +44,6 @@ final class MockFeatureFlagService: FeatureFlagService {
          viewEditCustomFieldsInProductsAndOrders: Bool = false,
          favoriteProducts: Bool = false,
          isProductGlobalUniqueIdentifierSupported: Bool = false,
-         receiptsForPOS: Bool = false,
          hideSitesInStorePicker: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
@@ -67,7 +65,6 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.viewEditCustomFieldsInProductsAndOrders = viewEditCustomFieldsInProductsAndOrders
         self.favoriteProducts = favoriteProducts
         self.isProductGlobalUniqueIdentifierSupported = isProductGlobalUniqueIdentifierSupported
-        self.receiptsForPOS = receiptsForPOS
         self.hideSitesInStorePicker = hideSitesInStorePicker
     }
 
@@ -113,8 +110,6 @@ final class MockFeatureFlagService: FeatureFlagService {
             return favoriteProducts
         case .productGlobalUniqueIdentifierSupport:
             return isProductGlobalUniqueIdentifierSupported
-        case .sendReceiptsForPointOfSale:
-            return receiptsForPOS
         case .hideSitesInStorePicker:
             return hideSitesInStorePicker
         default:

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderController.swift
@@ -41,5 +41,12 @@ final class MockPointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
         clearOrderWasCalled = true
     }
 
-    func sendReceipt(recipientEmail: String) async { }
+    var shouldThrowReceiptError: Bool = false
+    var sendReceiptWasCalled: Bool = false
+    func sendReceipt(recipientEmail: String) async throws {
+        sendReceiptWasCalled = true
+        if shouldThrowReceiptError {
+            throw NSError(domain: "some error", code: -1)
+        }
+    }
 }

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -298,6 +298,45 @@ struct PointOfSaleAggregateModelTests {
             // Then
             #expect(cardPresentPaymentService.collectPaymentChannel == .pos)
         }
+
+        @available(iOS 17.0, *)
+        @Test func sendReceipt_when_invoked_then_calls_controller() async throws {
+            // Given
+            let orderController = MockPointOfSaleOrderController()
+            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+                                                cardPresentPaymentService: MockCardPresentPaymentService(),
+                                                orderController: orderController,
+                                                collectOrderPaymentAnalyticsTracker: MockCollectOrderPaymentAnalyticsTracker())
+
+            // When
+            try await sut.sendReceipt(to: "")
+
+            // Then
+            #expect(orderController.sendReceiptWasCalled == true)
+        }
+
+        @available(iOS 17.0, *)
+        @Test func sendReceipt_when_invoked_with_error_then_returns_error() async throws {
+            // Given
+            let orderController = MockPointOfSaleOrderController()
+            orderController.shouldThrowReceiptError = true
+            let expectedError = NSError(domain: "some error", code: -1)
+
+            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+                                                cardPresentPaymentService: MockCardPresentPaymentService(),
+                                                orderController: orderController,
+                                                collectOrderPaymentAnalyticsTracker: MockCollectOrderPaymentAnalyticsTracker())
+
+            do {
+                // When
+                try await sut.sendReceipt(to: "")
+            } catch {
+                // Then
+                let nsError = error as NSError
+                #expect(nsError.domain == expectedError.domain)
+                #expect(nsError.code == expectedError.code)
+            }
+        }
     }
 
     struct PaymentTests {

--- a/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
@@ -88,64 +88,6 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_isEligibleForPOSReceipts_when_WooCommerce_version_is_correct_version_then_returns_true() {
-        // Given
-        let featureFlag = MockFeatureFlagService(receiptsForPOS: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let plugin = SystemPlugin.fake().copy(name: "WooCommerce",
-                                              version: "9.5",
-                                              active: true)
-
-        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
-            switch action {
-            case let .fetchSystemPlugin(_, _, onCompletion):
-                onCompletion(plugin)
-            default:
-                XCTFail("Unexpected action")
-            }
-        }
-        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
-
-        // When
-        let isEligible: Bool = waitFor { promise in
-            sut.isEligibleForPointOfSaleReceipts(onCompletion: { result in
-                promise(result)
-            })
-        }
-
-        // Then
-        XCTAssertTrue(isEligible)
-    }
-
-    func test_isEligibleForPOSReceipts_when_WooCommerce_version_is_incorrect_version_then_returns_false() {
-        // Given
-        let featureFlag = MockFeatureFlagService(receiptsForPOS: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let plugin = SystemPlugin.fake().copy(name: "WooCommerce",
-                                              version: "9.4",
-                                              active: true)
-
-        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
-            switch action {
-            case let .fetchSystemPlugin(_, _, onCompletion):
-                onCompletion(plugin)
-            default:
-                XCTFail("Unexpected action")
-            }
-        }
-        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
-
-        // When
-        let isEligible: Bool = waitFor { promise in
-            sut.isEligibleForPointOfSaleReceipts(onCompletion: { result in
-                promise(result)
-            })
-        }
-
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
     func test_when_WooCommerce_version_is_equal_or_above_minimum_then_returns_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15203
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR updates receipt-related events by:
- Updates old `pos_email_receipt_tapped` for new `pos_receipt_email_tapped`
- Updates old `pos_email_receipt_send_tapped` for new `pos_receipt_email_send_tapped`
- Adds `pos_receipt_email_success`, triggered on receipt success
- Adds `pos_receipt_email_failed`, triggered on receipt failure
- Removes `sendReceiptsForPointOfSale` feature flag.

In POS, go through the payment flow until you reach the success view. Then:

## Testing information
Tap "Email receipt":
```
🔵 Tracked pos_receipt_email_tapped, properties: [plan: , site_url: https://indiemelon.mystagingwebsite.com, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, was_ecommerce_trial: false, is_wpcom_store: false, blog_id: -1]
```

Tap the `Send` button
```
🔵 Tracked pos_receipt_email_send_tapped, properties: [blog_id: -1, was_ecommerce_trial: false, site_url: https://indiemelon.mystagingwebsite.com, is_wpcom_store: false, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, plan: ]
```

Enter a valid email, and send it:
```
🔵 Tracked pos_receipt_email_success, properties: [site_url: https://indiemelon.mystagingwebsite.com, plan: , was_ecommerce_trial: false, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, is_wpcom_store: false, blog_id: -1]

```

Re-run the app and repeat but throwing an error from `sendReceipt()` in the order controller, observe the event being tracked, and the error bubbling up to the view:

```
    func sendReceipt(recipientEmail: String) async throws {
        throw NSError(domain: "oopsie", code: -1)
        guard let order = order else {
            return
        }
        try await orderService.updatePOSOrder(order: order, recipientEmail: recipientEmail)
        try await receiptService.sendReceipt(order: order, recipientEmail: recipientEmail)
    }
```

```
🔵 Tracked pos_receipt_email_failed, properties: [store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, blog_id: -1, was_ecommerce_trial: false, is_wpcom_store: false, site_url: https://indiemelon.mystagingwebsite.com, plan: ]
```

![Simulator Screenshot - iPad Air 11 - iOS 17 5 M2 (US site) - 2025-02-19 at 14 29 31](https://github.com/user-attachments/assets/ad65db6e-f515-41c9-80ae-dcf822ffa822)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
