### PR TITLE
[Shipping labels] Use WooShippingAddress for addresses across Woo Shipping flow

### DIFF
--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -10,8 +10,8 @@ public protocol WooShippingRemoteProtocol {
                        completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void)
     func loadLabelRates(siteID: Int64,
                         orderID: Int64,
-                        originAddress: ShippingLabelAddress,
-                        destinationAddress: ShippingLabelAddress,
+                        originAddress: WooShippingAddress,
+                        destinationAddress: WooShippingAddress,
                         packages: [ShippingLabelPackageSelected],
                         completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
     func loadPackages(siteID: Int64,
@@ -20,8 +20,8 @@ public protocol WooShippingRemoteProtocol {
                              completion: @escaping (Result<WooShippingAccountSettings, Error>) -> Void)
     func purchaseShippingLabel(siteID: Int64,
                                orderID: Int64,
-                               originAddress: ShippingLabelAddress,
-                               destinationAddress: ShippingLabelAddress,
+                               originAddress: WooShippingAddress,
+                               destinationAddress: WooShippingAddress,
                                package: WooShippingPackagePurchase,
                                completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void)
     func checkLabelStatus(siteID: Int64,
@@ -36,7 +36,7 @@ public protocol WooShippingRemoteProtocol {
     func loadOriginAddresses(siteID: Int64,
                              completion: @escaping (Result<[WooShippingOriginAddress], Error>) -> Void)
     func addressValidation(siteID: Int64,
-                           address: ShippingLabelAddress,
+                           address: WooShippingAddress,
                            completion: @escaping (Result<WooShippingAddressValidationSuccess, Error>) -> Void)
     func updateOriginAddress(siteID: Int64,
                              address: WooShippingOriginAddress,
@@ -122,8 +122,8 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
     ///   - completion: Closure to be executed upon completion.
     public func loadLabelRates(siteID: Int64,
                                orderID: Int64,
-                               originAddress: ShippingLabelAddress,
-                               destinationAddress: ShippingLabelAddress,
+                               originAddress: WooShippingAddress,
+                               destinationAddress: WooShippingAddress,
                                packages: [ShippingLabelPackageSelected],
                                completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
         do {
@@ -203,8 +203,8 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
     ///   - completion: Closure to be executed upon completion.
     public func purchaseShippingLabel(siteID: Int64,
                                       orderID: Int64,
-                                      originAddress: ShippingLabelAddress,
-                                      destinationAddress: ShippingLabelAddress,
+                                      originAddress: WooShippingAddress,
+                                      destinationAddress: WooShippingAddress,
                                       package: WooShippingPackagePurchase,
                                       completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void) {
         do {
@@ -301,7 +301,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
     ///   - address: The address that should be verified.
     ///   - completion: Closure to be executed upon completion.
     public func addressValidation(siteID: Int64,
-                                  address: ShippingLabelAddress,
+                                  address: WooShippingAddress,
                                   completion: @escaping (Result<WooShippingAddressValidationSuccess, Error>) -> Void) {
         do {
             let parameters = [

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -135,7 +135,8 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
             remote.loadLabelRates(siteID: self.sampleSiteID,
                                   orderID: self.sampleOrderID,
-                                  originAddress: ShippingLabelAddress.fake(), destinationAddress: ShippingLabelAddress.fake(),
+                                  originAddress: WooShippingAddress.fake(),
+                                  destinationAddress: WooShippingAddress.fake(),
                                   packages: [ShippingLabelPackageSelected.fake()]) { (result) in
                 promise(result)
             }
@@ -155,7 +156,8 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
             remote.loadLabelRates(siteID: self.sampleSiteID,
                                   orderID: self.sampleOrderID,
-                                  originAddress: ShippingLabelAddress.fake(), destinationAddress: ShippingLabelAddress.fake(),
+                                  originAddress: WooShippingAddress.fake(),
+                                  destinationAddress: WooShippingAddress.fake(),
                                   packages: [ShippingLabelPackageSelected.fake()]) { result in
                 promise(result)
             }
@@ -270,8 +272,8 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
             remote.purchaseShippingLabel(siteID: self.sampleSiteID,
                                          orderID: self.sampleOrderID,
-                                         originAddress: ShippingLabelAddress.fake(),
-                                         destinationAddress: ShippingLabelAddress.fake(),
+                                         originAddress: WooShippingAddress.fake(),
+                                         destinationAddress: WooShippingAddress.fake(),
                                          package: WooShippingPackagePurchase.fake()) { result in
                 promise(result)
             }
@@ -291,8 +293,8 @@ final class WooShippingRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
             remote.purchaseShippingLabel(siteID: self.sampleSiteID,
                                          orderID: self.sampleOrderID,
-                                         originAddress: ShippingLabelAddress.fake(),
-                                         destinationAddress: ShippingLabelAddress.fake(),
+                                         originAddress: WooShippingAddress.fake(),
+                                         destinationAddress: WooShippingAddress.fake(),
                                          package: WooShippingPackagePurchase.fake()) { result in
                 promise(result)
             }
@@ -426,7 +428,7 @@ final class WooShippingRemoteTests: XCTestCase {
         // When
         let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
             remote.addressValidation(siteID: self.sampleSiteID,
-                                     address: ShippingLabelAddress.fake()) { result in
+                                     address: WooShippingAddress.fake()) { result in
                 promise(result)
             }
         }
@@ -447,7 +449,7 @@ final class WooShippingRemoteTests: XCTestCase {
         // When
         let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
             remote.addressValidation(siteID: self.sampleSiteID,
-                                     address: ShippingLabelAddress.fake()) { result in
+                                     address: WooShippingAddress.fake()) { result in
                 promise(result)
             }
         }
@@ -468,7 +470,7 @@ final class WooShippingRemoteTests: XCTestCase {
         // When
         let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
             remote.addressValidation(siteID: self.sampleSiteID,
-                                     address: ShippingLabelAddress.fake()) { result in
+                                     address: WooShippingAddress.fake()) { result in
                 promise(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -3,8 +3,8 @@ import Yosemite
 final class WooShippingServiceViewModel: ObservableObject {
     private let siteID: Int64
     private let orderID: Int64
-    private let originAddress: ShippingLabelAddress?
-    private let destinationAddress: ShippingLabelAddress?
+    private let originAddress: WooShippingAddress?
+    private let destinationAddress: WooShippingAddress?
     private let stores: StoresManager
 
     /// Whether the destination address is present and with non-empty fields.
@@ -36,8 +36,8 @@ final class WooShippingServiceViewModel: ObservableObject {
     let onSelectRate: ((_ selectedRate: WooShippingSelectedRate) -> Void)?
 
     init(order: Order,
-         originAddress: ShippingLabelAddress?,
-         destinationAddress: ShippingLabelAddress?,
+         originAddress: WooShippingAddress?,
+         destinationAddress: WooShippingAddress?,
          stores: StoresManager = ServiceLocator.stores,
          onSelectRate: ((_ selectedRate: WooShippingSelectedRate) -> Void)? = nil) {
         self.siteID = order.siteID

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -269,15 +269,15 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Validates the address remotely.
     @MainActor
     func remotelyValidateAddress() async {
-        let addressToValidate = ShippingLabelAddress(company: company.value,
-                                                     name: name.value,
-                                                     phone: phone.value,
-                                                     country: country.value,
-                                                     state: state.value,
-                                                     address1: address.value,
-                                                     address2: "",
-                                                     city: city.value,
-                                                     postcode: postalCode.value)
+        let addressToValidate = WooShippingAddress(company: company.value,
+                                                   name: name.value,
+                                                   phone: phone.value,
+                                                   country: country.value,
+                                                   state: state.value,
+                                                   address1: address.value,
+                                                   address2: "",
+                                                   city: city.value,
+                                                   postcode: postalCode.value)
         do {
             let validation = try await remotelyValidateAddress(addressToValidate)
             normalizeAddressVM = WooShippingNormalizeAddressViewModel(enteredAddress: validation.originalAddress,
@@ -459,7 +459,7 @@ private extension WooShippingEditAddressViewModel {
 
     /// Remotely validates the provided address.
     @MainActor
-    func remotelyValidateAddress(_ address: ShippingLabelAddress) async throws -> WooShippingAddressValidationSuccess {
+    func remotelyValidateAddress(_ address: WooShippingAddress) async throws -> WooShippingAddressValidationSuccess {
         try await withCheckedThrowingContinuation { continuation in
             isLoading = true
             let action = WooShippingAction.validateAddress(siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddress+Woo.swift
@@ -14,10 +14,14 @@ extension WooShippingOriginAddress {
         [fullName, company].compactMap { $0.isEmpty ? nil : $0 }.joined(separator: "\n")
     }
 
-    /// Returns the first and last name combined.
-    /// If only one name is present, that name is returned.
+    /// Returns the First + LastName combined according to language rules and Locale.
+    ///
     var fullName: String {
-        [firstName, lastName].compactMap { $0.isEmpty ? nil : $0 }.joined(separator: " ")
+        var components = PersonNameComponents()
+        components.givenName = firstName
+        components.familyName = lastName
+
+        return PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: [])
     }
 
     /// Returns the two Address Lines combined (if there are, effectively, two lines).

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -8,7 +8,7 @@ import Combine
 final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
     private let itemsDataSource: WooShippingItemsDataSource
-    private let destinationAddress: ShippingLabelAddress?
+    private let destinationAddress: WooShippingAddress?
     private let stores: StoresManager
     private var subscriptions: Set<AnyCancellable> = []
     private var debounceDuration: Double = 1
@@ -210,7 +210,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.items = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.originAddress = shippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
-        self.destinationAddress = shippingLabel.destinationAddress
+        self.destinationAddress = shippingLabel.destinationAddress.toWooShippingAddress()
         self.destinationAddressStatus = .verified
         self.onLabelPurchase = nil
         self.stores = stores
@@ -237,7 +237,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,
                                                              orderID: order.orderID,
                                                              originAddress: selectedOriginAddress.toShippingLabelAddress(),
-                                                             destinationAddress: destinationAddress,
+                                                             destinationAddress: destinationAddress.toShippingLabelAddress(),
                                                              package: packagePurchase) { [weak self] result in
             guard let self else { return }
             isPurchasingLabel = false
@@ -332,7 +332,7 @@ private extension WooShippingCreateLabelsViewModel {
                 originAddress = selectedOriginAddress?.formattedPostalAddress ?? ""
                 shippingService = WooShippingServiceViewModel(order: order,
                                                               originAddress: selectedOriginAddress?.toShippingLabelAddress(),
-                                                              destinationAddress: destinationAddress,
+                                                              destinationAddress: destinationAddress?.toShippingLabelAddress(),
                                                               stores: stores) { [weak self] selectedRate in
                     self?.selectedRate = selectedRate
                 }
@@ -388,57 +388,15 @@ private extension WooShippingCreateLabelsViewModel {
         return (name, currencyFormatter.formatAmount(Decimal(amount)) ?? amount.description)
     }
 
-    // We generate the default origin address using the information
-    // of the logged Account and of the website.
-    static func getDefaultOriginAddress(accountSettings: AccountSettings?,
-                                        company: String?,
-                                        siteAddress: SiteAddress,
-                                        account: Account?,
-                                        userDefaults: UserDefaults) -> ShippingLabelAddress? {
-        let address = Address(firstName: accountSettings?.firstName ?? "",
-                              lastName: accountSettings?.lastName ?? "",
-                              company: company ?? "",
-                              address1: siteAddress.address,
-                              address2: siteAddress.address2,
-                              city: siteAddress.city,
-                              state: siteAddress.state,
-                              postcode: siteAddress.postalCode,
-                              country: siteAddress.countryCode.rawValue,
-                              phone: userDefaults[.storePhoneNumber] ?? "",
-                              email: account?.email)
-        return fromAddressToShippingLabelAddress(address: address)
-    }
-
     /// Gets the destination address as a `ShippingLabelAddress`.
     /// The order's billing phone is used as a fallback if there is no shipping phone.
     ///
-    static func getDestinationAddress(order: Order, address: Address?) -> ShippingLabelAddress? {
+    static func getDestinationAddress(order: Order, address: Address?) -> WooShippingAddress? {
         guard let phone = address?.phone, phone.isNotEmpty else {
             let destinationAddress = address?.copy(phone: order.billingAddress?.phone)
-            return fromAddressToShippingLabelAddress(address: destinationAddress)
+            return destinationAddress?.toWooShippingAddress()
         }
-        return fromAddressToShippingLabelAddress(address: address)
-    }
-
-    static func fromAddressToShippingLabelAddress(address: Address?) -> ShippingLabelAddress? {
-        guard let address = address else { return nil }
-
-        // In this way we support localized name correctly,
-        // because the order is often reversed in a few Asian languages.
-        var components = PersonNameComponents()
-        components.givenName = address.firstName
-        components.familyName = address.lastName
-
-        let shippingLabelAddress = ShippingLabelAddress(company: address.company ?? "",
-                                                        name: PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: []),
-                                                        phone: address.phone ?? "",
-                                                        country: address.country,
-                                                        state: address.state,
-                                                        address1: address.address1,
-                                                        address2: address.address2 ?? "",
-                                                        city: address.city,
-                                                        postcode: address.postcode)
-        return shippingLabelAddress
+        return address?.toWooShippingAddress()
     }
 
     static func getStoredAccountSettings() -> AccountSettings? {
@@ -516,7 +474,7 @@ private extension WooShippingOriginAddress {
     ///
     func toShippingLabelAddress() -> ShippingLabelAddress {
         ShippingLabelAddress(company: company,
-                             name: fullName ?? "",
+                             name: fullName,
                              phone: phone,
                              country: country,
                              state: state,
@@ -524,5 +482,65 @@ private extension WooShippingOriginAddress {
                              address2: address2,
                              city: city,
                              postcode: postcode)
+    }
+}
+
+private extension WooShippingAddress {
+    /// Converts the address to a `ShippingLabelAddress`.
+    ///
+    /// This prepares the address for use in e.g. fetching available shipping rates or purchasing the label.
+    ///
+    func toShippingLabelAddress() -> ShippingLabelAddress {
+        ShippingLabelAddress(company: company,
+                             name: name,
+                             phone: phone,
+                             country: country,
+                             state: state,
+                             address1: address1,
+                             address2: address2,
+                             city: city,
+                             postcode: postcode)
+    }
+}
+
+private extension ShippingLabelAddress {
+    /// Converts the address to a `WooShippingAddress`.
+    ///
+    /// This prepares the address for use as a destination address in the shipping label.
+    ///
+    func toWooShippingAddress() -> WooShippingAddress {
+        WooShippingAddress(company: company,
+                           name: name,
+                           phone: phone,
+                           country: country,
+                           state: state,
+                           address1: address1,
+                           address2: address2,
+                           city: city,
+                           postcode: postcode)
+    }
+}
+
+private extension Address {
+    /// Converts the address to a `WooShippingAddress`.
+    ///
+    /// This prepares the address for use as a destination address in the shipping label.
+    ///
+    func toWooShippingAddress() -> WooShippingAddress {
+        // In this way we support localized name correctly,
+        // because the order is often reversed in a few Asian languages.
+        var components = PersonNameComponents()
+        components.givenName = firstName
+        components.familyName = lastName
+
+        return WooShippingAddress(company: company ?? "",
+                                  name: PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: []),
+                                  phone: phone ?? "",
+                                  country: country,
+                                  state: state,
+                                  address1: address1,
+                                  address2: address2 ?? "",
+                                  city: city,
+                                  postcode: postcode)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -236,8 +236,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                          productIDs: itemsDataSource.items.map(\.productOrVariationID))
         let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,
                                                              orderID: order.orderID,
-                                                             originAddress: selectedOriginAddress.toShippingLabelAddress(),
-                                                             destinationAddress: destinationAddress.toShippingLabelAddress(),
+                                                             originAddress: selectedOriginAddress.toWooShippingAddress(),
+                                                             destinationAddress: destinationAddress,
                                                              package: packagePurchase) { [weak self] result in
             guard let self else { return }
             isPurchasingLabel = false
@@ -331,8 +331,8 @@ private extension WooShippingCreateLabelsViewModel {
                 guard let self else { return }
                 originAddress = selectedOriginAddress?.formattedPostalAddress ?? ""
                 shippingService = WooShippingServiceViewModel(order: order,
-                                                              originAddress: selectedOriginAddress?.toShippingLabelAddress(),
-                                                              destinationAddress: destinationAddress?.toShippingLabelAddress(),
+                                                              originAddress: selectedOriginAddress?.toWooShippingAddress(),
+                                                              destinationAddress: destinationAddress,
                                                               stores: stores) { [weak self] selectedRate in
                     self?.selectedRate = selectedRate
                 }
@@ -468,38 +468,20 @@ private extension WooShippingCreateLabelsViewModel {
 }
 
 private extension WooShippingOriginAddress {
-    /// Converts the origin address to a `ShippingLabelAddress`.
+    /// Converts the origin address to a `WooShippingAddress`.
     ///
     /// This prepares the address for use in e.g. fetching available shipping rates or purchasing the label.
     ///
-    func toShippingLabelAddress() -> ShippingLabelAddress {
-        ShippingLabelAddress(company: company,
-                             name: fullName,
-                             phone: phone,
-                             country: country,
-                             state: state,
-                             address1: address1,
-                             address2: address2,
-                             city: city,
-                             postcode: postcode)
-    }
-}
-
-private extension WooShippingAddress {
-    /// Converts the address to a `ShippingLabelAddress`.
-    ///
-    /// This prepares the address for use in e.g. fetching available shipping rates or purchasing the label.
-    ///
-    func toShippingLabelAddress() -> ShippingLabelAddress {
-        ShippingLabelAddress(company: company,
-                             name: name,
-                             phone: phone,
-                             country: country,
-                             state: state,
-                             address1: address1,
-                             address2: address2,
-                             city: city,
-                             postcode: postcode)
+    func toWooShippingAddress() -> WooShippingAddress {
+        WooShippingAddress(company: company,
+                           name: fullName,
+                           phone: phone,
+                           country: country,
+                           state: state,
+                           address1: address1,
+                           address2: address2,
+                           city: city,
+                           postcode: postcode)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -62,7 +62,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     private(set) lazy var destinationAddressLines: [String]? = {
-        (destinationAddress?.formattedPostalAddress)?.components(separatedBy: .newlines)
+        (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")
     }()
 
     /// Possible statuses for a Woo Shipping destination address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -509,14 +509,8 @@ private extension Address {
     /// This prepares the address for use as a destination address in the shipping label.
     ///
     func toWooShippingAddress() -> WooShippingAddress {
-        // In this way we support localized name correctly,
-        // because the order is often reversed in a few Asian languages.
-        var components = PersonNameComponents()
-        components.givenName = firstName
-        components.familyName = lastName
-
         return WooShippingAddress(company: company ?? "",
-                                  name: PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: []),
+                                  name: fullName,
                                   phone: phone ?? "",
                                   country: country,
                                   state: state,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -726,16 +726,16 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     @MainActor
     func test_remotelyValidateAddress_sends_expected_address_to_validate() async {
         // Given
-        let expectedAddress = ShippingLabelAddress(company: "HEADQUARTERS",
-                                                   name: "JANE DOE",
-                                                   phone: "1-234-456-7890",
-                                                   country: "US",
-                                                   state: "NY",
-                                                   address1: "15 ALGONKIN ST STE 100",
-                                                   address2: "",
-                                                   city: "TICONDEROGA",
-                                                   postcode: "12883-1487")
-        var receivedAddress: ShippingLabelAddress?
+        let expectedAddress = WooShippingAddress(company: "HEADQUARTERS",
+                                                 name: "JANE DOE",
+                                                 phone: "1-234-456-7890",
+                                                 country: "US",
+                                                 state: "NY",
+                                                 address1: "15 ALGONKIN ST STE 100",
+                                                 address2: "",
+                                                 city: "TICONDEROGA",
+                                                 postcode: "12883-1487")
+        var receivedAddress: WooShippingAddress?
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -25,8 +25,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_init_sets_expected_values() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
-                                                    destinationAddress: ShippingLabelAddress.fake())
+                                                    originAddress: WooShippingAddress.fake(),
+                                                    destinationAddress: WooShippingAddress.fake())
 
         // Then
         XCTAssertNil(viewModel.selectedRate)
@@ -36,7 +36,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_loadLabelRates_generates_service_tabs_with_expected_data() throws {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
 
@@ -105,7 +105,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
             }
         }
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
 
@@ -121,7 +121,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Given
         let standardRate = sampleStandardRates()[1]
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
 
@@ -140,7 +140,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_selecting_service_card_signature_rate_updates_expected_values() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
         // When
@@ -157,7 +157,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_selecting_service_card_adult_signature_rate_updates_expected_values() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
 
@@ -176,7 +176,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Given
         var selectedRate: WooShippingSelectedRate?
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores) { rate in
             selectedRate = rate
@@ -193,7 +193,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_sortShipping_by_price_returns_sorted_list() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
 
@@ -210,7 +210,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_shortShipping_by_deliveryDays_returns_sorted_list() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
 
@@ -227,7 +227,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_hasDestinationAddress_true_when_destination_address_is_complete() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
                                                     destinationAddress: sampleDestinationAddress(),
                                                     stores: stores)
 
@@ -238,8 +238,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_hasDestinationAddress_false_when_destination_address_is_empty() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
-                                                    originAddress: ShippingLabelAddress.fake(),
-                                                    destinationAddress: ShippingLabelAddress.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
+                                                    destinationAddress: WooShippingAddress.fake(),
                                                     stores: stores)
 
         // Then
@@ -329,15 +329,15 @@ private extension WooShippingServiceViewModelTests {
                                   deliveryDateGuaranteed: false)]
     }
 
-    func sampleDestinationAddress() -> ShippingLabelAddress {
-        ShippingLabelAddress(company: "HEADQUARTERS",
-                             name: "JANE DOE",
-                             phone: "1-234-456-7890",
-                             country: "US",
-                             state: "NY",
-                             address1: "15 ALGONKIN ST STE 100",
-                             address2: "",
-                             city: "TICONDEROGA",
-                             postcode: "12883-1487")
+    func sampleDestinationAddress() -> WooShippingAddress {
+        WooShippingAddress(company: "HEADQUARTERS",
+                           name: "JANE DOE",
+                           phone: "1-234-456-7890",
+                           country: "US",
+                           state: "NY",
+                           address1: "15 ALGONKIN ST STE 100",
+                           address2: "",
+                           city: "TICONDEROGA",
+                           postcode: "12883-1487")
     }
 }

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -18,8 +18,8 @@ public enum WooShippingAction: Action {
     ///
     case loadLabelRates(siteID: Int64,
                         orderID: Int64,
-                        originAddress: ShippingLabelAddress,
-                        destinationAddress: ShippingLabelAddress,
+                        originAddress: WooShippingAddress,
+                        destinationAddress: WooShippingAddress,
                         packages: [ShippingLabelPackageSelected],
                         completion: (Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
 
@@ -37,8 +37,8 @@ public enum WooShippingAction: Action {
     ///
     case purchaseShippingLabel(siteID: Int64,
                                orderID: Int64,
-                               originAddress: ShippingLabelAddress,
-                               destinationAddress: ShippingLabelAddress,
+                               originAddress: WooShippingAddress,
+                               destinationAddress: WooShippingAddress,
                                package: WooShippingPackagePurchase,
                                backendProcessingDelay: TimeInterval = 2.0,
                                pollingDelay: TimeInterval = 1.0,
@@ -60,7 +60,7 @@ public enum WooShippingAction: Action {
     /// Validate a shipping address.
     ///
     case validateAddress(siteID: Int64,
-                         address: ShippingLabelAddress,
+                         address: WooShippingAddress,
                          completion: (Result<WooShippingAddressValidationSuccess, Error>) -> Void)
 
     /// Update an origin address.

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -109,8 +109,8 @@ private extension WooShippingStore {
 
     func loadLabelRates(siteID: Int64,
                         orderID: Int64,
-                        originAddress: ShippingLabelAddress,
-                        destinationAddress: ShippingLabelAddress,
+                        originAddress: WooShippingAddress,
+                        destinationAddress: WooShippingAddress,
                         packages: [ShippingLabelPackageSelected],
                         completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
         remote.loadLabelRates(siteID: siteID,
@@ -142,8 +142,8 @@ private extension WooShippingStore {
 
     func purchaseShippingLabel(siteID: Int64,
                                orderID: Int64,
-                               originAddress: ShippingLabelAddress,
-                               destinationAddress: ShippingLabelAddress,
+                               originAddress: WooShippingAddress,
+                               destinationAddress: WooShippingAddress,
                                package: WooShippingPackagePurchase,
                                backendProcessingDelay: TimeInterval,
                                pollingDelay: TimeInterval,
@@ -256,7 +256,7 @@ private extension WooShippingStore {
     }
 
     func validateAddress(siteID: Int64,
-                         address: ShippingLabelAddress,
+                         address: WooShippingAddress,
                          completion: @escaping (Result<WooShippingAddressValidationSuccess, Error>) -> Void) {
         remote.addressValidation(siteID: siteID, address: address, completion: completion)
     }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -156,8 +156,8 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
     func loadLabelRates(siteID: Int64,
                         orderID: Int64,
-                        originAddress: ShippingLabelAddress,
-                        destinationAddress: ShippingLabelAddress,
+                        originAddress: WooShippingAddress,
+                        destinationAddress: WooShippingAddress,
                         packages: [ShippingLabelPackageSelected],
                         completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
@@ -202,8 +202,8 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
 
     func purchaseShippingLabel(siteID: Int64,
                                orderID: Int64,
-                               originAddress: Networking.ShippingLabelAddress,
-                               destinationAddress: Networking.ShippingLabelAddress,
+                               originAddress: Networking.WooShippingAddress,
+                               destinationAddress: Networking.WooShippingAddress,
                                package: Networking.WooShippingPackagePurchase,
                                completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
@@ -267,7 +267,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
     }
 
     func addressValidation(siteID: Int64,
-                           address: ShippingLabelAddress,
+                           address: WooShippingAddress,
                            completion: @escaping (Result<WooShippingAddressValidationSuccess, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -212,8 +212,8 @@ final class WooShippingStoreTests: XCTestCase {
         let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
             let action = WooShippingAction.loadLabelRates(siteID: self.sampleSiteID,
                                                           orderID: self.sampleOrderID,
-                                                          originAddress: ShippingLabelAddress.fake(),
-                                                          destinationAddress: ShippingLabelAddress.fake(),
+                                                          originAddress: WooShippingAddress.fake(),
+                                                          destinationAddress: WooShippingAddress.fake(),
                                                           packages: [ShippingLabelPackageSelected.fake()]) { result in
                 promise(result)
             }
@@ -237,8 +237,8 @@ final class WooShippingStoreTests: XCTestCase {
         let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
             let action = WooShippingAction.loadLabelRates(siteID: self.sampleSiteID,
                                                           orderID: self.sampleOrderID,
-                                                          originAddress: ShippingLabelAddress.fake(),
-                                                          destinationAddress: ShippingLabelAddress.fake(),
+                                                          originAddress: WooShippingAddress.fake(),
+                                                          destinationAddress: WooShippingAddress.fake(),
                                                           packages: [ShippingLabelPackageSelected.fake()]) { result in
                 promise(result)
             }
@@ -619,7 +619,7 @@ final class WooShippingStoreTests: XCTestCase {
         // When
         let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
             let action = WooShippingAction.validateAddress(siteID: self.sampleSiteID,
-                                                           address: ShippingLabelAddress.fake()) { result in
+                                                           address: WooShippingAddress.fake()) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -640,7 +640,7 @@ final class WooShippingStoreTests: XCTestCase {
         // When
         let result: Result<WooShippingAddressValidationSuccess, Error> = waitFor { promise in
             let action = WooShippingAction.validateAddress(siteID: self.sampleSiteID,
-                                                           address: ShippingLabelAddress.fake()) { result in
+                                                           address: WooShippingAddress.fake()) { result in
                 promise(result)
             }
             store.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #15177
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates all layers (Networking, Yosemite, and UI) to use the `WooShippingAddress` type for addresses, instead of the legacy `ShippingLabelAddress` type. These types are very similar, but using the new type consistently will make it easier to handle addresses throughout the new Woo Shipping flow.

Note that these two types are encoded in the same way, so their usage in API requests sends the same request data in the same format. The only different is in how they are decoded, due to some variations in the Woo Shipping API responses.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: WooCommerce Shipping is installed, activated, and set up on your store.

1. Create or open an order with at least one physical product and the processing status, and a shipping address.
2. Tap "Create Shipping Label" in order details.
3. Tap the Shipment details bottom sheet to expand it, and confirm the "Ship to" address contains the order's shipping address (same behavior as before).

You can continue to test the shipping label flow, but note that there are some issues with the endpoints (fetching label rates and purchasing a label) that are not working as expected. This is a pre-existing issue (not connected to these changes) being discussed here: p1739892117670709-slack-C05VBLKHHV1

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.