### PR TITLE
Product Details: Update error handling for product saving failure

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] Filters applied in product selector no longer affect the main product list screen. [https://github.com/woocommerce/woocommerce-ios/pull/14764]
 - [*] Better error messages if Application Password login is disabled on user's website. [https://github.com/woocommerce/woocommerce-ios/pull/15031]
 - [**] Product Images: Update error handling [https://github.com/woocommerce/woocommerce-ios/pull/15105]
+- [*] Product Images: Improve error handling for product saving [https://github.com/woocommerce/woocommerce-ios/pull/15210]
 - [*] Merchants can mark and filter favorite products for quicker access. [https://github.com/woocommerce/woocommerce-ios/pull/14597]
 
 21.7

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -229,8 +229,7 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: handler) { [weak self] result in
             guard let self = self else { return }
             onProductSave(result)
-            if case let .failure(error) = result,
-                statusUpdatesExcludedProductKeys.contains(key) == false {
+            if case let .failure(error) = result {
                 self.errorsSubject.send(.init(siteID: key.siteID,
                                               productOrVariationID: key.productOrVariationID,
                                               error: .failedSavingProductAfterImageUpload(error: error)))

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -229,7 +229,8 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: handler) { [weak self] result in
             guard let self = self else { return }
             onProductSave(result)
-            if case let .failure(error) = result {
+            if case let .failure(error) = result,
+                statusUpdatesExcludedProductKeys.contains(key) == false {
                 self.errorsSubject.send(.init(siteID: key.siteID,
                                               productOrVariationID: key.productOrVariationID,
                                               error: .failedSavingProductAfterImageUpload(error: error)))

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -831,6 +831,12 @@ private extension MainTabBarController {
             presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
         }
 
+        if let productsSplitViewWrapperController = productsContainerController.wrappedController as? ProductsSplitViewWrapperController,
+           let productForm = productsSplitViewWrapperController.currentProductForm(for: error.productOrVariationID.id) {
+            // Ask the product form to display an alert about the error
+            return productForm.handleProductUploadError(error)
+        }
+
         let model: ProductLoaderViewController.Model = {
             switch error.productOrVariationID {
             case .product(let id):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -996,7 +996,9 @@ private extension ProductFormViewController {
 
                 // Dismisses the in-progress UI then presents the error alert.
                 self?.navigationController?.dismiss(animated: true) {
-                    self?.displayError(error: error)
+                    self?.displayProductSavingErrorAlert(error: error, onRetry: {
+                        self?.saveProductRemotely(status: status, onCompletion: onCompletion)
+                    })
                     onCompletion(.failure(error))
                 }
             case .success:
@@ -1054,6 +1056,21 @@ private extension ProductFormViewController {
             /// Discard the upload before uploading again to replace the failed upload.
             self?.productImageActionHandler.discardUpload(asset: asset)
             self?.productImageActionHandler.uploadMediaAssetToSiteMediaLibrary(asset: asset)
+        })
+        alert.addAction(retry)
+
+        present(alert, animated: true, completion: nil)
+    }
+
+    func displayProductSavingErrorAlert(error: ProductUpdateError, onRetry: @escaping () -> Void) {
+        let alert = UIAlertController(title: Localization.ProductSavingError.title,
+                                      message: error.errorDescription,
+                                      preferredStyle: .alert)
+        let cancel = UIAlertAction(title: Localization.ProductSavingError.cancel, style: .cancel, handler: { _ in })
+        alert.addAction(cancel)
+
+        let retry = UIAlertAction(title: Localization.ProductSavingError.retry, style: .default, handler: { _ in
+            onRetry()
         })
         alert.addAction(retry)
 
@@ -2176,6 +2193,24 @@ private enum Localization {
             "productFormViewController.imageUploadError.retry",
             value: "Retry",
             comment: "Button on the alert when there is an error uploading an image of a product. Tapping the button should retry the upload."
+        )
+    }
+
+    enum ProductSavingError {
+        static let title = NSLocalizedString(
+            "productFormViewController.productSavingError.title",
+            value: "Product was not saved",
+            comment: "Title of the alert when there is an error saving a product"
+        )
+        static let cancel = NSLocalizedString(
+            "productFormViewController.productSavingError.cancel",
+            value: "Cancel",
+            comment: "Button on the alert when there is an error saving a product. Tapping the button should cancel the saving."
+        )
+        static let retry = NSLocalizedString(
+            "productFormViewController.productSavingError.retry",
+            value: "Retry",
+            comment: "Button on the alert when there is an error saving a product. Tapping the button should retry the saving."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -263,15 +263,30 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     /// Handles the edge case when the user opens the product form of the same product whose background upload fails.
     /// In this case, we show an alert about the error instead of presenting a modal of the same product.
-    func handleProductUploadError(_ error: ProductImageUploadErrorInfo) {
-        switch error.error {
+    func handleProductUploadError(_ errorInfo: ProductImageUploadErrorInfo) {
+        switch errorInfo.error {
         case .failedSavingProductAfterImageUpload(let error):
-            displayProductSavingErrorAlert(error: error, onRetry: nil)
+            displayProductSavingErrorAlert(error: error, onRetry: { [weak self] in
+                self?.retrySavingProductImages()
+            })
         case .noActionHandlerFound, .noRemoteProductIDFound:
             displayError(error: .unexpected)
         case let .failedUploadingImage(asset, error):
             displayImageUploadErrorAlert(error: error, for: asset)
         }
+    }
+
+    private func retrySavingProductImages() {
+        let key = ProductImageUploaderKey(siteID: viewModel.productModel.siteID,
+                                          productOrVariationID: .product(id: viewModel.productModel.siteID),
+                                          isLocalID: viewModel.productModel.existsRemotely)
+        productImageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key: key, onProductSave: { [weak self] result in
+            if case .failure(let error) = result {
+                self?.handleProductUploadError(.init(siteID: key.siteID,
+                                                     productOrVariationID: key.productOrVariationID,
+                                                     error: .failedSavingProductAfterImageUpload(error: error)))
+            }
+        })
     }
 
     // MARK: Product preview action handling
@@ -1075,7 +1090,7 @@ private extension ProductFormViewController {
         present(alert, animated: true, completion: nil)
     }
 
-    func displayProductSavingErrorAlert(error: Error, onRetry: (() -> Void)?) {
+    func displayProductSavingErrorAlert(error: Error, onRetry: @escaping (() -> Void)) {
         let message: String = {
             if let updateError = error as? ProductUpdateError,
                 let description = updateError.errorDescription {
@@ -1089,12 +1104,10 @@ private extension ProductFormViewController {
         let cancel = UIAlertAction(title: Localization.ProductSavingError.cancel, style: .cancel, handler: { _ in })
         alert.addAction(cancel)
 
-        if let onRetry {
-            let retry = UIAlertAction(title: Localization.ProductSavingError.retry, style: .default, handler: { _ in
-                onRetry()
-            })
-            alert.addAction(retry)
-        }
+        let retry = UIAlertAction(title: Localization.ProductSavingError.retry, style: .default, handler: { _ in
+            onRetry()
+        })
+        alert.addAction(retry)
 
         present(alert, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -261,6 +261,19 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         saveProduct(status: .draft)
     }
 
+    /// Handles the edge case when the user opens the product form of the same product whose background upload fails.
+    /// In this case, we show an alert about the error instead of presenting a modal of the same product.
+    func handleProductUploadError(_ error: ProductImageUploadErrorInfo) {
+        switch error.error {
+        case .failedSavingProductAfterImageUpload(let error):
+            displayProductSavingErrorAlert(error: error, onRetry: nil)
+        case .noActionHandlerFound, .noRemoteProductIDFound:
+            displayError(error: .unexpected)
+        case let .failedUploadingImage(asset, error):
+            displayImageUploadErrorAlert(error: error, for: asset)
+        }
+    }
+
     // MARK: Product preview action handling
 
     @objc private func saveDraftAndDisplayProductPreview() {
@@ -1062,17 +1075,26 @@ private extension ProductFormViewController {
         present(alert, animated: true, completion: nil)
     }
 
-    func displayProductSavingErrorAlert(error: ProductUpdateError, onRetry: @escaping () -> Void) {
+    func displayProductSavingErrorAlert(error: Error, onRetry: (() -> Void)?) {
+        let message: String = {
+            if let updateError = error as? ProductUpdateError,
+                let description = updateError.errorDescription {
+                return description
+            }
+            return error.localizedDescription
+        }()
         let alert = UIAlertController(title: Localization.ProductSavingError.title,
-                                      message: error.errorDescription,
+                                      message: message,
                                       preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.ProductSavingError.cancel, style: .cancel, handler: { _ in })
         alert.addAction(cancel)
 
-        let retry = UIAlertAction(title: Localization.ProductSavingError.retry, style: .default, handler: { _ in
-            onRetry()
-        })
-        alert.addAction(retry)
+        if let onRetry {
+            let retry = UIAlertAction(title: Localization.ProductSavingError.retry, style: .default, handler: { _ in
+                onRetry()
+            })
+            alert.addAction(retry)
+        }
 
         present(alert, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -65,6 +65,16 @@ final class ProductsSplitViewCoordinator: NSObject {
     func startProductCreation() {
         productsViewController.startProductCreation()
     }
+
+    /// Returns the product form of the given product ID being displayed on the secondary column if available.
+    func currentProductForm(for productID: Int64) -> ProductFormViewController<ProductFormViewModel>? {
+        if let contentType = contentTypes.last,
+            case let .productForm(product) = contentType,
+            product?.productID == productID {
+            return secondaryNavigationController.topViewController as? ProductFormViewController<ProductFormViewModel>
+        }
+        return nil
+    }
 }
 
 private extension ProductsSplitViewCoordinator {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -33,6 +33,11 @@ final class ProductsSplitViewWrapperController: UIViewController {
     override var shouldShowOfflineBanner: Bool {
         return true
     }
+
+    /// Returns the product form of the given product ID being displayed if available.
+    func currentProductForm(for productID: Int64) -> ProductFormViewController<ProductFormViewModel>? {
+        coordinator.currentProductForm(for: productID)
+    }
 }
 
 private extension ProductsSplitViewWrapperController {

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -1418,8 +1418,8 @@ extension ProductUpdateError: LocalizedError {
                                      comment: "The message of the alert when there is an error updating the product global unique identifier")
         case .generic(let message):
             return message
-        case .unknown:
-            return NSLocalizedString("Unexpected error", comment: "The message of the alert when there is an unexpected error updating the product")
+        case .unknown(let error):
+            return error.localizedDescription
         case .variationInvalidImageId:
             return NSLocalizedString("Sorry, image removal on product variations is supported in WooCommerce 4.7 or greater, please update your site.",
                                      comment: "The title of the alert when there is an error removing the image from a Product Variation if WooCommerce <4.7")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15170 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When the background product upload/saving fails, we're sending error notices from the tab bar. The notice includes a button to navigate to the product form, without knowing whether the user is already on the same screen.

This PR improves the experience by:
- Ask the product form to display an error alert instead of presenting a modal when tapping on the error notice of the same product.
- Improve the error alert for the product saving failures with error details and an option to retry the saving.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Testing product saving failure alert
1. Open an existing product or create a new one.
2. Edit any details of the product.
3. Disconnect the Internet connection.
4. Tap Save to save the changes to the product details.
5. Confirm that an alert is displayed with the error details and the option to retry.

https://github.com/user-attachments/assets/24e0a477-6bac-44eb-9ca5-974eebcd7d43


Testing error notice action
1. Open an existing product or create a new one.
2. In Proxyman, set a breakpoint in the image upload POST requests. Alternatively, disconnect the Internet connection.
3. Select an image to upload, tap Save, and navigate back to the product list.
4. If you set the breakpoint in Proxyman earlier, mock a failure for the POSt request when it's about the send the response.
5. When the upload fails on the app, open the product form quickly while the error notice is still present.
6. Tap the See details action on the notice and confirm that an alert about the error is displayed on the product form instead of a new modal being presented.
7. Optional: repeat the same steps but this time open the product form of a different product. Tapping on See details should still present the product form of the product with the upload failure.


https://github.com/user-attachments/assets/f05c93cd-dba1-444e-a94e-5d8b71f65c2f



## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested the above test cases using simulators iPhone 16 Pro & iPad Mini iOS 18.2 and confirmed that everything works as expected.





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
