### PR TITLE
[Woo POS][Design System] Fix floating control ellipsis color in disabled state

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -88,7 +88,12 @@ private extension POSFloatingControlView {
     }
 
     var fontColor: Color {
-        .posOnSurface
+        switch backgroundAppearance {
+        case .primary:
+            .posOnSurface
+        case .secondary:
+            Self.secondaryFontColor
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fix for #15070 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the previous work to update colors for the floating control in https://github.com/woocommerce/woocommerce-ios/pull/15103, the disabled/secondary font color for the ellipsis button was missed. This PR fixes this color so that all buttons have the same font color in the disabled state when processing the payment.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Enter POS
- Add item(s) to cart and check out
- Pay with card --> when payment is processing, both buttons in the floating control should have the same foreground color that looks disabled

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

color scheme | before | after
-- | -- | --
light | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-20 at 13 37 15](https://github.com/user-attachments/assets/d7aea08e-52f0-4909-bbf8-fed663290936) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-20 at 13 53 20](https://github.com/user-attachments/assets/04042bcc-6ad5-4afe-b52d-86fae1b1c598)
dark | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-20 at 13 47 32](https://github.com/user-attachments/assets/47305b92-4867-417d-9f78-8d999756ce40) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-20 at 13 52 20](https://github.com/user-attachments/assets/737c3275-8440-41ca-ae38-ab54c132a41e)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.