### PR TITLE
[Woo POS] Create POS Aggregate Model in a task

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -2,11 +2,15 @@ import SwiftUI
 
 @available(iOS 17.0, *)
 struct PointOfSaleEntryPointView: View {
-    @State private var posModel: PointOfSaleAggregateModel
+    @State private var posModel: PointOfSaleAggregateModel?
     @StateObject private var posModalManager = POSModalManager()
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private let onPointOfSaleModeActiveStateChange: ((Bool) -> Void)
+    private let itemsController: PointOfSaleItemsControllerProtocol
+    private let cardPresentPaymentService: CardPresentPaymentFacade
+    private let orderController: PointOfSaleOrderControllerProtocol
+    private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
 
     init(itemsController: PointOfSaleItemsControllerProtocol,
          onPointOfSaleModeActiveStateChange: @escaping ((Bool) -> Void),
@@ -15,26 +19,36 @@ struct PointOfSaleEntryPointView: View {
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
 
-        let posModel = PointOfSaleAggregateModel(
-            itemsController: itemsController,
-            cardPresentPaymentService: cardPresentPaymentService,
-            orderController: orderController,
-            collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker)
-
-        self._posModel = State(wrappedValue: posModel)
+        self.itemsController = itemsController
+        self.cardPresentPaymentService = cardPresentPaymentService
+        self.orderController = orderController
+        self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
     }
 
     var body: some View {
-        PointOfSaleDashboardView()
+        Group {
+            if let posModel = posModel {
+                PointOfSaleDashboardView()
+                    .environment(posModel)
+            } else {
+                PointOfSaleLoadingView()
+            }
+        }
+        .task {
+            posModel = PointOfSaleAggregateModel(
+                itemsController: itemsController,
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController,
+                collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker)
+        }
         .environmentObject(posModalManager)
-        .environment(posModel)
         .onAppear {
             onPointOfSaleModeActiveStateChange(true)
         }
         .onDisappear {
             onPointOfSaleModeActiveStateChange(false)
             posModalManager.onDisappear()
-            posModel.pointOfSaleClosed()
+            posModel?.pointOfSaleClosed()
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -35,6 +35,9 @@ struct PointOfSaleEntryPointView: View {
             }
         }
         .task {
+            // We create the posModel in a task, not init, to avoid creating multiple copies during the view's lifecycle.
+            // Confusingly, init can be called more than once, but `task` matches the lifecycle.
+            // See https://developer.apple.com/documentation/swiftui/state#Store-observable-objects for details.
             posModel = PointOfSaleAggregateModel(
                 itemsController: itemsController,
                 cardPresentPaymentService: cardPresentPaymentService,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #15180 
Merge after: #15205
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Based on [Apple’s advice](https://developer.apple.com/documentation/swiftui/state#Store-observable-objects), this PR updates the `posModel` creation to happen in a task modifier, to avoid it being created whenever init is called (confusingly, init may happen more than once for a view.)

This doesn't resolve the memory leaks, but should reduce the number of `POSAggregateModel` allocations.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Add `print("PointOfSaleEntryPointView: aggregate model created")`  in the task, and `print("PointOfSaleEntryPointView: initialized")` in the init.

1. Launch the app and navigate to POS.
2. Do stuff in POS – it's not totally clear what triggers the extra inits. Onboarding and location permissions dialogs seemed to do it, but that might have been fluke.
3. Observe that you see one `aggregate model created` log for each time you open POS, but can see more than one `initialized` message

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This is a change at the root, but if we didn't create or inject the aggregate model correctly, it would be immediately obvious. See if you can break it, but I don't think it's necessary to go to every leaf node use of the aggregate model to do that.

I've tested on an iPad Air with iOS 17.7.2.
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.