### PR TITLE
[Woo POS] Show connection flow under location modal

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -246,14 +246,14 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
             /// Not-yet supported types
         case .selectSearchType:
             return nil
-            /// Immediately request location permission until POS view is created
+            /// Immediately request location permission until POS view is created, showing `Connecting to reader` underneath.
         case .locationRequestPreAlert(let requestPermission):
             requestPermission()
-            return nil
-            /// Skip location required step and rely on error during the payment process until POS view is created
+            self = .alert(.connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel()))
+            /// Skip location required step and rely on error during the payment process until POS view is created, showing `Connecting to reader` underneath.
         case .locationRequired(_, let skip):
             skip()
-            return nil
+            self = .alert(.connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel()))
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15183
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR resolves a presentation issue with the card reader connection flow.

To avoid the UI “jumping” and showing the unblurred POS underneath Apple’s location modal, then blurring it again, we can show the `connecting to reader` step during the location modal presentation.

Eventually we should replace these with explainer views about why location permission is required, as in IPP.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. In iOS settings, set your location permission for Woo to `Ask next time`
2. Launch the app and navigate to POS
3. Connect your reader
4. Observe that when the location permission modal shows, the screen behind is still blurred and has the `Connecting to reader` modal showing.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

It's worth testing the decline flow as well as the acceptance flow. For the decline flow, the reader still connects, and we rely on Stripe's check and error during the payment collection to prevent payments.

With an M2, it works correctly.
With a WisePad3, there's a pre-existing issue with taking a payment without location permissions. The reader stays stuck on the `Authorizing` step for a minute or two, and attempting to retry during this time will loop round with `Reader busy` errors. It resolves itself eventually, but we should still fix it. #15223

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

The screen recording doesn't capture the location permissions modal – in the before video, it shows when the Connection flow has a gap in the middle. In the after video, it shows above the `Connecting to reader` modal.

### Before

https://github.com/user-attachments/assets/cc4533be-c586-4339-803b-098f0890bc68


### After

https://github.com/user-attachments/assets/c22ef584-1a47-4f5a-b899-bb28b749ef75


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.