### PR TITLE
[Tooling] Fail tests if there's a failure that `trainer` didn't report

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1324,7 +1324,7 @@ lane :test_without_building do |options|
     fail_build: true
   )
 
-  # Trainer sometimes fails to detect test failures, so we manually fail the lane if there are failures to make sure there are no false positives
+  # Trainer sometimes doesn't detect test failures, so we manually throw an error in the lane if there are failures to make sure there are no false positives
   UI.user_error!("Tests failed with #{tests_result[:number_of_failures]} failures.") if tests_result[:number_of_failures].positive?
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1301,7 +1301,8 @@ lane :test_without_building do |options|
   # At the time of writing with Xcode 14.3, we need to explicitly set this value despite using test plans that configure parallelism.
   parallel_testing_value = options[:name] == 'UITests'
 
-  run_tests(
+  # Capture the result of run_tests
+  tests_result = run_tests(
     workspace: WORKSPACE_PATH,
     scheme: TEST_SCHEME,
     device: options[:device],
@@ -1322,6 +1323,9 @@ lane :test_without_building do |options|
     path: lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH],
     fail_build: true
   )
+
+  # Trainer sometimes fails to detect test failures, so we manually fail the lane if there are failures to make sure there are no false positives
+  UI.user_error!("Tests failed with #{tests_result[:number_of_failures]} failures.") if tests_result[:number_of_failures].positive?
 end
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Internal reference: p1740053759413429-slack-CC7L49W13

It seems `trainer` from `Fastlane` fails to report test failures in certain conditions (possibly related: https://github.com/fastlane/fastlane/issues/29174).

To create a safety net against false positives, this PR checks the results from `run_tests` and fails it after `trainer`, in case `trainer` hasn't stopped the execution yet.
