### PR TITLE
[Woo POS] Add full stop to the payment success message

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSalePaymentSuccessViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSalePaymentSuccessViewModel.swift
@@ -22,15 +22,15 @@ private extension PointOfSalePaymentSuccessViewModel {
         )
 
         static let messageCard = NSLocalizedString(
-            "pointOfSale.paymentSuccessful.message.card",
-            value: "A card payment of %1$@ was successfully made",
+            "pointOfSale.paymentSuccessful.message.card.1",
+            value: "A card payment of %1$@ was successfully made.",
             comment: "Message shown to users when payment is made. %1$@ is a placeholder for the order " +
             " total, e.g $10.50. Please include %1$@ in your formatted string"
         )
 
         static let messageCash = NSLocalizedString(
-            "pointOfSale.paymentSuccessful.message.cash",
-            value: "A cash payment of %1$@ was successfully made",
+            "pointOfSale.paymentSuccessful.message.cash.1",
+            value: "A cash payment of %1$@ was successfully made.",
             comment: "Message shown to users when payment is made. %1$@ is a placeholder for the order " +
             " total, e.g $10.50. Please include %1$@ in your formatted string"
         )

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -93,7 +93,7 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             return XCTFail("Expected payment success message not found")
         }
 
-        XCTAssertEqual(viewModel.message, "A card payment of $200.50 was successfully made")
+        XCTAssertEqual(viewModel.message, "A card payment of $200.50 was successfully made.")
     }
 
     func test_presentationStyle_for_paymentCaptureError_is_message_paymentCaptureError_with_correctActions() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15188
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a full stop to the description text of the payment success screen

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Take a card or cash payment
3. Observe that the description line "A cash payment of $1.00 was successfully made." ends with a full stop.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![card full stop](https://github.com/user-attachments/assets/aebc6b1f-3b9d-4fe4-9a0a-4370ee2fef8a)
![cash full stop](https://github.com/user-attachments/assets/0643d57f-a31d-43bf-a192-7e2325a7aecb)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.