### PR TITLE
[Shipping labels] Open address editing form for destination address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRequirements.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRequirements.swift
@@ -1,0 +1,34 @@
+import Yosemite
+
+struct WooShippingCustomsRequirements {
+    /// Checks whether a customs form is required for the given origin country/state and destination country/state.
+    ///
+    static func isCustomsRequired(originCountry: String?,
+                                  originState: String?,
+                                  destinationCountry: String?,
+                                  destinationState: String?) -> Bool {
+        // Special case: Any shipment from/to military addresses must have Customs
+        if originCountry == Constants.usCountryCode,
+           Constants.usMilitaryStates.contains(where: { $0 == originState }) {
+            return true
+        }
+        if destinationCountry == Constants.usCountryCode,
+           Constants.usMilitaryStates.contains(where: { $0 == destinationState }) {
+            return true
+        }
+
+        return originCountry != destinationCountry
+    }
+}
+
+private extension WooShippingCustomsRequirements {
+    enum Constants {
+        /// Country code for US - to check for international shipment
+        ///
+        static let usCountryCode = "US"
+
+        /// These US states are a special case because they represent military bases. They're considered "domestic",
+        /// but they require a Customs form to ship from/to them.
+        static let usMilitaryStates = ["AA", "AE", "AP"]
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -429,8 +429,7 @@ private extension WooShippingEditAddressView {
                                                 phone: "",
                                                 isDefaultAddress: true,
                                                 showCompanyField: false,
-                                                isVerified: true,
-                                                phoneNumberRequired: true))
+                                                isVerified: true))
 }
 
 #Preview("With Company") {
@@ -447,6 +446,5 @@ private extension WooShippingEditAddressView {
                                                 phone: "",
                                                 isDefaultAddress: false,
                                                 showCompanyField: true,
-                                                isVerified: false,
-                                                phoneNumberRequired: true))
+                                                isVerified: false))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -159,7 +159,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     private(set) var onOriginAddressEdited: ((WooShippingOriginAddress) -> Void)?
 
     /// Closure called when a destination address is done being edited and the changes are confirmed.
-    private(set) var onDestinationAddressEdited: ((WooShippingAddress) -> Void)?
+    /// Returns the updated address and email address.
+    private(set) var onDestinationAddressEdited: ((WooShippingAddress, String?) -> Void)?
 
     init(type: AddressType,
          id: String,
@@ -180,7 +181,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          debounceDelayInSeconds: Double = 1,
          onOriginAddressEdited: ((WooShippingOriginAddress) -> Void)? = nil,
-         onDestinationAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
+         onDestinationAddressEdited: ((WooShippingAddress, String?) -> Void)? = nil) {
         self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
@@ -271,10 +272,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     }
 
     convenience init(address: WooShippingAddress?,
+                     email: String?,
                      isVerified: Bool,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
-                     onAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
+                     onAddressEdited: ((WooShippingAddress, String?) -> Void)? = nil) {
         self.init(type: .destination,
                   id: UUID().uuidString,
                   name: address?.name ?? "",
@@ -284,7 +286,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   city: address?.city ?? "",
                   state: address?.state ?? "",
                   postalCode: address?.postcode ?? "",
-                  email: "",
+                  email: email ?? "",
                   phone: address?.phone ?? "",
                   isDefaultAddress: false,
                   showCompanyField: address?.company.isNotEmpty == true,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -158,6 +158,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// Closure called when an origin address is done being edited and the changes are confirmed.
     private(set) var onOriginAddressEdited: ((WooShippingOriginAddress) -> Void)?
 
+    /// Closure called when a destination address is done being edited and the changes are confirmed.
+    private(set) var onDestinationAddressEdited: ((WooShippingAddress) -> Void)?
+
     init(type: AddressType,
          id: String,
          name: String,
@@ -176,7 +179,8 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          debounceDelayInSeconds: Double = 1,
-         onOriginAddressEdited: ((WooShippingOriginAddress) -> Void)? = nil) {
+         onOriginAddressEdited: ((WooShippingOriginAddress) -> Void)? = nil,
+         onDestinationAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
         self.addressType = type
         self.id = id
         self.name = WooShippingAddressField(type: .name, value: name, required: company.isEmpty, validate: { _ in return nil })
@@ -264,6 +268,31 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   stores: stores,
                   storageManager: storageManager,
                   onOriginAddressEdited: onAddressEdited)
+    }
+
+    convenience init(address: WooShippingAddress?,
+                     isVerified: Bool,
+                     stores: StoresManager = ServiceLocator.stores,
+                     storageManager: StorageManagerType = ServiceLocator.storageManager,
+                     onAddressEdited: ((WooShippingAddress) -> Void)? = nil) {
+        self.init(type: .destination,
+                  id: UUID().uuidString,
+                  name: address?.name ?? "",
+                  company: address?.company ?? "",
+                  country: address?.country ?? "",
+                  address: address?.combinedAddress ?? "",
+                  city: address?.city ?? "",
+                  state: address?.state ?? "",
+                  postalCode: address?.postcode ?? "",
+                  email: "",
+                  phone: address?.phone ?? "",
+                  isDefaultAddress: false,
+                  showCompanyField: address?.company.isNotEmpty == true,
+                  isVerified: isVerified,
+                  phoneNumberRequired: false, // TODO: Check phone number requirements for destination address.
+                  stores: stores,
+                  storageManager: storageManager,
+                  onDestinationAddressEdited: onAddressEdited)
     }
 
     /// Validates the address remotely.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -439,9 +439,10 @@ extension WooShippingEditAddressViewModel {
                                             selectedState: String?,
                                             originCountryCode: String?,
                                             originStateCode: String?) -> Bool {
-        if addressType == .origin {
+        switch addressType {
+        case .origin:
             return true
-        } else {
+        case .destination:
             return WooShippingCustomsRequirements.isCustomsRequired(originCountry: originCountryCode,
                                                                     originState: originStateCode,
                                                                     destinationCountry: selectedCountryCode,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -61,8 +61,9 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         [name, company, country, address, city, state, postalCode, email, phone]
     }
 
-    /// Whether the phone number is required.
-    private let phoneNumberRequired: Bool
+    /// The origin address country code.
+    /// This is used to determine whether the phone number is required when editing a destination address.
+    private let originCountryCode: String?
 
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus {
@@ -131,7 +132,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Whether the address is in the US.
     var isUSAddress: Bool {
-        country.value == "US"
+        country.value == Constants.usCountryCode
     }
 
     /// States of the selected country.
@@ -176,7 +177,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          isDefaultAddress: Bool,
          showCompanyField: Bool,
          isVerified: Bool,
-         phoneNumberRequired: Bool,
+         originCountryCode: String? = nil,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          debounceDelayInSeconds: Double = 1,
@@ -202,11 +203,15 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.email = WooShippingAddressField(type: .email, value: email, required: true, validate: { newEmail in
             newEmail.isEmpty ? Localization.Validation.email : nil
         })
+        let phoneNumberRequired = Self.phoneNumberRequired(addressType: type,
+                                                           selectedCountryCode: country,
+                                                           selectedState: state,
+                                                           originCountryCode: originCountryCode)
         self.phone = WooShippingAddressField(type: .phone, value: phone, required: phoneNumberRequired, validate: { _ in return nil})
         self.isDefaultAddress = isDefaultAddress
         self.showCompanyField = showCompanyField
         self.originalAddressIsVerified = isVerified
-        self.phoneNumberRequired = phoneNumberRequired
+        self.originCountryCode = originCountryCode
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
@@ -247,6 +252,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         validateAddress()
     }
 
+    /// Used to initialize the view model with an origin address.
     convenience init(address: WooShippingOriginAddress,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -265,15 +271,16 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   isDefaultAddress: address.defaultAddress,
                   showCompanyField: address.company.isNotEmpty,
                   isVerified: address.isVerified,
-                  phoneNumberRequired: true,
                   stores: stores,
                   storageManager: storageManager,
                   onOriginAddressEdited: onAddressEdited)
     }
 
+    /// Used to initialize the view model with a destination address.
     convenience init(address: WooShippingAddress?,
                      email: String?,
                      isVerified: Bool,
+                     originCountryCode: String?,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      onAddressEdited: ((WooShippingAddress, String?) -> Void)? = nil) {
@@ -291,7 +298,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   isDefaultAddress: false,
                   showCompanyField: address?.company.isNotEmpty == true,
                   isVerified: isVerified,
-                  phoneNumberRequired: false, // TODO: Check phone number requirements for destination address.
+                  originCountryCode: originCountryCode,
                   stores: stores,
                   storageManager: storageManager,
                   onDestinationAddressEdited: onAddressEdited)
@@ -388,7 +395,10 @@ extension WooShippingEditAddressViewModel {
     ///
     private var isPhoneNumberValid: Bool {
         guard phone.value.isNotEmpty else {
-            return !phoneNumberRequired
+            return !Self.phoneNumberRequired(addressType: addressType,
+                                             selectedCountryCode: country.value,
+                                             selectedState: state.value,
+                                             originCountryCode: originCountryCode)
         }
         guard isUSAddress else {
             return true
@@ -398,6 +408,27 @@ extension WooShippingEditAddressViewModel {
             return phoneDigits.count == 11
         } else {
             return phoneDigits.count == 10
+        }
+    }
+
+    /// Whether the phone number is required.
+    /// - Parameters:
+    ///   - addressType: Type of address being edited.
+    ///   - selectedCountryCode: Country code of the selected country for the address being edited.
+    ///   - selectedState: Selected state for the address being edited.
+    ///   - originCountryCode: Country code of the origin address.
+    private static func phoneNumberRequired(addressType: AddressType,
+                                            selectedCountryCode: String?,
+                                            selectedState: String?,
+                                            originCountryCode: String?) -> Bool {
+        if addressType == .origin {
+            return true
+        } else {
+            if selectedCountryCode == Constants.usCountryCode,
+               Constants.usMilitaryStates.contains(where: { $0 == selectedState }) {
+                return true
+            }
+            return originCountryCode != selectedCountryCode
         }
     }
 }
@@ -436,6 +467,13 @@ private extension WooShippingEditAddressViewModel {
                 country.setDisplayValue(selectedCountry.name)
                 selectedState = nil
                 state.required = stateRequired
+
+                // Update phone number requirement based on selected country.
+                phone.required = Self.phoneNumberRequired(addressType: addressType,
+                                                          selectedCountryCode: selectedCountry.code,
+                                                          selectedState: selectedState?.code,
+                                                          originCountryCode: originCountryCode)
+                phone.validateField()
             }
             .store(in: &cancellables)
     }
@@ -447,6 +485,13 @@ private extension WooShippingEditAddressViewModel {
                 guard let self else { return }
                 state.value = selectedState?.code ?? ""
                 state.setDisplayValue(selectedState?.name ?? "")
+
+                // Update phone number requirement based on selected state.
+                phone.required = Self.phoneNumberRequired(addressType: addressType,
+                                                          selectedCountryCode: country.value,
+                                                          selectedState: selectedState?.code,
+                                                          originCountryCode: originCountryCode)
+                phone.validateField()
             }
             .store(in: &cancellables)
     }
@@ -547,6 +592,14 @@ private extension WooShippingEditAddressViewModel {
             "FM", // Micronesia
             "MP" // Northern Mariana Islands
         ]
+
+        /// Country code for US - to check for international shipment
+        ///
+        static let usCountryCode = "US"
+
+        /// These US states are a special case because they represent military bases. They're considered "domestic",
+        /// but they require a Customs form to ship from/to them.
+        static let usMilitaryStates = ["AA", "AE", "AP"]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -65,6 +65,10 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     /// This is used to determine whether the phone number is required when editing a destination address.
     private let originCountryCode: String?
 
+    /// The origin address state code.
+    /// This is used to determine whether the phone number is required when editing a destination address.
+    private let originStateCode: String?
+
     /// Status of the address, based on local validation and remote verification.
     var status: WooShippingAddressStatus {
         let isRemotelyVerified = originalAddressIsVerified && !hasChanges
@@ -132,7 +136,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Whether the address is in the US.
     var isUSAddress: Bool {
-        country.value == Constants.usCountryCode
+        country.value == "US"
     }
 
     /// States of the selected country.
@@ -178,6 +182,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
          showCompanyField: Bool,
          isVerified: Bool,
          originCountryCode: String? = nil,
+         originStateCode: String? = nil,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          debounceDelayInSeconds: Double = 1,
@@ -206,12 +211,14 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         let phoneNumberRequired = Self.phoneNumberRequired(addressType: type,
                                                            selectedCountryCode: country,
                                                            selectedState: state,
-                                                           originCountryCode: originCountryCode)
+                                                           originCountryCode: originCountryCode,
+                                                           originStateCode: originStateCode)
         self.phone = WooShippingAddressField(type: .phone, value: phone, required: phoneNumberRequired, validate: { _ in return nil})
         self.isDefaultAddress = isDefaultAddress
         self.showCompanyField = showCompanyField
         self.originalAddressIsVerified = isVerified
         self.originCountryCode = originCountryCode
+        self.originStateCode = originStateCode
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
         self.storageManager = storageManager
@@ -281,6 +288,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                      email: String?,
                      isVerified: Bool,
                      originCountryCode: String?,
+                     originStateCode: String?,
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      onAddressEdited: ((WooShippingAddress, String?) -> Void)? = nil) {
@@ -299,6 +307,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                   showCompanyField: address?.company.isNotEmpty == true,
                   isVerified: isVerified,
                   originCountryCode: originCountryCode,
+                  originStateCode: originStateCode,
                   stores: stores,
                   storageManager: storageManager,
                   onDestinationAddressEdited: onAddressEdited)
@@ -395,10 +404,7 @@ extension WooShippingEditAddressViewModel {
     ///
     private var isPhoneNumberValid: Bool {
         guard phone.value.isNotEmpty else {
-            return !Self.phoneNumberRequired(addressType: addressType,
-                                             selectedCountryCode: country.value,
-                                             selectedState: state.value,
-                                             originCountryCode: originCountryCode)
+            return !phoneNumberRequired(for: country.value, and: state.value)
         }
         guard isUSAddress else {
             return true
@@ -412,23 +418,34 @@ extension WooShippingEditAddressViewModel {
     }
 
     /// Whether the phone number is required.
+    ///
+    private func phoneNumberRequired(for country: String?, and state: String?) -> Bool {
+        Self.phoneNumberRequired(addressType: addressType,
+                                    selectedCountryCode: country,
+                                    selectedState: state,
+                                    originCountryCode: originCountryCode,
+                                    originStateCode: originStateCode)
+    }
+
+    /// Whether the phone number is required.
     /// - Parameters:
     ///   - addressType: Type of address being edited.
     ///   - selectedCountryCode: Country code of the selected country for the address being edited.
     ///   - selectedState: Selected state for the address being edited.
     ///   - originCountryCode: Country code of the origin address.
+    ///   - originStateCode: State code of the origin address.
     private static func phoneNumberRequired(addressType: AddressType,
                                             selectedCountryCode: String?,
                                             selectedState: String?,
-                                            originCountryCode: String?) -> Bool {
+                                            originCountryCode: String?,
+                                            originStateCode: String?) -> Bool {
         if addressType == .origin {
             return true
         } else {
-            if selectedCountryCode == Constants.usCountryCode,
-               Constants.usMilitaryStates.contains(where: { $0 == selectedState }) {
-                return true
-            }
-            return originCountryCode != selectedCountryCode
+            return WooShippingCustomsRequirements.isCustomsRequired(originCountry: originCountryCode,
+                                                                    originState: originStateCode,
+                                                                    destinationCountry: selectedCountryCode,
+                                                                    destinationState: selectedState)
         }
     }
 }
@@ -469,10 +486,7 @@ private extension WooShippingEditAddressViewModel {
                 state.required = stateRequired
 
                 // Update phone number requirement based on selected country.
-                phone.required = Self.phoneNumberRequired(addressType: addressType,
-                                                          selectedCountryCode: selectedCountry.code,
-                                                          selectedState: selectedState?.code,
-                                                          originCountryCode: originCountryCode)
+                phone.required = phoneNumberRequired(for: selectedCountry.code, and: selectedState?.code)
                 phone.validateField()
             }
             .store(in: &cancellables)
@@ -487,10 +501,7 @@ private extension WooShippingEditAddressViewModel {
                 state.setDisplayValue(selectedState?.name ?? "")
 
                 // Update phone number requirement based on selected state.
-                phone.required = Self.phoneNumberRequired(addressType: addressType,
-                                                          selectedCountryCode: country.value,
-                                                          selectedState: selectedState?.code,
-                                                          originCountryCode: originCountryCode)
+                phone.required = phoneNumberRequired(for: country.value, and: selectedState?.code)
                 phone.validateField()
             }
             .store(in: &cancellables)
@@ -592,14 +603,6 @@ private extension WooShippingEditAddressViewModel {
             "FM", // Micronesia
             "MP" // Northern Mariana Islands
         ]
-
-        /// Country code for US - to check for international shipment
-        ///
-        static let usCountryCode = "US"
-
-        /// These US states are a special case because they represent military bases. They're considered "domestic",
-        /// but they require a Customs form to ship from/to them.
-        static let usMilitaryStates = ["AA", "AE", "AP"]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -223,6 +223,10 @@ private extension WooShippingCreateLabelsView {
                 addressVerificationLabel
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            PencilEditButton {
+                // TODO: Open destination address editing flow.
+            }
+            .buttonStyle(TextButtonStyle())
         }
         .padding(Layout.bottomSheetPadding)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -136,6 +136,13 @@ struct WooShippingCreateLabelsView: View {
                     }
                 }
             }
+            .sheet(item: $viewModel.addressToEdit) { addressToEdit in
+                NavigationStack {
+                    WooShippingEditAddressView(viewModel: addressToEdit)
+                        .navigationTitle(Localization.BottomSheet.editDestination)
+                        .navigationBarTitleDisplayMode(.inline)
+                }
+            }
         }
     }
 }
@@ -229,13 +236,6 @@ private extension WooShippingCreateLabelsView {
             .buttonStyle(TextButtonStyle())
         }
         .padding(Layout.bottomSheetPadding)
-        .sheet(item: $viewModel.addressToEdit) { addressToEdit in
-            NavigationStack {
-                WooShippingEditAddressView(viewModel: addressToEdit)
-                    .navigationTitle(Localization.BottomSheet.editDestination)
-                    .navigationBarTitleDisplayMode(.inline)
-            }
-        }
     }
 
     /// View showing the order details, such as order items and shipping costs.
@@ -344,6 +344,11 @@ private extension WooShippingCreateLabelsView {
             .padding(.vertical, 12)
             .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .fill(Color(uiColor: isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
+            .onTapGesture {
+                if !isDestinationAddressVerified {
+                    viewModel.editDestinationAddress()
+                }
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -224,11 +224,18 @@ private extension WooShippingCreateLabelsView {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             PencilEditButton {
-                // TODO: Open destination address editing flow.
+                viewModel.editDestinationAddress()
             }
             .buttonStyle(TextButtonStyle())
         }
         .padding(Layout.bottomSheetPadding)
+        .sheet(item: $viewModel.addressToEdit) { addressToEdit in
+            NavigationStack {
+                WooShippingEditAddressView(viewModel: addressToEdit)
+                    .navigationTitle(Localization.BottomSheet.editDestination)
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+        }
     }
 
     /// View showing the order details, such as order items and shipping costs.
@@ -431,6 +438,9 @@ private extension WooShippingCreateLabelsView {
                                                           value: "Purchase Label · %1$@",
                                                           comment: "Label for button to purchase the shipping label on the shipping label creation screen, " +
                                                           "including the label price. Reads like: 'Purchase Label · $7.63'")
+            static let editDestination = NSLocalizedString("wooShipping.createLabels.bottomSheet.editDestination",
+                                                          value: "Edit Destination",
+                                                          comment: "Title for the edit destination address screen in the shipping label creation flow")
         }
 
         enum AddressVerification {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -152,17 +152,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
               let destinationAddress = destinationAddress else {
             return false
         }
-        // Special case: Any shipment from/to military addresses must have Customs
-        if originAddress.country == Constants.usCountryCode,
-           Constants.usMilitaryStates.contains(where: { $0 == originAddress.state }) {
-            return true
-        }
-        if destinationAddress.country == Constants.usCountryCode,
-           Constants.usMilitaryStates.contains(where: { $0 == destinationAddress.state }) {
-            return true
-        }
-
-        return originAddress.country != destinationAddress.country
+        return WooShippingCustomsRequirements.isCustomsRequired(originCountry: originAddress.country,
+                                                                originState: originAddress.state,
+                                                                destinationCountry: destinationAddress.country,
+                                                                destinationState: destinationAddress.state)
     }
 
     /// Initialize the view model without an existing shipping label.
@@ -287,6 +280,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                         email: destinationEmail,
                                                         isVerified: destinationAddressStatus == .verified,
                                                         originCountryCode: selectedOriginAddress?.country,
+                                                        originStateCode: selectedOriginAddress?.state,
                                                         onAddressEdited: { [weak self] editedAddress, editedEmail in
             guard let self else {
                 return
@@ -477,16 +471,6 @@ private extension WooShippingCreateLabelsViewModel {
                                                               value: "Destination address missing",
                                                               comment: "Notice when a destination address is missing on the shipping label creation screen")
         }
-    }
-
-    enum Constants {
-        /// Country code for US - to check for international shipment
-        ///
-        static let usCountryCode = "US"
-
-        /// These US states are a special case because they represent military bases. They're considered "domestic",
-        /// but they require a Customs form to ship from/to them.
-        static let usMilitaryStates = ["AA", "AE", "AP"]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -8,7 +8,7 @@ import Combine
 final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
     private let itemsDataSource: WooShippingItemsDataSource
-    private let destinationAddress: WooShippingAddress?
+    private var destinationAddress: WooShippingAddress?
     private let stores: StoresManager
     private var subscriptions: Set<AnyCancellable> = []
     private var debounceDuration: Double = 1
@@ -78,6 +78,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// This property can be set to display a notice with the provided label about the destination address status.
     @Published var destinationAddressStatusNoticeLabel: String?
+
+    /// View model for address to edit.
+    /// Setting this property will navigate to the address edit screen.
+    @Published var addressToEdit: WooShippingEditAddressViewModel?
 
     /// Shipping lines for the order, with formatted amount.
     let shippingLines: [WooShipping_ShippingLineViewModel]
@@ -272,6 +276,20 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     func onCustomsFormFilled(form: ShippingLabelCustomsForm) {
         customsForm = form
+    }
+
+    /// Sets the `addressToEdit` property for editing the destination address.
+    /// After the address is edited, the destination address is replaced with the updated address.
+    func editDestinationAddress() {
+        addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress,
+                                                        isVerified: destinationAddressStatus == .verified,
+                                                        onAddressEdited: { [weak self] editedAddress in
+            guard let self else {
+                return
+            }
+            destinationAddress = editedAddress
+            addressToEdit = nil // Dismisses address edit screen
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -286,6 +286,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress,
                                                         email: destinationEmail,
                                                         isVerified: destinationAddressStatus == .verified,
+                                                        originCountryCode: selectedOriginAddress?.country,
                                                         onAddressEdited: { [weak self] editedAddress, editedEmail in
             guard let self else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -9,6 +9,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
     private let itemsDataSource: WooShippingItemsDataSource
     private var destinationAddress: WooShippingAddress?
+    private var destinationEmail: String?
     private let stores: StoresManager
     private var subscriptions: Set<AnyCancellable> = []
     private var debounceDuration: Double = 1
@@ -182,6 +183,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.onLabelPurchase = onLabelPurchase
         self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
+        self.destinationEmail = order.shippingAddress?.email ?? order.billingAddress?.email
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.selectedOriginAddress = selectedOriginAddress
         self.selectedPackage = selectedPackage
@@ -282,12 +284,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// After the address is edited, the destination address is replaced with the updated address.
     func editDestinationAddress() {
         addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress,
+                                                        email: destinationEmail,
                                                         isVerified: destinationAddressStatus == .verified,
-                                                        onAddressEdited: { [weak self] editedAddress in
+                                                        onAddressEdited: { [weak self] editedAddress, editedEmail in
             guard let self else {
                 return
             }
             destinationAddress = editedAddress
+            destinationEmail = editedEmail
             addressToEdit = nil // Dismisses address edit screen
         })
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2382,6 +2382,7 @@
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEAB739C2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */; };
 		CEAEB75A2CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAEB7592CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift */; };
+		CEB739502D6897C700411231 /* WooShippingCustomsRequirements.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7394F2D6897C300411231 /* WooShippingCustomsRequirements.swift */; };
 		CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */; };
 		CEC3CC6D2C93127300B93FBE /* WooShippingItemsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */; };
 		CEC3CC6F2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */; };
@@ -2585,9 +2586,9 @@
 		DE02ABBE2B578D0E008E0AC4 /* CreditCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABBD2B578D0E008E0AC4 /* CreditCardType.swift */; };
 		DE02ABC02B57D333008E0AC4 /* BlazeConfirmPaymentViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABBF2B57D333008E0AC4 /* BlazeConfirmPaymentViewModelTests.swift */; };
 		DE02ABC22B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABC12B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift */; };
-		DE06D6602D64699D00419FFA /* AuthenticatedWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE06D65F2D64699D00419FFA /* AuthenticatedWebViewModelTests.swift */; };
 		DE02C65C2D5A0B9F0089850D /* FailedProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02C65B2D5A0B9F0089850D /* FailedProductImageCollectionViewCell.swift */; };
 		DE02C65E2D5A0C5D0089850D /* FailedProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE02C65D2D5A0C5D0089850D /* FailedProductImageCollectionViewCell.xib */; };
+		DE06D6602D64699D00419FFA /* AuthenticatedWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE06D65F2D64699D00419FFA /* AuthenticatedWebViewModelTests.swift */; };
 		DE0A2EAA281BA083007A8015 /* ProductCategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */; };
 		DE0A2EAD281BA1FA007A8015 /* ProductCategorySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */; };
 		DE0A2EAF281BA278007A8015 /* ProductCategorySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */; };
@@ -5576,6 +5577,7 @@
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsView.swift; sourceTree = "<group>"; };
 		CEAEB7592CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPostPurchaseView.swift; sourceTree = "<group>"; };
+		CEB7394F2D6897C300411231 /* WooShippingCustomsRequirements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCustomsRequirements.swift; sourceTree = "<group>"; };
 		CEC3CC6A2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModel.swift; sourceTree = "<group>"; };
 		CEC3CC6C2C93127300B93FBE /* WooShippingItemsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemsViewModel.swift; sourceTree = "<group>"; };
 		CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsViewModel.swift; sourceTree = "<group>"; };
@@ -5782,9 +5784,9 @@
 		DE02ABBD2B578D0E008E0AC4 /* CreditCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardType.swift; sourceTree = "<group>"; };
 		DE02ABBF2B57D333008E0AC4 /* BlazeConfirmPaymentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeConfirmPaymentViewModelTests.swift; sourceTree = "<group>"; };
 		DE02ABC12B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationErrorView.swift; sourceTree = "<group>"; };
-		DE06D65F2D64699D00419FFA /* AuthenticatedWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE02C65B2D5A0B9F0089850D /* FailedProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		DE02C65D2D5A0C5D0089850D /* FailedProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FailedProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
+		DE06D65F2D64699D00419FFA /* AuthenticatedWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE0A2EA9281BA083007A8015 /* ProductCategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryList.swift; sourceTree = "<group>"; };
 		DE0A2EAC281BA1FA007A8015 /* ProductCategorySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelector.swift; sourceTree = "<group>"; };
 		DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelectorViewModel.swift; sourceTree = "<group>"; };
@@ -11170,6 +11172,7 @@
 		B90DD08C2D12FA6600EFC06A /* WooShipping Customs */ = {
 			isa = PBXGroup;
 			children = (
+				CEB7394F2D6897C300411231 /* WooShippingCustomsRequirements.swift */,
 				B90D217F2D1ED1DE00ED60ED /* WooShippingCustomsItemOriginCountryInfoDialog.swift */,
 				B90D217D2D1ECA1F00ED60ED /* WooShippingCustomsItemDescriptionInfoDialog.swift */,
 				B90D217B2D1B06F600ED60ED /* WooShippingCustomsItemViewModel.swift */,
@@ -15446,6 +15449,7 @@
 				8602BC9F2B19AE48001EDF20 /* ProfilerThemesPickerView.swift in Sources */,
 				B6F3796E293796BC00718561 /* AnalyticsHubWeekToDateRangeData.swift in Sources */,
 				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */,
+				CEB739502D6897C700411231 /* WooShippingCustomsRequirements.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
 				31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */,
 				01F42C182CE34AD2003D0A5A /* CardPresentModalSuccessEmailSent.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -500,6 +500,17 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.destinationAddressStatus, .missing)
         XCTAssertNotNil(viewModel.destinationAddressStatusNoticeLabel)
     }
+
+    func test_editDestinationAddress_sets_addressToEdit_view_model() throws {
+        // Given
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake())
+
+        // When
+        viewModel.editDestinationAddress()
+
+        // Then
+        XCTAssertNotNil(viewModel.addressToEdit)
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -123,6 +123,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         email: email,
                                                         isVerified: false,
                                                         originCountryCode: "US",
+                                                        originStateCode: "CA",
                                                         storageManager: storageManager)
 
         // Then
@@ -248,7 +249,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.phone.required)
     }
 
-    func test_phone_number_not_required_for_destination_address_in_same_country_as_origin() {
+    func test_phone_number_not_required_for_destination_address_when_customs_form_not_required() {
         // Given
         let address = WooShippingAddress(company: "HEADQUARTERS",
                                          name: "JANE DOE",
@@ -264,13 +265,14 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let viewModel = WooShippingEditAddressViewModel(address: address,
                                                         email: "",
                                                         isVerified: false,
-                                                        originCountryCode: address.country)
+                                                        originCountryCode: address.country,
+                                                        originStateCode: "CA")
 
         // Then
         XCTAssertFalse(viewModel.phone.required)
     }
 
-    func test_phone_number_required_for_destination_address_in_different_country_from_origin() {
+    func test_phone_number_required_for_destination_address_when_customs_form_required() {
         // Given
         let address = WooShippingAddress(company: "HEADQUARTERS",
                                          name: "JANE DOE",
@@ -286,7 +288,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let viewModel = WooShippingEditAddressViewModel(address: address,
                                                         email: "",
                                                         isVerified: false,
-                                                        originCountryCode: "CA")
+                                                        originCountryCode: "CA",
+                                                        originStateCode: "BC")
 
         // Then
         XCTAssertTrue(viewModel.phone.required)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -102,6 +102,43 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.countries.count, 1, "Should only include USPS-supported countries for origin addresses")
     }
 
+    func test_destination_address_inits_with_expected_values() {
+        // Given
+        let storageManager = MockStorageManager()
+        let state = StateOfACountry(code: "NY", name: "New York")
+        let countries = [Country(code: "US", name: "United States", states: [state]), Country(code: "CA", name: "Canada", states: [])]
+        storageManager.insertSampleCountries(readOnlyCountries: countries)
+        let address = WooShippingAddress(company: "HEADQUARTERS",
+                                         name: "JANE DOE",
+                                         phone: "223-456-7890",
+                                         country: "US",
+                                         state: "NY",
+                                         address1: "15 ALGONKIN ST",
+                                         address2: "STE 100",
+                                         city: "TICONDEROGA",
+                                         postcode: "12883-1487")
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(address: address,
+                                                        isVerified: false,
+                                                        storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.name.value, address.name)
+        XCTAssertEqual(viewModel.country.value, address.country)
+        XCTAssertEqual(viewModel.company.value, address.company)
+        XCTAssertEqual(viewModel.address.value, address.combinedAddress)
+        XCTAssertEqual(viewModel.city.value, address.city)
+        XCTAssertEqual(viewModel.state.value, address.state)
+        XCTAssertEqual(viewModel.postalCode.value, address.postcode)
+        XCTAssertEqual(viewModel.phone.value, address.phone)
+        XCTAssertEqual(viewModel.email.value, "")
+        XCTAssertTrue(viewModel.showCompanyField)
+        XCTAssertEqual(viewModel.status, .missingInformation)
+        XCTAssertFalse(viewModel.showSaveAsDefault)
+        XCTAssertEqual(viewModel.countries.count, 2, "Should include all countries for destination addresses")
+    }
+
     func test_it_validates_address_with_missing_information_and_sets_expected_status_on_init() {
         // Given & When
         let viewModel = WooShippingEditAddressViewModel(type: .destination,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -39,7 +39,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: saveAsDefault,
                                                         showCompanyField: showCompanyField,
                                                         isVerified: isVerified,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // Then
@@ -123,6 +122,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let viewModel = WooShippingEditAddressViewModel(address: address,
                                                         email: email,
                                                         isVerified: false,
+                                                        originCountryCode: "US",
                                                         storageManager: storageManager)
 
         // Then
@@ -156,8 +156,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         phone: "",
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
-                                                        isVerified: false,
-                                                        phoneNumberRequired: true)
+                                                        isVerified: false)
 
         // Then
         XCTAssertEqual(viewModel.status, .missingInformation)
@@ -181,7 +180,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         stores: stores,
                                                         storageManager: storageManager)
 
@@ -212,8 +210,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         phone: "",
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
-                                                        isVerified: true,
-                                                        phoneNumberRequired: false)
+                                                        isVerified: true)
 
         // Then
         XCTAssertFalse(viewModel.company.required)
@@ -234,33 +231,65 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         phone: "",
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
-                                                        isVerified: true,
-                                                        phoneNumberRequired: false)
+                                                        isVerified: true)
 
         // Then
         XCTAssertFalse(viewModel.name.required)
     }
 
-    func test_phone_number_not_required_when_phoneNumberRequired_set_to_false() {
+    func test_phone_number_required_for_origin_address() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .origin,
-                                                        id: "",
-                                                        name: "",
-                                                        company: "",
-                                                        country: "",
-                                                        address: "",
-                                                        city: "",
-                                                        state: "",
-                                                        postalCode: "",
+        let address = WooShippingOriginAddress.fake()
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(address: address)
+
+        // Then
+        XCTAssertTrue(viewModel.phone.required)
+    }
+
+    func test_phone_number_not_required_for_destination_address_in_same_country_as_origin() {
+        // Given
+        let address = WooShippingAddress(company: "HEADQUARTERS",
+                                         name: "JANE DOE",
+                                         phone: "223-456-7890",
+                                         country: "US",
+                                         state: "NY",
+                                         address1: "15 ALGONKIN ST",
+                                         address2: "STE 100",
+                                         city: "TICONDEROGA",
+                                         postcode: "12883-1487")
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(address: address,
                                                         email: "",
-                                                        phone: "",
-                                                        isDefaultAddress: true,
-                                                        showCompanyField: true,
-                                                        isVerified: true,
-                                                        phoneNumberRequired: false)
+                                                        isVerified: false,
+                                                        originCountryCode: address.country)
 
         // Then
         XCTAssertFalse(viewModel.phone.required)
+    }
+
+    func test_phone_number_required_for_destination_address_in_different_country_from_origin() {
+        // Given
+        let address = WooShippingAddress(company: "HEADQUARTERS",
+                                         name: "JANE DOE",
+                                         phone: "223-456-7890",
+                                         country: "US",
+                                         state: "NY",
+                                         address1: "15 ALGONKIN ST",
+                                         address2: "STE 100",
+                                         city: "TICONDEROGA",
+                                         postcode: "12883-1487")
+
+        // When
+        let viewModel = WooShippingEditAddressViewModel(address: address,
+                                                        email: "",
+                                                        isVerified: false,
+                                                        originCountryCode: "CA")
+
+        // Then
+        XCTAssertTrue(viewModel.phone.required)
     }
 
     func test_it_inits_with_expected_values_for_origin_address_type() {
@@ -284,7 +313,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // Then
@@ -313,7 +341,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // Then
@@ -349,7 +376,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         stores: stores,
                                                         storageManager: storageManager)
 
@@ -377,7 +403,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // Then
@@ -406,7 +431,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // Then
@@ -436,7 +460,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // When
@@ -468,7 +491,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // When
@@ -499,7 +521,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // When
@@ -526,7 +547,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         debounceDelayInSeconds: 0)
 
         // When
@@ -558,7 +578,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -588,7 +607,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         debounceDelayInSeconds: 0)
 
         // When
@@ -622,7 +640,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -652,7 +669,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
 
@@ -679,7 +695,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         debounceDelayInSeconds: 0)
         // Precondition check
         viewModel.validate(.name)
@@ -712,7 +727,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         storageManager: storageManager)
 
         // Check precondition
@@ -744,7 +758,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -799,7 +812,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         debounceDelayInSeconds: 0)
@@ -829,7 +841,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -866,7 +877,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         isDefaultAddress: true,
                                                         showCompanyField: true,
                                                         isVerified: true,
-                                                        phoneNumberRequired: true,
                                                         stores: stores,
                                                         debounceDelayInSeconds: 0)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -117,9 +117,11 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                          address2: "STE 100",
                                          city: "TICONDEROGA",
                                          postcode: "12883-1487")
+        let email = "TEST@EXAMPLE.COM"
 
         // When
         let viewModel = WooShippingEditAddressViewModel(address: address,
+                                                        email: email,
                                                         isVerified: false,
                                                         storageManager: storageManager)
 
@@ -132,9 +134,9 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.state.value, address.state)
         XCTAssertEqual(viewModel.postalCode.value, address.postcode)
         XCTAssertEqual(viewModel.phone.value, address.phone)
-        XCTAssertEqual(viewModel.email.value, "")
+        XCTAssertEqual(viewModel.email.value, email)
         XCTAssertTrue(viewModel.showCompanyField)
-        XCTAssertEqual(viewModel.status, .missingInformation)
+        XCTAssertEqual(viewModel.status, .unverified)
         XCTAssertFalse(viewModel.showSaveAsDefault)
         XCTAssertEqual(viewModel.countries.count, 2, "Should include all countries for destination addresses")
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15177
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the UI layer to begin the address editing flow for a destination address:

* Adds an edit (pencil) icon to the Ship To address in the bottom sheet.
* When the edit icon is tapped, it opens the address editing form in a sheet with the destination address details prefilled.
* When the "unverified address" or "missing address" banner in the collapsed bottom sheet is tapped, it opens the address editing form.

The address editing form works as follows for destination addresses:

* Phone number is required when a customs form is required:
   * The destination address is in a different country than the origin address.
   * The origin state is a US military state.
   * The destination state is a US military state.
* Selecting a new country or state updates the local validation for the phone number, to meet the requirements above.
* There is no "default address" toggle (only shown for editing origin addresses).
* Otherwise, the address form works the same as it does for origin addresses.

Note that this only adds support for opening the address form; the rest of the destination address editing flow will be completed in https://github.com/woocommerce/woocommerce-ios/issues/15178.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: WooCommerce Shipping is installed, activated, and set up on your store.

1. Create or open an order with at least one physical product and the processing status, and a shipping address.
2. Tap "Create Shipping Label" in order details.
3. Tap the "Destination address unverified" notice at the bottom of the screen and confirm the address form opens with the shipping (destination) address details pre-filled.
4. Tap "Cancel" to close the form.
5. Open the Shipment details bottom sheet and confirm you see a pencil (edit) icon next to the "Ship to" address.
6. Tap the edit icon and confirm the address form opens with the shipping (destination) address details pre-filled.
7. Confirm you can edit the address and see the expected local validation.
8. Select a different country from the origin address and confirm a phone number is required.
9. Select the United States as the country and an "Armed Forces" state and confirm a phone number is required.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/45a5a697-a0ac-472d-99c7-dc98380d5424



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.