### PR TITLE
15193 Set trailing internal padding on item row

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -46,10 +46,10 @@ struct ItemRowView: View {
                         .font(.posButtonSymbolMedium)
                 })
                 .accessibilityLabel(Localization.removeFromCartAccessibilityLabel)
-                .padding(.trailing, Constants.cardContentHorizontalPadding)
                 .foregroundColor(Color.posOnSurfaceVariantLowest)
             }
         }
+        .padding(.trailing, Constants.cardContentHorizontalPadding)
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
         .background(Color.posSurfaceContainerLowest)
         .posItemCardBorderStyles()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15193
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This ensures we always have internal trailing padding on cart items, whether they're shown in the checkout (with no remove button) or on the item list (with remove button) 

We achieve this by moving the padding from the remove button, to the row itself. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and go to POS
2. Add items to the cart with various length names
3. Change your dynamic type size
4. Observe that theres always padding at the end of the item row
5. Checkout
6. Repeat steps 3 and 4

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on an iPad Air running iOS 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before
![before fixing padding](https://github.com/user-attachments/assets/74ddace6-3b82-479b-8c12-6c4071dfd33a)

### After
![after fixing padding](https://github.com/user-attachments/assets/af3183cb-cc3e-45a7-a6b3-86f8933b3482)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.