### PR TITLE
[Tooling] Exclude retries when making sure tests are not failing

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1324,8 +1324,8 @@ lane :test_without_building do |options|
     fail_build: true
   )
 
-  # Trainer sometimes doesn't detect test failures, so we manually throw an error in the lane if there are failures to make sure there are no false positives
-  UI.user_error!("Tests failed with #{tests_result[:number_of_failures]} failures.") if tests_result[:number_of_failures].positive?
+  # `trainer` sometimes doesn't detect test failures, so we manually throw an error in the lane if there are failures to make sure there are no false positives
+  UI.user_error!("Tests failed with #{tests_result[:number_of_failures_excluding_retries]} failures.") if tests_result[:number_of_failures_excluding_retries].positive?
 end
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to https://github.com/woocommerce/woocommerce-ios/pull/15224

Use the field `number_of_failures_excluding_retries` from the test report to asses whether we need to fail the tests CI job in case `trainer` didn't report the errors properly.