### PR TITLE
[Woo POS][Design System] Updates from design review: skeleton item card view, cash view

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -2,23 +2,31 @@ import SwiftUI
 
 struct GhostItemCardView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
+    @State private var viewWidth: CGFloat = 0.0
 
     private var dimension: CGFloat {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
     }
 
     var body: some View {
-        HStack(spacing: Constants.cardSpacing) {
-            Spacer()
-                .frame(width: dimension, height: dimension)
+        HStack(alignment: .center, spacing: Constants.cardSpacing) {
             Rectangle()
-                .foregroundColor(.posOnSurfaceVariantLowest)
-                .frame(height: Layout.placeholderHeight * scale)
-                .cornerRadius(Layout.cornerRadius)
-                .padding(.horizontal, Constants.horizontalTextPadding)
-            Spacer()
                 .frame(width: dimension, height: dimension)
+            VStack(alignment: .leading) {
+                Rectangle()
+                    .frame(width: viewWidth * 0.5, height: Layout.placeholderHeight * scale)
+                    .cornerRadius(Layout.cornerRadius)
+                Rectangle()
+                    .frame(width: viewWidth * 0.1, height: Layout.placeholderHeight * scale)
+                    .cornerRadius(Layout.cornerRadius)
+            }
+            .padding(.horizontal, Constants.horizontalTextPadding)
+            Spacer()
         }
+        .measureWidth { width in
+            viewWidth = width
+        }
+        .foregroundColor(.posOnSurfaceVariantLowest)
         .shimmering()
         .frame(maxWidth: .infinity, idealHeight: dimension)
         .background(Color.posSurfaceBright)
@@ -30,7 +38,7 @@ private extension GhostItemCardView {
     typealias Constants = PointOfSaleItemListCardConstants
 
     enum Layout {
-        static let placeholderHeight: CGFloat = 36
+        static let placeholderHeight: CGFloat = 32
         static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -159,7 +159,7 @@ private extension PointOfSaleCollectCashView {
     }
 
     private var backgroundColor: Color {
-        .posSurface
+        .posSurfaceBright
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -93,7 +93,6 @@ struct PointOfSaleCollectCashView: View {
                 .padding([.horizontal])
                 .padding(.bottom, keyboardFrame.height)
             }
-            .background(backgroundColor)
             .animation(.easeInOut, value: errorMessage)
             .animation(.easeInOut, value: changeDueMessage)
             .onChange(of: textFieldAmountInput) { _ in

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -5,6 +5,7 @@ import WooFoundation
 @available(iOS 17.0, *)
 struct PointOfSaleCollectCashView: View {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @FocusState private var isTextFieldFocused: Bool
 
@@ -31,79 +32,85 @@ struct PointOfSaleCollectCashView: View {
                                                                                       allowNegativeNumber: false)
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
-                POSPageHeaderView(title: Localization.backNavigationTitle,
-                                  subtitle: formattedOrderTotal,
-                                  backButtonConfiguration: .init(state: isLoading ? .disabled: .enabled,
-                                                                 action: {
-                    Task { @MainActor in
-                        await posModel.cancelCashPayment()
-                        isTextFieldFocused = false
-                    }
-                }))
-
+        GeometryReader { geometry in
+            ScrollView {
                 VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
-                    Spacer()
-
-                    VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.xSmall)) {
-                        FormattableAmountTextField(viewModel: textFieldViewModel, style: .pos)
-                            .focused($isTextFieldFocused)
-                            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-                            .onSubmit {
-                                Task { @MainActor in
-                                    await submitCashAmount()
-                                }
-                            }
-                            .onChange(of: textFieldViewModel.amount) { newValue in
-                                textFieldAmountInput = newValue
-                                updateChangeDueMessage()
-                            }
-
-                        if let changeDue = changeDueMessage {
-                            Text(changeDue)
-                                .font(.posBodySmallRegular())
-                                .foregroundColor(.posOnSurfaceVariantLowest)
-                        }
-
-                        if let errorMessage = errorMessage {
-                            Text(errorMessage)
-                                .font(.posBodySmallRegular())
-                                .foregroundColor(.posError)
-                        }
-                    }
-
-                    Spacer()
-
-                    Button(action: {
+                    POSPageHeaderView(title: Localization.backNavigationTitle,
+                                      subtitle: formattedOrderTotal,
+                                      backButtonConfiguration: .init(state: isLoading ? .disabled: .enabled,
+                                                                     action: {
                         Task { @MainActor in
-                            await submitCashAmount()
+                            await posModel.cancelCashPayment()
+                            isTextFieldFocused = false
                         }
-                    }, label: {
-                        Text(Localization.markPaymentCompletedButtonTitle)
-                    })
-                    .measureFrame {
-                        buttonFrame = $0
+                    }))
+
+                    VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
+                        Spacer()
+
+                        VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.xSmall)) {
+                            FormattableAmountTextField(viewModel: textFieldViewModel, style: .pos)
+                                .focused($isTextFieldFocused)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+                                .onSubmit {
+                                    Task { @MainActor in
+                                        await submitCashAmount()
+                                    }
+                                }
+                                .onChange(of: textFieldViewModel.amount) { newValue in
+                                    textFieldAmountInput = newValue
+                                    updateChangeDueMessage()
+                                }
+
+                            if let changeDue = changeDueMessage {
+                                Text(changeDue)
+                                    .font(.posBodySmallRegular())
+                                    .foregroundColor(.posOnSurfaceVariantLowest)
+                            }
+
+                            if let errorMessage = errorMessage {
+                                Text(errorMessage)
+                                    .font(.posBodySmallRegular())
+                                    .foregroundColor(.posError)
+                            }
+                        }
+
+                        Spacer()
+
+                        Button(action: {
+                            Task { @MainActor in
+                                await submitCashAmount()
+                            }
+                        }, label: {
+                            Text(Localization.markPaymentCompletedButtonTitle)
+                        })
+                        .measureFrame {
+                            buttonFrame = $0
+                        }
+                        .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
+                        .frame(maxWidth: .infinity)
+                        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+                        .disabled(isLoading)
                     }
-                    .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
-                    .frame(maxWidth: .infinity)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-                    .disabled(isLoading)
+                    .padding([.horizontal])
+                    .padding(.bottom, max(keyboardFrame.height - geometry.safeAreaInsets.bottom,
+                                          floatingControlAreaSize.height) + Constants.bottomPadding
+                    )
                 }
-                .padding([.horizontal])
-                .padding(.bottom, keyboardFrame.height)
+                .frame(minHeight: geometry.size.height)
+                .animation(.easeInOut, value: errorMessage)
+                .animation(.easeInOut, value: changeDueMessage)
+                .onChange(of: textFieldAmountInput) { _ in
+                    errorMessage = nil
+                }
+                .onReceive(Publishers.keyboardFrame) {
+                    keyboardFrame = $0
+                    shouldMinimizePadding = $0.intersects(buttonFrame)
+                }
+                .animation(.default, value: shouldMinimizePadding)
             }
-            .animation(.easeInOut, value: errorMessage)
-            .animation(.easeInOut, value: changeDueMessage)
-            .onChange(of: textFieldAmountInput) { _ in
-                errorMessage = nil
-            }
-            .onReceive(Publishers.keyboardFrame) {
-                keyboardFrame = $0
-                shouldMinimizePadding = $0.intersects(buttonFrame)
-            }
-            .animation(.default, value: shouldMinimizePadding)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func markComplete() async throws {
@@ -147,6 +154,7 @@ private extension PointOfSaleCollectCashView {
 private extension PointOfSaleCollectCashView {
     enum Constants {
         static let minimumPadding: CGFloat = POSSpacing.xSmall
+        static let bottomPadding: CGFloat = POSPadding.medium
     }
 
     private func conditionalPadding(_ padding: CGFloat) -> CGFloat {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -37,7 +37,7 @@ struct TotalsView: View {
                                 }
                                 .transition(.opacity)
                                 .accessibilityShowsLargeContentViewer()
-                                .background(backgroundColor)
+                                .background(backgroundColor.ignoresSafeArea(.all))
                                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                                 .minimumScaleFactor(isShowingTotalsFields ? 0.5 : 1)
                                 .geometryGroup()
@@ -95,7 +95,7 @@ struct TotalsView: View {
         case .card(.processingPayment):
             .posPrimary
         case .cash(.collectingCash):
-            .posSurface
+            .posSurfaceBright
         default:
             .clear
         }

--- a/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
@@ -67,7 +67,7 @@ final class TotalsViewHelper {
 
     func shouldApplyPadding(paymentState: PointOfSalePaymentState) -> Bool {
         switch paymentState {
-        case .card(.cardPaymentSuccessful), .cash(.paymentSuccess):
+        case .card(.cardPaymentSuccessful), .cash(.paymentSuccess), .cash(.collectingCash):
             return false
         default:
             return true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #15234

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request includes several changes to the presentation and layout of views in the WooCommerce POS module. The updates focus on improving the visual appearance and responsiveness of the user interface.

### GhostItemCardView Improvements:

This addresses the design review feedback qJpoXnTMMBPsgHBedaBWGv-fi-20_4288#1143087383.

* Added a `@State` property to track the view width and adjusted the layout to use this width for better scaling of elements.
* Updated the layout constants, including reducing the placeholder height to improve the visual design.

### PointOfSaleCollectCashView Enhancements:

It took me some time to figure out why there's extra padding as in the design review qJpoXnTMMBPsgHBedaBWGv-fi-18_4220#1143096631. It was because:

- `TotalsView` is applying a padding that shouldn't be for the cash view, this was now disabled in `TotalsViewHelper`.
- `PointOfSaleCollectCashView`'s bottom padding was using the keyboard height, which is observed correctly. However, the cash view is shown outside the safe area and the bottom safe area inset contributes to the final extra padding. This is now fixed within `PointOfSaleCollectCashView` to set the bottom padding that accounts for keyboard height, safe area bottom inset, and floating control height.

Changes:

* Introduced `GeometryReader` (despite the issues GeometryReader has like taking up remaining space, I'd still use it for one single view in the same view hierarchy level whose geometry is being read) to dynamically adjust the layout based on the available space and safe area insets. Spacer's don't always work in scroll view when the content view height doesn't have a contstraint. Now the scroll view content height has a minimum of the scroll view height so that the button can be pinned to the bottom. [[1]](diffhunk://#diff-de00ce3c9288868fcb58748a1656cce1897d803f9e1f874e096fd14b93e1c237R35) [[2]](diffhunk://#diff-de00ce3c9288868fcb58748a1656cce1897d803f9e1f874e096fd14b93e1c237L94-R100)
* Added a new constant for bottom padding and adjusted the padding logic to account for the floating control area size.
* Changed the background color to `posSurfaceBright` for better visual consistency.

#### TotalsView Adjustments:
* Modified the background to ignore safe area insets for a more seamless appearance.
* Updated the background color for the cash payment state to `posSurfaceBright`.

#### TotalsViewHelper Update:
* Adjusted the padding logic to ensure no padding is applied when collecting cash, aligning with other payment success states.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### GhostItemCardView Improvements

- Enter POS with at least one variable product
- Tap on a variable product --> the skeleton view should match the design 1qcjzXitBHU7xPnpCOWnNM-fi-47_19437 (the width of the placeholder rectangles is based on the same fraction to the row width as in the design, instead of a hard-coded width for better scaling)

### Cash view improvements

- Enter POS
- Add item(s) to cart and check out
- Tap `Cash payment` --> the cash view should have the same background color as in design (surface bright)
- Toggle keyboard appearance to bring it up and down --> when the keyboard is present, the CTA should be pinned to the bottom with 16px padding above the keyboard. when the keyboard is not present, the CTA should be pinned to the bottom with 16px padding above the floating control.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Skeleton item card view:

smaller font size | largest font size
-- | --
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-24 at 09 58 49](https://github.com/user-attachments/assets/7aa528c7-1cb2-4e50-b464-316caef01a70) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-02-24 at 09 58 28](https://github.com/user-attachments/assets/e097b56f-237c-43ad-adac-15acad47984c)


Cash view:


https://github.com/user-attachments/assets/72f9b454-0ed8-4396-a1c9-5be15fe6ee36



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.