### PR TITLE
[Woo POS][Design System] Update error icon size

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -16,21 +16,21 @@ struct PointOfSaleItemListErrorView: View {
             VStack(alignment: .center, spacing: POSSpacing.none) {
                 POSErrorExclamationMark(size: .large)
 
-                Spacer().frame(height: POSSpacing.large)
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
 
                 Text(error.title)
                     .accessibilityAddTraits(.isHeader)
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posHeadingBold)
 
-                Spacer().frame(height: POSSpacing.small)
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textSpacing)
 
                 Text(error.subtitle)
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posBodyLargeRegular())
                     .padding([.leading, .trailing])
 
-                Spacer().frame(height: POSSpacing.xxLarge)
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
 
                 Button(action: {
                     onRetry?()

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -13,19 +13,25 @@ struct PointOfSaleItemListErrorView: View {
     var body: some View {
         VStack {
             Spacer()
-            VStack(alignment: .center) {
-                POSErrorExclamationMark()
-                    .padding(.bottom)
+            VStack(alignment: .center, spacing: POSSpacing.none) {
+                POSErrorExclamationMark(size: .large)
+
+                Spacer().frame(height: POSSpacing.large)
+
                 Text(error.title)
                     .accessibilityAddTraits(.isHeader)
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posHeadingBold)
-                    .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
+
+                Spacer().frame(height: POSSpacing.small)
+
                 Text(error.subtitle)
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posBodyLargeRegular())
                     .padding([.leading, .trailing])
-                    .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
+
+                Spacer().frame(height: POSSpacing.xxLarge)
+
                 Button(action: {
                     onRetry?()
                 }, label: {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -6,7 +6,6 @@ enum PointOfSaleCardPresentPaymentLayout {
     static let textAndButtonSpacing: CGFloat = POSSpacing.xxLarge
     static let textSpacing: CGFloat = POSSpacing.small
     static let buttonSpacing: CGFloat = POSSpacing.large
-    static let largeErrorIconSize: CGFloat = 84
     static let horizontalPadding: CGFloat = POSPadding.xxLarge
     static let errorContentMaxWidth: CGFloat = 604
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -6,7 +6,6 @@ enum PointOfSaleCardPresentPaymentLayout {
     static let textAndButtonSpacing: CGFloat = POSSpacing.xxLarge
     static let textSpacing: CGFloat = POSSpacing.small
     static let buttonSpacing: CGFloat = POSSpacing.large
-    static let errorIconSize: CGFloat = 64
     static let largeErrorIconSize: CGFloat = 84
     static let horizontalPadding: CGFloat = POSPadding.xxLarge
     static let errorContentMaxWidth: CGFloat = 604

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -3,7 +3,7 @@ import Foundation
 enum PointOfSaleCardPresentPaymentLayout {
     static let headerSize: CGSize = .init(width: 156, height: 156)
     static let imageAndTextSpacing: CGFloat = POSSpacing.large
-    static let textAndButtonSpacing: CGFloat = POSSpacing.xLarge
+    static let textAndButtonSpacing: CGFloat = POSSpacing.xxLarge
     static let textSpacing: CGFloat = POSSpacing.small
     static let buttonSpacing: CGFloat = POSSpacing.large
     static let errorIconSize: CGFloat = 64

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
@@ -9,7 +9,7 @@ struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: POSSpacing.none) {
-            POSErrorExclamationMark()
+            POSErrorExclamationMark(size: .large)
                 .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
 
             Spacer()

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/Presented Views/PointOfSaleCardPresentPaymentCaptureFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/Presented Views/PointOfSaleCardPresentPaymentCaptureFailedView.swift
@@ -5,7 +5,7 @@ struct PointOfSaleCardPresentPaymentCaptureFailedView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: POSSpacing.none) {
-            POSErrorExclamationMark()
+            POSErrorExclamationMark(size: .large)
                 .accessibilityAddTraits(.isHeader)
 
             Spacer()

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
@@ -35,7 +35,7 @@ struct ItemListErrorCardView: View {
                     .font(Constants.itemTitleFont)
             }
             .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-            .frame(maxWidth: Constants.accessoryButtonMaxWidth * scale)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(Constants.accessoryButtonPadding * (1 / scale))
         }
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
@@ -8,7 +8,7 @@ struct ItemListErrorCardView: View {
 
     var body: some View {
         HStack(spacing: Constants.cardSpacing) {
-            POSErrorExclamationMark(size: 48)
+            POSErrorExclamationMark(size: .small)
             .frame(width: min(Constants.productCardSize * scale, Constants.maximumProductCardSize),
                    height: Constants.productCardSize * scale)
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
@@ -10,7 +10,6 @@ enum PointOfSaleItemListCardConstants {
     static let verticalTextPadding: CGFloat = POSPadding.small
     static let itemTitleFont: POSFontStyle = .posBodyLargeBold
     static let itemDetailFont: POSFontStyle = .posBodyLargeRegular()
-    static let accessoryButtonMaxWidth: CGFloat = 136
     static let accessoryButtonPadding: CGFloat = POSPadding.medium
     static let backgroundColor: Color = .posSurfaceContainerLowest
     static let titleColor: Color = .posOnSurface

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
@@ -6,10 +6,11 @@ struct PointOfSaleOrderSyncErrorMessageView: View {
     var body: some View {
         HStack(alignment: .center) {
             Spacer()
-            VStack(alignment: .center, spacing: Constants.headerSpacing) {
+            VStack(alignment: .center, spacing: POSSpacing.none) {
                 Spacer()
-                POSErrorExclamationMark()
-                VStack(alignment: .center, spacing: Constants.textSpacing) {
+                POSErrorExclamationMark(size: .large)
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
+                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                     Text(viewModel.title)
                         .foregroundStyle(Color.posOnSurface)
                         .font(.posHeadingBold)
@@ -19,11 +20,12 @@ struct PointOfSaleOrderSyncErrorMessageView: View {
                         .font(.posBodyLargeRegular())
                         .padding([.leading, .trailing])
                 }
-                Spacer()
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
                 Button(viewModel.actionModel.title, action: viewModel.actionModel.handler)
                     .buttonStyle(POSFilledButtonStyle(size: .normal))
                     .padding([.leading, .trailing], Constants.buttonSidePadding)
                     .padding([.bottom], Constants.buttonBottomPadding)
+                Spacer()
             }
             .multilineTextAlignment(.center)
             Spacer()

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageViewModel.swift
@@ -29,8 +29,8 @@ private extension PointOfSaleOrderSyncErrorMessageViewModel {
         )
 
         static let actionTitle = NSLocalizedString(
-            "pointOfSale.orderSync.error.retry",
-            value: "Retry",
+            "pointOfSale.orderSync.error.tryAgain",
+            value: "Try again",
             comment: "Button title to retry synchronizing order and calculating order totals"
         )
     }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorExclamationMark.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorExclamationMark.swift
@@ -3,8 +3,8 @@ import SwiftUI
 struct POSErrorExclamationMark: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-    private let size: CGFloat
-    init(size: CGFloat = PointOfSaleCardPresentPaymentLayout.errorIconSize) {
+    private let size: POSErrorAndAlertIconSize
+    init(size: POSErrorAndAlertIconSize = .medium) {
         self.size = size
     }
 
@@ -12,14 +12,17 @@ struct POSErrorExclamationMark: View {
         Image(decorative: PointOfSaleAssets.exclamationMark.imageName)
             .resizable()
             .aspectRatio(contentMode: .fit)
-            .frame(maxHeight: size)
+            .frame(maxHeight: size.dimension)
             .layoutPriority(-1)
-            .foregroundStyle(Color.posAlert)
             .accessibilityHidden(true)
             .renderedIf(!dynamicTypeSize.isAccessibilitySize)
     }
 }
 
 #Preview {
-    POSErrorExclamationMark()
+    HStack {
+        POSErrorExclamationMark(size: .small)
+        POSErrorExclamationMark(size: .medium)
+        POSErrorExclamationMark(size: .large)
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorXMark.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorXMark.swift
@@ -5,7 +5,7 @@ struct POSErrorXMark: View {
 
     var body: some View {
         Image(decorative: PointOfSaleAssets.error.imageName)
-            .font(.system(size: PointOfSaleCardPresentPaymentLayout.largeErrorIconSize))
+            .font(.system(size: POSErrorAndAlertIconSize.large.dimension))
             .foregroundStyle(Color.posAlert)
             .accessibilityHidden(true)
             .renderedIf(!dynamicTypeSize.isAccessibilitySize)

--- a/WooCommerce/Classes/POS/Utils/POSErrorAndAlertIconSize.swift
+++ b/WooCommerce/Classes/POS/Utils/POSErrorAndAlertIconSize.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Various sizes of error and alert icons in POS.
+/// Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-1114_19201
+enum POSErrorAndAlertIconSize {
+    case small
+    case medium
+    case large
+
+    var dimension: CGFloat {
+        switch self {
+        case .small:
+            return 40.0
+        case .medium:
+            return 56.0
+        case .large:
+            return 80.0
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -623,6 +623,7 @@
 		02EFF81A2ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */; };
 		02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */; };
 		02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */; };
+		02F3884C2D6C38BB00619396 /* POSErrorAndAlertIconSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F3884B2D6C38BB00619396 /* POSErrorAndAlertIconSize.swift */; };
 		02F3A6842A618CD7004CD2E8 /* WordPressMediaLibraryPickerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryPickerCoordinator.swift */; };
 		02F3A6862A619270004CD2E8 /* WordPressMediaLibraryImagePickerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F3A6852A619270004CD2E8 /* WordPressMediaLibraryImagePickerCoordinatorTests.swift */; };
 		02F49ADA23BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F49AD923BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift */; };
@@ -3839,6 +3840,7 @@
 		02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardInputViewModelTests.swift; sourceTree = "<group>"; };
 		02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAICoordinatorTests.swift; sourceTree = "<group>"; };
 		02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainPurchaseSuccessView.swift; sourceTree = "<group>"; };
+		02F3884B2D6C38BB00619396 /* POSErrorAndAlertIconSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSErrorAndAlertIconSize.swift; sourceTree = "<group>"; };
 		02F3A6832A618CD7004CD2E8 /* WordPressMediaLibraryPickerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMediaLibraryPickerCoordinator.swift; sourceTree = "<group>"; };
 		02F3A6852A619270004CD2E8 /* WordPressMediaLibraryImagePickerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressMediaLibraryImagePickerCoordinatorTests.swift; sourceTree = "<group>"; };
 		02F49AD923BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TitleAndTextFieldTableViewCell.ViewModel+State.swift"; sourceTree = "<group>"; };
@@ -7182,6 +7184,7 @@
 				68625DE52D4134D50042B231 /* DynamicVStack.swift */,
 				02055B132D5DAB6400E51059 /* POSCornerRadiusStyle.swift */,
 				020564972D5DC96600E51059 /* POSShadowStyle.swift */,
+				02F3884B2D6C38BB00619396 /* POSErrorAndAlertIconSize.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -16878,6 +16881,7 @@
 				20E188842AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift in Sources */,
 				EE8A30452B74948C001D7C66 /* OrderAttributionInfo+Origin.swift in Sources */,
 				205B7ECF2C19FD5200D14A36 /* PointOfSalePaymentSuccessViewModel.swift in Sources */,
+				02F3884C2D6C38BB00619396 /* POSErrorAndAlertIconSize.swift in Sources */,
 				026D4652295D763B0037F59A /* CountryCode+FlagEmoji.swift in Sources */,
 				B9F3DAAD29BB71B100DDD545 /* CollectPaymentAppIntent.swift in Sources */,
 				011D7A352CEC87B70007C187 /* CardPresentModalErrorEmailSent.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15234 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request focuses on improving the consistency of error icon sizes based on the new design guide 1qcjzXitBHU7xPnpCOWnNM-fi-1114_19201, plus spacing tweaks in its use cases. The key changes include the introduction of a new enumeration for error icon sizes and adjustments to spacing constants.

### Introduction of `POSErrorAndAlertIconSize` Enumeration:

* [`WooCommerce/Classes/POS/Utils/POSErrorAndAlertIconSize.swift`](diffhunk://#diff-9de2ad5da573f777f3eb41f53d797447f67ae5b2b9622399a7ff86cbfdd0603fR1-R20): Added a new enumeration `POSErrorAndAlertIconSize` to define small, medium, and large sizes for error and alert icons. This change standardizes the icon sizes across the application.

### Updates to Error Icon Sizes:

* [`WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorExclamationMark.swift`](diffhunk://#diff-1840dc68f542e663050c06bd5a8489a4bea091dd1f17ee0d88d41524242dc8ffL6-R27): Modified `POSErrorExclamationMark` to use the new `POSErrorAndAlertIconSize` enumeration for defining icon sizes.
* [`WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorXMark.swift`](diffhunk://#diff-e3d10bc59bdf0292e94778f46ac52a0cb465be82cac284e8dd6b985aed68e81fL8-R8): Updated `POSErrorXMark` to utilize the `POSErrorAndAlertIconSize` enumeration for setting the icon size.

### Adjustments to Spacing and Layout:

* [`WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift`](diffhunk://#diff-82429f2bf5e76342d5ecd74acb3049331f1036470b8a014617e06ccc13a5917bL16-R34): Adjusted the spacing and layout in `PointOfSaleItemListErrorView` to use consistent spacing constants and the new icon size.
* [`WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift`](diffhunk://#diff-a379308defc936797bb6615bce82c9485c325a6bfd77a17392bb1fc3ae7df4e2L6-L10): Updated spacing constants in `PointOfSaleCardPresentPaymentLayout` to ensure consistent layout.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Turn off network connection
- Enter POS with at least one variable product --> the product list loading error UI should match the design (except for the Products header)
- Turn on network connection and reload item list
- Turn off network connection
- Tap on a variable product --> the variation list loading error UI should match the design
- Go back to the product list, scroll to the bottom --> the infinite scroll error card should have the ! icon fitting the image size
- Add item(s) to cart and check out --> the order sync error should match the design

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested the order validation error (< minimum payment amount), and payment error with an invalid order amount.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Item list loading error (design 1qcjzXitBHU7xPnpCOWnNM-fi-1076_15843):

products | variations
-- | --
![IMG_0456](https://github.com/user-attachments/assets/ae9d214f-6785-49ff-b808-9443dae91790) | ![IMG_0457](https://github.com/user-attachments/assets/6ec9eb99-b79b-4155-821e-ba4c507e1dc5)


Infinite scroll loading error:

<img src="https://github.com/user-attachments/assets/a6e2bb99-c3f7-4a3c-adef-d4606562d695" width="500" />

Order sync error (design 1qcjzXitBHU7xPnpCOWnNM-fi-1096_16832) | valiadation error
-- | --
![IMG_0458](https://github.com/user-attachments/assets/626f2392-baa2-464c-a077-5c22fad2d0cf) | ![IMG_0460](https://github.com/user-attachments/assets/92e447da-ecb1-4408-ab0f-c34f7c9e3d95)

Payment error (design 1qcjzXitBHU7xPnpCOWnNM-fi-1096_18311) (just to ensure the icon size matches):

<img src="https://github.com/user-attachments/assets/6a7d9d78-3f3e-4780-b521-41b4798b6866" width="500" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added. of