### PR TITLE
Fix issue showing order details from push notifications

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -34,7 +34,10 @@ final class OrdersSplitViewWrapperController: UIViewController {
             return
         }
 
-        presentDetails(for: Int64(orderID), siteID: Int64(siteID), note: note)
+        // workaround - delay to ensure the transition to the secondary column works after switching stores
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [self] in
+            presentDetails(for: Int64(orderID), siteID: Int64(siteID), note: note)
+        }
     }
 
     func presentDetails(for orderID: Int64, siteID: Int64, note: Note? = nil) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15242 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a small delay as a workaround for the issue when displaying order details fails after switching stores on iOS 18 devices.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store on a physical device running iOS 18 and above.
2. On the web place an order for another store that is connected to the same WPCom account.
3. When the push notification of the order comes on the device, tap on it.
4. Notice that the app switches to the new store and navigates to the detail page of the new order successfully.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on both iPhone 16 Pro iOS 18.1.1 and iPad Pro iOS 18.2 and confirmed that navigation to the order details screen upon tapping push notifications works correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/241a11da-d415-4063-8ab3-d27d1f1ddc8c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.