### PR TITLE
[POS] Improve Get Support

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -77,6 +77,7 @@ struct PointOfSaleDashboardView: View {
         .posRootModal()
         .sheet(isPresented: $showSupport) {
             supportForm
+                .interactiveDismissDisabled(true)
         }
         .sheet(isPresented: $showDocumentation) {
             documentationView

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -120,7 +120,8 @@ private extension PointOfSaleDashboardView {
     var supportForm: some View {
         NavigationView {
             SupportForm(isPresented: $showSupport,
-                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag))
+                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag,
+                                                        defaultSite: ServiceLocator.stores.sessionManager.defaultSite))
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Localization.supportDone) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -118,7 +118,7 @@ struct SupportForm: View {
                             .subheadlineStyle()
 
                         TextField("", text: $viewModel.siteAddress)
-                            .autocorrectionDisabled(true) // Disables autocorrect
+                            .autocorrectionDisabled(true)
                             .textInputAutocapitalization(.never)
                             .keyboardType(.URL)
                             .bodyStyle()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -118,6 +118,8 @@ struct SupportForm: View {
                             .subheadlineStyle()
 
                         TextField("", text: $viewModel.siteAddress)
+                            .autocorrectionDisabled(true) // Disables autocorrect
+                            .textInputAutocapitalization(.never)
                             .keyboardType(.URL)
                             .bodyStyle()
                             .padding(insets: Layout.subjectInsets)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15191
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we improve the Get Support form of the POS by:

- Avoid tapping outside the Get support modal dismisses it and loses your progress when typing the ticket contents.
- Pre-populate the site address in get support
- Disable autocorrection and capitalization in the site address on the support form

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to POS
2. Tap on Get Support
3. Check that the above is working

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

See above

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/34573c3d-3827-4112-b48b-9259732c0aa7



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The support form now requires a designated close action instead of allowing swipe-to-dismiss, ensuring a more intentional interaction.
  - The form is updated to automatically apply a default site context for improved consistency.
  - The site address input has been refined by disabling autocorrection and auto-capitalization, allowing for more precise text entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->