### PR TITLE
[Shipping Labels] Confirm edited destination address

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2847,6 +2847,24 @@ extension Networking.WooShippingDestinationAddress {
         )
     }
 }
+extension Networking.WooShippingNormalizedAddress {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingNormalizedAddress {
+        .init(
+            company: .fake(),
+            firstName: .fake(),
+            lastName: .fake(),
+            phone: .fake(),
+            country: .fake(),
+            state: .fake(),
+            address1: .fake(),
+            address2: .fake(),
+            city: .fake(),
+            postcode: .fake()
+        )
+    }
+}
 extension Networking.WooShippingOriginAddress {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1238,6 +1238,7 @@
 		EE57C1542980F18500BC31E7 /* ShipmentTrackingProviderListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C1532980F18500BC31E7 /* ShipmentTrackingProviderListMapperTests.swift */; };
 		EE57C1562980F3BF00BC31E7 /* shipment_tracking_single_without_data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C1552980F3BF00BC31E7 /* shipment_tracking_single_without_data.json */; };
 		EE57C1582980F3D400BC31E7 /* shipment_tracking_providers_without_data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C1572980F3D400BC31E7 /* shipment_tracking_providers_without_data.json */; };
+		EE5EEDE72D6F2D5400E1EC05 /* WooShippingNormalizedAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5EEDE62D6F2D4000E1EC05 /* WooShippingNormalizedAddress.swift */; };
 		EE62EE61295ACF8D009C965B /* RequestConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */; };
 		EE62EE63295AD45E009C965B /* String+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE62295AD45E009C965B /* String+URL.swift */; };
 		EE62EE65295AD46D009C965B /* String+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE64295AD46D009C965B /* String+URLTests.swift */; };
@@ -2460,6 +2461,7 @@
 		EE57C1532980F18500BC31E7 /* ShipmentTrackingProviderListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipmentTrackingProviderListMapperTests.swift; sourceTree = "<group>"; };
 		EE57C1552980F3BF00BC31E7 /* shipment_tracking_single_without_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = shipment_tracking_single_without_data.json; sourceTree = "<group>"; };
 		EE57C1572980F3D400BC31E7 /* shipment_tracking_providers_without_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = shipment_tracking_providers_without_data.json; sourceTree = "<group>"; };
+		EE5EEDE62D6F2D4000E1EC05 /* WooShippingNormalizedAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingNormalizedAddress.swift; sourceTree = "<group>"; };
 		EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConverterTests.swift; sourceTree = "<group>"; };
 		EE62EE62295AD45E009C965B /* String+URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URL.swift"; sourceTree = "<group>"; };
 		EE62EE64295AD46D009C965B /* String+URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLTests.swift"; sourceTree = "<group>"; };
@@ -2642,6 +2644,7 @@
 		451A97C72609FDE50059D135 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
+				EE5EEDE62D6F2D4000E1EC05 /* WooShippingNormalizedAddress.swift */,
 				CEC7D5902CDD0C1C00111B79 /* WooShippingCreatePackageResponse.swift */,
 				DAF367A72CE75C5B00D1B327 /* WooShippingPackagesResponse.swift */,
 				CE1EA4BE2CEBA0AF0039F477 /* WooShippingPackagePurchase.swift */,
@@ -5345,6 +5348,7 @@
 				68BFF8FC2B6767FA00B15FF2 /* ReceiptMapper.swift in Sources */,
 				EE105F432D671F23005AB07F /* WooShippingDestinationAddressUpdate.swift in Sources */,
 				74D522B62113607F00042831 /* StatGranularity.swift in Sources */,
+				EE5EEDE72D6F2D5400E1EC05 /* WooShippingNormalizedAddress.swift in Sources */,
 				02C2549A25636E1500A04423 /* ShippingLabelAddress.swift in Sources */,
 				03DCB786262739D200C8953D /* CouponMapper.swift in Sources */,
 				DAEE64282D1048A00031DCDC /* WooShippingOriginAddress.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -4212,6 +4212,45 @@ extension Networking.WooShippingDestinationAddress {
     }
 }
 
+extension Networking.WooShippingNormalizedAddress {
+    public func copy(
+        company: CopiableProp<String> = .copy,
+        firstName: CopiableProp<String> = .copy,
+        lastName: CopiableProp<String> = .copy,
+        phone: CopiableProp<String> = .copy,
+        country: CopiableProp<String> = .copy,
+        state: CopiableProp<String> = .copy,
+        address1: CopiableProp<String> = .copy,
+        address2: CopiableProp<String> = .copy,
+        city: CopiableProp<String> = .copy,
+        postcode: CopiableProp<String> = .copy
+    ) -> Networking.WooShippingNormalizedAddress {
+        let company = company ?? self.company
+        let firstName = firstName ?? self.firstName
+        let lastName = lastName ?? self.lastName
+        let phone = phone ?? self.phone
+        let country = country ?? self.country
+        let state = state ?? self.state
+        let address1 = address1 ?? self.address1
+        let address2 = address2 ?? self.address2
+        let city = city ?? self.city
+        let postcode = postcode ?? self.postcode
+
+        return Networking.WooShippingNormalizedAddress(
+            company: company,
+            firstName: firstName,
+            lastName: lastName,
+            phone: phone,
+            country: country,
+            state: state,
+            address1: address1,
+            address2: address2,
+            city: city,
+            postcode: postcode
+        )
+    }
+}
+
 extension Networking.WooShippingOriginAddress {
     public func copy(
         id: CopiableProp<String> = .copy,

--- a/Networking/Networking/Model/ShippingLabel/Packages/WooShippingNormalizedAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/WooShippingNormalizedAddress.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Codegen
+
+/// Represents a normalized address for the WooCommerce Shipping extension.
+///
+public struct WooShippingNormalizedAddress: Equatable, GeneratedFakeable, GeneratedCopiable {
+    /// The name of the company at the address.
+    public let company: String
+
+    /// The first name of the sender/receiver at the address.
+    public let firstName: String
+
+    /// The last name of the sender/receiver at the address.
+    public let lastName: String
+
+    /// The contact phone number at the address.
+    public let phone: String
+
+    /// The country the address is in (ISO code).
+    public let country: String
+
+    /// The state the address is in (ISO code).
+    public let state: String
+
+    /// The first line of address (street, number, floor, etc.).
+    public let address1: String
+
+    /// The second line of address, empty if the address is only one line.
+    public let address2: String
+
+    /// The city the address is in.
+    public let city: String
+
+    /// Postal code of the address.
+    public let postcode: String
+
+    public init(company: String,
+                firstName: String,
+                lastName: String,
+                phone: String,
+                country: String,
+                state: String,
+                address1: String,
+                address2: String,
+                city: String,
+                postcode: String) {
+        self.company = company
+        self.firstName = firstName
+        self.lastName = lastName
+        self.phone = phone
+        self.country = country
+        self.state = state
+        self.address1 = address1
+        self.address2 = address2
+        self.city = city
+        self.postcode = postcode
+    }
+}
+
+// MARK: Codable
+extension WooShippingNormalizedAddress: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let firstName = try container.decodeIfPresent(String.self, forKey: .firstName) ?? ""
+        let lastName = try container.decodeIfPresent(String.self, forKey: .lastName) ?? ""
+        let company = try container.decode(String.self, forKey: .company)
+        let phone = try container.decode(String.self, forKey: .phone)
+        let country = try container.decode(String.self, forKey: .country)
+        let state = try container.decode(String.self, forKey: .state)
+        let address1 = try container.decodeIfPresent(String.self, forKey: .address1) ?? container.decode(String.self, forKey: .alternateAddress1)
+        let address2 = try container.decode(String.self, forKey: .address2)
+        let city = try container.decode(String.self, forKey: .city)
+        let postcode = try container.decode(String.self, forKey: .postcode)
+
+        self.init(company: company,
+                  firstName: firstName,
+                  lastName: lastName,
+                  phone: phone,
+                  country: country,
+                  state: state,
+                  address1: address1,
+                  address2: address2,
+                  city: city,
+                  postcode: postcode)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case company
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case phone
+        case country
+        case state
+        case address1 = "address"
+        case alternateAddress1 = "address_1"
+        case address2 = "address_2"
+        case city
+        case postcode
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 internal struct WooShippingVerifyDestinationAddressResponse: Equatable {
     let result: Result<WooShippingVerifyDestinationAddressSuccess, WooShippingAddressValidationError>
 
-    init(normalizedAddress: WooShippingAddress?,
+    init(normalizedAddress: WooShippingNormalizedAddress?,
          isTrivialNormalization: Bool?,
          isVerified: Bool?,
          errors: WooShippingAddressValidationError?) {
@@ -31,7 +31,7 @@ internal struct WooShippingVerifyDestinationAddressResponse: Equatable {
 extension WooShippingVerifyDestinationAddressResponse: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let normalizedAddress = try container.decodeIfPresent(WooShippingAddress.self, forKey: .normalized)
+        let normalizedAddress = try container.decodeIfPresent(WooShippingNormalizedAddress.self, forKey: .normalized)
         let isTrivialNormalization = try container.decodeIfPresent(Bool.self, forKey: .isTrivialNormalization)
         let isVerified = try container.decodeIfPresent(Bool.self, forKey: .isVerified)
         let errors = try container.decodeIfPresent(WooShippingAddressValidationError.self, forKey: .errors)

--- a/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressSuccess.swift
+++ b/Networking/Networking/Model/ShippingLabel/VerifyDestinationAddress/WooShippingVerifyDestinationAddressSuccess.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents Shipping Label Destination Address that has been verified by the WooCommerce Shipping extension.
 ///
 public struct WooShippingVerifyDestinationAddressSuccess: Equatable {
-    public let normalizedAddress: WooShippingAddress
+    public let normalizedAddress: WooShippingNormalizedAddress
 
     /// Optional property -  We will receive this property in response only when the address is not already verified.
     ///
@@ -17,7 +17,7 @@ public struct WooShippingVerifyDestinationAddressSuccess: Equatable {
 
     public let isVerified: Bool
 
-    public init(normalizedAddress: WooShippingAddress,
+    public init(normalizedAddress: WooShippingNormalizedAddress,
                 isTrivialNormalization: Bool?,
                 isVerified: Bool) {
         self.normalizedAddress = normalizedAddress

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 internal struct WooShippingAddressValidationResponse: Equatable {
     let result: Result<WooShippingAddressValidationSuccess, WooShippingAddressValidationError>
 
-    init(normalizedAddress: WooShippingAddress?,
+    init(normalizedAddress: WooShippingNormalizedAddress?,
          originalAddress: WooShippingAddress?,
          isTrivialNormalization: Bool?,
          errors: WooShippingAddressValidationError?) {
@@ -30,7 +30,7 @@ internal struct WooShippingAddressValidationResponse: Equatable {
 extension WooShippingAddressValidationResponse: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let normalizedAddress = try container.decodeIfPresent(WooShippingAddress.self, forKey: .normalized)
+        let normalizedAddress = try container.decodeIfPresent(WooShippingNormalizedAddress.self, forKey: .normalized)
         let originalAddress = try container.decodeIfPresent(WooShippingAddress.self, forKey: .original)
         let isTrivialNormalization = try container.decodeIfPresent(Bool.self, forKey: .isTrivialNormalization)
         let errors = try container.decodeIfPresent(WooShippingAddressValidationError.self, forKey: .errors)

--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationSuccess.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddressValidationSuccess.swift
@@ -5,7 +5,7 @@ import Codegen
 /// Represents Shipping Label Address that has been validated by the WooCommerce Shipping extension.
 ///
 public struct WooShippingAddressValidationSuccess: Equatable {
-    public let normalizedAddress: WooShippingAddress
+    public let normalizedAddress: WooShippingNormalizedAddress
     public let originalAddress: WooShippingAddress
 
     /// When sending an address to normalize to the server, if the response has the is_trivial_normalization property set to true,
@@ -15,7 +15,7 @@ public struct WooShippingAddressValidationSuccess: Equatable {
     ///
     public let isTrivialNormalization: Bool
 
-    public init(normalizedAddress: WooShippingAddress, originalAddress: WooShippingAddress, isTrivialNormalization: Bool) {
+    public init(normalizedAddress: WooShippingNormalizedAddress, originalAddress: WooShippingAddress, isTrivialNormalization: Bool) {
         self.normalizedAddress = normalizedAddress
         self.originalAddress = originalAddress
         self.isTrivialNormalization = isTrivialNormalization

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingDestinationAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingDestinationAddress+Woo.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Contacts
+import Yosemite
+
+// Yosemite.WooShippingDestinationAddress Helper Methods
+//
+extension WooShippingDestinationAddress {
+    /// Returns the First + LastName combined according to language rules and Locale.
+    ///
+    var fullName: String {
+        var components = PersonNameComponents()
+        components.givenName = firstName
+        components.familyName = lastName
+
+        return PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: [])
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingDestinationAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingDestinationAddress+Woo.swift
@@ -14,4 +14,20 @@ extension WooShippingDestinationAddress {
 
         return PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: [])
     }
+
+    /// Converts the destination address to a `WooShippingAddress`.
+    ///
+    /// This prepares the address for use in e.g. fetching available shipping rates or purchasing the label.
+    ///
+    func toWooShippingAddress() -> WooShippingAddress {
+        WooShippingAddress(company: company,
+                           name: name.isNotEmpty ? name : fullName,
+                           phone: phone,
+                           country: country,
+                           state: state,
+                           address1: address1,
+                           address2: address2,
+                           city: city,
+                           postcode: postcode)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -433,7 +433,7 @@ private extension WooShippingEditAddressView {
 }
 
 #Preview("With Company") {
-    WooShippingEditAddressView(viewModel: .init(type: .destination,
+    WooShippingEditAddressView(viewModel: .init(type: .destination(orderID: 123),
                                                 id: UUID().uuidString,
                                                 name: "HEADQUARTERS",
                                                 company: "COMPANY",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -328,7 +328,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         do {
             let validation = try await remotelyValidateAddress(addressToValidate)
             normalizeAddressVM = WooShippingNormalizeAddressViewModel(enteredAddress: validation.originalAddress,
-                                                                      suggestedAddress: validation.normalizedAddress,
+                                                                      suggestedAddress: validation.normalizedAddress.toWooShippingAddress(),
                                                                       onConfirm: { [weak self] confirmedAddress in
                 guard let self else { return }
                 if addressType == .origin {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -290,6 +290,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Used to initialize the view model with a destination address.
     convenience init(address: WooShippingAddress?,
+                     orderID: Int64,
                      email: String?,
                      isVerified: Bool,
                      originCountryCode: String?,
@@ -297,7 +298,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      onAddressEdited: ((WooShippingAddress, String?) -> Void)? = nil) {
-        self.init(type: .destination,
+        self.init(type: .destination(orderID: orderID),
                   id: UUID().uuidString,
                   name: address?.name ?? "",
                   company: address?.company ?? "",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -229,7 +229,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.storageManager = storageManager
         self.debounceDelay = debounceDelayInSeconds
         self.onOriginAddressEdited = onOriginAddressEdited
-
+        self.onDestinationAddressEdited = onDestinationAddressEdited
         // Set validation rules for fields that rely on instance properties.
         self.name.validate = { [weak self] newName in
             guard let self, self.company.value.isEmpty else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -406,7 +406,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                                                     postcode: address.postcode,
                                                     country: address.country,
                                                     phone: address.phone,
-                                                    name: name.value,
+                                                    name: address.name,
                                                     firstName: "",
                                                     lastName: "",
                                                     email: email.value)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -337,8 +337,12 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
                                                                       suggestedAddress: validation.normalizedAddress.toWooShippingAddress(),
                                                                       onConfirm: { [weak self] confirmedAddress in
                 guard let self else { return }
-                if addressType == .origin {
+                switch addressType {
+                case .origin:
                     updateConfirmedOriginAddress(confirmedAddress)
+                case .destination(let orderID):
+                    updateConfirmedDestinationAddress(for: orderID,
+                                                      with: confirmedAddress)
                 }
             })
         } catch let error as WooShippingAddressValidationError {
@@ -386,6 +390,35 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
             } catch {
                 // TODO: Display error if origin address update fails.
                 DDLogError("⛔️ Error updating origin address for Woo Shipping label: \(error)")
+            }
+        }
+    }
+
+    /// Updates the destination address remotely with the provided (normalized) address and other edits.
+    private func updateConfirmedDestinationAddress(for orderID: Int64,
+                                                   with address: WooShippingAddress) {
+        // Merge the provided (normalized) address with the edited address fields.
+        let address = WooShippingDestinationAddress(company: address.company,
+                                                    address1: address.address1,
+                                                    address2: address.address2,
+                                                    city: address.city,
+                                                    state: address.state,
+                                                    postcode: address.postcode,
+                                                    country: address.country,
+                                                    phone: address.phone,
+                                                    name: name.value,
+                                                    firstName: "",
+                                                    lastName: "",
+                                                    email: email.value)
+
+        Task { @MainActor in
+            do {
+                let updatedDestinationAddress = try await updateDestinationAddress(for: orderID,
+                                                                                   with: address)
+                onDestinationAddressEdited?(updatedDestinationAddress.toWooShippingAddress(), email.value)
+            } catch {
+                // TODO: Display error if destination address update fails.
+                DDLogError("⛔️ Error updating destination address for Woo Shipping label: \(error)")
             }
         }
     }
@@ -579,6 +612,28 @@ private extension WooShippingEditAddressViewModel {
             let action = WooShippingAction.updateOriginAddress(siteID: siteID,
                                                                address: address,
                                                                isVerified: address.isVerified) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(result):
+                    continuation.resume(returning: result.address)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+                isLoading = false
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Updates a destination address remotely.
+    @MainActor
+    func updateDestinationAddress(for orderID: Int64,
+                                  with address: WooShippingDestinationAddress) async throws -> WooShippingDestinationAddress {
+        return try await withCheckedThrowingContinuation { continuation in
+            isLoading = true
+            let action = WooShippingAction.updateDestinationAddress(siteID: siteID,
+                                                                    orderID: orderID,
+                                                                    address: address) { [weak self] result in
                 guard let self else { return }
                 switch result {
                 case let .success(result):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -14,7 +14,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     enum AddressType {
         case origin
-        case destination
+        case destination(orderID: Int64)
     }
 
     /// Type of address being edited.
@@ -38,7 +38,12 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Whether to show the "save as default" toggle, to save the address as the default origin address.
     var showSaveAsDefault: Bool {
-        addressType == .origin
+        switch addressType {
+        case .origin:
+            return true
+        case .destination:
+            return false
+        }
     }
 
     /// Whether to show the company field by default.
@@ -353,7 +358,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
 
     /// Updates the origin address remotely with the provided (normalized) address and other edits.
     private func updateConfirmedOriginAddress(_ address: WooShippingAddress) {
-        guard addressType == .origin else {
+        guard case .origin = addressType else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizedAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizedAddress+Woo.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Contacts
+import Yosemite
+
+// Yosemite.WooShippingNormalizedAddress Helper Methods
+//
+extension WooShippingNormalizedAddress {
+
+    /// Returns the First + LastName combined according to language rules and Locale.
+    ///
+    var fullName: String {
+        var components = PersonNameComponents()
+        components.givenName = firstName
+        components.familyName = lastName
+
+        return PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: [])
+    }
+
+    /// Converts the normalized address to a `WooShippingAddress`.
+    ///
+    /// This prepares the address for use in e.g. fetching available shipping rates or purchasing the label.
+    ///
+    func toWooShippingAddress() -> WooShippingAddress {
+        WooShippingAddress(company: company,
+                           name: fullName,
+                           phone: phone,
+                           country: country,
+                           state: state,
+                           address1: address1,
+                           address2: address2,
+                           city: city,
+                           postcode: postcode)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -275,6 +275,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// After the address is edited, the destination address is replaced with the updated address.
     func editDestinationAddress() {
         addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress,
+                                                        orderID: order.orderID,
                                                         email: destinationEmail,
                                                         isVerified: destinationAddressStatus == .verified,
                                                         originCountryCode: selectedOriginAddress?.country,
@@ -331,7 +332,7 @@ private extension WooShippingCreateLabelsViewModel {
             guard let self else { return }
             switch result {
             case .success(let address):
-                destinationAddress = address.normalizedAddress
+                destinationAddress = address.normalizedAddress.toWooShippingAddress()
                 destinationAddressStatus = address.isVerified ? .verified : .unverified
             case .failure(let error):
                 DDLogError("⛔️ Error loading destination addresses for Woo Shipping labels: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -62,9 +62,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     @Published private(set) var originAddress: String = ""
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
-    private(set) lazy var destinationAddressLines: [String]? = {
+    var destinationAddressLines: [String]? {
         (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")
-    }()
+    }
 
     /// Possible statuses for a Woo Shipping destination address.
     enum DestinationAddressStatus {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -73,7 +73,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         case missing
     }
 
-    // TODO: Add support for updating the destination address status when it is edited.
     /// The current destination address status.
     @Published private(set) var destinationAddressStatus: DestinationAddressStatus?
 
@@ -286,6 +285,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             }
             destinationAddress = editedAddress
             destinationEmail = editedEmail
+            destinationAddressStatus = .verified
             addressToEdit = nil // Dismisses address edit screen
         })
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2985,6 +2985,8 @@
 		EE5B5BBD2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */; };
 		EE5B5BC42AB83749009BCBD6 /* AddProductWithAIContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BC32AB83749009BCBD6 /* AddProductWithAIContainerView.swift */; };
 		EE5B5BC72AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5BC62AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift */; };
+		EE5EEDE92D6F2F8700E1EC05 /* WooShippingNormalizedAddress+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5EEDE82D6F2F8300E1EC05 /* WooShippingNormalizedAddress+Woo.swift */; };
+		EE5EEDEB2D6F32FE00E1EC05 /* WooShippingDestinationAddress+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5EEDEA2D6F32F200E1EC05 /* WooShippingDestinationAddress+Woo.swift */; };
 		EE66BB0E2B29BF2800518DAF /* ThemeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE66BB0D2B29BF2800518DAF /* ThemeInstaller.swift */; };
 		EE66BB102B29D24600518DAF /* DefaultThemeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE66BB0F2B29D24600518DAF /* DefaultThemeInstallerTests.swift */; };
 		EE66BB122B29D65400518DAF /* MockThemeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE66BB112B29D65400518DAF /* MockThemeInstaller.swift */; };
@@ -6183,6 +6185,8 @@
 		EE5B5BBC2AB41ED9009BCBD6 /* MockProductCreationAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductCreationAIEligibilityChecker.swift; sourceTree = "<group>"; };
 		EE5B5BC32AB83749009BCBD6 /* AddProductWithAIContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIContainerView.swift; sourceTree = "<group>"; };
 		EE5B5BC62AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIContainerViewModel.swift; sourceTree = "<group>"; };
+		EE5EEDE82D6F2F8300E1EC05 /* WooShippingNormalizedAddress+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingNormalizedAddress+Woo.swift"; sourceTree = "<group>"; };
+		EE5EEDEA2D6F32F200E1EC05 /* WooShippingDestinationAddress+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingDestinationAddress+Woo.swift"; sourceTree = "<group>"; };
 		EE66BB0D2B29BF2800518DAF /* ThemeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeInstaller.swift; sourceTree = "<group>"; };
 		EE66BB0F2B29D24600518DAF /* DefaultThemeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultThemeInstallerTests.swift; sourceTree = "<group>"; };
 		EE66BB112B29D65400518DAF /* MockThemeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockThemeInstaller.swift; sourceTree = "<group>"; };
@@ -12341,6 +12345,8 @@
 		CE7FE6922D13249D000F9475 /* WooShippingAddresses */ = {
 			isa = PBXGroup;
 			children = (
+				EE5EEDEA2D6F32F200E1EC05 /* WooShippingDestinationAddress+Woo.swift */,
+				EE5EEDE82D6F2F8300E1EC05 /* WooShippingNormalizedAddress+Woo.swift */,
 				CE755F762D4A79C2002539F6 /* WooShippingAddress+Woo.swift */,
 				CECAE7102D23168D000AE10B /* WooShippingOriginAddress+Woo.swift */,
 				CE7FE6932D1324BD000F9475 /* WooShippingOriginAddressListView.swift */,
@@ -15743,6 +15749,7 @@
 				26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */,
 				025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */,
 				CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */,
+				EE5EEDE92D6F2F8700E1EC05 /* WooShippingNormalizedAddress+Woo.swift in Sources */,
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
 				B90D217C2D1B06F700ED60ED /* WooShippingCustomsItemViewModel.swift in Sources */,
@@ -16964,6 +16971,7 @@
 				203163BB2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */,
 				CEC3CC6B2C92FDB700B93FBE /* WooShippingItemRowViewModel.swift in Sources */,
 				B90D217A2D1B06D000ED60ED /* WooShippingCustomsItem.swift in Sources */,
+				EE5EEDEB2D6F32FE00E1EC05 /* WooShippingDestinationAddress+Woo.swift in Sources */,
 				AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */,
 				203163B72C1C5EDF001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift in Sources */,
 				2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -204,11 +204,11 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_order_destination_address_is_loaded_from_remote_and_set_as_destination_address() {
         // Given
-        let destinationAddresses = WooShippingAddress.fake().copy(country: "US",
-                                                                  state: "CA",
-                                                                  address1: "123 Main Street",
-                                                                  city: "San Francisco",
-                                                                  postcode: "12345")
+        let destinationAddresses = WooShippingNormalizedAddress.fake().copy(country: "US",
+                                                                            state: "CA",
+                                                                            address1: "123 Main Street",
+                                                                            city: "San Francisco",
+                                                                            postcode: "12345")
         let order = Order.fake()
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
@@ -515,7 +515,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case .verifyDestinationAddress(_, _, let completion):
-                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingAddress.fake(),
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
                                                                                isTrivialNormalization: false,
                                                                                isVerified: false)))
             case .loadPackages, .loadOriginAddresses:
@@ -541,7 +541,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case .verifyDestinationAddress(_, _, let completion):
-                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingAddress.fake(),
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
                                                                                isTrivialNormalization: nil,
                                                                                isVerified: true)))
             case .loadPackages, .loadOriginAddresses:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -1017,6 +1017,105 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(editedAddress, expectedAddress)
     }
+
+    @MainActor
+    func test_destination_address_update_sends_expected_origin_address_to_remote() async {
+        // Given
+        let sampleOrderID: Int64 = 123
+        let destinationAddress = WooShippingAddress.fake().copy(name: "JANE DOE",
+                                                                phone: "123-456-7890")
+        let suggestedAddress = WooShippingNormalizedAddress(company: "HEADQUARTERS",
+                                                            firstName: "JANE",
+                                                            lastName: "DOE",
+                                                            phone: "123-456-7890",
+                                                            country: "US",
+                                                            state: "NY",
+                                                            address1: "15 ALGONKIN ST STE 100",
+                                                            address2: "",
+                                                            city: "TICONDEROGA",
+                                                            postcode: "12883-1487")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingEditAddressViewModel(address: destinationAddress,
+                                                        orderID: sampleOrderID,
+                                                        email: "TEXT@EXAMPLE.COM",
+                                                        isVerified: false,
+                                                        originCountryCode: nil,
+                                                        originStateCode: nil,
+                                                        stores: stores)
+
+        // When
+        let receivedAddress: WooShippingDestinationAddress = await waitForAsync { promise in
+            stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+                switch action {
+                case let .validateAddress(_, _, completion):
+                    completion(.success(.init(normalizedAddress: suggestedAddress, originalAddress: .fake(), isTrivialNormalization: true)))
+                case let .updateDestinationAddress(_, _, address, completion):
+                    promise(address)
+                    completion(.success(WooShippingDestinationAddressUpdate(address: address, isVerified: true)))
+                default:
+                    XCTFail("Unexpected action received: \(action)")
+                }
+            }
+            await viewModel.remotelyValidateAddress()
+            viewModel.normalizeAddressVM?.confirmSelectedAddress()
+        }
+
+        // Then
+        let expectedAddress = WooShippingDestinationAddress(company: suggestedAddress.company,
+                                                            address1: suggestedAddress.address1,
+                                                            address2: suggestedAddress.address2,
+                                                            city: suggestedAddress.city,
+                                                            state: suggestedAddress.state,
+                                                            postcode: suggestedAddress.postcode,
+                                                            country: suggestedAddress.country,
+                                                            phone: suggestedAddress.phone,
+                                                            name: suggestedAddress.fullName,
+                                                            firstName: "",
+                                                            lastName: "",
+                                                            email: "TEXT@EXAMPLE.COM")
+        XCTAssertEqual(receivedAddress, expectedAddress)
+    }
+
+    @MainActor
+    func test_destination_address_update_calls_onDestinationAddressEdited_closure() async {
+        // Given
+        let sampleOrderID: Int64 = 123
+        let normalizedAddress = WooShippingNormalizedAddress.fake().copy(firstName: "JANE",
+                                                                         lastName: "DOE",
+                                                                         phone: "123-456-7890")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let result: (WooShippingAddress, String?) = await waitForAsync { promise in
+            stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+                switch action {
+                case let .validateAddress(_, _, completion):
+                    completion(.success(.init(normalizedAddress: normalizedAddress, originalAddress: .fake(), isTrivialNormalization: true)))
+                case let .updateDestinationAddress(_, _, address, completion):
+                    completion(.success(WooShippingDestinationAddressUpdate(address: address, isVerified: true)))
+                default:
+                    XCTFail("Unexpected action received: \(action)")
+                }
+            }
+            // When
+
+            let viewModel = WooShippingEditAddressViewModel(address: .fake(),
+                                                            orderID: sampleOrderID,
+                                                            email: "TEXT@EXAMPLE.COM",
+                                                            isVerified: false,
+                                                            originCountryCode: nil,
+                                                            originStateCode: nil,
+                                                            stores: stores) { address, email in
+                promise((address, email))
+            }
+            viewModel.name.value = "JANE DOE"
+
+            await viewModel.remotelyValidateAddress()
+            viewModel.normalizeAddressVM?.confirmSelectedAddress()
+        }
+
+        // Then
+        XCTAssertEqual(result.0, normalizedAddress.toWooShippingAddress())
+        XCTAssertEqual(result.1, "TEXT@EXAMPLE.COM")
+    }
 }
 
 private extension WooShippingEditAddressViewModel {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -983,7 +983,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                        country: suggestedAddress.country,
                                                        phone: originAddress.phone,
                                                        firstName: suggestedAddress.fullName,
-                                                       lastName: suggestedAddress.lastName,
+                                                       lastName: "",
                                                        email: originAddress.email,
                                                        defaultAddress: originAddress.defaultAddress,
                                                        isVerified: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -937,15 +937,16 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                                  firstName: "JANE",
                                                                  lastName: "DOE",
                                                                  email: "TEXT@EXAMPLE.COM")
-        let suggestedAddress = WooShippingAddress(company: "HEADQUARTERS",
-                                                  name: "JANE DOE",
-                                                  phone: "123-456-7890",
-                                                  country: "US",
-                                                  state: "NY",
-                                                  address1: "15 ALGONKIN ST STE 100",
-                                                  address2: "",
-                                                  city: "TICONDEROGA",
-                                                  postcode: "12883-1487")
+        let suggestedAddress = WooShippingNormalizedAddress(company: "HEADQUARTERS",
+                                                            firstName: "JANE",
+                                                            lastName: "DOE",
+                                                            phone: "123-456-7890",
+                                                            country: "US",
+                                                            state: "NY",
+                                                            address1: "15 ALGONKIN ST STE 100",
+                                                            address2: "",
+                                                            city: "TICONDEROGA",
+                                                            postcode: "12883-1487")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingEditAddressViewModel(address: originAddress, stores: stores)
 
@@ -976,8 +977,8 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                        postcode: suggestedAddress.postcode,
                                                        country: suggestedAddress.country,
                                                        phone: originAddress.phone,
-                                                       firstName: suggestedAddress.name,
-                                                       lastName: "",
+                                                       firstName: suggestedAddress.fullName,
+                                                       lastName: suggestedAddress.lastName,
                                                        email: originAddress.email,
                                                        defaultAddress: originAddress.defaultAddress,
                                                        isVerified: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -4,6 +4,8 @@ import Yosemite
 
 final class WooShippingEditAddressViewModelTests: XCTestCase {
 
+    private let sampleOrderID: Int64 = 123
+
     func test_it_inits_with_expected_values() {
         // Given
         let id = "default_address"
@@ -120,6 +122,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // When
         let viewModel = WooShippingEditAddressViewModel(address: address,
+                                                        orderID: sampleOrderID,
                                                         email: email,
                                                         isVerified: false,
                                                         originCountryCode: "US",
@@ -144,7 +147,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_it_validates_address_with_missing_information_and_sets_expected_status_on_init() {
         // Given & When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -263,6 +266,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // When
         let viewModel = WooShippingEditAddressViewModel(address: address,
+                                                        orderID: sampleOrderID,
                                                         email: "",
                                                         isVerified: false,
                                                         originCountryCode: address.country,
@@ -286,6 +290,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // When
         let viewModel = WooShippingEditAddressViewModel(address: address,
+                                                        orderID: sampleOrderID,
                                                         email: "",
                                                         isVerified: false,
                                                         originCountryCode: "CA",
@@ -330,7 +335,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: countries)
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -365,7 +370,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -392,7 +397,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [.init(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -420,7 +425,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         storageManager.insertSampleCountries(readOnlyCountries: [country])
 
         // When
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -449,7 +454,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let state = StateOfACountry(code: "NY", name: "New York")
         let country = Country(code: "US", name: "United States", states: [state])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -480,7 +485,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let state = StateOfACountry(code: "NY", name: "New York")
         let country = Country(code: "US", name: "United States", states: [state])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -510,7 +515,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
@@ -536,7 +541,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validateAddress_sets_expected_properties_when_all_fields_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -567,7 +572,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
@@ -596,7 +601,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validate_sets_expected_properties_when_all_fields_empty() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -629,7 +634,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [.fake()])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -658,7 +663,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -684,7 +689,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
     func test_validate_removes_valid_field_from_invalidFields() {
         // Given
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -716,7 +721,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let storageManager = MockStorageManager()
         let country = Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])
         storageManager.insertSampleCountries(readOnlyCountries: [country])
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "JANE DOE",
                                                         company: "HEADQUARTERS",
@@ -747,7 +752,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Given
         var isLoadingDuringRemoteAction = false
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -801,7 +806,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                 completion(.success(.init(normalizedAddress: .fake(), originalAddress: .fake(), isTrivialNormalization: true)))
             }
         }
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: expectedAddress.name,
                                                         company: expectedAddress.company,
@@ -830,7 +835,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
     func test_remotelyValidateAddress_sets_normalizeAddressVM_on_success() async {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",
@@ -866,7 +871,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let expectedAddressError = "House number is missing"
         let expectedGeneralError = "Address not found"
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingEditAddressViewModel(type: .destination,
+        let viewModel = WooShippingEditAddressViewModel(type: .destination(orderID: sampleOrderID),
                                                         id: "",
                                                         name: "",
                                                         company: "",

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -182,6 +182,7 @@ public typealias TopEarnerStatsItem = Networking.TopEarnerStatsItem
 public typealias User = Networking.User
 public typealias WooAPIVersion = Networking.WooAPIVersion
 public typealias WooShippingAddress = Networking.WooShippingAddress
+public typealias WooShippingNormalizedAddress = Networking.WooShippingNormalizedAddress
 public typealias WooShippingAddressValidationSuccess = Networking.WooShippingAddressValidationSuccess
 public typealias WooShippingAddressValidationError = Networking.WooShippingAddressValidationError
 public typealias WooShippingCustomPackage = Networking.WooShippingCustomPackage

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -610,7 +610,7 @@ final class WooShippingStoreTests: XCTestCase {
     func test_validateAddress_returns_WooShippingAddressValidationSuccess_on_success() throws {
         // Given
         let remote = MockWooShippingRemote()
-        let expectedResult = WooShippingAddressValidationSuccess(normalizedAddress: WooShippingAddress.fake(),
+        let expectedResult = WooShippingAddressValidationSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
                                                                  originalAddress: WooShippingAddress.fake(),
                                                                  isTrivialNormalization: true)
         remote.whenAddressValidation(siteID: sampleSiteID, thenReturn: .success(expectedResult))
@@ -702,7 +702,7 @@ final class WooShippingStoreTests: XCTestCase {
     func test_verifyDestinationAddress_returns_WooShippingVerifyDestinationAddressSuccess_on_success() throws {
         // Given
         let remote = MockWooShippingRemote()
-        let expectedResult = WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingAddress.fake(),
+        let expectedResult = WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
                                                                         isTrivialNormalization: true,
                                                                         isVerified: true)
         remote.whenVerifyDestinationAddress(siteID: sampleSiteID, thenReturn: .success(expectedResult))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15178 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds code to handle the edited/validated destination address that the merchant confirms they want to use for the shipping label.

Changes
- Add `WooShippingNormalizedAddress` Model to parse responses from [the normalize address](https://github.com/woocommerce/woocommerce-shipping/blob/trunk/docs/api/address.md#normalize-address) and [the verify destination address](https://github.com/woocommerce/woocommerce-shipping/blob/trunk/docs/api/address.md#verify-destination-address) endpoints. 
    - These endpoints send first name and last name in their responses. The previously used model `WooShippingAddress` doesn't have first name and last name properties and the name info will be lost. 
- Pass order ID to edit address view model and store it as an associated value in `AddressType` enum.
- Add code to save the confirmed destination address to remote.
- Unit tests.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: WooCommerce Shipping is installed, activated, and set up on your store.

1. Create or open an order with at least one physical product and the processing status, and a shipping address.
1. Open the order detail screen from the mobile app. 
1. Tap "Create Shipping Label" in order details.
1. Tap the pencil icon near the "Ship to" address to edit the destination address.
1. Make changes to the address and follow the steps to save the address.
1. Navigate back to the order list screen and open the order detail screen again.
1. Tap "Create Shipping Label" in order details and validate that the changes made to the destination address is successfully saved. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- Tested that the destination address can be edited and saved successfully. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ab74f24b-bbb7-47a3-a647-800848eb9865


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.