### PR TITLE
[Shipping Labels] Disable editing addresses of an existing shipping label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -231,20 +231,26 @@ private extension WooShippingCreateLabelsView {
         HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
             Text(Localization.BottomSheet.shipFrom)
                 .trackSize(size: $shipmentDetailsShipFromSize)
-            Button {
-                isOriginAddressListPresented = true
-            } label: {
-                HStack {
-                    Text(viewModel.originAddress)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Image(systemName: "ellipsis")
-                        .frame(width: Layout.ellipsisWidth)
-                        .bold()
+            if viewModel.canViewLabel,
+               let addressLines = viewModel.originAddressLines {
+                AddressLinesView(addressLines: addressLines)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Button {
+                    isOriginAddressListPresented = true
+                } label: {
+                    HStack {
+                        Text(viewModel.originAddress)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Image(systemName: "ellipsis")
+                            .frame(width: Layout.ellipsisWidth)
+                            .bold()
+                    }
                 }
+                .buttonStyle(TextButtonStyle())
             }
-            .buttonStyle(TextButtonStyle())
         }
         .padding(Layout.bottomSheetPadding)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -264,12 +264,14 @@ private extension WooShippingCreateLabelsView {
                     }
                 }
                 addressVerificationLabel
+                    .renderedIf(!viewModel.canViewLabel)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             PencilEditButton {
                 viewModel.editDestinationAddress()
             }
             .buttonStyle(TextButtonStyle())
+            .renderedIf(!viewModel.canViewLabel)
         }
         .padding(Layout.bottomSheetPadding)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -394,6 +394,21 @@ private extension WooShippingCreateLabelsView {
     }
 }
 
+private struct AddressLinesView: View {
+    let addressLines: [String]
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            ForEach(addressLines, id: \.self) { addressLine in
+                Text(addressLine)
+                    .if(addressLine == addressLines.first) { line in
+                        line.bold()
+                    }
+            }
+        }
+    }
+}
+
 // MARK: Store Options
 extension EnvironmentValues {
     @Entry var shippingWeightUnit: String = ServiceLocator.shippingSettingsService.weightUnit ?? ""

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -256,12 +256,7 @@ private extension WooShippingCreateLabelsView {
                 .frame(width: shipmentDetailsShipFromSize.width, alignment: .leading)
             VStack(alignment: .leading) {
                 if let addressLines = viewModel.destinationAddressLines {
-                    ForEach(addressLines, id: \.self) { addressLine in
-                        Text(addressLine)
-                            .if(addressLine == addressLines.first) { line in
-                                line.bold()
-                            }
-                    }
+                    AddressLinesView(addressLines: addressLines)
                 }
                 addressVerificationLabel
                     .renderedIf(!viewModel.canViewLabel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -71,6 +71,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Address to ship from (store address), formatted for display.
     @Published private(set) var originAddress: String = ""
 
+    /// Address to ship from (store address), formatted for display and split into separate lines to allow additional formatting.
+    var originAddressLines: [String]? {
+        originAddress.components(separatedBy: ", ")
+    }
+
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     var destinationAddressLines: [String]? {
         (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15268
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To match the web experience, we shouldn't allow editing of origin and destination addresses of an existing shipping label. Below the UI while viewing an existing shipping label in web.

<img width="1323" alt="Screenshot 2025-03-04 at 6 14 35 AM" src="https://github.com/user-attachments/assets/7df0903c-2719-4512-ac07-ef69111491aa" />


This PR disables editing origin/destination addresses of an existing shipping label. 

Changes
- Show edit button in destination address only in creation mode.
- Add a subview to reuse the view code for showing address lines.
- Show full address lines of origin address while viewing a created a shipping label. This matches the web behaviour.  

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->


Prerequisite: WooCommerce Shipping is installed, activated, and set up on your store.
1. Create or open an order with at least one physical product and the processing status, and a shipping address.
1. Open the order from the mobile app. 
1. Tap "Create Shipping Label" in order details.
1. Validate that you can edit the origin and destination address as before.
1. Complete the steps and create a shipping label.
1. Navigate to the order details page again. 
1. Tap "View purchased shipping label" button to view the details of the existing shipping label.
1. Confirm that the origin and destination addresses cannot be edited. 
 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- Tested that editing origin and destination addresses work as before in the "Create shipping label" flow.
- Tested that origin and destination addresses of an existing shipping label cannot be edited. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Screen | Landscape | Portriat |
|--------|--------|--------|
| Create shipping label | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-04 at 10 14 14](https://github.com/user-attachments/assets/d22e26d5-c2b1-4831-b3cf-7adfe7ad3ed0) | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-04 at 10 14 11](https://github.com/user-attachments/assets/233fe0ae-c2bb-4a15-a97e-d889038a76ba) |
| View existing shipping label | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-04 at 10 13 28](https://github.com/user-attachments/assets/5a54951e-0304-4f92-8f2c-c93d90499c34) | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-04 at 10 13 24](https://github.com/user-attachments/assets/0dcb6cf3-0054-4104-9195-d07469c8f9b9) | 
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.