### PR TITLE
Shipping Labels: Handle unverified origin address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingOriginAddressListView.swift
@@ -21,8 +21,18 @@ struct WooShippingOriginAddressListView: View {
                                     .bold()
                             }
                         }
+
                         if let formattedAddress = address.formattedPostalAddress {
                             Text(formattedAddress)
+                        }
+
+                        if !address.isVerified {
+                            HStack(spacing: 4) {
+                                Image(systemName: "exclamationmark.circle")
+                                Text(Localization.unverified)
+                            }
+                            .font(.subheadline)
+                            .foregroundStyle(Constants.red)
                         }
                     }
                     Spacer()
@@ -63,6 +73,8 @@ private extension WooShippingOriginAddressListView {
     enum Constants {
         static let verticalSpacing: CGFloat = 8
         static let cornerRadius: CGFloat = 8
+        static let red = Color(UIColor(light: .withColorStudio(.red, shade: .shade60),
+                                       dark: .withColorStudio(.red, shade: .shade40)))
     }
 }
 
@@ -78,6 +90,9 @@ private extension WooShippingOriginAddressListView {
         static let editOrigin = NSLocalizedString("wooShipping.originAddresses.editOrigin",
                                                     value: "Edit Origin",
                                                     comment: "Title for the edit origin address screen in the shipping label creation flow")
+        static let unverified = NSLocalizedString("wooShipping.originAddresses.unverified",
+                                                  value: "Unverified address",
+                                                  comment: "Label when an address is unverified on the shipping label creation screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -71,6 +71,11 @@ struct WooShippingCreateLabelsView: View {
                     }
                 }
             }
+            .sheet(isPresented: $isOriginAddressListPresented) {
+                WooShippingOriginAddressListView(viewModel: viewModel.originAddresses)
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
+            }
             .sheet(item: $viewModel.addressToEdit) { addressToEdit in
                 NavigationStack {
                     WooShippingEditAddressView(viewModel: addressToEdit)
@@ -161,11 +166,6 @@ private extension WooShippingCreateLabelsView {
             .padding([.bottom, .horizontal], Layout.bottomSheetPadding)
         }
         .ignoresSafeArea(edges: .horizontal)
-        .sheet(isPresented: $isOriginAddressListPresented) {
-            WooShippingOriginAddressListView(viewModel: viewModel.originAddresses)
-                .presentationDetents([.medium, .large])
-                .presentationDragIndicator(.visible)
-        }
     }
 
     var missingDataState: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -257,25 +257,37 @@ private extension WooShippingCreateLabelsView {
         HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
             Text(Localization.BottomSheet.shipFrom)
                 .trackSize(size: $shipmentDetailsShipFromSize)
+
             if viewModel.canViewLabel,
                let addressLines = viewModel.originAddressLines {
                 AddressLinesView(addressLines: addressLines)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
-                Button {
-                    isOriginAddressListPresented = true
-                } label: {
-                    HStack {
-                        Text(viewModel.originAddress)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Image(systemName: "ellipsis")
-                            .frame(width: Layout.ellipsisWidth)
-                            .bold()
+                VStack(alignment: .leading) {
+                    Button {
+                        isOriginAddressListPresented = true
+                    } label: {
+                        HStack {
+                            Text(viewModel.originAddress)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            Image(systemName: "ellipsis")
+                                .frame(width: Layout.ellipsisWidth)
+                                .bold()
+                        }
+                    }
+                    .buttonStyle(TextButtonStyle())
+
+                    if viewModel.isOriginAddressUnverified {
+                        HStack(spacing: 4) {
+                            Image(systemName: "exclamationmark.circle")
+                            Text(Localization.AddressVerification.unverified)
+                        }
+                        .font(.subheadline)
+                        .foregroundStyle(Layout.red)
                     }
                 }
-                .buttonStyle(TextButtonStyle())
             }
         }
         .padding(Layout.bottomSheetPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -191,17 +191,35 @@ private extension WooShippingCreateLabelsView {
                 .foregroundStyle(Color(.primary))
                 .bold()
 
-            addressVerificationNotice(with: viewModel.destinationAddressStatusNoticeLabel,
-                                      isVerified: isDestinationAddressVerified,
-                                      onDismiss: {
-                withAnimation {
-                    viewModel.destinationAddressStatusNoticeLabel = nil
-                }
-            }, onTap: {
-                if !isDestinationAddressVerified {
-                    viewModel.editDestinationAddress()
-                }
-            })
+            // Unverified notice for origin address
+            if let originAddressUnverifiedNoticeLabel = viewModel.originAddressUnverifiedNoticeLabel {
+                addressVerificationNotice(with: originAddressUnverifiedNoticeLabel,
+                                          isVerified: false,
+                                          onDismiss: {
+                    withAnimation {
+                        viewModel.originAddressUnverifiedNoticeLabel = nil
+                    }
+                },
+                                          onTap: {
+                    viewModel.editSelectedOriginAddress()
+                })
+            }
+
+            // Verification notice for destination address
+            if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel {
+                addressVerificationNotice(with: destinationAddressStatusNoticeLabel,
+                                          isVerified: isDestinationAddressVerified,
+                                          onDismiss: {
+                    withAnimation {
+                        viewModel.destinationAddressStatusNoticeLabel = nil
+                    }
+                },
+                                          onTap: {
+                    if !isDestinationAddressVerified {
+                        viewModel.editDestinationAddress()
+                    }
+                })
+            }
         }
     }
 
@@ -373,28 +391,26 @@ private extension WooShippingCreateLabelsView {
 
     /// View showing a notice about an address verification status.
     @ViewBuilder
-    func addressVerificationNotice(with label: String?,
+    func addressVerificationNotice(with label: String,
                                    isVerified: Bool,
                                    onDismiss: @escaping () -> Void,
                                    onTap: @escaping () -> Void) -> some View {
-        if let label {
-            HStack(spacing: 8) {
-                Image(systemName: isVerified ? "checkmark.circle" : "exclamationmark.circle")
-                Text(label)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Button(action: onDismiss) {
-                    Image(systemName: "xmark")
-                        .renderedIf(!isVerified)
-                }
+        HStack(spacing: 8) {
+            Image(systemName: isVerified ? "checkmark.circle" : "exclamationmark.circle")
+            Text(label)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .renderedIf(!isVerified)
             }
-            .font(.subheadline)
-            .foregroundStyle(isVerified ? Layout.green : Layout.red)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                .fill(Color(uiColor: isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
-            .onTapGesture(perform: onTap)
         }
+        .font(.subheadline)
+        .foregroundStyle(isVerified ? Layout.green : Layout.red)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
+            .fill(Color(uiColor: isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
+        .onTapGesture(perform: onTap)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -190,10 +190,18 @@ private extension WooShippingCreateLabelsView {
             Text(Localization.BottomSheet.shipmentDetails)
                 .foregroundStyle(Color(.primary))
                 .bold()
-            addressVerificationNotice(with: viewModel.destinationAddressStatusNoticeLabel)
-                .onTapGesture {
-                    // TODO: Start address editing/verification flow if needed (if destination address is unverified).
+
+            addressVerificationNotice(with: viewModel.destinationAddressStatusNoticeLabel,
+                                      isVerified: isDestinationAddressVerified,
+                                      onDismiss: {
+                withAnimation {
+                    viewModel.destinationAddressStatusNoticeLabel = nil
                 }
+            }, onTap: {
+                if !isDestinationAddressVerified {
+                    viewModel.editDestinationAddress()
+                }
+            })
         }
     }
 
@@ -363,34 +371,29 @@ private extension WooShippingCreateLabelsView {
         }
     }
 
-    /// View showing a notice about the destination address verification status.
+    /// View showing a notice about an address verification status.
     @ViewBuilder
-    func addressVerificationNotice(with label: String?) -> some View {
-        if let label = viewModel.destinationAddressStatusNoticeLabel {
+    func addressVerificationNotice(with label: String?,
+                                   isVerified: Bool,
+                                   onDismiss: @escaping () -> Void,
+                                   onTap: @escaping () -> Void) -> some View {
+        if let label {
             HStack(spacing: 8) {
-                Image(systemName: isDestinationAddressVerified ? "checkmark.circle" : "exclamationmark.circle")
+                Image(systemName: isVerified ? "checkmark.circle" : "exclamationmark.circle")
                 Text(label)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Button {
-                    withAnimation {
-                        viewModel.destinationAddressStatusNoticeLabel = nil
-                    }
-                } label: {
+                Button(action: onDismiss) {
                     Image(systemName: "xmark")
-                        .renderedIf(!isDestinationAddressVerified)
+                        .renderedIf(!isVerified)
                 }
             }
             .font(.subheadline)
-            .foregroundStyle(isDestinationAddressVerified ? Layout.green : Layout.red)
+            .foregroundStyle(isVerified ? Layout.green : Layout.red)
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
             .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .fill(Color(uiColor: isDestinationAddressVerified ? .withColorStudio(.green, shade: .shade0) : .withColorStudio(.red, shade: .shade0))))
-            .onTapGesture {
-                if !isDestinationAddressVerified {
-                    viewModel.editDestinationAddress()
-                }
-            }
+            .onTapGesture(perform: onTap)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -309,7 +309,24 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     }
 
     func editSelectedOriginAddress() {
-        // TODO
+        guard let selectedOriginAddress else {
+            return
+        }
+        addressToEdit = WooShippingEditAddressViewModel(address: selectedOriginAddress, onAddressEdited: { [weak self] editedAddress in
+            guard let self, let index = originAddresses.addresses.firstIndex(where: { $0.id == editedAddress.id }) else {
+                return
+            }
+            var addresses = originAddresses.addresses
+            addresses.remove(at: index)
+            addresses.insert(editedAddress, at: index)
+            self.selectedOriginAddress = editedAddress
+            originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
+                                                                    selectedAddressID: editedAddress.id)
+            originAddresses.onSelect = { [weak self] selectedAddress in
+                self?.selectedOriginAddress = selectedAddress
+            }
+            addressToEdit = nil // Dismisses address edit screen
+        })
     }
 
     /// Sets the `addressToEdit` property for editing the destination address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -68,6 +68,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Address to ship from (store address).
     @Published private var selectedOriginAddress: WooShippingOriginAddress?
 
+    /// Whether the origin address is unverified.
+    var isOriginAddressUnverified: Bool {
+        selectedOriginAddress?.isVerified == false
+    }
+
     /// Address to ship from (store address), formatted for display.
     @Published private(set) var originAddress: String = ""
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -76,6 +76,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         originAddress.components(separatedBy: ", ")
     }
 
+    /// This property can be set to display a notice with the provided label about the origin address status.
+    @Published var originAddressUnverifiedNoticeLabel: String?
+
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     var destinationAddressLines: [String]? {
         (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")
@@ -305,6 +308,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         customsForm = form
     }
 
+    func editSelectedOriginAddress() {
+        // TODO
+    }
+
     /// Sets the `addressToEdit` property for editing the destination address.
     /// After the address is edited, the destination address is replaced with the updated address.
     func editDestinationAddress() {
@@ -429,6 +436,13 @@ private extension WooShippingCreateLabelsViewModel {
             .sink { [weak self] selectedOriginAddress in
                 guard let self else { return }
                 originAddress = selectedOriginAddress?.formattedPostalAddress ?? ""
+                originAddressUnverifiedNoticeLabel = {
+                    if let selectedOriginAddress, !selectedOriginAddress.isVerified {
+                        return Localization.OriginAddressStatus.unverified
+                    }
+                    return nil
+                }()
+
                 shippingService = WooShippingServiceViewModel(order: order,
                                                               originAddress: selectedOriginAddress?.toWooShippingAddress(),
                                                               destinationAddress: destinationAddress,
@@ -542,6 +556,14 @@ private extension WooShippingCreateLabelsViewModel {
                                                               value: "Adult Signature Required",
                                                               comment: "Label for row showing the additional cost to require an adult signature " +
                                                               "on the shipping label creation screen")
+
+        enum OriginAddressStatus {
+            static let unverified = NSLocalizedString(
+                "wooShipping.createLabels.addressVerification.originUnverified",
+                value: "Origin address unverified",
+                comment: "Notice when a origin address is unverified on the shipping label creation screen"
+            )
+        }
 
         enum DestinationAddressStatus {
             static let verified = NSLocalizedString("wooShipping.createLabels.addressVerification.destinationVerified",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -161,6 +161,105 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.originAddresses.addresses, [originAddress])
     }
 
+    func test_origin_unverified_state_is_correct() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let originAddress = WooShippingOriginAddress(id: "default_address",
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadPackages, .verifyDestinationAddress:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores)
+        XCTAssertFalse(viewModel.isOriginAddressUnverified)
+        XCTAssertNil(viewModel.originAddressUnverifiedNoticeLabel)
+
+        // Then
+        waitUntil {
+            viewModel.originAddress.isNotEmpty
+        }
+        XCTAssertTrue(viewModel.isOriginAddressUnverified)
+        XCTAssertNotNil(viewModel.originAddressUnverifiedNoticeLabel)
+    }
+
+    func test_editSelectedOriginAddress_sets_addressToEdit_view_model() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let originAddress = WooShippingOriginAddress(id: "default_address",
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadPackages, .verifyDestinationAddress:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores)
+
+        // When
+        waitUntil {
+            viewModel.originAddress.isNotEmpty
+        }
+        viewModel.editSelectedOriginAddress()
+
+        // Then
+        XCTAssertNotNil(viewModel.addressToEdit)
+        XCTAssertEqual(viewModel.addressToEdit?.company.value, originAddress.company)
+        XCTAssertEqual(viewModel.addressToEdit?.address.value, originAddress.combinedAddress)
+        XCTAssertEqual(viewModel.addressToEdit?.city.value, originAddress.city)
+        XCTAssertEqual(viewModel.addressToEdit?.country.value, originAddress.country)
+        XCTAssertEqual(viewModel.addressToEdit?.phone.value, originAddress.phone)
+        XCTAssertEqual(viewModel.addressToEdit?.name.value, originAddress.fullName)
+        XCTAssertEqual(viewModel.addressToEdit?.email.value, originAddress.email)
+        XCTAssertEqual(viewModel.addressToEdit?.isDefaultAddress, originAddress.defaultAddress)
+    }
+
     func test_customsFormRequired_when_origin_and_destination_in_US_then_returns_false() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14879 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the shipping label creation form to display error notices for unverified origin address. 
Changes include:
- Show unverified label for unverified addresses in the origin address list and the expanded creation form.
- Show error notice in the collapsed mode of the creation form for unverified origin address.
- Handle navigation to the edit screen from the error notice.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store with Woo Shipping plugin set up.
- In Proxyman, put a breakpoint for the response of `/wcshipping/v1/address/origins` request.
- Open a completed order eligible for creating shipping labels and select Create shipping label.
- When the breakpoint pauses, update the response for the origin addresses to be unverified.
- Confirm that an error notice is displayed in the collapsed creation form about the unverified origin address.
- Tap the notice and confirm that the edit form for the origin address is displayed.
- Close the form and expand the creation form.
- Confirm that there is a label under the origin address saying "Unverified address".
- Tap the origin address, confirm that "Unverified address" is displayed for all unverified addresses in the list.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed all the tests above.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/e7c55415-19f8-42a8-9cfb-93f2188eb5dc" width=320 />
<img src="https://github.com/user-attachments/assets/042b7f81-9b73-4b65-8571-307956e3ed57" width=320 />
<img src="https://github.com/user-attachments/assets/a5bf425a-396f-422b-a288-f75a6ab7920b" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
