### PR TITLE
Shipping Labels: Show error alert when saving custom package fails

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
@@ -14,6 +14,7 @@ struct WooAddCustomPackageView: View {
 
     @State private var isSavingPackage: Bool = false
     @State private var isAddingPackage: Bool = false
+    @State private var showingSavingError = false
 
     @Environment(\.shippingDimensionsUnit) private var dimensionsUnit
     @Environment(\.shippingWeightUnit) private var weightUnit
@@ -161,6 +162,16 @@ struct WooAddCustomPackageView: View {
                 }
                 .scrollDismissesKeyboard(.interactively)
                 .disabled(isSavingPackage)
+                .alert(Localization.SavingPackageError.title, isPresented: $showingSavingError, actions: {
+                    Button(Localization.SavingPackageError.cancel) {}
+                    Button(Localization.SavingPackageError.proceed) {
+                        Task {
+                            await addPackageButtonTapped()
+                        }
+                    }
+                }, message: {
+                    Text(Localization.SavingPackageError.message)
+                })
             }
         }
     }
@@ -197,7 +208,7 @@ struct WooAddCustomPackageView: View {
             addPackageAction(data)
         case .failure(let failure):
             // show failure
-            print(failure)
+            DDLogError("⛔️ Error adding package: \(failure)")
         }
     }
 
@@ -209,8 +220,8 @@ struct WooAddCustomPackageView: View {
         case .success(let data):
             addPackageAction(data)
         case .failure(let failure):
-            // show failure
-            print(failure)
+            DDLogError("⛔️ Error saving package: \(failure)")
+            showingSavingError = true
         }
     }
 
@@ -267,5 +278,29 @@ extension WooAddCustomPackageView {
         static let savePackageTemplatePlaceholder = NSLocalizedString("wooShipping.createLabel.addPackage.savePackageTemplatePlaceholder",
                                                            value: "Enter a unique package name",
                                                            comment: "Placeholder text for package name field")
+        enum SavingPackageError {
+            static let title = NSLocalizedString(
+                "wooShipping.createLabel.addPackage.savingPackageError.title",
+                value: "We couldn't save your package as a template",
+                comment: "Title of the error alert when saving a package as template fails in the shipping label creation flow"
+            )
+            static let message = NSLocalizedString(
+                "wooShipping.createLabel.addPackage.savingPackageError.message",
+                value: "Do you want to proceed without saving it?",
+                comment: "Message of the error alert when saving a package as template fails in the shipping label creation flow"
+            )
+            static let cancel = NSLocalizedString(
+                "wooShipping.createLabel.addPackage.savingPackageError.cancel",
+                value: "Cancel",
+                comment: "Button on the error alert when saving a package as template fails in the shipping label creation flow. " +
+                "Tapping on this button would cancel the saving."
+            )
+            static let proceed = NSLocalizedString(
+                "wooShipping.createLabel.addPackage.savingPackageError.proceed",
+                value: "Proceed",
+                comment: "Button on the error alert when saving a package as template fails in the shipping label creation flow. " +
+                "Tapping on this button would proceed with the creation flow without saving the package."
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
@@ -163,11 +163,15 @@ struct WooAddCustomPackageView: View {
                 .scrollDismissesKeyboard(.interactively)
                 .disabled(isSavingPackage)
                 .alert(Localization.SavingPackageError.title, isPresented: $showingSavingError, actions: {
-                    Button(Localization.SavingPackageError.cancel) {}
-                    Button(Localization.SavingPackageError.proceed) {
+                    Button(role: .cancel) {} label: {
+                        Text(Localization.SavingPackageError.cancel)
+                    }
+                    Button {
                         Task {
                             await addPackageButtonTapped()
                         }
+                    } label: {
+                        Text(Localization.SavingPackageError.proceed)
                     }
                 }, message: {
                     Text(Localization.SavingPackageError.message)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
@@ -12,8 +12,7 @@ struct WooAddCustomPackageView: View {
     @FocusState var packageTemplateNameFieldFocused: Bool
     @FocusState var focusedField: WooShippingPackageUnitType?
 
-    @State private var isSavingPackage: Bool = false
-    @State private var isAddingPackage: Bool = false
+    @State private var isSavingPackage = false
     @State private var showingSavingError = false
 
     @Environment(\.shippingDimensionsUnit) private var dimensionsUnit
@@ -131,14 +130,10 @@ struct WooAddCustomPackageView: View {
                         else {
                             Spacer()
                             Button(selectionButtonText) {
-                                Task { @MainActor in
-                                    isAddingPackage = true
-                                    await addPackageButtonTapped()
-                                    isAddingPackage = false
-                                }
+                                confirmPackage()
                             }
                             .disabled(selectionButtonDisabled)
-                            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isAddingPackage))
+                            .buttonStyle(PrimaryButtonStyle())
                             .padding(.bottom)
                         }
                     }
@@ -167,9 +162,7 @@ struct WooAddCustomPackageView: View {
                         Text(Localization.SavingPackageError.cancel)
                     }
                     Button {
-                        Task {
-                            await addPackageButtonTapped()
-                        }
+                        confirmPackage()
                     } label: {
                         Text(Localization.SavingPackageError.proceed)
                     }
@@ -203,17 +196,11 @@ struct WooAddCustomPackageView: View {
 
     // MARK: - actions
 
-    @MainActor
-    private func addPackageButtonTapped() async {
-        let packageDataResult = await viewModel.addPackageAction()
-        // call addPackageAction with data
-        switch packageDataResult {
-        case .success(let data):
-            addPackageAction(data)
-        case .failure(let failure):
-            // show failure
-            DDLogError("⛔️ Error adding package: \(failure)")
+    private func confirmPackage() {
+        guard let packageData = viewModel.packageData else {
+            return
         }
+        addPackageAction(packageData)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -104,10 +104,10 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
         let result: Result<WooShippingPackageDataRepresentable, Error> = await withCheckedContinuation { continuation in
             let action = WooShippingAction.createPackage(siteID: siteID,
                                                          customPackage: customPackage,
-                                                         predefinedOption: nil) { [weak self] result in
+                                                         predefinedOption: nil) { result in
                 switch result {
                 case let .success(packages):
-                    guard let self, let savedPackage = packages.customPackages.first(where: { $0.name == customPackage.name }) else {
+                    guard let savedPackage = packages.customPackages.first(where: { $0.name == customPackage.name }) else {
                         return continuation.resume(returning: .failure(WooShippingAddCustomPackageViewModel.Error.failedSavingTemplate))
                     }
                     let packageData = WooShippingPackageData(id: savedPackage.id,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -64,7 +64,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
                                       packageType: packageType.rawValue)
     }
 
-    private func preparePackageData() -> WooShippingPackageDataRepresentable? {
+    var packageData: WooShippingPackageDataRepresentable? {
         guard validateCustomPackageInputFields() else { return nil }
 
         return packageDataFromCurrentData
@@ -76,23 +76,11 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
         case failure(Swift.Error)
     }
 
-    func addPackageAction(package: WooShippingPackageDataRepresentable? = nil) async -> Result<WooShippingPackageDataRepresentable, Error> {
-        guard let packageData = package ?? preparePackageData() else {
-            return .failure(WooShippingAddCustomPackageViewModel.Error.packageDataNotValid)
-        }
-
-        // TODO: use WooShippingAction to POST the package to backend
-        // - if successful, return the package data
-        // - if not, return error
-
-        return .success(packageData)
-    }
-
     @MainActor
     /// Saves custom package as template remotely.
     ///
     func savePackageAsTemplateAction() async -> Result<WooShippingPackageDataRepresentable, Error> {
-        guard let packageData = preparePackageData() else {
+        guard let packageData else {
             return .failure(WooShippingAddCustomPackageViewModel.Error.packageDataNotValid)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -109,6 +109,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.validateCustomPackageInputFields(), false)
+        XCTAssertNil(viewModel.packageData)
     }
 
     @MainActor
@@ -124,6 +125,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.validateCustomPackageInputFields(), true)
+        XCTAssertNotNil(viewModel.packageData)
     }
 
     @MainActor
@@ -148,8 +150,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.validateCustomPackageInputFields(), true)
     }
 
-    @MainActor
-    func test_add_package_action() async {
+    func test_packageData_is_correct() throws {
         // Given
         let dimensionUnit = "cm"
         let weightUnit = "kg"
@@ -170,17 +171,11 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         viewModel.fieldValues[.width] = width
         viewModel.fieldValues[.height] = height
         viewModel.fieldValues[.weight] = weight
-        let packageDataResult = await viewModel.addPackageAction()
 
         // Then
-        switch packageDataResult {
-        case .success(let packageData):
-            XCTAssertNotNil(packageData)
-            XCTAssertEqual(packageData.dimensionsDescription(unit: dimensionUnit), expectedDimensions)
-            XCTAssertEqual(packageData.weightDescription(unit: weightUnit), expectedWeight)
-        case .failure(let failure):
-            XCTFail(failure.localizedDescription)
-        }
+        let packageData = try XCTUnwrap(viewModel.packageData)
+        XCTAssertEqual(packageData.dimensionsDescription(unit: dimensionUnit), expectedDimensions)
+        XCTAssertEqual(packageData.weightDescription(unit: weightUnit), expectedWeight)
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14880 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an alert for when saving custom package fails. The alert has CTAs to either dismiss the alert or proceed with the creation flow without saving the package.

Additionally, the logic for confirming custom packages without saving was also simplified since there is no remote request to make in this case.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a test store with Woo Shipping set up.
- Select an order with a physical product that's eligible to create shipping labels.
- Select the Create shipping label button to start the creation flow > Add a package.
- Enter dimensions for the package and enable saving the package as a template.
- Enter the name and weight for the package.
- Disable the Internet connection and tap Add Package Details.
- When the request times out, confirm that an alert is displayed about the failed saving.
- Confirm that tapping Save dismisses the alert, and tapping Proceed navigates back to the creation flow with the package details selected.
- Optional: Confirm that adding custom package without saving still works correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 for the above test case and confirmed that the alert works as expected.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/f457380a-a32b-4b03-9399-582b1269d919" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
