### PR TITLE
Improve accessibility for login flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 21.9
 -----
 - [*] Product Form: Reset uploaded images upon discarding changes [https://github.com/woocommerce/woocommerce-ios/pull/15265]
+- [*] Improved accessibility on login flow [https://github.com/woocommerce/woocommerce-ios/pull/15281]
 
 
 21.8

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.xib
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,11 +36,11 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="0a6-Ee-KF8">
                             <rect key="frame" x="20" y="20" width="374" height="190"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mXN-0a-h6C" userLabel="Action Button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="mXN-0a-h6C" userLabel="Action Button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="374" height="50"/>
                                     <color key="backgroundColor" red="0.58823529409999997" green="0.34509803919999998" blue="0.54117647059999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="vyG-JP-b9F"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="vyG-JP-b9F"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <state key="normal" title="Enter Your Store Address"/>
@@ -51,11 +51,11 @@
                                         <action selector="addStoreWasPressed" destination="-1" eventType="touchUpInside" id="ceu-IF-kAI"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0KD-hY-YaS" userLabel="Action Button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0KD-hY-YaS" userLabel="Action Button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="70" width="374" height="50"/>
                                     <color key="backgroundColor" red="0.58823529409999997" green="0.34509803919999998" blue="0.54117647059999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="Bue-lt-N74"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="Bue-lt-N74"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <state key="normal" title="Continue"/>
@@ -66,10 +66,10 @@
                                         <action selector="actionWasPressed" destination="-1" eventType="touchUpInside" id="xAv-sT-ofI"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Slo-h4-7qY" userLabel="secondary action button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="Slo-h4-7qY" userLabel="secondary action button" customClass="FancyAnimatedButton" customModule="WooCommerce" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="140" width="374" height="50"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="HG6-bp-QRu"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="HG6-bp-QRu"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <state key="normal" title="Try another account">

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -89,10 +89,7 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                                            <rect key="frame" x="0.0" y="92" width="320" height="277"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" id="gTk-ha-fYx"/>
-                                            </constraints>
+                                            <rect key="frame" x="16" y="92" width="288" height="277"/>
                                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -139,7 +136,9 @@
                                         </stackView>
                                     </subviews>
                                     <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="a2d-le-aKc" secondAttribute="trailing" constant="16" id="2sE-aM-cg8"/>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" id="PDa-3m-ZOR"/>
+                                        <constraint firstItem="a2d-le-aKc" firstAttribute="leading" secondItem="Fpu-CN-1IB" secondAttribute="leading" constant="16" id="S1x-6u-6tn"/>
                                         <constraint firstAttribute="trailing" secondItem="A0z-Ng-wf9" secondAttribute="trailing" constant="16" id="bma-eJ-xbp"/>
                                         <constraint firstItem="A0z-Ng-wf9" firstAttribute="leading" secondItem="Fpu-CN-1IB" secondAttribute="leading" constant="16" id="oOI-nb-mf8"/>
                                         <constraint firstItem="kzF-p3-hX2" firstAttribute="width" secondItem="Fpu-CN-1IB" secondAttribute="width" id="qq8-bi-UI8"/>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -58,17 +58,17 @@
                                     <rect key="frame" x="0.0" y="238" width="320" height="443"/>
                                     <subviews>
                                         <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A0z-Ng-wf9">
-                                            <rect key="frame" x="16" y="0.0" width="288" height="52"/>
+                                            <rect key="frame" x="16" y="0.0" width="288" height="60"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zBy-VF-FIv">
-                                                    <rect key="frame" x="16" y="16" width="20" height="20"/>
+                                                    <rect key="frame" x="16" y="20" width="20" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="20" id="986-EL-Yi1"/>
                                                         <constraint firstAttribute="height" constant="20" id="AlD-JX-qxp"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="this-is-a-really-really-long-long-long-store-address.com" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="9" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FBm-iy-87d">
-                                                    <rect key="frame" x="52" y="16" width="220" height="20"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="this-is-a-really-really-long-long-long-store-address.com" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="9" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FBm-iy-87d">
+                                                    <rect key="frame" x="52" y="16" width="220" height="28"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="X3U-aM-aNl"/>
                                                     </constraints>
@@ -80,7 +80,7 @@
                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" secondItem="FBm-iy-87d" secondAttribute="trailing" constant="16" id="30a-ic-95Z"/>
-                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" id="3bF-B3-asS"/>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="3bF-B3-asS"/>
                                                 <constraint firstItem="zBy-VF-FIv" firstAttribute="leading" secondItem="A0z-Ng-wf9" secondAttribute="leading" constant="16" id="Unc-qY-xLv"/>
                                                 <constraint firstItem="zBy-VF-FIv" firstAttribute="centerY" secondItem="FBm-iy-87d" secondAttribute="centerY" id="b06-x7-gE3"/>
                                                 <constraint firstItem="FBm-iy-87d" firstAttribute="top" secondItem="A0z-Ng-wf9" secondAttribute="top" constant="16" id="dsg-ky-000"/>
@@ -89,7 +89,7 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                                            <rect key="frame" x="16" y="92" width="288" height="277"/>
+                                            <rect key="frame" x="16" y="100" width="288" height="269"/>
                                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -38,29 +38,29 @@
                     <rect key="frame" x="0.0" y="48" width="414" height="639"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="16" y="8" width="382" height="623"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="697"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B4M-dS-aoc">
-                                    <rect key="frame" x="71" y="0.0" width="240" height="32"/>
+                                    <rect key="frame" x="87" y="0.0" width="240" height="50"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" id="aVT-0Y-a4a"/>
                                     </constraints>
                                 </view>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                                    <rect key="frame" x="73" y="48" width="236" height="206"/>
+                                    <rect key="frame" x="89" y="66" width="236" height="206"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="206" id="T1N-ra-XOB"/>
                                     </constraints>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="Fpu-CN-1IB">
-                                    <rect key="frame" x="0.0" y="270" width="382" height="252.5"/>
+                                    <rect key="frame" x="0.0" y="288" width="414" height="260.5"/>
                                     <subviews>
                                         <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A0z-Ng-wf9">
-                                            <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="52"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ybM-Zk-Zlr">
-                                                    <rect key="frame" x="28.5" y="16" width="325" height="20"/>
+                                                    <rect key="frame" x="21.5" y="16" width="371.5" height="20"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zBy-VF-FIv">
                                                             <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -70,7 +70,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="this-is-a-really-really-long-long-long-store-address.com" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FBm-iy-87d">
-                                                            <rect key="frame" x="36" y="0.0" width="289" height="20"/>
+                                                            <rect key="frame" x="36" y="0.0" width="335.5" height="20"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" id="X3U-aM-aNl"/>
                                                             </constraints>
@@ -95,7 +95,7 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                                            <rect key="frame" x="3.5" y="92" width="375" height="86.5"/>
+                                            <rect key="frame" x="19.5" y="92" width="375" height="94.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" id="gTk-ha-fYx"/>
                                             </constraints>
@@ -105,20 +105,20 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kzF-p3-hX2">
-                                            <rect key="frame" x="0.0" y="218.5" width="382" height="34"/>
+                                            <rect key="frame" x="0.0" y="226.5" width="414" height="34"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="edC-D9-2TV" userLabel="Separator Line">
-                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="1"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="1"/>
                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="LQ2-ug-9D7"/>
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ZaQ-g1-ch4">
-                                                    <rect key="frame" x="0.0" y="9" width="382" height="16"/>
+                                                    <rect key="frame" x="0.0" y="9" width="414" height="16"/>
                                                     <subviews>
                                                         <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                                                            <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="414" height="16"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                                                             </constraints>
@@ -130,7 +130,7 @@
                                                     </constraints>
                                                 </stackView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6fN-tG-EuB" userLabel="Separator Line">
-                                                    <rect key="frame" x="0.0" y="33" width="382" height="1"/>
+                                                    <rect key="frame" x="0.0" y="33" width="414" height="1"/>
                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="33B-fR-DgO"/>
@@ -152,7 +152,7 @@
                                     </constraints>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QgR-Qw-rQN">
-                                    <rect key="frame" x="71" y="538.5" width="240" height="84.5"/>
+                                    <rect key="frame" x="87" y="564.5" width="240" height="132.5"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" id="I88-gy-QAM"/>
@@ -160,17 +160,20 @@
                                 </view>
                             </subviews>
                             <constraints>
+                                <constraint firstAttribute="height" constant="697" id="2rT-uc-ZeB"/>
+                                <constraint firstItem="B4M-dS-aoc" firstAttribute="leading" secondItem="QgR-Qw-rQN" secondAttribute="leading" id="IRT-eI-vKz"/>
+                                <constraint firstItem="B4M-dS-aoc" firstAttribute="leading" secondItem="jIt-xb-rrN" secondAttribute="leading" constant="87" id="Vce-fG-Wn9"/>
+                                <constraint firstItem="Fpu-CN-1IB" firstAttribute="leading" secondItem="jIt-xb-rrN" secondAttribute="leadingMargin" id="Z5h-WP-q6u"/>
                                 <constraint firstItem="QgR-Qw-rQN" firstAttribute="height" secondItem="B4M-dS-aoc" secondAttribute="height" multiplier="2.65" id="qsV-Ak-vb0"/>
                             </constraints>
                         </stackView>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="zV2-0c-gPq" secondAttribute="leading" constant="16" id="0Eq-QA-zAD"/>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="zV2-0c-gPq" secondAttribute="top" constant="8" id="59x-ea-Hwz"/>
-                        <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="16" id="JMi-tB-A1k"/>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="width" secondItem="400-04-ig6" secondAttribute="width" constant="-32" id="JXw-Lb-9aQ"/>
-                        <constraint firstItem="zV2-0c-gPq" firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="8" id="Xa5-Tq-WWH"/>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="bottom" secondItem="ZYw-uz-r4k" secondAttribute="bottom" id="new-bottom-constraint"/>
+                        <constraint firstItem="zV2-0c-gPq" firstAttribute="width" secondItem="jIt-xb-rrN" secondAttribute="width" id="1wM-w6-VSm"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="ZYw-uz-r4k" secondAttribute="top" id="2D1-Dr-Cqx"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="ZYw-uz-r4k" secondAttribute="leading" id="Eev-aL-4kl"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="bottom" secondItem="ZYw-uz-r4k" secondAttribute="bottom" id="Qef-PJ-vLo"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="trailing" secondItem="ZYw-uz-r4k" secondAttribute="trailing" id="vVQ-Kn-iJk"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="ZYw-uz-r4k"/>
                     <viewLayoutGuide key="frameLayoutGuide" id="zV2-0c-gPq"/>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
+    <accessibilityOverrides isEnabled="YES" dynamicTypePreference="10"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
@@ -31,71 +32,64 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="400-04-ig6">
-                    <rect key="frame" x="0.0" y="48" width="414" height="639"/>
+                    <rect key="frame" x="0.0" y="20" width="320" height="373"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="697"/>
+                            <rect key="frame" x="0.0" y="0.0" width="320" height="697"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B4M-dS-aoc">
-                                    <rect key="frame" x="87" y="0.0" width="240" height="50"/>
+                                    <rect key="frame" x="87" y="0.0" width="146" height="0.0"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" id="aVT-0Y-a4a"/>
                                     </constraints>
                                 </view>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                                    <rect key="frame" x="89" y="66" width="236" height="206"/>
+                                    <rect key="frame" x="42" y="16" width="236" height="206"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="206" id="T1N-ra-XOB"/>
                                     </constraints>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="Fpu-CN-1IB">
-                                    <rect key="frame" x="0.0" y="288" width="414" height="260.5"/>
+                                    <rect key="frame" x="0.0" y="238" width="320" height="443"/>
                                     <subviews>
                                         <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A0z-Ng-wf9">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="52"/>
+                                            <rect key="frame" x="16" y="0.0" width="288" height="52"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ybM-Zk-Zlr">
-                                                    <rect key="frame" x="21.5" y="16" width="371.5" height="20"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zBy-VF-FIv">
-                                                            <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="20" id="986-EL-Yi1"/>
-                                                                <constraint firstAttribute="height" constant="20" id="AlD-JX-qxp"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="this-is-a-really-really-long-long-long-store-address.com" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FBm-iy-87d">
-                                                            <rect key="frame" x="36" y="0.0" width="335.5" height="20"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" id="X3U-aM-aNl"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                    </subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zBy-VF-FIv">
+                                                    <rect key="frame" x="16" y="16" width="20" height="20"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="4iz-bG-Qeh"/>
+                                                        <constraint firstAttribute="width" constant="20" id="986-EL-Yi1"/>
+                                                        <constraint firstAttribute="height" constant="20" id="AlD-JX-qxp"/>
                                                     </constraints>
-                                                </stackView>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="this-is-a-really-really-long-long-long-store-address.com" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="9" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FBm-iy-87d">
+                                                    <rect key="frame" x="52" y="16" width="220" height="20"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="X3U-aM-aNl"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
-                                                <constraint firstItem="ybM-Zk-Zlr" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="A0z-Ng-wf9" secondAttribute="leading" constant="16" id="2wR-2t-UDy"/>
+                                                <constraint firstAttribute="trailing" secondItem="FBm-iy-87d" secondAttribute="trailing" constant="16" id="30a-ic-95Z"/>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" id="3bF-B3-asS"/>
-                                                <constraint firstItem="ybM-Zk-Zlr" firstAttribute="top" secondItem="A0z-Ng-wf9" secondAttribute="top" constant="16" id="7kK-fa-mGc"/>
-                                                <constraint firstItem="ybM-Zk-Zlr" firstAttribute="centerX" secondItem="A0z-Ng-wf9" secondAttribute="centerX" id="qe6-AM-nVr"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ybM-Zk-Zlr" secondAttribute="trailing" constant="16" id="tSt-Ob-FnC"/>
-                                                <constraint firstAttribute="bottom" secondItem="ybM-Zk-Zlr" secondAttribute="bottom" constant="16" id="vSo-20-One"/>
+                                                <constraint firstItem="zBy-VF-FIv" firstAttribute="leading" secondItem="A0z-Ng-wf9" secondAttribute="leading" constant="16" id="Unc-qY-xLv"/>
+                                                <constraint firstItem="zBy-VF-FIv" firstAttribute="centerY" secondItem="FBm-iy-87d" secondAttribute="centerY" id="b06-x7-gE3"/>
+                                                <constraint firstItem="FBm-iy-87d" firstAttribute="top" secondItem="A0z-Ng-wf9" secondAttribute="top" constant="16" id="dsg-ky-000"/>
+                                                <constraint firstItem="FBm-iy-87d" firstAttribute="leading" secondItem="zBy-VF-FIv" secondAttribute="trailing" constant="16" id="k2i-uk-r2e"/>
+                                                <constraint firstAttribute="bottom" secondItem="FBm-iy-87d" secondAttribute="bottom" constant="16" id="qI8-hl-hEf"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                                            <rect key="frame" x="19.5" y="92" width="375" height="94.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
+                                            <rect key="frame" x="0.0" y="92" width="320" height="277"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" id="gTk-ha-fYx"/>
                                             </constraints>
@@ -105,20 +99,20 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kzF-p3-hX2">
-                                            <rect key="frame" x="0.0" y="226.5" width="414" height="34"/>
+                                            <rect key="frame" x="0.0" y="409" width="320" height="34"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="edC-D9-2TV" userLabel="Separator Line">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="1"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="320" height="1"/>
                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="LQ2-ug-9D7"/>
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ZaQ-g1-ch4">
-                                                    <rect key="frame" x="0.0" y="9" width="414" height="16"/>
+                                                    <rect key="frame" x="0.0" y="9" width="320" height="16"/>
                                                     <subviews>
                                                         <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                                                            <rect key="frame" x="0.0" y="0.0" width="414" height="16"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="16"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                                                             </constraints>
@@ -130,7 +124,7 @@
                                                     </constraints>
                                                 </stackView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6fN-tG-EuB" userLabel="Separator Line">
-                                                    <rect key="frame" x="0.0" y="33" width="414" height="1"/>
+                                                    <rect key="frame" x="0.0" y="33" width="320" height="1"/>
                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="33B-fR-DgO"/>
@@ -146,17 +140,14 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" id="PDa-3m-ZOR"/>
-                                        <constraint firstAttribute="trailing" secondItem="A0z-Ng-wf9" secondAttribute="trailing" id="bma-eJ-xbp"/>
-                                        <constraint firstItem="A0z-Ng-wf9" firstAttribute="leading" secondItem="Fpu-CN-1IB" secondAttribute="leading" id="oOI-nb-mf8"/>
+                                        <constraint firstAttribute="trailing" secondItem="A0z-Ng-wf9" secondAttribute="trailing" constant="16" id="bma-eJ-xbp"/>
+                                        <constraint firstItem="A0z-Ng-wf9" firstAttribute="leading" secondItem="Fpu-CN-1IB" secondAttribute="leading" constant="16" id="oOI-nb-mf8"/>
                                         <constraint firstItem="kzF-p3-hX2" firstAttribute="width" secondItem="Fpu-CN-1IB" secondAttribute="width" id="qq8-bi-UI8"/>
                                     </constraints>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QgR-Qw-rQN">
-                                    <rect key="frame" x="87" y="564.5" width="240" height="132.5"/>
+                                    <rect key="frame" x="87" y="697" width="146" height="0.0"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" id="I88-gy-QAM"/>
-                                    </constraints>
                                 </view>
                             </subviews>
                             <constraints>
@@ -179,27 +170,27 @@
                     <viewLayoutGuide key="frameLayoutGuide" id="zV2-0c-gPq"/>
                 </scrollView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                    <rect key="frame" x="0.0" y="687" width="414" height="175"/>
+                    <rect key="frame" x="0.0" y="393" width="320" height="175"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                            <rect key="frame" x="16" y="16" width="382" height="139"/>
+                            <rect key="frame" x="16" y="16" width="288" height="139"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button" customClass="ButtonActivityIndicator" customModule="WooCommerce" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="382" height="33"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="288" height="33"/>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <state key="normal" title="Primary Action Button">
                                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
-                                    <rect key="frame" x="0.0" y="53" width="382" height="33"/>
+                                    <rect key="frame" x="0.0" y="53" width="288" height="33"/>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <state key="normal" title="Secondary Action Button">
                                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>
                                 </button>
                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Lorem ipsum" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ao7-ef-q0R">
-                                    <rect key="frame" x="0.0" y="106" width="382" height="33"/>
+                                    <rect key="frame" x="0.0" y="106" width="288" height="33"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <color key="textColor" systemColor="labelColor"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/Password.storyboard
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/Password.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21179.7" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21169.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,16 +12,16 @@
         <!--Password View Controller-->
         <scene sceneID="7Rf-Qz-qsw">
             <objects>
-                <viewController storyboardIdentifier="PasswordViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="PasswordViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PasswordViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="PasswordViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFS-Ic-byk" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="561"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="541"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
@@ -29,12 +29,12 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xwA-rd-6jO" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="561" width="375" height="106"/>
+                                        <rect key="frame" x="0.0" y="541" width="375" height="106"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="RjB-bg-t6D">
                                                 <rect key="frame" x="16" y="8" width="343" height="90"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
@@ -47,7 +47,7 @@
                                                             <action selector="handleContinueButtonTapped:" destination="aQT-Gx-U3x" eventType="touchUpInside" id="Yeh-8i-cow"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IAk-wS-Gex" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="IAk-wS-Gex" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="60" width="343" height="30"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" title="Button"/>

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,26 +19,25 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ciD-RW-w3b">
-                        <rect key="frame" x="16" y="12" width="286" height="48"/>
+                        <rect key="frame" x="16" y="12" width="286" height="52"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="5X7-in-Ybt">
-                                <rect key="frame" x="0.0" y="0.0" width="286" height="48"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="5X7-in-Ybt">
+                                <rect key="frame" x="0.0" y="0.0" width="286" height="52"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
+                                        <rect key="frame" x="0.0" y="2" width="48" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="48" id="BHy-vU-hNn"/>
-                                            <constraint firstAttribute="width" secondItem="odI-Gb-fXa" secondAttribute="height" multiplier="1:1" id="McZ-Z1-Yaf"/>
                                             <constraint firstAttribute="height" constant="48" id="u4Z-Cy-2ey"/>
                                         </constraints>
                                     </imageView>
                                     <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
-                                        <rect key="frame" x="59" y="0.0" width="227" height="48"/>
+                                        <rect key="frame" x="59" y="2" width="227" height="48"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" staticText="YES"/>
                                         </accessibility>
                                         <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="axC-0i-jGu"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="48" id="axC-0i-jGu"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <textInputTraits key="textInputTraits" textContentType="username"/>

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -10,6 +10,9 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     @IBOutlet private weak var button: UIButton!
     @IBOutlet private weak var borderView: UIView!
     @IBOutlet private weak var borderWidth: NSLayoutConstraint!
+    @IBOutlet private weak var iconViewWidth: NSLayoutConstraint!
+    @IBOutlet private weak var iconTrailingPadding: NSLayoutConstraint!
+
     @IBAction private func textLinkButtonTapped(_ sender: UIButton) {
         actionHandler?()
     }
@@ -44,8 +47,12 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         borderView.isHidden = !showBorder
 
         iconView.image = icon
-        iconView.isHidden = icon == nil
         iconView.tintColor = buttonTitleColor
+
+        let noIcon = icon == nil
+        iconView.isHidden = noIcon
+        iconViewWidth.constant = noIcon ? 0 : Constants.iconWidth
+        iconTrailingPadding.constant = noIcon ? 0 : Constants.iconTrailingPadding
     }
 
     /// Toggle button enabled / disabled
@@ -72,5 +79,7 @@ private extension TextLinkButtonTableViewCell {
 extension TextLinkButtonTableViewCell {
     struct Constants {
         static let passkeysID = "Passkeys"
+        static let iconWidth: CGFloat = 20
+        static let iconTrailingPadding: CGFloat = 16
     }
 }

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <accessibilityOverrides isEnabled="YES" dynamicTypePreference="9"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,40 +12,30 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextLinkButtonTableViewCell" id="KGk-i7-Jjw" userLabel="TextLinkButtonTableViewCell" customClass="TextLinkButtonTableViewCell" customModule="WordPressAuthenticator">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="46"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextLinkButtonTableViewCell" rowHeight="109" id="KGk-i7-Jjw" userLabel="TextLinkButtonTableViewCell" customClass="TextLinkButtonTableViewCell" customModule="WordPressAuthenticator">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="109"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="46"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="109"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ago-9i-5Yl">
-                        <rect key="frame" x="16" y="11" width="288" height="22"/>
-                        <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="phone-icon" translatesAutoresizingMaskIntoConstraints="NO" id="ku4-hw-2bT">
-                                <rect key="frame" x="0.0" y="0.0" width="22" height="22"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="ku4-hw-2bT" secondAttribute="height" multiplier="1:1" id="Ys5-4A-JpX"/>
-                                </constraints>
-                            </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ofe-LL-CbC">
-                                <rect key="frame" x="30" y="0.0" width="258" height="22"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="ejX-sY-dNm"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                <state key="normal" title="Button"/>
-                                <connections>
-                                    <action selector="textLinkButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="nY9-jd-WF5"/>
-                                </connections>
-                            </button>
-                        </subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="phone-icon" translatesAutoresizingMaskIntoConstraints="NO" id="ku4-hw-2bT">
+                        <rect key="frame" x="16" y="44" width="20" height="20"/>
                         <constraints>
-                            <constraint firstItem="ku4-hw-2bT" firstAttribute="centerY" secondItem="ofe-LL-CbC" secondAttribute="centerY" id="kBp-hz-l1i"/>
+                            <constraint firstAttribute="width" constant="20" id="A1L-c0-MvS"/>
+                            <constraint firstAttribute="width" secondItem="ku4-hw-2bT" secondAttribute="height" multiplier="1:1" id="Ys5-4A-JpX"/>
                         </constraints>
-                    </stackView>
+                    </imageView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ofe-LL-CbC">
+                        <rect key="frame" x="52" y="12" width="252" height="84"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                        <state key="normal" title="Find your store address"/>
+                        <connections>
+                            <action selector="textLinkButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="nY9-jd-WF5"/>
+                        </connections>
+                    </button>
                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xr7-80-xLk">
-                        <rect key="frame" x="16" y="44" width="304" height="1"/>
+                        <rect key="frame" x="16" y="107" width="304" height="1"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="0TA-3S-RTi"/>
@@ -53,12 +44,14 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="xr7-80-xLk" secondAttribute="trailing" id="4bK-tU-GZP"/>
-                    <constraint firstAttribute="leadingMargin" secondItem="ago-9i-5Yl" secondAttribute="leading" id="CSN-gf-0XX"/>
-                    <constraint firstItem="xr7-80-xLk" firstAttribute="top" secondItem="ago-9i-5Yl" secondAttribute="bottom" constant="11" id="ODh-6H-4EG"/>
+                    <constraint firstItem="ku4-hw-2bT" firstAttribute="centerY" secondItem="ofe-LL-CbC" secondAttribute="centerY" id="5xX-Ag-xrb"/>
+                    <constraint firstItem="ofe-LL-CbC" firstAttribute="leading" secondItem="ku4-hw-2bT" secondAttribute="trailing" constant="16" id="DEp-Y8-70w"/>
+                    <constraint firstItem="ofe-LL-CbC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="Ej1-Ns-I82"/>
+                    <constraint firstItem="xr7-80-xLk" firstAttribute="top" secondItem="ofe-LL-CbC" secondAttribute="bottom" constant="11" id="Jka-S8-cgt"/>
                     <constraint firstItem="xr7-80-xLk" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Pub-Ud-xHo"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="ago-9i-5Yl" secondAttribute="trailing" id="bka-VO-kqR"/>
                     <constraint firstAttribute="bottom" secondItem="xr7-80-xLk" secondAttribute="bottom" constant="1" id="fbb-di-NHu"/>
-                    <constraint firstItem="ago-9i-5Yl" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="nQJ-ZD-9pa"/>
+                    <constraint firstItem="ku4-hw-2bT" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="is8-at-H6J"/>
+                    <constraint firstAttribute="trailing" secondItem="ofe-LL-CbC" secondAttribute="trailing" constant="16" id="yvI-xG-wvV"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -69,9 +62,11 @@
                 <outlet property="borderView" destination="xr7-80-xLk" id="tw4-jZ-ity"/>
                 <outlet property="borderWidth" destination="0TA-3S-RTi" id="HYi-5W-eNL"/>
                 <outlet property="button" destination="ofe-LL-CbC" id="lDp-3a-YIR"/>
+                <outlet property="iconTrailingPadding" destination="DEp-Y8-70w" id="sFG-Ju-Tdx"/>
                 <outlet property="iconView" destination="ku4-hw-2bT" id="vHS-gu-3vo"/>
+                <outlet property="iconViewWidth" destination="A1L-c0-MvS" id="cgA-R6-fmj"/>
             </connections>
-            <point key="canvasLocation" x="131.8840579710145" y="146.65178571428569"/>
+            <point key="canvasLocation" x="131.8840579710145" y="167.07589285714286"/>
         </tableViewCell>
     </objects>
     <resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15116 
Also closes: #14629 
Also closes: #14974 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses accessibility issues during the login and Jetpack setup flow. Changes include:
- Updated constraints on `ULErrorViewController` that caused the scroll view to not work.
- Removed the fixed height of the buttons on the store picker screen.
- Updated the button on the password screen to allow word-wrapping in the title label.
- Updated the text link button used in the login flow to allow showing all content by replacing the stack view.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: Set the device text to a larger size, e.g. 190%.
Testing login flow:

1. Open the app to the login screen (log out if needed first).
2. Enter a non-WordPress URL and confirm that the error screen text is not truncated and the button labels are shown properly.
3. Enter the URL for a Jetpack-connected store, and then enter an email address that is not registered at WordPress.com. Verify that the email error screen has all-visible button labels.
4. Log in to a non-WooCommerce, Jetpack-connected site and verify that the button labels on the WordPress.com email screen do not overflow the available space.
5. On the password screen, verify that the magic link button label is not truncated.
6. On the non-WooCommerce site error screen, verify that the button label is not truncated.
7. Tap "See Connected Stores" and verify the login button label is not truncated.
8. Log in to an account with 2FA and verify that the "Text me a code" button label is not truncated.


Step 3|Step 4|Step 5|Step 6|Step 7|Step 8
-|-|-|-|-|-
![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 18 10 09](https://github.com/user-attachments/assets/a54a6027-6fda-44ee-93e4-a83af8d12829) | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 18 03 39](https://github.com/user-attachments/assets/e8752d4b-0dde-48cf-9c01-f3e266b0d313) | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 18 20 14](https://github.com/user-attachments/assets/ed4b6f55-082d-4d2c-bc20-c21290ac27a7) | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 18 09 08](https://github.com/user-attachments/assets/d221b474-ab33-4698-9ef3-cb74817197aa) | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 19 35 59](https://github.com/user-attachments/assets/e49e5294-dbc2-405b-9e77-ce7ea96336f2) | ![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 19 07 59](https://github.com/user-attachments/assets/fac12401-3b74-4afc-82c4-6c448ad84b15)


Testing Jetpack setup:

1. Log in to a test store.
2. Navigate to the hub menu and open the store picker.
3. Select Connect an existing store and enter a store address.
4. Enter the address of an Woo store without Jetpack.
5. Confirm that the Connect Jetpack screen can be scrolled properly.

<img src="https://github.com/user-attachments/assets/94da396e-db36-40ea-8e14-5c45e3cfb564" width=320 />


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed all the test cases above.




---


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
