### PR TITLE
[Woo POS]Track new cash events

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -139,6 +139,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleViewDocsTapped,
             WooAnalyticsStat.pointOfSaleReaderReadyForCardPayment,
             WooAnalyticsStat.pointOfSaleCashCollectPaymentSuccess,
+            WooAnalyticsStat.pointOfSaleCashPaymentTapped,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -140,6 +140,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleReaderReadyForCardPayment,
             WooAnalyticsStat.pointOfSaleCashCollectPaymentSuccess,
             WooAnalyticsStat.pointOfSaleCashPaymentTapped,
+            WooAnalyticsStat.pointOfSaleCashPaymentFailed,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1277,6 +1277,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleCheckoutTapped = "checkout_tapped"
     case pointOfSaleBackToCartTapped = "back_to_cart_tapped"
     case pointOfSaleCashPaymentTapped = "cash_payment_tapped"
+    case pointOfSaleCashPaymentFailed = "cash_payment_failed"
     case pointOfSaleBackToCheckoutFromCashTapped = "back_to_checkout_from_cash"
     case pointOfSaleClearCartTapped = "clear_cart_tapped"
     case pointOfSaleExitMenuItemTapped = "exit_menu_item_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1276,6 +1276,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleItemRemovedFromCart = "item_removed_from_cart"
     case pointOfSaleCheckoutTapped = "checkout_tapped"
     case pointOfSaleBackToCartTapped = "back_to_cart_tapped"
+    case pointOfSaleCashPaymentTapped = "cash_payment_tapped"
     case pointOfSaleBackToCheckoutFromCashTapped = "back_to_checkout_from_cash"
     case pointOfSaleClearCartTapped = "clear_cart_tapped"
     case pointOfSaleExitMenuItemTapped = "exit_menu_item_tapped"

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -152,8 +152,11 @@ protocol PointOfSaleOrderControllerProtocol {
                                                  fields: fieldsToUpdate,
                                                  onCompletion: { [weak self] result in
                 guard let self = self else { return }
-                if case .success = result {
+                switch result {
+                case .success:
                     self.celebrate()
+                case .failure:
+                    analytics.track(.pointOfSaleCashPaymentFailed)
                 }
                 continuation.resume(with: result)
             })

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -253,6 +253,7 @@ extension PointOfSaleAggregateModel {
     // Once we get the callback from the card service, we switch to cash collection state
     @MainActor
     func startCashPayment() async {
+        analytics.track(.pointOfSaleCashPaymentTapped)
         try? await cardPresentPaymentService.cancelPayment()
         paymentState = .cash(.collectingCash)
     }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -406,6 +406,51 @@ struct PointOfSaleOrderControllerTests {
             // Then
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "order_creation_failed" }) != nil)
         }
+
+        @MainActor
+        @available(iOS 17.0, *)
+        @Test func collectCashPayment_when_failure_tracks_correct_event() async throws {
+            // Given
+            // In order to test the order controller failure we need to succeed first in both having a site and creating a successful order
+            // which requires quite a bit of setup:
+            let sampleSiteID: Int64 = 1234
+            let mockStores = MockStoresManager(sessionManager: .testingInstance)
+            mockStores.sessionManager.setStoreId(sampleSiteID)
+
+            let mockOrderService = MockPOSOrderService()
+            let mockAnalyticsProvider = MockAnalyticsProvider()
+            let mockAnalytics = WooAnalytics(analyticsProvider: mockAnalyticsProvider)
+
+            let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                                 receiptService: MockReceiptService(),
+                                                 stores: mockStores,
+                                                 analytics: mockAnalytics)
+
+            let orderItem = OrderItem.fake()
+            let fakeOrder = Order.fake().copy(items: [orderItem])
+            mockOrderService.orderToReturn = fakeOrder
+            await sut.syncOrder(for: [makeItem()], retryHandler: {})
+
+            // When
+            let completionResult: Bool = await withCheckedContinuation { continuation in
+                mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                    switch action {
+                    case let .updateOrder(_, _, _, _, onCompletion):
+                        onCompletion(.failure(NSError(domain: "oops", code: -1)))
+                        continuation.resume(returning: true)
+                    default:
+                        #expect(Bool(false), "Unexpected action \(action)")
+                    }
+                }
+                Task { @MainActor in
+                    try await sut.collectCashPayment()
+                }
+            }
+
+            // Then
+            #expect(completionResult == true)
+            #expect(mockAnalyticsProvider.receivedEvents.first(where: { $0 == "cash_payment_failed" }) != nil)
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -432,12 +432,12 @@ struct PointOfSaleOrderControllerTests {
             await sut.syncOrder(for: [makeItem()], retryHandler: {})
 
             // When
-            let completionResult: Bool = await withCheckedContinuation { continuation in
+            await withCheckedContinuation { continuation in
                 mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
                     switch action {
                     case let .updateOrder(_, _, _, _, onCompletion):
                         onCompletion(.failure(NSError(domain: "oops", code: -1)))
-                        continuation.resume(returning: true)
+                        continuation.resume()
                     default:
                         #expect(Bool(false), "Unexpected action \(action)")
                     }
@@ -448,7 +448,6 @@ struct PointOfSaleOrderControllerTests {
             }
 
             // Then
-            #expect(completionResult == true)
             #expect(mockAnalyticsProvider.receivedEvents.first(where: { $0 == "cash_payment_failed" }) != nil)
         }
     }

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -869,6 +869,24 @@ struct PointOfSaleAggregateModelTests {
             // Then
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "back_to_checkout_from_cash" }) != nil)
         }
+
+        @available(iOS 17.0, *)
+        @Test func startCashPayment_when_invoked_tracks_expected_event() async throws {
+            // Given
+            let mockAnalyticsProvider = MockAnalyticsProvider()
+            let mockAnalytics = WooAnalytics(analyticsProvider: mockAnalyticsProvider)
+            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+                                                cardPresentPaymentService: MockCardPresentPaymentService(),
+                                                orderController: MockPointOfSaleOrderController(),
+                                                analytics: mockAnalytics,
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+
+            // When
+            await sut.startCashPayment()
+
+            // Then
+            #expect(mockAnalyticsProvider.receivedEvents.first(where: { $0 == "cash_payment_tapped" }) != nil)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15270 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->


## Description
This PR adds two new cash events to POS, ref: pdfdoF-6hn-p2#comment-7662
- `pos_cash_payment_tapped`
- `pos_cash_payment_failed`


## Testing information
1. On success:
  * In POS, process a cash-paid order. Upon tapping the cash collection button in the totals view, observe the `pos_cash_payment_tapped` tapped message is logged in the console:

```
🔵 Tracked pos_cash_payment_tapped, properties: [was_ecommerce_trial: false, blog_id: -1, site_url: https://indiemelon.mystagingwebsite.com, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, plan: , is_wpcom_store: false]
```

2. On failure:
  * In `OrderStore`, within `func updateOrder(siteID: Int64, ...` force a failure from the service by returning some error like `return onCompletion(.failure(NSError(domain: "oops", code: -1)))`
  * In POS, attempt to process a cash-paid order, observe it fails and the event `pos_cash_payment_failed` is logged:
```
🔵 Tracked pos_cash_payment_failed, properties: [blog_id: -1, plan: , store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, is_wpcom_store: false, was_ecommerce_trial: false, site_url: https://indiemelon.mystagingwebsite.com]
```

🐰  @coderabbitai review

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
