### PR TITLE
[Shipping Labels] Fix showing obsolete rates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -85,8 +85,13 @@ final class WooShippingServiceViewModel: ObservableObject {
                                                       orderID: orderID,
                                                       originAddress: originAddress,
                                                       destinationAddress: destinationAddress,
-                                                      packages: [selectedPackage]) { [weak self] result in
-            guard let self else { return }
+                                                      packages: [selectedPackage]) { [weak self] remotePackages, result in
+            guard let self,
+                  /// Avoids showing the obsolete rates if the user changes the package weight while loading.
+                  [self.selectedPackage] == remotePackages else {
+                return
+            }
+
             switch result {
             case let .success(rates):
                 guard let rates = rates.first(where: { $0.packageID == selectedPackage.id }) else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -504,9 +504,9 @@ private extension WooShippingCreateLabelsViewModel {
             .sink { [weak self] destinationAddress in
                 guard let self else { return }
                 let shippingService = WooShippingServiceViewModel(order: order,
-                                                              originAddress: selectedOriginAddress?.toWooShippingAddress(),
-                                                              destinationAddress: destinationAddress,
-                                                              stores: stores) { [weak self] selectedRate in
+                                                                  originAddress: selectedOriginAddress?.toWooShippingAddress(),
+                                                                  destinationAddress: destinationAddress,
+                                                                  stores: stores) { [weak self] selectedRate in
                     self?.selectedRate = selectedRate
                 }
                 self.shippingService = shippingService

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -655,8 +655,8 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
                 isPurchasingLabelDuringPurchase = viewModel.isPurchasingLabel
                 completion(.success(ShippingLabel.fake()))
-            case let .loadLabelRates(_, _, _, _, _, completion):
-                completion(.success([]))
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success([]))
             case .loadAccountSettings(_, let completion):
                 completion(.success(self.settings))
             case .loadPackages, .loadOriginAddresses, .verifyDestinationAddress:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -15,8 +15,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
-            case let .loadLabelRates(_, _, _, _, _, completion):
-                completion(.success(self.sampleLabelRates()))
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success(self.sampleLabelRates()))
             default:
                 XCTFail("Received unexpected action: \(action)")
             }
@@ -99,8 +99,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
-            case let .loadLabelRates(_, _, _, _, _, completion):
-                completion(.failure(NetworkError.timeout()))
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .failure(NetworkError.timeout()))
             default:
                 XCTFail("Received unexpected action: \(action)")
             }
@@ -230,8 +230,8 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
-            case let .loadLabelRates(_, _, _, _, _, completion):
-                completion(.failure(NetworkError.timeout()))
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .failure(NetworkError.timeout()))
             default:
                 XCTFail("Received unexpected action: \(action)")
             }

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -16,12 +16,14 @@ public enum WooShippingAction: Action {
 
     /// Fetch list of shipping label rates for the order.
     ///
+    /// - Sends back the `packages` parameter value along with the result in the completion handler
+    ///
     case loadLabelRates(siteID: Int64,
                         orderID: Int64,
                         originAddress: WooShippingAddress,
                         destinationAddress: WooShippingAddress,
                         packages: [ShippingLabelPackageSelected],
-                        completion: (Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
+                        completion: ([ShippingLabelPackageSelected], Result<[ShippingLabelCarriersAndRates], Error>) -> Void)
 
     /// Fetch list of packages.
     ///

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -116,13 +116,15 @@ private extension WooShippingStore {
                         originAddress: WooShippingAddress,
                         destinationAddress: WooShippingAddress,
                         packages: [ShippingLabelPackageSelected],
-                        completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
+                        completion: @escaping ([ShippingLabelPackageSelected], Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
         remote.loadLabelRates(siteID: siteID,
                               orderID: orderID,
                               originAddress: originAddress,
                               destinationAddress: destinationAddress,
                               packages: packages,
-                              completion: completion)
+                              completion: { result in
+            completion(packages, result)
+        })
     }
 
     func loadPackages(siteID: Int64,

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -251,6 +251,63 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertEqual(error as? NetworkError, expectedError)
     }
 
+    func test_loadLabelRates_returns_sent_packages_on_success() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedRates = sampleLabelRates()
+        remote.whenLoadLabelRates(siteID: sampleSiteID, thenReturn: .success(expectedRates))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        let samplePackage = ShippingLabelPackageSelected.fake().copy(id: "test_package",
+                                                                     boxID: "test_box_id",
+                                                                     length: 11,
+                                                                     width: 12,
+                                                                     height: 10)
+
+        // When
+        let receivedValue: [ShippingLabelPackageSelected] = waitFor { promise in
+            let action = WooShippingAction.loadLabelRates(siteID: self.sampleSiteID,
+                                                          orderID: self.sampleOrderID,
+                                                          originAddress: WooShippingAddress.fake(),
+                                                          destinationAddress: WooShippingAddress.fake(),
+                                                          packages: [samplePackage]) { packages, _ in
+                promise(packages)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(receivedValue, [samplePackage])
+    }
+
+    func test_loadLabelRates_returns_sent_packages_on_failure() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedError = NetworkError.notFound()
+        remote.whenLoadLabelRates(siteID: sampleSiteID, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        let samplePackage = ShippingLabelPackageSelected.fake().copy(id: "test_package",
+                                                                     boxID: "test_box_id",
+                                                                     length: 11,
+                                                                     width: 12,
+                                                                     height: 10)
+        // When
+        let receivedValue: [ShippingLabelPackageSelected] = waitFor { promise in
+            let action = WooShippingAction.loadLabelRates(siteID: self.sampleSiteID,
+                                                          orderID: self.sampleOrderID,
+                                                          originAddress: WooShippingAddress.fake(),
+                                                          destinationAddress: WooShippingAddress.fake(),
+                                                          packages: [samplePackage]) { packages, _ in
+                promise(packages)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(receivedValue, [samplePackage])
+    }
+
     // MARK: `loadPackages`
 
     func test_loadPackages_returns_success_response_with_rates() throws {

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -214,7 +214,7 @@ final class WooShippingStoreTests: XCTestCase {
                                                           orderID: self.sampleOrderID,
                                                           originAddress: WooShippingAddress.fake(),
                                                           destinationAddress: WooShippingAddress.fake(),
-                                                          packages: [ShippingLabelPackageSelected.fake()]) { result in
+                                                          packages: [ShippingLabelPackageSelected.fake()]) { _, result in
                 promise(result)
             }
             store.onAction(action)
@@ -239,7 +239,7 @@ final class WooShippingStoreTests: XCTestCase {
                                                           orderID: self.sampleOrderID,
                                                           originAddress: WooShippingAddress.fake(),
                                                           destinationAddress: WooShippingAddress.fake(),
-                                                          packages: [ShippingLabelPackageSelected.fake()]) { result in
+                                                          packages: [ShippingLabelPackageSelected.fake()]) { _, result in
                 promise(result)
             }
             store.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15302
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Stops showing rates from previously sent network requests. 

Changes
- `WooShippingStore` - Send back the packages sent in the load label rates request. 
- Check that the currently selected package is equal to the package from response before updating UI.
- Unit tests. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with the Woo Shipping plugin set up.
2. Open an existing completed order with at least one physical product.
3. Select Create shipping label > Select package.
4. Change package weights multiple times in a row and use values ranging from zero to non-zero values. 
5. Validate that the rates are loaded for the currently entered package weight. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- Tested that rates are loaded for the current selected package weight. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/bbe54f8b-b47a-4bfc-aad4-664e6284ca3b


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.