### PR TITLE
[Shipping Labels] Show custom error when no label rates available

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -33,7 +33,11 @@ struct WooShippingServiceView: View {
                     MissingDataStateView(title: Localization.noWeightTitle,
                                          message: Localization.noWeightMessage)
                 case WooShippingServiceViewModel.Error.failedLoadingLabelRates:
-                    errorState
+                    ErrorState(message: Localization.failedLoadingDataError) {
+                        if let package = viewModel.selectedPackage {
+                            viewModel.loadLabelRates(for: package)
+                        }
+                    }
                 }
             }
         }
@@ -78,24 +82,6 @@ struct WooShippingServiceView: View {
         .padding(.horizontal, Layout.padding * -1) // Offset the additional padding in TopTabView
     }
 
-    var errorState: some View {
-        VStack(spacing: Layout.padding) {
-            Image(uiImage: .grayErrorIcon)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: Layout.errorIconSize, height: Layout.errorIconSize)
-            Text(Localization.failedLoadingDataError)
-                .multilineTextAlignment(.center)
-            Button(Localization.retryCTA) {
-                if let package = viewModel.selectedPackage {
-                    viewModel.loadLabelRates(for: package)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(WooShippingServiceView.Layout.placeholderPadding)
-    }
-
     var progressView: some View {
         VStack(spacing: Layout.placeholderPadding) {
             Image(uiImage: .wooShippingRatesPlaceholder)
@@ -107,6 +93,31 @@ struct WooShippingServiceView: View {
         .padding(Layout.placeholderPadding)
         .roundedBorder(cornerRadius: 8, lineColor: Color(.border), lineWidth: 1, dashed: true)
         .padding(.vertical, Layout.padding)
+    }
+}
+
+private struct ErrorState: View {
+    let message: String
+    let retryAction: () -> Void
+
+    var body: some View {
+        VStack(spacing: WooShippingServiceView.Layout.padding) {
+            Image(uiImage: .grayErrorIcon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Layout.errorIconSize, height: Layout.errorIconSize)
+            Text(message)
+                .multilineTextAlignment(.center)
+            Button(WooShippingServiceView.Localization.retryCTA) {
+                retryAction()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(WooShippingServiceView.Layout.placeholderPadding)
+    }
+
+    enum Layout {
+        static let errorIconSize: CGFloat = 86
     }
 }
 
@@ -153,7 +164,6 @@ fileprivate extension WooShippingServiceView {
         static let padding: CGFloat = 16
         static let innerSpacing: CGFloat = 8
         static let placeholderPadding: CGFloat = 32
-        static let errorIconSize: CGFloat = 86
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -38,6 +38,12 @@ struct WooShippingServiceView: View {
                             viewModel.loadLabelRates(for: package)
                         }
                     }
+                case .noRatesAvailable:
+                    ErrorState(message: Localization.noRatesAvailable) {
+                        if let package = viewModel.selectedPackage {
+                            viewModel.loadLabelRates(for: package)
+                        }
+                    }
                 }
             }
         }
@@ -197,6 +203,11 @@ private extension WooShippingServiceView {
                                                               value: "We are unable to load shipping rates",
                                                               comment: "Error message when loading shipping label rates "
                                                               + "failed on the shipping label creation screen")
+        static let noRatesAvailable = NSLocalizedString("wooShipping.createLabels.rates.noRatesAvailable",
+                                                        value: "We couldn't find a shipping service for the combination of the selected package "
+                                                        + "and the total shipment weight. Please adjust your input and try again.",
+                                                        comment: "Error message when no shipping rates were found "
+                                                        + "based on the combination of the selected package and the total shipment weight.")
         static let retryCTA = NSLocalizedString("wooShipping.createLabels.rates.retryCTA",
                                                 value: "Retry",
                                                 comment: "Button to retry loading data on the shipping label creation screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -39,11 +39,7 @@ struct WooShippingServiceView: View {
                         }
                     }
                 case .noRatesAvailable:
-                    ErrorState(message: Localization.noRatesAvailable) {
-                        if let package = viewModel.selectedPackage {
-                            viewModel.loadLabelRates(for: package)
-                        }
-                    }
+                    ErrorState(message: Localization.noRatesAvailable)
                 }
             }
         }
@@ -104,7 +100,12 @@ struct WooShippingServiceView: View {
 
 private struct ErrorState: View {
     let message: String
-    let retryAction: () -> Void
+    let retryAction: (() -> Void)?
+
+    init(message: String, retryAction: (() -> Void)? = nil) {
+        self.message = message
+        self.retryAction = retryAction
+    }
 
     var body: some View {
         VStack(spacing: WooShippingServiceView.Layout.padding) {
@@ -114,8 +115,10 @@ private struct ErrorState: View {
                 .frame(width: Layout.errorIconSize, height: Layout.errorIconSize)
             Text(message)
                 .multilineTextAlignment(.center)
-            Button(WooShippingServiceView.Localization.retryCTA) {
-                retryAction()
+            if let retryAction {
+                Button(WooShippingServiceView.Localization.retryCTA) {
+                    retryAction()
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -94,11 +94,13 @@ final class WooShippingServiceViewModel: ObservableObject {
 
             switch result {
             case let .success(rates):
-                guard let rates = rates.first(where: { $0.packageID == selectedPackage.id }) else {
+                guard let rates = rates.first(where: { $0.packageID == selectedPackage.id }),
+                      rates.defaultRates.isNotEmpty else {
                     DDLogError("⛔️ Fetched shipping label rates for Woo Shipping do not include rates for selected package: \(selectedPackage)")
-                    updateLoadingState(to: .error(Error.failedLoadingLabelRates))
+                    updateLoadingState(to: .error(Error.noRatesAvailable))
                     return
                 }
+
                 standardRates = rates.defaultRates
                 signatureRates = rates.signatureRequired
                 adultSignatureRates = rates.adultSignatureRequired
@@ -146,6 +148,7 @@ extension WooShippingServiceViewModel {
         case missingDestinationAddress
         case missingShipmentWeight
         case failedLoadingLabelRates
+        case noRatesAvailable
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -261,6 +261,33 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.loadingState, .error(.missingShipmentWeight))
     }
+
+    func test_when_loadLabelRates_receives_empty_rates_it_sets_error_state() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let emptyRates = [ShippingLabelCarriersAndRates(packageID: Self.samplePackageID,
+                                                        defaultRates: [],
+                                                        signatureRequired: [],
+                                                        adultSignatureRequired: [])]
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success(emptyRates))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
+                                                    destinationAddress: sampleDestinationAddress(),
+                                                    stores: stores)
+
+        // When
+        viewModel.loadLabelRates(for: samplePackage)
+
+        // Then
+        XCTAssertEqual(viewModel.loadingState, .error(.noRatesAvailable))
+    }
 }
 
 private extension WooShippingServiceViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #14885
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Show a custom error message when no label rates are available for the selected package and weight combination.

This error message follows the below web implementation.

<img width="524" alt="image" src="https://github.com/user-attachments/assets/ef8fac7f-f949-425f-9fa3-63611a7ae3f2" />


Changes
- New error case to handle no label rates available case.
- Show custom error message when no label rates are available. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
2. Create an order with multiple products and enter the quantity as more than 100 for each product. Select products with a lot of weight.
3. Open the order detail page on the web and validate that no shipping label rates are available for this order due to the large amount of products and weight. 
3. Open the order detail page from the mobile app. 
4. Select Create shipping label > Select package.
5. Make sure that you see an error message explaining that no label rates are available for this combination of the package and weight. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I validated that a custom error message is displayed when no label rates are available for an order with a high product quantity and weight. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/199a2c19-c7cd-43e3-891a-ccbe7a38c2cd" width="320"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.