### PR TITLE
Enable scrolling in card present modals when it cannot grow in size anymore

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 -----
 - [*] Product Form: Fix crash related to picking photos [https://github.com/woocommerce/woocommerce-ios/pull/15275]
 - [internal] Assign `siteID` and `productID` to image product upload statuses. [https://github.com/woocommerce/woocommerce-ios/pull/15196]
-
+- [*] Payments: Improved payment views' adaptability to larger accessibility font sizes [https://github.com/woocommerce/woocommerce-ios/pull/15328].
 
 21.9
 -----

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccessEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccessEmailSent.swift
@@ -45,7 +45,7 @@ final class CardPresentModalBuiltInSuccessEmailSent: CardPresentPaymentsModalVie
         let attributedString = NSMutableAttributedString(string: formattedMessage)
         if let emailRange = formattedMessage.range(of: email) {
             let nsRange = NSRange(emailRange, in: formattedMessage)
-            attributedString.addAttributes([.font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)], range: nsRange)
+            attributedString.addAttributes([.font: UIFont.preferredFont(forTextStyle: .body).bold], range: nsRange)
         }
         self.bottomAttributedTitle = attributedString
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessEmailSent.swift
@@ -45,7 +45,7 @@ final class CardPresentModalSuccessEmailSent: CardPresentPaymentsModalViewModel 
         let attributedString = NSMutableAttributedString(string: formattedMessage)
         if let emailRange = formattedMessage.range(of: email) {
             let nsRange = NSRange(emailRange, in: formattedMessage)
-            attributedString.addAttributes([.font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)], range: nsRange)
+            attributedString.addAttributes([.font: UIFont.preferredFont(forTextStyle: .body).bold], range: nsRange)
         }
         self.bottomAttributedTitle = attributedString
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -185,14 +185,14 @@ private extension CardPresentPaymentsModalViewController {
     func stylePrimaryButton() {
         primaryButton.applyPrimaryButtonStyle()
         primaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        primaryButton.titleLabel?.minimumScaleFactor = 0.5
+        primaryButton.titleLabel?.minimumScaleFactor = 0.3
         primaryButton.titleLabel?.lineBreakMode = .byClipping
     }
 
     func styleSecondaryButton() {
         secondaryButton.applyPaymentsModalCancelButtonStyle()
         secondaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        secondaryButton.titleLabel?.minimumScaleFactor = 0.5
+        secondaryButton.titleLabel?.minimumScaleFactor = 0.3
         secondaryButton.titleLabel?.lineBreakMode = .byClipping
     }
 
@@ -200,7 +200,7 @@ private extension CardPresentPaymentsModalViewController {
         if viewModel.actionsMode != .secondaryActionAndAuxiliaryButton {
             auxiliaryButton.applyLinkButtonStyle()
         }
-        auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
+        auxiliaryButton.titleLabel?.minimumScaleFactor = 0.3
         auxiliaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
         auxiliaryButton.titleLabel?.lineBreakMode = .byClipping
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -149,10 +149,12 @@ private extension CardPresentPaymentsModalViewController {
 
     func styleTopTitle() {
         topTitleLabel.applyBodyStyle()
+        topTitleLabel.numberOfLines = 0
     }
 
     func styleTopSubtitle() {
         topSubtitleLabel.applyTitleStyle()
+        topSubtitleLabel.numberOfLines = 0
     }
 
     func styleBottomLabels() {
@@ -166,10 +168,12 @@ private extension CardPresentPaymentsModalViewController {
 
     func styleBottomTitle() {
         bottomTitleLabel.applySubheadlineStyle()
+        bottomTitleLabel.numberOfLines = 0
     }
 
     func styleBottomSubtitle() {
         bottomSubtitleLabel.applyFootnoteStyle()
+        bottomSubtitleLabel.numberOfLines = 0
     }
 
     func styleActionButtons() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -15,7 +15,7 @@
                 <outlet property="actionButtonsView" destination="10Z-y1-ZQ6" id="L1z-Zs-L2J"/>
                 <outlet property="auxiliaryButton" destination="maO-19-PuQ" id="cQA-7p-jmo"/>
                 <outlet property="bottomLabels" destination="k73-qi-GuD" id="LvQ-UE-SBc"/>
-                <outlet property="bottomPaddingRegular" destination="lVZ-pu-Fmb" id="CJM-oy-oSx"/>
+                <outlet property="bottomPaddingRegular" destination="aDA-Fr-QSd" id="sGY-Rs-GbK"/>
                 <outlet property="bottomSubtitleLabel" destination="2Sx-5s-f7J" id="Mco-Vu-Li6"/>
                 <outlet property="bottomTitleLabel" destination="oAj-lv-0k9" id="Clc-oi-Ywf"/>
                 <outlet property="buttonsSpacer" destination="OFI-6w-cag" id="Uva-gQ-T7X"/>
@@ -25,6 +25,7 @@
                 <outlet property="mainStackView" destination="jIt-xb-rrN" id="mSC-3J-47R"/>
                 <outlet property="primaryActionButtonsStackView" destination="mhI-fa-Yzw" id="dx9-oe-Pnq"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
+                <outlet property="scrollView" destination="yA2-8g-wqa" id="df0-r6-3Nj"/>
                 <outlet property="secondaryButton" destination="9Ap-Te-Fsi" id="07U-PT-JrQ"/>
                 <outlet property="topSubtitleLabel" destination="aVs-Lf-QTr" id="uKV-ox-li8"/>
                 <outlet property="topTitleLabel" destination="oDv-zz-CTp" id="wIT-XT-OIO"/>
@@ -40,137 +41,180 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
                     <rect key="frame" x="47.5" y="90.5" width="280" height="506"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="16" y="32" width="248" height="458"/>
+                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yA2-8g-wqa">
+                            <rect key="frame" x="0.0" y="0.0" width="280" height="506"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
-                                    <rect key="frame" x="103.5" y="0.0" width="41.5" height="49"/>
+                                <view contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="cT0-IY-TKZ" userLabel="ContentView">
+                                    <rect key="frame" x="0.0" y="0.0" width="280" height="506"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
-                                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="aVs-Lf-QTr">
-                                            <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </stackView>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="1000" image="woo-celebration" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                                    <rect key="frame" x="57" y="81" width="134" height="117"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" relation="lessThanOrEqual" secondItem="Osv-Wo-lxW" secondAttribute="width" multiplier="1:1" id="dDT-H7-4Ey"/>
-                                    </constraints>
-                                </imageView>
-                                <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
-                                    <rect key="frame" x="103.5" y="230" width="41.5" height="49"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAj-lv-0k9">
-                                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Sx-5s-f7J">
-                                            <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </stackView>
-                                <view contentMode="scaleToFill" verticalHuggingPriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="OFI-6w-cag" userLabel="Buttons Spacer">
-                                    <rect key="frame" x="4" y="311" width="240" height="0.0"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                </view>
-                                <view contentMode="scaleToFill" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="0.0" y="343" width="248" height="115"/>
-                                    <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
-                                            <rect key="frame" x="0.0" y="0.0" width="248" height="115"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
+                                            <rect key="frame" x="16" y="32" width="248" height="458"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                                                    <rect key="frame" x="0.0" y="0.0" width="248" height="79"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
+                                                    <rect key="frame" x="103.5" y="0.0" width="41.5" height="49"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
-                                                            <rect key="frame" x="0.0" y="0.0" width="248" height="32"/>
-                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                            <state key="normal" title="Primary Action Button">
-                                                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            </state>
-                                                            <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                            </userDefinedRuntimeAttributes>
-                                                        </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
-                                                            <rect key="frame" x="0.0" y="47" width="248" height="32"/>
-                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                            <state key="normal" title="Secondary Action Button">
-                                                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            </state>
-                                                            <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
-                                                            </userDefinedRuntimeAttributes>
-                                                        </button>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
+                                                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="aVs-Lf-QTr">
+                                                            <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
                                                     </subviews>
                                                 </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
-                                                    <rect key="frame" x="0.0" y="85" width="248" height="30"/>
-                                                    <state key="normal" title="Button"/>
-                                                </button>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="1000" image="woo-celebration" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
+                                                    <rect key="frame" x="57" y="81" width="134" height="117"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" secondItem="Osv-Wo-lxW" secondAttribute="width" multiplier="1:1" id="dDT-H7-4Ey"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
+                                                    <rect key="frame" x="103.5" y="230" width="41.5" height="49"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAj-lv-0k9">
+                                                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Sx-5s-f7J">
+                                                            <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                                <view contentMode="scaleToFill" verticalHuggingPriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="OFI-6w-cag" userLabel="Buttons Spacer">
+                                                    <rect key="frame" x="4" y="311" width="240" height="0.0"/>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                </view>
+                                                <view contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
+                                                    <rect key="frame" x="0.0" y="343" width="248" height="115"/>
+                                                    <subviews>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
+                                                            <rect key="frame" x="0.0" y="0.0" width="248" height="115"/>
+                                                            <subviews>
+                                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="248" height="79"/>
+                                                                    <subviews>
+                                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="248" height="32"/>
+                                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                                            <state key="normal" title="Primary Action Button">
+                                                                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                            </state>
+                                                                            <userDefinedRuntimeAttributes>
+                                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                                            </userDefinedRuntimeAttributes>
+                                                                        </button>
+                                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
+                                                                            <rect key="frame" x="0.0" y="47" width="248" height="32"/>
+                                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                                            <state key="normal" title="Secondary Action Button">
+                                                                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                            </state>
+                                                                            <userDefinedRuntimeAttributes>
+                                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                                                            </userDefinedRuntimeAttributes>
+                                                                        </button>
+                                                                    </subviews>
+                                                                </stackView>
+                                                                <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
+                                                                    <rect key="frame" x="0.0" y="85" width="248" height="30"/>
+                                                                    <state key="normal" title="Button"/>
+                                                                </button>
+                                                            </subviews>
+                                                        </stackView>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstAttribute="bottom" secondItem="o73-de-cj4" secondAttribute="bottom" id="0Lj-9r-YQS"/>
+                                                        <constraint firstItem="o73-de-cj4" firstAttribute="leading" secondItem="10Z-y1-ZQ6" secondAttribute="leading" id="IYM-BA-7mY"/>
+                                                        <constraint firstItem="o73-de-cj4" firstAttribute="top" secondItem="10Z-y1-ZQ6" secondAttribute="top" id="YFA-8t-f2d"/>
+                                                        <constraint firstAttribute="trailing" secondItem="o73-de-cj4" secondAttribute="trailing" id="nhS-Yt-Ser"/>
+                                                    </constraints>
+                                                </view>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="10Z-y1-ZQ6" firstAttribute="leading" secondItem="jIt-xb-rrN" secondAttribute="leading" id="0sg-Uf-xbd"/>
+                                                <constraint firstAttribute="width" constant="248" id="5mF-DG-RgQ"/>
+                                                <constraint firstAttribute="trailing" secondItem="10Z-y1-ZQ6" secondAttribute="trailing" id="Nrr-ur-lj3"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="5mF-DG-RgQ"/>
+                                                </mask>
+                                            </variation>
+                                            <variation key="heightClass=regular-widthClass=regular">
+                                                <mask key="constraints">
+                                                    <include reference="5mF-DG-RgQ"/>
+                                                </mask>
+                                            </variation>
                                         </stackView>
                                     </subviews>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="o73-de-cj4" secondAttribute="bottom" id="0Lj-9r-YQS"/>
-                                        <constraint firstItem="o73-de-cj4" firstAttribute="leading" secondItem="10Z-y1-ZQ6" secondAttribute="leading" id="IYM-BA-7mY"/>
-                                        <constraint firstItem="o73-de-cj4" firstAttribute="top" secondItem="10Z-y1-ZQ6" secondAttribute="top" id="YFA-8t-f2d"/>
-                                        <constraint firstAttribute="trailing" secondItem="o73-de-cj4" secondAttribute="trailing" id="nhS-Yt-Ser"/>
+                                        <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="16" id="BMd-Yq-dB0"/>
+                                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="cT0-IY-TKZ" secondAttribute="top" constant="32" id="JN4-8h-4hn"/>
+                                        <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="cT0-IY-TKZ" secondAttribute="centerX" id="N7x-7X-RKQ"/>
+                                        <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="cT0-IY-TKZ" secondAttribute="leading" constant="16" id="QLV-1Y-pEz"/>
+                                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="16" id="SZJ-2o-CVr"/>
+                                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="42" id="aDA-Fr-QSd"/>
+                                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="cT0-IY-TKZ" secondAttribute="top" constant="42" id="xnl-JS-RF4"/>
                                     </constraints>
+                                    <variation key="default">
+                                        <mask key="constraints">
+                                            <exclude reference="aDA-Fr-QSd"/>
+                                            <exclude reference="xnl-JS-RF4"/>
+                                        </mask>
+                                    </variation>
+                                    <variation key="heightClass=regular-widthClass=regular">
+                                        <mask key="constraints">
+                                            <exclude reference="BMd-Yq-dB0"/>
+                                            <exclude reference="QLV-1Y-pEz"/>
+                                            <exclude reference="SZJ-2o-CVr"/>
+                                            <include reference="aDA-Fr-QSd"/>
+                                            <exclude reference="JN4-8h-4hn"/>
+                                            <include reference="xnl-JS-RF4"/>
+                                        </mask>
+                                    </variation>
                                 </view>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="10Z-y1-ZQ6" firstAttribute="leading" secondItem="jIt-xb-rrN" secondAttribute="leading" id="0sg-Uf-xbd"/>
-                                <constraint firstAttribute="trailing" secondItem="10Z-y1-ZQ6" secondAttribute="trailing" id="Nrr-ur-lj3"/>
-                                <constraint firstAttribute="width" constant="248" id="wyC-vo-Y5l"/>
+                                <constraint firstItem="cT0-IY-TKZ" firstAttribute="width" secondItem="BYO-mz-lgM" secondAttribute="width" id="2ga-AZ-C0H"/>
+                                <constraint firstItem="LNR-4G-y49" firstAttribute="trailing" secondItem="cT0-IY-TKZ" secondAttribute="trailing" id="7SC-O7-PLq"/>
+                                <constraint firstItem="cT0-IY-TKZ" firstAttribute="height" secondItem="LNR-4G-y49" secondAttribute="height" id="Gwr-sw-hyg"/>
+                                <constraint firstAttribute="height" secondItem="cT0-IY-TKZ" secondAttribute="height" priority="251" id="J7f-Gd-tg9"/>
+                                <constraint firstItem="LNR-4G-y49" firstAttribute="leading" secondItem="cT0-IY-TKZ" secondAttribute="leading" id="ZlU-Pp-cCi"/>
+                                <constraint firstItem="LNR-4G-y49" firstAttribute="top" secondItem="cT0-IY-TKZ" secondAttribute="top" id="bTM-Fm-emr"/>
+                                <constraint firstItem="LNR-4G-y49" firstAttribute="bottom" secondItem="cT0-IY-TKZ" secondAttribute="bottom" id="kYK-A0-ApI"/>
                             </constraints>
-                            <variation key="default">
-                                <mask key="constraints">
-                                    <exclude reference="wyC-vo-Y5l"/>
-                                </mask>
-                            </variation>
-                            <variation key="heightClass=regular-widthClass=regular">
-                                <mask key="constraints">
-                                    <include reference="wyC-vo-Y5l"/>
-                                </mask>
-                            </variation>
-                        </stackView>
+                            <viewLayoutGuide key="contentLayoutGuide" id="LNR-4G-y49"/>
+                            <viewLayoutGuide key="frameLayoutGuide" id="BYO-mz-lgM"/>
+                        </scrollView>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="8Tg-Q2-wkH" secondAttribute="leading" constant="16" id="80k-pZ-tsR"/>
+                        <constraint firstAttribute="bottom" secondItem="yA2-8g-wqa" secondAttribute="bottom" id="2oW-Yy-V3j"/>
+                        <constraint firstItem="yA2-8g-wqa" firstAttribute="leading" secondItem="8Tg-Q2-wkH" secondAttribute="leading" id="6gX-Ic-eWO"/>
+                        <constraint firstItem="yA2-8g-wqa" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" id="9pM-f5-AEO"/>
                         <constraint firstAttribute="width" constant="454" id="Apy-47-NLE"/>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="42" id="FxC-xu-ACf"/>
                         <constraint firstAttribute="height" priority="250" constant="382" id="J6m-sz-CD5"/>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="32" id="JLA-XJ-MiD"/>
-                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="16" id="bkK-x1-zVB"/>
-                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="42" id="lVZ-pu-Fmb"/>
+                        <constraint firstItem="cT0-IY-TKZ" firstAttribute="width" secondItem="8Tg-Q2-wkH" secondAttribute="width" id="iBr-cB-W8i"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="382" id="n7H-7U-izh"/>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="8Tg-Q2-wkH" secondAttribute="centerX" id="p6Y-jJ-KuU"/>
+                        <constraint firstAttribute="trailing" secondItem="yA2-8g-wqa" secondAttribute="trailing" id="ou8-S0-DQW"/>
                         <constraint firstAttribute="width" constant="280" id="uaz-2N-7M4"/>
-                        <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="16" id="ufT-Yf-gsb"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="490" id="w7w-an-P9s"/>
                     </constraints>
                     <variation key="default">
                         <mask key="constraints">
                             <exclude reference="Apy-47-NLE"/>
                             <exclude reference="w7w-an-P9s"/>
-                            <exclude reference="lVZ-pu-Fmb"/>
-                            <exclude reference="FxC-xu-ACf"/>
                         </mask>
                     </variation>
                     <variation key="heightClass=regular-widthClass=regular">
@@ -179,12 +223,6 @@
                             <exclude reference="uaz-2N-7M4"/>
                             <exclude reference="n7H-7U-izh"/>
                             <include reference="w7w-an-P9s"/>
-                            <exclude reference="ufT-Yf-gsb"/>
-                            <exclude reference="80k-pZ-tsR"/>
-                            <exclude reference="bkK-x1-zVB"/>
-                            <include reference="lVZ-pu-Fmb"/>
-                            <include reference="FxC-xu-ACf"/>
-                            <exclude reference="JLA-XJ-MiD"/>
                         </mask>
                     </variation>
                 </view>
@@ -199,7 +237,7 @@
                 <constraint firstItem="8Tg-Q2-wkH" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="ixj-rO-M4u"/>
                 <constraint firstItem="8Tg-Q2-wkH" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="npE-Rq-vMx"/>
             </constraints>
-            <point key="canvasLocation" x="137.68115942028987" y="86.383928571428569"/>
+            <point key="canvasLocation" x="136.80000000000001" y="85.907046476761622"/>
         </view>
     </objects>
     <resources>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -25,7 +25,6 @@
                 <outlet property="mainStackView" destination="jIt-xb-rrN" id="mSC-3J-47R"/>
                 <outlet property="primaryActionButtonsStackView" destination="mhI-fa-Yzw" id="dx9-oe-Pnq"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
-                <outlet property="scrollView" destination="yA2-8g-wqa" id="df0-r6-3Nj"/>
                 <outlet property="secondaryButton" destination="9Ap-Te-Fsi" id="07U-PT-JrQ"/>
                 <outlet property="topSubtitleLabel" destination="aVs-Lf-QTr" id="uKV-ox-li8"/>
                 <outlet property="topTitleLabel" destination="oDv-zz-CTp" id="wIT-XT-OIO"/>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15321
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

`CardPresentPaymentsModalViewController` used for all the modals during the card reader connection and payment process may cut some content if it doesn't fit anymore.

`CardPresentPaymentsModalViewController` already has dynamic abilities, since it grows from minimum to maximum size while the content is growing. However, if modals contain a lot of elements with larger dynamic type sizes, then some content may be cut.

## Solution

Wrap modal content in the `UISCrollView`. I had to play around with constraints and priorities to make sure scrolling only kicked in once the modal could not grow in size anymore.

Due to the addition of scroll view, I removed limits of how long the text can be, so it wouldn't be cut or shrunk when dynamic type size grows. 

Additionally, there were issues with button content not fitting. I couldn't quickly figure out why buttons cannot go into multiline so decided to reduce `minimumScaleFactor`. This is not a perfect solution but I don't notice issues with button text being cut-off anymore.

## Possible improvements

There could be more improvements to this solution. For example, growing modal in width, especially on iPad, once a certain accessibility size is reached. We could also put a button container in a separate scroll view. It looks like this is what native iOS alerts do, so both some actions and some content are always visible.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider stating the goal of the workflow instead and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set location permission of Woo app to `Ask next time`
2. Create an order and start pthe ayment process
3. Increase/decrease dynamic type size and confirm different modals grow in size and enable scrolling once the content doesn't fit anymore

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The constraints differ depending on the size class, so I performed testing both at Storyboard level, iPhone 14 Pro 17.7 device, iPad Air M2 18.3 device, and simulator to make sure the changes in layout didn't break anything. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### iPad Device

https://github.com/user-attachments/assets/9917dd65-9ed2-470b-ae2f-658f848ad301

### iPhone Device

https://github.com/user-attachments/assets/c53f4c28-19fe-4fca-b333-78d42902e403

### iPad Simulator

https://github.com/user-attachments/assets/6637fcd6-890b-4a8b-8c62-ec1efa594ab4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.