### PR TITLE
[Woo POS] Coupons: Fetch coupons from local storage

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -141,7 +141,7 @@ protocol PointOfSaleItemsControllerProtocol {
                                                  parentItem: parent,
                                                  pageNumber: pageNumber,
                                                  appendToExistingItems: appendToExistingItems)
-        case .simpleProduct, .variation:
+        case .simpleProduct, .variation, .coupon:
             assertionFailure("Unsupported parent type for loading child items: \(parent)")
             return false
         }
@@ -161,7 +161,8 @@ protocol PointOfSaleItemsControllerProtocol {
 @available(iOS 17.0, *)
 private extension PointOfSaleItemsController {
     func loadPointOfSaleCoupons() {
-        itemProvider.providePointOfSaleCoupons()
+        let posCoupons = itemProvider.providePointOfSaleCoupons()
+        debugPrint(posCoupons)
     }
 }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -160,6 +160,13 @@ protocol PointOfSaleItemsControllerProtocol {
 
 @available(iOS 17.0, *)
 private extension PointOfSaleItemsController {
+    func loadPointOfSaleCoupons() {
+        itemProvider.providePointOfSaleCoupons()
+    }
+}
+
+@available(iOS 17.0, *)
+private extension PointOfSaleItemsController {
     func setLoadingState(base: ItemListBaseItem) {
         switch base {
         case .root:

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -119,6 +119,8 @@ private extension POSItem {
             return CartItem(id: UUID(), item: variation, title: variation.parentProductName, subtitle: variation.name, quantity: 1)
         case .variableParentProduct:
             return nil
+        case .coupon:
+            return nil
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -116,6 +116,8 @@ private struct ItemListRow: View {
             }, label: {
                 VariationCardView(variation: variation)
             })
+        case .coupon:
+            EmptyView()
         }
     }
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -56,6 +56,10 @@ final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
                           name: "Product 1",
                           formattedPrice: "$1.00")
     }
+
+    func providePointOfSaleCoupons() {
+        // no-op
+    }
 }
 
 @available(iOS 17.0, *)

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -57,8 +57,8 @@ final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
                           formattedPrice: "$1.00")
     }
 
-    func providePointOfSaleCoupons() {
-        // no-op
+    func providePointOfSaleCoupons() -> [POSItem] {
+        []
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -95,11 +95,13 @@ final class HubMenuViewModel: ObservableObject {
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
 
     private(set) lazy var posItemProvider: PointOfSaleItemServiceProtocol = {
+        let storage = ServiceLocator.storageManager
         let currencySettings = ServiceLocator.currencySettings
 
         return PointOfSaleItemService(siteID: siteID,
                                       currencySettings: currencySettings,
-                                      credentials: credentials)
+                                      credentials: credentials,
+                                      storage: storage)
     }()
 
     private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -45,6 +45,10 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
 
         return .init(items: MockPointOfSaleItemService.makeInitialVariationItems(), hasMorePages: shouldSimulateTwoPagesOfVariations)
     }
+
+    func providePointOfSaleCoupons() -> [Yosemite.POSItem] {
+        []
+    }
 }
 
 extension MockPointOfSaleItemService {

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		6801E41A2D1002CE00F9DF46 /* POSReceiptServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6801E4192D1002CC00F9DF46 /* POSReceiptServiceTests.swift */; };
 		6801E41C2D1007D200F9DF46 /* MockPOSReceiptsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6801E41B2D1007D000F9DF46 /* MockPOSReceiptsRemote.swift */; };
 		681D952B28E0F62B00C4039E /* CustomerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681D952A28E0F62B00C4039E /* CustomerAction.swift */; };
+		6823533F2D82A90C00F24470 /* POSCoupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6823533E2D82A90A00F24470 /* POSCoupon.swift */; };
 		687F83722C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */; };
 		6889089F28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6889089E28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift */; };
 		6898F3742C0842150039F10A /* PointOfSaleItemServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */; };
@@ -806,6 +807,7 @@
 		6801E4192D1002CC00F9DF46 /* POSReceiptServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSReceiptServiceTests.swift; sourceTree = "<group>"; };
 		6801E41B2D1007D000F9DF46 /* MockPOSReceiptsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSReceiptsRemote.swift; sourceTree = "<group>"; };
 		681D952A28E0F62B00C4039E /* CustomerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerAction.swift; sourceTree = "<group>"; };
+		6823533E2D82A90A00F24470 /* POSCoupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCoupon.swift; sourceTree = "<group>"; };
 		687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemServiceTests.swift; sourceTree = "<group>"; };
 		6889089E28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Customer+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemServiceProtocol.swift; sourceTree = "<group>"; };
@@ -1532,6 +1534,7 @@
 		6898F3722C0840FE0039F10A /* PointOfSale */ = {
 			isa = PBXGroup;
 			children = (
+				6823533E2D82A90A00F24470 /* POSCoupon.swift */,
 				6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */,
 				68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */,
 				027ADB6B2D1BF3AD009608DB /* POSVariableParentProduct.swift */,
@@ -2664,6 +2667,7 @@
 				86BB4C962B89FCF30096E92D /* CustomerFilter.swift in Sources */,
 				247CE84A2583246800F9D9D1 /* MockOrderStatusActionHandler.swift in Sources */,
 				B9AECD402850FE4600E78584 /* Order+CardPresentPayment.swift in Sources */,
+				6823533F2D82A90C00F24470 /* POSCoupon.swift in Sources */,
 				7492FADB217FAE4D00ED2C69 /* SiteSetting+ReadOnlyType.swift in Sources */,
 				209AD3CE2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift in Sources */,
 				DEDA8DAF2B1847C80076BF0F /* WordPressThemeStore.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
@@ -1,0 +1,5 @@
+
+public struct POSCoupon: Equatable, Hashable {
+    public let id: UUID
+    public let couponID: Int64
+}

--- a/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
@@ -1,4 +1,3 @@
-
 public struct POSCoupon: Equatable, Hashable {
     public let id: UUID
     public let couponID: Int64

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -7,6 +7,7 @@ import class Networking.AlamofireNetwork
 import enum Alamofire.AFError
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
+import Storage
 
 public enum PointOfSaleItemServiceError: Error, Equatable {
     case requestFailed
@@ -21,20 +22,27 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     private let currencyFormatter: CurrencyFormatter
     private let productsRemote: ProductsRemote
     private let variationRemote: ProductVariationsRemoteProtocol
+    private let storage: StorageManagerType
 
-    public init(siteID: Int64, currencySettings: CurrencySettings, network: Network) {
+    public init(siteID: Int64,
+                currencySettings: CurrencySettings,
+                network: Network,
+                storage: StorageManagerType) {
         self.siteID = siteID
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.productsRemote = ProductsRemote(network: network)
         self.variationRemote = ProductVariationsRemote(network: network)
+        self.storage = storage
     }
 
     public convenience init(siteID: Int64,
                             currencySettings: CurrencySettings,
-                            credentials: Credentials?) {
+                            credentials: Credentials?,
+                            storage: StorageManagerType) {
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
-                  network: AlamofireNetwork(credentials: credentials))
+                  network: AlamofireNetwork(credentials: credentials),
+                  storage: storage)
     }
 
     /// Provides a list of products for the Point of Sale, by fetching simple products from the remote, applying any eligibility criteria,
@@ -88,6 +96,26 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             )
         } catch AFError.explicitlyCancelled {
             throw PointOfSaleItemServiceError.requestCancelled
+        }
+    }
+
+    // TODO:
+    // gh-15326 - Map coupons and return PagedItems<POSItem> to be used in POS
+    public func providePointOfSaleCoupons() {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
+                                          ascending: false)
+
+        let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
+                                                                matching: predicate,
+                                                                sortedBy: [descriptor])
+
+        do {
+            try resultsController.performFetch()
+            let coupons = resultsController.fetchedObjects
+            debugPrint("Coupons: \(coupons)")
+        } catch {
+            debugPrint(error)
         }
     }
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -100,8 +100,8 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     }
 
     // TODO:
-    // gh-15326 - Map coupons and return PagedItems<POSItem> to be used in POS
-    public func providePointOfSaleCoupons() {
+    // gh-15326 - Return PagedItems<POSItem> instead.
+    public func providePointOfSaleCoupons() -> [POSItem] {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
                                           ascending: false)
@@ -112,10 +112,17 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
 
         do {
             try resultsController.performFetch()
-            let coupons = resultsController.fetchedObjects
-            debugPrint("Coupons: \(coupons)")
+            let storeCoupons = resultsController.fetchedObjects
+            return mapCouponsToPOSItems(coupons: storeCoupons)
         } catch {
             debugPrint(error)
+            return []
+        }
+    }
+
+    private func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
+        coupons.compactMap { coupon in
+                .coupon(POSCoupon(id: UUID(), couponID: coupon.couponID))
         }
     }
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemService.swift
@@ -22,12 +22,12 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     private let currencyFormatter: CurrencyFormatter
     private let productsRemote: ProductsRemote
     private let variationRemote: ProductVariationsRemoteProtocol
-    private let storage: StorageManagerType
+    private let storage: StorageManagerType?
 
     public init(siteID: Int64,
                 currencySettings: CurrencySettings,
                 network: Network,
-                storage: StorageManagerType) {
+                storage: StorageManagerType? = nil) {
         self.siteID = siteID
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.productsRemote = ProductsRemote(network: network)
@@ -102,6 +102,9 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
     // TODO:
     // gh-15326 - Return PagedItems<POSItem> instead.
     public func providePointOfSaleCoupons() -> [POSItem] {
+        guard let storage = storage else {
+            return []
+        }
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
                                           ascending: false)

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -55,6 +55,7 @@ public extension Sequence where Element == POSOrderableItem {
 public protocol PointOfSaleItemServiceProtocol {
     func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem>
     func providePointOfSaleVariationItems(for parentProduct: POSVariableParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem>
+    func providePointOfSaleCoupons()
 }
 
 // Default implementation for convenience, so we do not need to pass the first page explicitly

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleItemServiceProtocol.swift
@@ -4,6 +4,7 @@ public enum POSItem: Equatable, Identifiable, Hashable {
     case simpleProduct(POSSimpleProduct)
     case variableParentProduct(POSVariableParentProduct)
     case variation(POSVariation)
+    case coupon(POSCoupon)
 
     public var id: UUID {
         switch self {
@@ -13,6 +14,8 @@ public enum POSItem: Equatable, Identifiable, Hashable {
             return parentProduct.id
         case .variation(let variation):
             return variation.id
+        case .coupon(let coupon):
+            return coupon.id
         }
     }
 }
@@ -55,7 +58,7 @@ public extension Sequence where Element == POSOrderableItem {
 public protocol PointOfSaleItemServiceProtocol {
     func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem>
     func providePointOfSaleVariationItems(for parentProduct: POSVariableParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem>
-    func providePointOfSaleCoupons()
+    func providePointOfSaleCoupons() -> [POSItem]
 }
 
 // Default implementation for convenience, so we do not need to pass the first page explicitly


### PR DESCRIPTION
Closes: #15350   

## Description
This PR starts the work to allow coupons usage into POS by fetching them from the site's local storage. This is a small initial step to reuse what we already have in place, and we might move data fetching entirely to the remote API ([task](https://github.com/woocommerce/woocommerce-ios/issues/15324)) depending on exploration as we progress.

Ideally, the item provider will deal with these, and the POS will have no knowledge of where the data comes from, it will just have access to an array of `POSItem` and these could come over the network, from device, o from somewhere else.

Some caveats from this approach:
- If the merchant hasn't fetched coupons previously in the app, no coupons would be stored.
- If the merchant has disabled coupons in WooCommerce settings, depending the flows they've followed in the app, these could have been sync and flushed results in local storage, so no coupons would be stored.

## Testing information
- In `PointOfSaleItemsController` init, add `loadPointOfSaleCoupons()`
- Using a store with coupons enabled in WC settings, assure that we have coupons in local storage by going to Menu > Coupons
- Run the app, load POS, observe the console showing coupons converted to minimal POSItem objects:
> [
Yosemite.POSItem.coupon(Yosemite.POSCoupon(id: 0EB6B480-27B9-4C36-8C1D-585C9863013A, couponID: 3015)), 
Yosemite.POSItem.coupon(Yosemite.POSCoupon(id: FBC69D84-8554-4DEF-BB8D-D1FDE76F0073, couponID: 1171)), 
Yosemite.POSItem.coupon(Yosemite.POSCoupon(id: 61E54C37-2B2E-494D-9116-058DC5FBDD2B, couponID: 1155)), 
Yosemite.POSItem.coupon(Yosemite.POSCoupon(id: 8E750EEF-6D4C-4BD1-A4C9-2A71D84D87AB, couponID: 1153)), 
...

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.

@coderabbitai review
