### PR TITLE
Shipping Labels: Initial navigation for HAZMAT row

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmat.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmat.swift
@@ -5,18 +5,23 @@ struct WooShippingHazmat: View {
     let enabled: Bool
 
     var body: some View {
-        AdaptiveStack {
-            Text(Localization.hazmatLabel)
-                .bodyStyle()
-            Spacer()
-            Text("No") // TODO: Replace with actual hazmat selection for package
-                .secondaryBodyStyle()
-            if enabled {
-                Image(uiImage: .chevronImage) // TODO: Replace with actual navigation to hazmat declaration screen
+        Button(action: {
+            // TODO: show sheet
+        }) {
+            AdaptiveStack {
+                Text(Localization.hazmatLabel)
+                    .bodyStyle()
+                Spacer()
+                Text("No") // TODO: Replace with actual hazmat selection for package
                     .secondaryBodyStyle()
+                if enabled {
+                    Image(uiImage: .chevronImage) // TODO: Replace with actual navigation to hazmat declaration screen
+                        .secondaryBodyStyle()
+                }
             }
+            .padding(.vertical, Layout.verticalPadding)
         }
-        .padding(.vertical, Layout.verticalPadding)
+        .buttonStyle(.plain)
         .disabled(!enabled)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct WooShippingHazmatDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Binding private var isHazardous: Bool
+
+    init(isHazardous: Binding<Bool>) {
+        self._isHazardous = isHazardous
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack {
+                HStack {
+                    Button(Localization.cancel) {
+                        dismiss()
+                    }
+                    .padding(.vertical)
+                    Spacer()
+                }
+
+                Text(Localization.title)
+                    .secondaryTitleStyle()
+                    .bold()
+
+                Spacer()
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+private extension WooShippingHazmatDetailView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "wooShippingHazmatDetailView.title",
+            value: "Are you shipping dangerous goods or hazardous materials?",
+            comment: "Title of the HAZMAT detail view in the shipping label creation flow"
+        )
+        static let cancel = NSLocalizedString(
+            "wooShippingHazmatDetailView.cancel",
+            value: "Cancel",
+            comment: "Button to dismiss the HAZMAT detail view in the shipping label creation flow"
+        )
+    }
+}
+
+#Preview {
+    WooShippingHazmatDetailView(isHazardous: .constant(true))
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct WooShippingHazmat: View {
+struct WooShippingHazmatRow: View {
     /// Whether the interactions (navigation/setting selection) are enabled.
     let enabled: Bool
 
@@ -26,7 +26,7 @@ struct WooShippingHazmat: View {
     }
 }
 
-private extension WooShippingHazmat {
+private extension WooShippingHazmatRow {
     enum Layout {
         static let backgroundRadius: CGFloat = 8
         static let verticalPadding: CGFloat = 24
@@ -40,6 +40,6 @@ private extension WooShippingHazmat {
 }
 
 #Preview {
-    WooShippingHazmat(enabled: true)
+    WooShippingHazmatRow(enabled: true)
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -6,6 +6,8 @@ struct WooShippingHazmatRow: View {
 
     @Binding private var isHazardous: Bool
 
+    @State private var isShowingDetailView = false
+
     init(isHazardous: Binding<Bool>, enabled: Bool) {
         self._isHazardous = isHazardous
         self.enabled = enabled
@@ -13,7 +15,7 @@ struct WooShippingHazmatRow: View {
 
     var body: some View {
         Button(action: {
-            // TODO: show sheet
+            isShowingDetailView = true
         }) {
             AdaptiveStack {
                 Text(Localization.hazmatLabel)
@@ -29,6 +31,9 @@ struct WooShippingHazmatRow: View {
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
+        .sheet(isPresented: $isShowingDetailView) {
+            WooShippingHazmatDetailView(isHazardous: $isHazardous)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -2,7 +2,14 @@ import SwiftUI
 
 struct WooShippingHazmatRow: View {
     /// Whether the interactions (navigation/setting selection) are enabled.
-    let enabled: Bool
+    private let enabled: Bool
+
+    @Binding private var isHazardous: Bool
+
+    init(isHazardous: Binding<Bool>, enabled: Bool) {
+        self._isHazardous = isHazardous
+        self.enabled = enabled
+    }
 
     var body: some View {
         Button(action: {
@@ -12,12 +19,11 @@ struct WooShippingHazmatRow: View {
                 Text(Localization.hazmatLabel)
                     .bodyStyle()
                 Spacer()
-                Text("No") // TODO: Replace with actual hazmat selection for package
+                Text(isHazardous ? Localization.yes : Localization.no)
                     .secondaryBodyStyle()
-                if enabled {
-                    Image(uiImage: .chevronImage) // TODO: Replace with actual navigation to hazmat declaration screen
-                        .secondaryBodyStyle()
-                }
+                Image(uiImage: .chevronImage)
+                    .secondaryBodyStyle()
+                    .renderedIf(enabled)
             }
             .padding(.vertical, Layout.verticalPadding)
         }
@@ -36,10 +42,20 @@ private extension WooShippingHazmatRow {
         static let hazmatLabel = NSLocalizedString("wooShipping.createLabel.hazmatLabel",
                                                    value: "Are you shipping dangerous goods or hazardous materials?",
                                                    comment: "Label for section in shipping label creation to declare when a package contains hazardous materials.")
+        static let yes = NSLocalizedString(
+            "wooShipping.createLabel.hazmatRow.yes",
+            value: "Yes",
+            comment: "Value for section in shipping label creation to declare when a package contains hazardous materials."
+        )
+        static let no = NSLocalizedString(
+            "wooShipping.createLabel.hazmatRow.no",
+            value: "No",
+            comment: "Value for section in shipping label creation to declare when a package does not contain hazardous materials."
+        )
     }
 }
 
 #Preview {
-    WooShippingHazmatRow(enabled: true)
+    WooShippingHazmatRow(isHazardous: .constant(false), enabled: true)
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -44,7 +44,7 @@ private extension WooShippingHazmatRow {
     }
 
     enum Localization {
-        static let hazmatLabel = NSLocalizedString("wooShipping.createLabel.hazmatLabel",
+        static let hazmatLabel = NSLocalizedString("wooShipping.createLabel.hazmatRow.label",
                                                    value: "Are you shipping dangerous goods or hazardous materials?",
                                                    comment: "Label for section in shipping label creation to declare when a package contains hazardous materials.")
         static let yes = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -106,7 +106,7 @@ private extension WooShippingCreateLabelsView {
 
                 WooShippingItems(viewModel: viewModel.items)
 
-                WooShippingHazmat(enabled: !viewModel.canViewLabel)
+                WooShippingHazmatRow(enabled: !viewModel.canViewLabel)
 
                 WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
                                       customsFormViewModel: viewModel.customsFormViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -106,7 +106,8 @@ private extension WooShippingCreateLabelsView {
 
                 WooShippingItems(viewModel: viewModel.items)
 
-                WooShippingHazmatRow(enabled: !viewModel.canViewLabel)
+                WooShippingHazmatRow(isHazardous: $viewModel.containsHazardousMaterials,
+                                     enabled: !viewModel.canViewLabel)
 
                 WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
                                       customsFormViewModel: viewModel.customsFormViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -22,7 +22,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private var debounceDuration: Double = 1
 
     @Published var containsHazardousMaterials = false
-    
+
     @Published var labelPurchaseErrorNotice: Notice?
 
     let order: Order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -21,6 +21,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private var subscriptions: Set<AnyCancellable> = []
     private var debounceDuration: Double = 1
 
+    @Published var containsHazardousMaterials = false
+    
     @Published var labelPurchaseErrorNotice: Notice?
 
     let order: Order

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2793,6 +2793,7 @@
 		DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */; };
 		DEC0293A29C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */; };
 		DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */; };
+		DEC17AE02D82C513005A6E6D /* WooShippingHazmatDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC17ADF2D82C513005A6E6D /* WooShippingHazmatDetailView.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
 		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
 		DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */; };
@@ -5994,6 +5995,7 @@
 		DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationWebViewController.swift; sourceTree = "<group>"; };
 		DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationViewModel.swift; sourceTree = "<group>"; };
 		DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmails.swift; sourceTree = "<group>"; };
+		DEC17ADF2D82C513005A6E6D /* WooShippingHazmatDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingHazmatDetailView.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
 		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
 		DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInput.swift; sourceTree = "<group>"; };
@@ -12338,6 +12340,7 @@
 			isa = PBXGroup;
 			children = (
 				CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmatRow.swift */,
+				DEC17ADF2D82C513005A6E6D /* WooShippingHazmatDetailView.swift */,
 			);
 			path = "WooShipping Hazmat Section";
 			sourceTree = "<group>";
@@ -15554,6 +15557,7 @@
 				025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */,
 				EE9D031B2B89E4470077CED1 /* FilterOrdersByProduct+Analytics.swift in Sources */,
 				20C6E7512CDE4AEA00CD124C /* ItemListState.swift in Sources */,
+				DEC17AE02D82C513005A6E6D /* WooShippingHazmatDetailView.swift in Sources */,
 				86967D812B4E21C600C20CA8 /* BlazeAddParameterViewModel.swift in Sources */,
 				EE45E2B92A409BA40085F227 /* ProductDescriptionAITooltipUseCase.swift in Sources */,
 				DE02ABBA2B56981C008E0AC4 /* BlazeConfirmPaymentView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2361,7 +2361,7 @@
 		CE755F752D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE755F742D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift */; };
 		CE755F772D4A79C8002539F6 /* WooShippingAddress+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE755F762D4A79C2002539F6 /* WooShippingAddress+Woo.swift */; };
 		CE7B4A582CA191FB00F764EB /* WooShippingItemRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */; };
-		CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */; };
+		CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmatRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmatRow.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
 		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
@@ -5561,7 +5561,7 @@
 		CE755F742D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingNormalizeAddressViewModelTests.swift; sourceTree = "<group>"; };
 		CE755F762D4A79C2002539F6 /* WooShippingAddress+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooShippingAddress+Woo.swift"; sourceTree = "<group>"; };
 		CE7B4A572CA191F400F764EB /* WooShippingItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRowViewModelTests.swift; sourceTree = "<group>"; };
-		CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingHazmat.swift; sourceTree = "<group>"; };
+		CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmatRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingHazmatRow.swift; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
@@ -12337,7 +12337,7 @@
 		CE7B4A592CA1BF7800F764EB /* WooShipping Hazmat Section */ = {
 			isa = PBXGroup;
 			children = (
-				CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmat.swift */,
+				CE7B4A5A2CA1BF9900F764EB /* WooShippingHazmatRow.swift */,
 			);
 			path = "WooShipping Hazmat Section";
 			sourceTree = "<group>";
@@ -15967,7 +15967,7 @@
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,
 				03B9E5272A14EA89005C77F5 /* CardReaderSupportDeterminer.swift in Sources */,
 				DEF8CF1629A8C2EB00800A60 /* AdminRoleRequiredView.swift in Sources */,
-				CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmat.swift in Sources */,
+				CE7B4A5B2CA1BF9900F764EB /* WooShippingHazmatRow.swift in Sources */,
 				0258B4D82B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift in Sources */,
 				DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */,
 				DE69C54D27BB719A000BB888 /* CouponRestrictions.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15312 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the navigation from the HAZMAT row on the shipping label creation form to a new detail screen. The screen UI will be updated in a separate PR.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store with Woo Shipping plugin set up.
- Open an existing order in completed status with one or more physical products.
- Select Create shipping label.
- Tap the HAZMAT row and confirm that a new screen for HAZMAT is presented.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 in both portrait and landscape mode and confirmed that the navigation works correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/4ea33972-1e06-4693-9104-f77cea55f712



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
