### PR TITLE
Add site related info to survey URLs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Product Form: Fix crash related to picking photos [https://github.com/woocommerce/woocommerce-ios/pull/15275]
 - [internal] Assign `siteID` and `productID` to image product upload statuses. [https://github.com/woocommerce/woocommerce-ios/pull/15196]
 - [*] Payments: Improved payment views' adaptability to larger accessibility font sizes [https://github.com/woocommerce/woocommerce-ios/pull/15328].
+- [internal] Add site related properties to crowdsignal surveys. [https://github.com/woocommerce/woocommerce-ios/pull/15353]
 
 21.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -69,33 +69,40 @@ extension SurveyViewController {
         case orderFormShippingLines
 
         fileprivate var url: URL {
-            switch self {
-            case .inAppFeedback:
-                return WooConstants.URLs.inAppFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-            case .productsFeedback:
-                return WooConstants.URLs.productsFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-            case .addOnsI1:
-                return WooConstants.URLs.orderAddOnI1Feedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-            case .orderCreation:
-                return WooConstants.URLs.orderCreationFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-            case .orderFormShippingLines:
-                return WooConstants.URLs.orderCreationShippingFeedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagAppVersion(Bundle.main.bundleVersion())
-            }
+            let url: URL = {
+                switch self {
+                case .inAppFeedback:
+                    return WooConstants.URLs.inAppFeedback
+                        .asURL()
+                        .tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion())
+                case .productsFeedback:
+                    return WooConstants.URLs.productsFeedback
+                        .asURL()
+                        .tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion())
+                case .addOnsI1:
+                    return WooConstants.URLs.orderAddOnI1Feedback
+                        .asURL()
+                        .tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion())
+                case .orderCreation:
+                    return WooConstants.URLs.orderCreationFeedback
+                        .asURL()
+                        .tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion())
+                case .orderFormShippingLines:
+                    return WooConstants.URLs.orderCreationShippingFeedback
+                        .asURL()
+                        .tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion())
+                }
+            }()
+
+            let session = ServiceLocator.stores.sessionManager
+            return url.tagSiteInfo(siteID: session.defaultSite?.siteID,
+                                   storeUUID: session.defaultStoreUUID,
+                                   storeURL: session.defaultSite?.url)
         }
 
         fileprivate var title: String {

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -74,35 +74,28 @@ extension SurveyViewController {
                 case .inAppFeedback:
                     return WooConstants.URLs.inAppFeedback
                         .asURL()
-                        .tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion())
                 case .productsFeedback:
                     return WooConstants.URLs.productsFeedback
                         .asURL()
-                        .tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion())
                 case .addOnsI1:
                     return WooConstants.URLs.orderAddOnI1Feedback
                         .asURL()
-                        .tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion())
                 case .orderCreation:
                     return WooConstants.URLs.orderCreationFeedback
                         .asURL()
-                        .tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion())
                 case .orderFormShippingLines:
                     return WooConstants.URLs.orderCreationShippingFeedback
                         .asURL()
-                        .tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion())
                 }
             }()
 
             let session = ServiceLocator.stores.sessionManager
-            return url.tagSiteInfo(siteID: session.defaultSite?.siteID,
-                                   storeUUID: session.defaultStoreUUID,
-                                   storeURL: session.defaultSite?.url)
+            return url
+                .tagPlatform("ios")
+                .tagAppVersion(Bundle.main.bundleVersion())
+                .tagSiteInfo(siteID: session.defaultSite?.siteID,
+                             storeUUID: session.defaultStoreUUID,
+                             storeURL: session.defaultSite?.url)
         }
 
         fileprivate var title: String {

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -185,6 +185,9 @@ extension URL {
     private enum Tags {
         static let surveyRequestPlatformTag = "woo-mobile-platform"
         static let surveyRequestAppVersionTag = "app-version"
+        static let surveyRequestSiteIdTag = "site-id"
+        static let surveyRequestStoreUUIDTag = "store-id"
+        static let surveyRequestStoreURLTag = "store-url"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -168,6 +168,22 @@ extension URL {
         appendingQueryItem(URLQueryItem(name: Tags.surveyRequestAppVersionTag, value: version))
     }
 
+    func tagSiteInfo(siteID: Int64?,
+                     storeUUID: String?,
+                     storeURL: String?) -> URL {
+        var url = self
+        if let siteID = siteID {
+            url = url.appendingQueryItem(URLQueryItem(name: Tags.surveyRequestSiteIdTag, value: "\(siteID)"))
+        }
+        if let storeUUID = storeUUID {
+            url = url.appendingQueryItem(URLQueryItem(name: Tags.surveyRequestStoreUUIDTag, value: storeUUID))
+        }
+        if let storeURL = storeURL {
+            url = url.appendingQueryItem(URLQueryItem(name: Tags.surveyRequestStoreURLTag, value: storeURL))
+        }
+        return url
+    }
+
     private func appendingQueryItem(_ queryItem: URLQueryItem) -> URL {
         guard var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
             assertionFailure("Cannot create URL components from \(self)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -3,11 +3,32 @@ import WebKit
 import XCTest
 import TestKit
 
+@testable import Yosemite
 @testable import WooCommerce
 
 /// Test cases for `SurveyViewController`.
 ///
 final class SurveyViewControllerTests: XCTestCase {
+    private let siteID: Int64 = 123
+    private let testURL = "https://example.com"
+    private let storeUUID = "8363cd24-2501-463f-b21b-649315a0d507"
+
+    override func setUp() {
+        super.setUp()
+
+        let site = Site.fake().copy(siteID: siteID, url: testURL)
+        let storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                              isWPCom: true,
+                                                                              defaultSite: site,
+                                                                              defaultStoreUUID: storeUUID))
+        ServiceLocator.setStores(storesManager)
+    }
+
+    override func tearDown() {
+        ServiceLocator.setStores(MockStoresManager(sessionManager: .testingInstance))
+
+        super.tearDown()
+    }
 
     func test_it_loads_the_correct_inApp_feedback_survey() throws {
         // Given
@@ -19,7 +40,10 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL().tagPlatform("ios").tagAppVersion(Bundle.main.bundleVersion()))
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL()
+            .tagPlatform("ios")
+            .tagAppVersion(Bundle.main.bundleVersion())
+            .tagSiteInfo(siteID: siteID, storeUUID: storeUUID, storeURL: testURL))
     }
 
     func test_it_loads_the_correct_product_feedback_survey() throws {
@@ -32,8 +56,9 @@ final class SurveyViewControllerTests: XCTestCase {
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
         XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsFeedback
-                        .asURL().tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion()))
+                        .asURL()            .tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion())
+                        .tagSiteInfo(siteID: siteID, storeUUID: storeUUID, storeURL: testURL))
     }
 
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -40,7 +40,8 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL()
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback
+            .asURL()
             .tagPlatform("ios")
             .tagAppVersion(Bundle.main.bundleVersion())
             .tagSiteInfo(siteID: siteID, storeUUID: storeUUID, storeURL: testURL))
@@ -56,9 +57,10 @@ final class SurveyViewControllerTests: XCTestCase {
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
         XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsFeedback
-                        .asURL()            .tagPlatform("ios")
-                        .tagAppVersion(Bundle.main.bundleVersion())
-                        .tagSiteInfo(siteID: siteID, storeUUID: storeUUID, storeURL: testURL))
+            .asURL()
+            .tagPlatform("ios")
+            .tagAppVersion(Bundle.main.bundleVersion())
+            .tagSiteInfo(siteID: siteID, storeUUID: storeUUID, storeURL: testURL))
     }
 
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
@@ -22,4 +22,18 @@ final class URL_SurveyViewControllerTests: XCTestCase {
 
         XCTAssertEqual(expectedURL, actualURL)
     }
+
+    func test_tagging_site_info_appends_the_correct_tag_data() throws {
+        let siteID: Int64 = 123
+        let testURL = "https://example.com"
+        let storeUUID = "8363cd24-2501-463f-b21b-649315a0d507"
+
+        let expectedURL = "https://testurl.com?site-id=\(siteID)&store-id=\(storeUUID)&store-url=\(testURL)"
+
+        let actualURL = URL(string: "https://testurl.com")?.tagSiteInfo(siteID: siteID,
+                                                                        storeUUID: storeUUID,
+                                                                        storeURL: testURL).absoluteString
+
+        XCTAssertEqual(expectedURL, actualURL)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15288
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Appends `store_id`, `site_id`, and `store_url` to all the crowdsignal urls. Those values are added as [custom tags](https://crowdsignal.com/support/using-custom-tags-to-track-survey-responses/), just as we currently do with appVersionTag and platformTag.

Changes
- Add new string key values for store related tags. Following [this Android code](https://github.com/woocommerce/woocommerce-android/pull/13675/files#diff-996b161809ec7ca8aa70ed437a8e65d2cad3f9785f77f1ecb22bdeb0e647c4aaR103-R105)
- Append site-related tags for all survey URLs
- Unit tests

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Login into the app using a WPCOM account
- Navigate to "Menu" -> "Settings" -> "Send Feedback"
- Fill in the survey and submit. (The survey is a test survey in debug mode and don't worry about the values.)
- Open the survey from crowdsignal by searching for "Woo app - General feedback - TEST survey". Internal - P91TBi-8Cx-p2
- Validate that the site related values are added to the survey response. (Ref example survey screenshot from [the Android PR](https://github.com/woocommerce/woocommerce-android/pull/13675)


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Validated from crowdsignal that the site related values are sent in the test survey. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 16 Pro - 2025-03-13 at 14 55 48](https://github.com/user-attachments/assets/bb44db8e-284c-44c6-8ca3-59039e57b403)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.