### PR TITLE
Shipping Labels: UI for HAZMAT detail screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -24,6 +24,20 @@ struct WooShippingHazmatDetailView: View {
                     .secondaryTitleStyle()
                     .bold()
 
+                Toggle(isOn: $isHazardous) {
+                    Text(Localization.toggleLabel)
+                }
+                .padding()
+
+                Button(Localization.selectCategory) {
+                    // TODO: navigate to category list
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.bottom)
+                .renderedIf(isHazardous)
+
+                Divider()
+
                 Spacer()
             }
             .padding(.horizontal)
@@ -42,6 +56,16 @@ private extension WooShippingHazmatDetailView {
             "wooShippingHazmatDetailView.cancel",
             value: "Cancel",
             comment: "Button to dismiss the HAZMAT detail view in the shipping label creation flow"
+        )
+        static let toggleLabel = NSLocalizedString(
+            "wooShippingHazmatDetailView.switchLabel",
+            value: "Contains hazardous materials",
+            comment: "Label of the toggle on the HAZMAT detail view in the shipping label creation flow"
+        )
+        static let selectCategory = NSLocalizedString(
+            "wooShippingHazmatDetailView.selectCategory",
+            value: "Select Category",
+            comment: "Button to select hazardous material category on the HAZMAT detail view in the shipping label creation flow"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -11,12 +11,12 @@ struct WooShippingHazmatDetailView: View {
 
     var body: some View {
         ScrollView {
-            VStack {
+            VStack(spacing: Constants.verticalSpacing) {
                 HStack {
                     Button(Localization.cancel) {
                         dismiss()
                     }
-                    .padding(.vertical)
+                    .padding(.top)
                     Spacer()
                 }
 
@@ -27,25 +27,67 @@ struct WooShippingHazmatDetailView: View {
                 Toggle(isOn: $isHazardous) {
                     Text(Localization.toggleLabel)
                 }
-                .padding()
 
                 Button(Localization.selectCategory) {
                     // TODO: navigate to category list
                 }
                 .buttonStyle(PrimaryButtonStyle())
-                .padding(.bottom)
                 .renderedIf(isHazardous)
 
                 Divider()
 
+                Text(Localization.detailLine1)
+                AttributedText(detailLine2AttributedString, enablesLinkUnderline: true)
+                AttributedText(detailLine3AttributedString, enablesLinkUnderline: true)
+
                 Spacer()
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal)
         }
     }
 }
 
 private extension WooShippingHazmatDetailView {
+    var detailLine2AttributedString: NSAttributedString {
+        let content = String.localizedStringWithFormat(Localization.detailLine2, Constants.hazmatURL, Localization.searchTool)
+
+        let mutableAttributedText = NSMutableAttributedString(
+            string: content,
+            attributes: [.font: UIFont.body,
+                         .foregroundColor: UIColor.text]
+        )
+
+        mutableAttributedText.setAsLink(textToFind: Constants.hazmatURL,
+                                        linkURL: Constants.hazmatURL)
+        mutableAttributedText.setAsLink(textToFind: Localization.searchTool,
+                                        linkURL: Constants.searchToolURL)
+        return mutableAttributedText
+    }
+
+    var detailLine3AttributedString: NSAttributedString {
+        let content = String.localizedStringWithFormat(Localization.detailLine3, Constants.DHLExpressName)
+
+        let mutableAttributedText = NSMutableAttributedString(
+            string: content,
+            attributes: [.font: UIFont.body,
+                         .foregroundColor: UIColor.text]
+        )
+
+        mutableAttributedText.setAsLink(textToFind: Constants.DHLExpressName,
+                                        linkURL: Constants.DHLExpressURL)
+        return mutableAttributedText
+    }
+}
+
+private extension WooShippingHazmatDetailView {
+    enum Constants {
+        static let verticalSpacing: CGFloat = 16
+        static let hazmatURL = "https://www.usps.com/hazmat"
+        static let searchToolURL = "https://pe.usps.com/hazmat/index"
+        static let DHLExpressName = "DHL Express"
+        static let DHLExpressURL = "https://www.dhl.com/us-en/home/express.html"
+    }
     enum Localization {
         static let title = NSLocalizedString(
             "wooShippingHazmatDetailView.title",
@@ -66,6 +108,31 @@ private extension WooShippingHazmatDetailView {
             "wooShippingHazmatDetailView.selectCategory",
             value: "Select Category",
             comment: "Button to select hazardous material category on the HAZMAT detail view in the shipping label creation flow"
+        )
+        static let detailLine1 = NSLocalizedString(
+            "wooShippingHazmatDetailView.detailLine1",
+            value: "Potentially hazardous material includes items such as batteries, dry ice, " +
+            "flammable liquids, aerosols, ammunition, fireworks, nail polish, perfume, paint, solvents, " +
+            "and more. Hazardous items must ship in separate packages.",
+            comment: "First line of the explanation on the HAZMAT detail view in the shipping label creation flow"
+        )
+        static let detailLine2 = NSLocalizedString(
+            "wooShippingHazmatDetailView.detailLine2",
+            value: "Learn how to securely package, label, and ship HAZMAT through USPS® at " +
+            "%1$@. Determine your product's mailability using the %2$@.",
+            comment: "Second line of the explanation on the HAZMAT detail view in the shipping label creation flow. " +
+            "The placeholders are links to detail pages for HAZMAT."
+        )
+        static let searchTool = NSLocalizedString(
+            "wooShippingHazmatDetailView.searchTool",
+            value: "USPS HAZMAT Search Tool",
+            comment: "Name of the search tool linked on the HAZMAT detail view in the shipping label creation flow."
+        )
+        static let detailLine3 = NSLocalizedString(
+            "wooShippingHazmatDetailView.detailLine3",
+            value: "WooCommerce Shipping does not currently support HAZMAT shipments through %1$@.",
+            comment: "Third line of the explanation on the HAZMAT detail view in the shipping label creation flow. " +
+            "The placeholder is DHL Express."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -39,8 +39,8 @@ struct WooShippingHazmatDetailView: View {
                 Divider()
 
                 Text(Localization.detailLine1)
-                AttributedText(detailLine2AttributedString, enablesLinkUnderline: true)
-                AttributedText(detailLine3AttributedString, enablesLinkUnderline: true)
+                Text(detailLine2AttributedString)
+                Text(detailLine3AttributedString)
 
                 Spacer()
             }
@@ -56,34 +56,49 @@ struct WooShippingHazmatDetailView: View {
 }
 
 private extension WooShippingHazmatDetailView {
-    var detailLine2AttributedString: NSAttributedString {
+    var detailLine2AttributedString: AttributedString {
         let content = String.localizedStringWithFormat(Localization.detailLine2, Constants.hazmatURL, Localization.searchTool)
+        var attributedText = AttributedString(content)
+        attributedText.font = .body
+        attributedText.foregroundColor = Color(.text)
 
-        let mutableAttributedText = NSMutableAttributedString(
-            string: content,
-            attributes: [.font: UIFont.body,
-                         .foregroundColor: UIColor.text]
-        )
+        if let range1 = attributedText.range(of: Constants.hazmatURL),
+           let url = URL(string: Constants.hazmatURL) {
+            var linkContainer = AttributeContainer()
+                .link(url)
+                .foregroundColor(Color.accentColor)
+            linkContainer.underlineStyle = .single
+            attributedText[range1].mergeAttributes(linkContainer)
+        }
 
-        mutableAttributedText.setAsLink(textToFind: Constants.hazmatURL,
-                                        linkURL: Constants.hazmatURL)
-        mutableAttributedText.setAsLink(textToFind: Localization.searchTool,
-                                        linkURL: Constants.searchToolURL)
-        return mutableAttributedText
+        if let range2 = attributedText.range(of: Localization.searchTool),
+           let url = URL(string: Constants.searchToolURL) {
+            var linkContainer = AttributeContainer()
+                .link(url)
+                .foregroundColor(Color.accentColor)
+            linkContainer.underlineStyle = .single
+            attributedText[range2].mergeAttributes(linkContainer)
+        }
+        return attributedText
     }
 
-    var detailLine3AttributedString: NSAttributedString {
+    var detailLine3AttributedString: AttributedString {
         let content = String.localizedStringWithFormat(Localization.detailLine3, Constants.DHLExpressName)
 
-        let mutableAttributedText = NSMutableAttributedString(
-            string: content,
-            attributes: [.font: UIFont.body,
-                         .foregroundColor: UIColor.text]
-        )
+        var attributedText = AttributedString(content)
+        attributedText.font = .body
+        attributedText.foregroundColor = Color(.text)
 
-        mutableAttributedText.setAsLink(textToFind: Constants.DHLExpressName,
-                                        linkURL: Constants.DHLExpressURL)
-        return mutableAttributedText
+        if let range = attributedText.range(of: Constants.DHLExpressName),
+           let url = URL(string: Constants.DHLExpressURL) {
+            var linkContainer = AttributeContainer()
+                .link(url)
+                .foregroundColor(Color.accentColor)
+            linkContainer.underlineStyle = .single
+            attributedText[range].mergeAttributes(linkContainer)
+        }
+
+        return attributedText
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -5,6 +5,8 @@ struct WooShippingHazmatDetailView: View {
 
     @Binding private var isHazardous: Bool
 
+    @State private var detailURL: URL?
+
     init(isHazardous: Binding<Bool>) {
         self._isHazardous = isHazardous
     }
@@ -43,6 +45,11 @@ struct WooShippingHazmatDetailView: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .environment(\.openURL, OpenURLAction { url in
+                detailURL = url
+                return .handled
+            })
+            .safariSheet(url: $detailURL)
             .padding(.horizontal)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -25,6 +25,7 @@ struct WooShippingHazmatDetailView: View {
                 Text(Localization.title)
                     .secondaryTitleStyle()
                     .bold()
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 Toggle(isOn: $isHazardous) {
                     Text(Localization.toggleLabel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -39,12 +39,14 @@ struct WooShippingHazmatDetailView: View {
                 Divider()
 
                 Text(Localization.detailLine1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 Text(detailLine2AttributedString)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 Text(detailLine3AttributedString)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 Spacer()
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             .environment(\.openURL, OpenURLAction { url in
                 detailURL = url
                 return .handled

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -12,48 +12,51 @@ struct WooShippingHazmatDetailView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: Constants.verticalSpacing) {
-                HStack {
-                    Button(Localization.cancel) {
-                        dismiss()
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: Constants.verticalSpacing) {
+
+                    Text(Localization.title)
+                        .secondaryTitleStyle()
+                        .bold()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Toggle(isOn: $isHazardous) {
+                        Text(Localization.toggleLabel)
                     }
-                    .padding(.top)
+
+                    Button(Localization.selectCategory) {
+                        // TODO: navigate to category list
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .renderedIf(isHazardous)
+
+                    Divider()
+
+                    Text(Localization.detailLine1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text(detailLine2AttributedString)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text(detailLine3AttributedString)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
                     Spacer()
                 }
-
-                Text(Localization.title)
-                    .secondaryTitleStyle()
-                    .bold()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Toggle(isOn: $isHazardous) {
-                    Text(Localization.toggleLabel)
+                .environment(\.openURL, OpenURLAction { url in
+                    detailURL = url
+                    return .handled
+                })
+                .safariSheet(url: $detailURL)
+                .padding(.horizontal)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(Localization.cancel) {
+                            dismiss()
+                        }
+                    }
                 }
-
-                Button(Localization.selectCategory) {
-                    // TODO: navigate to category list
-                }
-                .buttonStyle(PrimaryButtonStyle())
-                .renderedIf(isHazardous)
-
-                Divider()
-
-                Text(Localization.detailLine1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text(detailLine2AttributedString)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text(detailLine3AttributedString)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Spacer()
+                .toolbarBackground(Color.clear, for: .navigationBar)
             }
-            .environment(\.openURL, OpenURLAction { url in
-                detailURL = url
-                return .handled
-            })
-            .safariSheet(url: $detailURL)
-            .padding(.horizontal)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15313 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the UI of HAZMAT detail screen by adding the toggle, button, and explanation text. The navigation to the category list will be handled in a separate PR.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a test store with Woo Shipping plugin set up.
- Open a completed order with at least one physical product.
- Select Create shipping label and tap the HAZMAT row.
- Confirm that the presented screen matches the design. Tapping on any link should open an in-app web view.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested the new screen in both light and dark mode using simulator iPhone 16 Pro iOS 18.2 and confirmed that the screen matches the design. Also tested with large font sizes and confirmed that accessibility is good.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Light mode | Dark mode 
--- | ---
<img src="https://github.com/user-attachments/assets/7c8e5811-1748-4a03-8164-88240588ac82" width=320 /> | <img src="https://github.com/user-attachments/assets/ed0ce6d9-db4d-4fab-a22a-74ee4aded083" width=320 />
<img src="https://github.com/user-attachments/assets/035a8e34-05ec-4fb0-8fe8-e0b736059b2e" width=320 /> | <img src="https://github.com/user-attachments/assets/b9a72dd9-6c49-4e16-bf01-5791ae2fc9f0" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
