### PR TITLE
[HACK week] Allow merchants to use their own API keys for AI-powered features

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,6 +95,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backgroundProductImageUpload:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .allowMerchantAIAPIKey:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -204,4 +204,8 @@ public enum FeatureFlag: Int {
     /// Supports uploading product images in background
     ///
     case backgroundProductImageUpload
+
+    /// Allows merchants to use their own API keys for AI-powered features
+    ///
+    case allowMerchantAIAPIKey
 }

--- a/Networking/Networking/Mapper/AIProductMapper.swift
+++ b/Networking/Networking/Mapper/AIProductMapper.swift
@@ -14,4 +14,12 @@ struct AIProductMapper: Mapper {
             .removingSuffix("```")
         return try decoder.decode(AIProduct.self, from: Data(textCompletion.utf8))
     }
+
+    func map(dictionary: [String: Any]) throws -> AIProduct {
+        // For non-network requests we pass [String: Any] to the map() as data, however decoding
+        // relies on mapping to a JetpackAIQueryResponse model, which fails in the direct API usage key
+        let decoder = JSONDecoder()
+        let data = try JSONSerialization.data(withJSONObject: dictionary)
+        return try decoder.decode(AIProduct.self, from: data)
+    }
 }

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -119,9 +119,10 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
             throw URLError(.userAuthenticationRequired)
         }
+        let selectedModel = UserDefaults.standard.string(forKey: "OpenAIModel") ?? "gpt-4o"
 
         let requestBody: [String: Any] = [
-            "model": "gpt-4",
+            "model": selectedModel,
             "messages": [["role": "user", "content": base]],
             "max_tokens": ParameterValue.maxTokens
         ]
@@ -185,6 +186,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
             // TODO: If retrieved here, handle error case
             throw URLError(.userAuthenticationRequired)
         }
+        let selectedModel = UserDefaults.standard.string(forKey: "OpenAIModel") ?? "gpt-4o"
         let prompt = """
         What is the ISO language code of the language used in the below text?
         Do not include any explanations and only provide the ISO language code in your response.
@@ -192,7 +194,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         """
 
         let requestBody: [String: Any] = [
-            "model": "gpt-4o", // TODO: Pass model
+            "model": selectedModel,
             "messages": [["role": "user", "content": prompt]],
             "max_tokens": 400 // TODO: Allow max_tokens. Check why 10. It used ~110 for 2 calls as per https://platform.openai.com/usage
         ]

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeychainAccess
 
 /// Used by backend to track AI-generation usage and measure costs
 public enum GenerativeContentRemoteFeature: String {
@@ -14,6 +15,31 @@ public enum GenerativeContentRemoteResponseFormat: String {
     case text = "text"
 }
 
+public struct AIProviderKeyStorage {
+    private let keychain: Keychain
+
+    public init(keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) {
+        self.keychain = keychain
+    }
+    
+    // Returns the merchant AI API if available
+    public var aiProviderAPIKey: String? {
+        guard let key = keychain.aiProviderAPIKey else {
+            return nil
+        }
+        return key
+    }
+}
+
+private extension Keychain {
+    private static let keychainAIProviderAPIKey = "aiProviderAPIKey"
+    
+    var aiProviderAPIKey: String? {
+        get { self[Keychain.keychainAIProviderAPIKey] }
+        set { self[Keychain.keychainAIProviderAPIKey] = newValue }
+    }
+}
+
 /// Protocol for `GenerativeContentRemote` mainly used for mocking.
 ///
 public protocol GenerativeContentRemoteProtocol {
@@ -21,11 +47,13 @@ public protocol GenerativeContentRemoteProtocol {
     /// - Parameters:
     ///   - siteID: WPCOM ID of the site.
     ///   - base: Prompt for the AI-generated text.
+    ///   - shouldUseMerchantAIKey: If should use the merchant's API key for AI functionalities
     ///   - feature: Used by backend to track AI-generation usage and measure costs
     ///   - responseFormat: enum parameter to specify response format.
     /// - Returns: AI-generated text based on the prompt if Jetpack AI is enabled.
     func generateText(siteID: Int64,
                       base: String,
+                      shouldUseMerchantAIKey: Bool,
                       feature: GenerativeContentRemoteFeature,
                       responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String
 
@@ -33,10 +61,12 @@ public protocol GenerativeContentRemoteProtocol {
     /// - Parameters:
     ///   - siteID: WPCOM ID of the site.
     ///   - string: String from which we should identify the language
+    ///   - shouldUseMerchantAIKey: If should use the merchant's API key for AI functionalities
     ///   - feature: Used by backend to track AI-generation usage and measure costs
     /// - Returns: ISO code of the language
     func identifyLanguage(siteID: Int64,
                           string: String,
+                          shouldUseMerchantAIKey: Bool,
                           feature: GenerativeContentRemoteFeature) async throws -> String
 
     /// Generates a product using provided info
@@ -46,6 +76,7 @@ public protocol GenerativeContentRemoteProtocol {
     ///   - keywords: Keywords describing the product to input for AI prompt
     ///   - language: Language to generate the product details
     ///   - tone: Tone of AI - Represented by `AIToneVoice`
+    ///   - shouldUseMerchantAIKey: If should use the merchant's API key for AI functionalities
     ///   - currencySymbol: Currency symbol to generate product price
     ///   - dimensionUnit: Weight unit to generate product dimensions
     ///   - weightUnit: Weight unit to generate product weight
@@ -57,6 +88,7 @@ public protocol GenerativeContentRemoteProtocol {
                            keywords: String,
                            language: String,
                            tone: String,
+                           shouldUseMerchantAIKey: Bool,
                            currencySymbol: String,
                            dimensionUnit: String?,
                            weightUnit: String?,
@@ -72,24 +104,16 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
     }
 
     private var token: JWToken?
-
-    private var shouldUseMerchantAIAPIKey: Bool {
-        // TODO: Handle case when key non-empty, but disabled
-        guard let key = UserDefaults.standard.string(forKey: "AIProviderAPIKey"), !key.isEmpty else {
-            return false
-        }
-        return true
-    }
+    private var storage: AIProviderKeyStorage = AIProviderKeyStorage()
 
     public func generateText(siteID: Int64,
                              base: String,
+                             shouldUseMerchantAIKey: Bool,
                              feature: GenerativeContentRemoteFeature,
                              responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
-        if shouldUseMerchantAIAPIKey {
-            debugPrint("🍍 Using merchant API key")
+        if shouldUseMerchantAIKey {
             return try await generateTextUsingMerchantAPIKey(base: base, responseFormat: responseFormat)
         } else {
-            debugPrint("🍍 Using Jetpack tunnel")
             return try await generateTextUsingJetpack(siteID: siteID,
                                                       base: base,
                                                       feature: feature,
@@ -116,10 +140,9 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
     private func generateTextUsingMerchantAPIKey(base: String,
                                                  responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
-        guard let key = UserDefaults.standard.string(forKey: "AIProviderApiKey"), !key.isEmpty else {
-            throw URLError(.userAuthenticationRequired)
+        guard let key = storage.aiProviderAPIKey else {
+            throw URLError(.unknown)
         }
-
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
         let selectedProvider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI") ?? .openAI
 
@@ -148,12 +171,11 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
     public func identifyLanguage(siteID: Int64,
                                  string: String,
+                                 shouldUseMerchantAIKey: Bool,
                                  feature: GenerativeContentRemoteFeature) async throws -> String {
-        if shouldUseMerchantAIAPIKey {
-            debugPrint("🍍 identifyLanguage... using merchant API key")
+        if shouldUseMerchantAIKey {
             return try await identifyLanguageUsingMerchantAPIKey(string: string)
         } else {
-            debugPrint("🍍 identifyLanguage... using Jetpack tunnel")
             return try await identifyLanguageUsingJetpack(siteID: siteID,
                                                           string: string,
                                                           feature: feature)
@@ -177,10 +199,8 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
     }
 
     private func identifyLanguageUsingMerchantAPIKey(string: String) async throws -> String {
-
-        guard let key = UserDefaults.standard.string(forKey: "AIProviderAPIKey"), !key.isEmpty else {
-            // TODO: If retrieved here, handle error case
-            throw URLError(.userAuthenticationRequired)
+        guard let key = storage.aiProviderAPIKey else {
+            throw URLError(.unknown)
         }
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
         let selectedProvider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI") ?? .openAI
@@ -208,13 +228,13 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                   keywords: String,
                                   language: String,
                                   tone: String,
+                                  shouldUseMerchantAIKey: Bool,
                                   currencySymbol: String,
                                   dimensionUnit: String?,
                                   weightUnit: String?,
                                   categories: [ProductCategory],
                                   tags: [ProductTag]) async throws -> AIProduct {
-        if shouldUseMerchantAIAPIKey {
-            debugPrint("🍍 generateAIProduct... using merchant API key")
+        if shouldUseMerchantAIKey {
             return try await generateAIProductUsingMerchantAPIKey(productName: productName,
                                                                 keywords: keywords,
                                                                 language: language,
@@ -225,7 +245,6 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                                                 categories: categories,
                                                                 tags: tags)
         } else {
-            debugPrint("🍍 generateAIProduct... using Jetpack tunnel")
             return try await generateAIProductUsingJetpack(siteID: siteID,
                                                         productName: productName,
                                                         keywords: keywords,
@@ -291,9 +310,6 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                                    weightUnit: String?,
                                                    categories: [ProductCategory],
                                                    tags: [ProductTag]) async throws -> AIProduct {
-        guard let key = UserDefaults.standard.string(forKey: "AIProviderAPIKey"), !key.isEmpty else {
-            throw URLError(.userAuthenticationRequired)
-        }
         let selectedProvider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI") ?? .openAI
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
 
@@ -317,6 +333,10 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
         let prompt = inputComponents.joined(separator: "\n") + "\n" + expectedJsonFormat
 
+        guard let key = storage.aiProviderAPIKey else {
+            throw URLError(.unknown)
+        }
+        
         let request = try createAIRequest(
                 provider: selectedProvider,
                 apiKey: key,

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -85,6 +85,22 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                              base: String,
                              feature: GenerativeContentRemoteFeature,
                              responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
+        if shouldUseMerchantAIAPIKey {
+            debugPrint("🍍 Using merchant API key")
+            return try await generateTextUsingMerchantAPIKey(base: base, responseFormat: responseFormat)
+        } else {
+            debugPrint("🍍 Using Jetpack tunnel")
+            return try await generateTextUsingJetpack(siteID: siteID,
+                                                      base: base,
+                                                      feature: feature,
+                                                      responseFormat: responseFormat)
+        }
+    }
+    
+    private func generateTextUsingJetpack(siteID: Int64,
+                                          base: String,
+                                          feature: GenerativeContentRemoteFeature,
+                                          responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
         do {
             guard let token, token.isTokenValid(for: siteID) else {
                 throw GenerativeContentRemoteError.tokenNotFound
@@ -98,19 +114,55 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         }
     }
 
+    private func generateTextUsingMerchantAPIKey(base: String,
+                                                 responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
+        guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        let requestBody: [String: Any] = [
+            "model": "gpt-4",
+            "messages": [["role": "user", "content": base]],
+            "max_tokens": ParameterValue.maxTokens
+        ]
+
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
+        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.httpBody = requestData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let choices = json?["choices"] as? [[String: Any]],
+              let message = choices.first?["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     public func identifyLanguage(siteID: Int64,
                                  string: String,
                                  feature: GenerativeContentRemoteFeature) async throws -> String {
         if shouldUseMerchantAIAPIKey {
-            debugPrint("🍍 Using merchant API key")
+            debugPrint("🍍 identifyLanguage... using merchant API key")
             return try await identifyLanguageUsingMerchantAPIKey(string: string)
         } else {
+            debugPrint("🍍 identifyLanguage... using Jetpack tunnel")
             return try await identifyLanguageUsingJetpack(siteID: siteID,
                                                           string: string,
                                                           feature: feature)
         }
     }
-    
+
     private func identifyLanguageUsingJetpack(siteID: Int64,
                                               string: String,
                                               feature: GenerativeContentRemoteFeature) async throws -> String {
@@ -126,7 +178,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
             return try await identifyLanguage(siteID: siteID, string: string, feature: feature, token: token)
         }
     }
-    
+
     private func identifyLanguageUsingMerchantAPIKey(string: String) async throws -> String {
 
         guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
@@ -142,7 +194,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         let requestBody: [String: Any] = [
             "model": "gpt-4o", // TODO: Pass model
             "messages": [["role": "user", "content": prompt]],
-            "max_tokens": 10 // TODO: Allow max_tokens. Check why 10. It used ~110 for 2 calls as per https://platform.openai.com/usage
+            "max_tokens": 400 // TODO: Allow max_tokens. Check why 10. It used ~110 for 2 calls as per https://platform.openai.com/usage
         ]
 
         let requestData = try JSONSerialization.data(withJSONObject: requestBody)
@@ -178,38 +230,181 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                   weightUnit: String?,
                                   categories: [ProductCategory],
                                   tags: [ProductTag]) async throws -> AIProduct {
-
+        if shouldUseMerchantAIAPIKey {
+            debugPrint("🍍 generateAIProduct... using merchant API key")
+            return try await generateAIProductUsingMerchantAPIKey(productName: productName,
+                                                                keywords: keywords,
+                                                                language: language,
+                                                                tone: tone,
+                                                                currencySymbol: currencySymbol,
+                                                                dimensionUnit: dimensionUnit,
+                                                                weightUnit: weightUnit,
+                                                                categories: categories,
+                                                                tags: tags)
+        } else {
+            debugPrint("🍍 generateAIProduct... using Jetpack tunnel")
+            return try await generateAIProductUsingJetpack(siteID: siteID,
+                                                        productName: productName,
+                                                        keywords: keywords,
+                                                        language: language,
+                                                        tone: tone,
+                                                        currencySymbol: currencySymbol,
+                                                        dimensionUnit: dimensionUnit,
+                                                        weightUnit: weightUnit,
+                                                        categories: categories,
+                                                        tags: tags)
+        }
+    }
+    
+    private func generateAIProductUsingJetpack(siteID: Int64,
+                                            productName: String?,
+                                            keywords: String,
+                                            language: String,
+                                            tone: String,
+                                            currencySymbol: String,
+                                            dimensionUnit: String?,
+                                            weightUnit: String?,
+                                            categories: [ProductCategory],
+                                            tags: [ProductTag]) async throws -> AIProduct {
         do {
             guard let token, token.isTokenValid(for: siteID) else {
                 throw GenerativeContentRemoteError.tokenNotFound
             }
             return try await generateAIProduct(siteID: siteID,
-                                               productName: productName,
-                                               keywords: keywords,
-                                               language: language,
-                                               tone: tone,
-                                               currencySymbol: currencySymbol,
-                                               dimensionUnit: dimensionUnit,
-                                               weightUnit: weightUnit,
-                                               categories: categories,
-                                               tags: tags,
-                                               token: token)
+                                            productName: productName,
+                                            keywords: keywords,
+                                            language: language,
+                                            tone: tone,
+                                            currencySymbol: currencySymbol,
+                                            dimensionUnit: dimensionUnit,
+                                            weightUnit: weightUnit,
+                                            categories: categories,
+                                            tags: tags,
+                                            token: token)
         } catch GenerativeContentRemoteError.tokenNotFound,
                 WordPressApiError.unknown(code: TokenExpiredError.code, message: TokenExpiredError.message) {
             let token = try await fetchToken(siteID: siteID)
             self.token = token
             return try await generateAIProduct(siteID: siteID,
-                                               productName: productName,
-                                               keywords: keywords,
-                                               language: language,
-                                               tone: tone,
-                                               currencySymbol: currencySymbol,
-                                               dimensionUnit: dimensionUnit,
-                                               weightUnit: weightUnit,
-                                               categories: categories,
-                                               tags: tags,
-                                               token: token)
+                                            productName: productName,
+                                            keywords: keywords,
+                                            language: language,
+                                            tone: tone,
+                                            currencySymbol: currencySymbol,
+                                            dimensionUnit: dimensionUnit,
+                                            weightUnit: weightUnit,
+                                            categories: categories,
+                                            tags: tags,
+                                            token: token)
         }
+    }
+
+    private func generateAIProductUsingMerchantAPIKey(productName: String?,
+                                                   keywords: String,
+                                                   language: String,
+                                                   tone: String,
+                                                   currencySymbol: String,
+                                                   dimensionUnit: String?,
+                                                   weightUnit: String?,
+                                                   categories: [ProductCategory],
+                                                   tags: [ProductTag]) async throws -> AIProduct {
+        guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        var inputComponents = [
+            "You are a WooCommerce SEO and marketing expert, perform in-depth research about the product " +
+            "using the provided name, keywords and tone, and give your response in the below JSON format.",
+            "keywords: ```\(keywords)```",
+            "tone: ```\(tone)```",
+        ]
+
+        if let productName = productName, !productName.isEmpty {
+            inputComponents.insert("name: ```\(productName)```", at: 1)
+        }
+
+        let jsonResponseFormatDict: [String: Any] = {
+            let tagsPrompt: String = {
+                guard !tags.isEmpty else {
+                    return "Suggest an array of the best matching tags for this product."
+                }
+                return "Given the list of available tags ```\(tags.map { $0.name }.joined(separator: ", "))```, " +
+                    "suggest an array of the best matching tags for this product. You can suggest new tags as well."
+            }()
+
+            let categoriesPrompt: String = {
+                guard !categories.isEmpty else {
+                    return "Suggest an array of the best matching categories for this product."
+                }
+                return "Given the list of available categories ```\(categories.map { $0.name }.joined(separator: ", "))```, " +
+                    "suggest an array of the best matching categories for this product. You can suggest new categories as well."
+            }()
+
+            let shippingPrompt = {
+                var dict = [String: String]()
+                if let weightUnit {
+                    dict["weight"] = "Guess and provide only the number in \(weightUnit)"
+                }
+                if let dimensionUnit {
+                    dict["length"] = "Guess and provide only the number in \(dimensionUnit)"
+                    dict["width"] = "Guess and provide only the number in \(dimensionUnit)"
+                    dict["height"] = "Guess and provide only the number in \(dimensionUnit)"
+                }
+                return dict
+            }()
+
+            return ["names": "An array of strings, containing three different names of the product, written in the language with ISO code ```\(language)```",
+                    "descriptions": "An array of strings, each containing three different product descriptions of around 100 words long each in a ```\(tone)``` tone, "
+                    + "written in the language with ISO code ```\(language)```",
+                    "short_descriptions": "An array of strings, each containing three different short descriptions of the product in a ```\(tone)``` tone, "
+                    + "written in the language with ISO code ```\(language)```",
+                    "virtual": "A boolean value that shows whether the product is virtual or physical",
+                    "shipping": shippingPrompt,
+                    "price": "Guess the price in \(currencySymbol), do not include the currency symbol, "
+                    + "only provide the price as a number",
+                    "tags": tagsPrompt,
+                    "categories": categoriesPrompt]
+        }()
+
+        let expectedJsonFormat =
+            "Your response should be in JSON format and don't send anything extra. " +
+            "Don't include the word JSON in your response:" +
+            "\n" +
+            (jsonResponseFormatDict.toJSONEncoded() ?? "")
+
+        let prompt = inputComponents.joined(separator: "\n") + "\n" + expectedJsonFormat
+
+        let requestBody: [String: Any] = [
+            "model": "gpt-4",
+            "messages": [["role": "user", "content": prompt]],
+            "max_tokens": ParameterValue.maxTokens
+        ]
+
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
+        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.httpBody = requestData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let choices = json?["choices"] as? [[String: Any]],
+              let message = choices.first?["message"] as? [String: Any],
+              let content = message["content"] as? String,
+              let data = content.data(using: .utf8),
+              let productJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        // We don't need siteID for direct API calls, but need a new mapper
+        let mapper = AIProductMapper(siteID: 0)
+        return try mapper.map(dictionary: productJson)
     }
 }
 

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -544,7 +544,7 @@ private extension GenerativeContentRemote {
 
         return request
     }
-    
+
     private func parseAIResponse(json: [String: Any]?, provider: AIProvider) throws -> String {
         if provider == .openAI {
             // openAI

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -119,30 +119,16 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         guard let key = UserDefaults.standard.string(forKey: "AIProviderApiKey"), !key.isEmpty else {
             throw URLError(.userAuthenticationRequired)
         }
+
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
+        let selectedProvider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI") ?? .openAI
 
-        let requestBody: [String: Any] = [
-            "model": selectedModel,
-            "messages": [["role": "user", "content": base]],
-            "max_tokens": ParameterValue.maxTokens
-        ]
-
-        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
-
-        var request: URLRequest
-        let selectedProvider = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
-        if selectedProvider == "OpenAI" {
-            request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
-            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        } else { // Anthropic
-            request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
-            request.setValue(key, forHTTPHeaderField: "x-api-key")
-            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-        }
-
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = requestData
+        let request = try createAIRequest(
+            provider: selectedProvider,
+            apiKey: key,
+            model: selectedModel,
+            prompt: base
+        )
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -197,29 +183,15 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
             throw URLError(.userAuthenticationRequired)
         }
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
+        let selectedProvider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI") ?? .openAI
         let prompt = String(format: AIRequestPrompts.identifyLanguage, string)
 
-        let requestBody: [String: Any] = [
-            "model": selectedModel,
-            "messages": [["role": "user", "content": prompt]],
-            "max_tokens": 400
-        ]
-        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
-
-        var request: URLRequest
-        let selectedProvider = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
-        if selectedProvider == "OpenAI" {
-            request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
-            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        } else { // Anthropic
-            request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
-            request.setValue(key, forHTTPHeaderField: "x-api-key")
-            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-        }
-
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = requestData
+        let request = try createAIRequest(
+                provider: selectedProvider,
+                apiKey: key,
+                model: selectedModel,
+                prompt: prompt
+            )
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -228,7 +200,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         }
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        if selectedProvider == "OpenAI" {
+        if selectedProvider == .openAI {
             guard let choices = json?["choices"] as? [[String: Any]],
                   let message = choices.first?["message"] as? [String: Any],
                   let content = message["content"] as? String else {
@@ -335,6 +307,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         guard let key = UserDefaults.standard.string(forKey: "AIProviderAPIKey"), !key.isEmpty else {
             throw URLError(.userAuthenticationRequired)
         }
+        let selectedProvider = AIProvider(rawValue: UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI") ?? .openAI
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
 
         var inputComponents = [String(format: AIRequestPrompts.inputComponents, keywords, tone)]
@@ -357,28 +330,12 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
         let prompt = inputComponents.joined(separator: "\n") + "\n" + expectedJsonFormat
 
-        let requestBody: [String: Any] = [
-            "model": selectedModel,
-            "messages": [["role": "user", "content": prompt]],
-            "max_tokens": ParameterValue.maxTokens
-        ]
-
-        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
-
-        var request: URLRequest
-        let selectedProvider = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
-        if selectedProvider == "OpenAI" {
-            request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
-            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        } else { // Anthropic
-            request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
-            request.setValue(key, forHTTPHeaderField: "x-api-key")
-            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-        }
-
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = requestData
+        let request = try createAIRequest(
+                provider: selectedProvider,
+                apiKey: key,
+                model: selectedModel,
+                prompt: prompt
+            )
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -390,7 +347,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
         var contentString: String
 
-        if selectedProvider == "OpenAI" {
+        if selectedProvider == .openAI {
             guard let choices = json?["choices"] as? [[String: Any]],
                   let message = choices.first?["message"] as? [String: Any],
                   let content = message["content"] as? String else {
@@ -578,6 +535,44 @@ private struct AIRequestPrompts {
 }
 
 private extension GenerativeContentRemote {
+    private enum AIProvider: String {
+        case openAI = "OpenAI"
+        case anthropic = "Anthropic"
+
+        var requestURL: String {
+            switch self {
+            case .openAI:
+                return "https://api.openai.com/v1/chat/completions"
+            case .anthropic:
+                return "https://api.anthropic.com/v1/messages"
+            }
+        }
+    }
+
+    private func createAIRequest(provider: AIProvider, apiKey: String, model: String, prompt: String) throws -> URLRequest {
+        let requestBody: [String: Any] = [
+            "model": model,
+            "messages": [["role": "user", "content": prompt]],
+            "max_tokens": ParameterValue.maxTokens
+        ]
+
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
+        var request = URLRequest(url: URL(string: provider.requestURL)!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = requestData
+
+        switch provider {
+        case .openAI:
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        case .anthropic:
+            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        }
+
+        return request
+    }
+
     private func formatExpectedJsonResponse(_ jsonResponseFormat: [String: Any]) -> String {
         return "Your response should be in JSON format and don't send anything extra. " +
                "Don't include the word JSON in your response:\n" +

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -200,20 +200,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         }
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        if selectedProvider == .openAI {
-            guard let choices = json?["choices"] as? [[String: Any]],
-                  let message = choices.first?["message"] as? [String: Any],
-                  let content = message["content"] as? String else {
-                throw URLError(.cannotParseResponse)
-            }
-            return content.trimmingCharacters(in: .whitespacesAndNewlines)
-        } else { // Anthropic
-            guard let content = json?["content"] as? [[String: Any]],
-                  let text = content.first?["text"] as? String else {
-                throw URLError(.cannotParseResponse)
-            }
-            return text.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
+        return try parseAIResponse(json: json, provider: selectedProvider)
     }
 
     public func generateAIProduct(siteID: Int64,
@@ -345,22 +332,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
 
-        var contentString: String
-
-        if selectedProvider == .openAI {
-            guard let choices = json?["choices"] as? [[String: Any]],
-                  let message = choices.first?["message"] as? [String: Any],
-                  let content = message["content"] as? String else {
-                throw URLError(.cannotParseResponse)
-            }
-            contentString = content
-        } else { // Anthropic
-            guard let content = json?["content"] as? [[String: Any]],
-                  let text = content.first?["text"] as? String else {
-                throw URLError(.cannotParseResponse)
-            }
-            contentString = text
-        }
+        let contentString = try parseAIResponse(json: json, provider: selectedProvider)
 
         guard let data = contentString.data(using: .utf8),
               let productJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -571,6 +543,25 @@ private extension GenerativeContentRemote {
         }
 
         return request
+    }
+    
+    private func parseAIResponse(json: [String: Any]?, provider: AIProvider) throws -> String {
+        if provider == .openAI {
+            // openAI
+            guard let choices = json?["choices"] as? [[String: Any]],
+                  let message = choices.first?["message"] as? [String: Any],
+                  let content = message["content"] as? String else {
+                throw URLError(.cannotParseResponse)
+            }
+            return content.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            // Anthropic // TODO: Switch to be explicit
+            guard let content = json?["content"] as? [[String: Any]],
+                  let text = content.first?["text"] as? String else {
+                throw URLError(.cannotParseResponse)
+            }
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 
     private func formatExpectedJsonResponse(_ jsonResponseFormat: [String: Any]) -> String {

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -73,6 +73,14 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
     private var token: JWToken?
 
+    private var shouldUseMerchantAIAPIKey: Bool {
+        // TODO: Handle case when key non-empty, but disabled
+        guard let openAIApiKey = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !openAIApiKey.isEmpty else {
+            return false
+        }
+        return true
+    }
+
     public func generateText(siteID: Int64,
                              base: String,
                              feature: GenerativeContentRemoteFeature,
@@ -93,6 +101,19 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
     public func identifyLanguage(siteID: Int64,
                                  string: String,
                                  feature: GenerativeContentRemoteFeature) async throws -> String {
+        if shouldUseMerchantAIAPIKey {
+            debugPrint("🍍 Using merchant API key")
+            return try await identifyLanguageUsingMerchantAPIKey(string: string)
+        } else {
+            return try await identifyLanguageUsingJetpack(siteID: siteID,
+                                                          string: string,
+                                                          feature: feature)
+        }
+    }
+    
+    private func identifyLanguageUsingJetpack(siteID: Int64,
+                                              string: String,
+                                              feature: GenerativeContentRemoteFeature) async throws -> String {
         do {
             guard let token, token.isTokenValid(for: siteID) else {
                 throw GenerativeContentRemoteError.tokenNotFound
@@ -104,6 +125,47 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
             self.token = token
             return try await identifyLanguage(siteID: siteID, string: string, feature: feature, token: token)
         }
+    }
+    
+    private func identifyLanguageUsingMerchantAPIKey(string: String) async throws -> String {
+
+        guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
+            // TODO: If retrieved here, handle error case
+            throw URLError(.userAuthenticationRequired)
+        }
+        let prompt = """
+        What is the ISO language code of the language used in the below text?
+        Do not include any explanations and only provide the ISO language code in your response.
+        Text: ```\(string)```
+        """
+
+        let requestBody: [String: Any] = [
+            "model": "gpt-4o", // TODO: Pass model
+            "messages": [["role": "user", "content": prompt]],
+            "max_tokens": 10 // TODO: Allow max_tokens. Check why 10. It used ~110 for 2 calls as per https://platform.openai.com/usage
+        ]
+
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
+        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.httpBody = requestData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let choices = json?["choices"] as? [[String: Any]],
+              let message = choices.first?["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        return content.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     public func generateAIProduct(siteID: Int64,

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -96,7 +96,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                                       responseFormat: responseFormat)
         }
     }
-    
+
     private func generateTextUsingJetpack(siteID: Int64,
                                           base: String,
                                           feature: GenerativeContentRemoteFeature,
@@ -197,11 +197,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
             throw URLError(.userAuthenticationRequired)
         }
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
-        let prompt = """
-        What is the ISO language code of the language used in the below text?
-        Do not include any explanations and only provide the ISO language code in your response.
-        Text: ```\(string)```
-        """
+        let prompt = String(format: AIRequestPrompts.identifyLanguage, string)
 
         let requestBody: [String: Any] = [
             "model": selectedModel,
@@ -283,7 +279,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                                         tags: tags)
         }
     }
-    
+
     private func generateAIProductUsingJetpack(siteID: Int64,
                                             productName: String?,
                                             keywords: String,
@@ -341,65 +337,23 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         }
         let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
 
-        var inputComponents = [
-            "You are a WooCommerce SEO and marketing expert, perform in-depth research about the product " +
-            "using the provided name, keywords and tone, and give your response in the below JSON format.",
-            "keywords: ```\(keywords)```",
-            "tone: ```\(tone)```",
-        ]
+        var inputComponents = [String(format: AIRequestPrompts.inputComponents, keywords, tone)]
 
         if let productName = productName, !productName.isEmpty {
             inputComponents.insert("name: ```\(productName)```", at: 1)
         }
 
-        let jsonResponseFormatDict: [String: Any] = {
-            let tagsPrompt: String = {
-                guard !tags.isEmpty else {
-                    return "Suggest an array of the best matching tags for this product."
-                }
-                return "Given the list of available tags ```\(tags.map { $0.name }.joined(separator: ", "))```, " +
-                    "suggest an array of the best matching tags for this product. You can suggest new tags as well."
-            }()
+        let jsonResponseFormatDict = generateAIProductResponseFormat(
+            tags: tags,
+            categories: categories,
+            language: language,
+            tone: tone,
+            currencySymbol: currencySymbol,
+            dimensionUnit: dimensionUnit,
+            weightUnit: weightUnit
+        )
 
-            let categoriesPrompt: String = {
-                guard !categories.isEmpty else {
-                    return "Suggest an array of the best matching categories for this product."
-                }
-                return "Given the list of available categories ```\(categories.map { $0.name }.joined(separator: ", "))```, " +
-                    "suggest an array of the best matching categories for this product. You can suggest new categories as well."
-            }()
-
-            let shippingPrompt = {
-                var dict = [String: String]()
-                if let weightUnit {
-                    dict["weight"] = "Guess and provide only the number in \(weightUnit)"
-                }
-                if let dimensionUnit {
-                    dict["length"] = "Guess and provide only the number in \(dimensionUnit)"
-                    dict["width"] = "Guess and provide only the number in \(dimensionUnit)"
-                    dict["height"] = "Guess and provide only the number in \(dimensionUnit)"
-                }
-                return dict
-            }()
-
-            return ["names": "An array of strings, containing three different names of the product, written in the language with ISO code ```\(language)```",
-                    "descriptions": "An array of strings, each containing three different product descriptions of around 100 words long each in a ```\(tone)``` tone, "
-                    + "written in the language with ISO code ```\(language)```",
-                    "short_descriptions": "An array of strings, each containing three different short descriptions of the product in a ```\(tone)``` tone, "
-                    + "written in the language with ISO code ```\(language)```",
-                    "virtual": "A boolean value that shows whether the product is virtual or physical",
-                    "shipping": shippingPrompt,
-                    "price": "Guess the price in \(currencySymbol), do not include the currency symbol, "
-                    + "only provide the price as a number",
-                    "tags": tagsPrompt,
-                    "categories": categoriesPrompt]
-        }()
-
-        let expectedJsonFormat =
-            "Your response should be in JSON format and don't send anything extra. " +
-            "Don't include the word JSON in your response:" +
-            "\n" +
-            (jsonResponseFormatDict.toJSONEncoded() ?? "")
+        let expectedJsonFormat = formatExpectedJsonResponse(jsonResponseFormatDict)
 
         let prompt = inputComponents.joined(separator: "\n") + "\n" + expectedJsonFormat
 
@@ -410,7 +364,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         ]
 
         let requestData = try JSONSerialization.data(withJSONObject: requestBody)
-        
+
         var request: URLRequest
         let selectedProvider = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
         if selectedProvider == "OpenAI" {
@@ -421,7 +375,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
             request.setValue(key, forHTTPHeaderField: "x-api-key")
             request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         }
-        
+
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = requestData
@@ -433,9 +387,9 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         }
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-            
+
         var contentString: String
-            
+
         if selectedProvider == "OpenAI" {
             guard let choices = json?["choices"] as? [[String: Any]],
                   let message = choices.first?["message"] as? [String: Any],
@@ -500,11 +454,7 @@ private extension GenerativeContentRemote {
                           string: String,
                           feature: GenerativeContentRemoteFeature,
                           token: JWToken) async throws -> String {
-        let prompt = [
-            "What is the ISO language code of the language used in the below text?" +
-            "Do not include any explanations and only provide the ISO language code in your response.",
-            "Text: ```\(string)```"
-        ].joined(separator: "\n")
+        let prompt = String(format: AIRequestPrompts.identifyLanguage, string)
         let parameters: [String: Any] = [ParameterKey.token: token.token,
                                          ParameterKey.question: prompt,
                                          ParameterKey.stream: ParameterValue.stream,
@@ -530,12 +480,7 @@ private extension GenerativeContentRemote {
                            categories: [ProductCategory],
                            tags: [ProductTag],
                            token: JWToken) async throws -> AIProduct {
-        var inputComponents = [
-            "You are a WooCommerce SEO and marketing expert, perform in-depth research about the product " +
-            "using the provided name, keywords and tone, and give your response in the below JSON format.",
-            "keywords: ```\(keywords)```",
-            "tone: ```\(tone)```",
-        ]
+        var inputComponents = [String(format: AIRequestPrompts.inputComponents, keywords, tone)]
 
         // Name will be added only if `productName` is available.
         // TODO: this code related to `productName` can be removed after releasing the new product creation with AI flow. Github issue: 13108
@@ -545,58 +490,17 @@ private extension GenerativeContentRemote {
 
         let input = inputComponents.joined(separator: "\n")
 
-        let jsonResponseFormatDict: [String: Any] = {
-            let tagsPrompt: String = {
-                guard !tags.isEmpty else {
-                    return "Suggest an array of the best matching tags for this product."
-                }
+        let jsonResponseFormatDict = generateAIProductResponseFormat(
+            tags: tags,
+            categories: categories,
+            language: language,
+            tone: tone,
+            currencySymbol: currencySymbol,
+            dimensionUnit: dimensionUnit,
+            weightUnit: weightUnit
+        )
 
-                return "Given the list of available tags ```\(tags.map { $0.name }.joined(separator: ", "))```, " +
-                        "suggest an array of the best matching tags for this product. You can suggest new tags as well."
-            }()
-
-            let categoriesPrompt: String = {
-                guard !categories.isEmpty else {
-                    return "Suggest an array of the best matching categories for this product."
-                }
-
-                return "Given the list of available categories ```\(categories.map { $0.name }.joined(separator: ", "))```, " +
-                        "suggest an array of the best matching categories for this product. You can suggest new categories as well."
-            }()
-
-            let shippingPrompt = {
-                var dict = [String: String]()
-                if let weightUnit {
-                    dict["weight"] = "Guess and provide only the number in \(weightUnit)"
-                }
-
-                if let dimensionUnit {
-                    dict["length"] = "Guess and provide only the number in \(dimensionUnit)"
-                    dict["width"] = "Guess and provide only the number in \(dimensionUnit)"
-                    dict["height"] = "Guess and provide only the number in \(dimensionUnit)"
-                }
-                return dict
-            }()
-
-            // swiftlint:disable line_length
-            return ["names": "An array of strings, containing three different names of the product, written in the language with ISO code ```\(language)```",
-                    "descriptions": "An array of strings, each containing three different product descriptions of around 100 words long each in a ```\(tone)``` tone, "
-                    + "written in the language with ISO code ```\(language)```",
-                    "short_descriptions": "An array of strings, each containing three different short descriptions of the product in a ```\(tone)``` tone, "
-                    + "written in the language with ISO code ```\(language)```",
-                    "virtual": "A boolean value that shows whether the product is virtual or physical",
-                    "shipping": shippingPrompt,
-                    "price": "Guess the price in \(currencySymbol), do not include the currency symbol, "
-                    + "only provide the price as a number",
-                    "tags": tagsPrompt,
-                    "categories": categoriesPrompt]
-        }()
-
-        let expectedJsonFormat =
-        "Your response should be in JSON format and don't send anything extra. " +
-        "Don't include the word JSON in your response:" +
-        "\n" +
-        (jsonResponseFormatDict.toJSONEncoded() ?? "")
+        let expectedJsonFormat = formatExpectedJsonResponse(jsonResponseFormatDict)
 
         let prompt = input + "\n" + expectedJsonFormat
 
@@ -655,5 +559,79 @@ private extension GenerativeContentRemote {
 private extension JWToken {
     func isTokenValid(for currentSelectedSiteID: Int64) -> Bool {
         expiryDate > Date() && siteID == currentSelectedSiteID
+    }
+}
+
+private struct AIRequestPrompts {
+    static let identifyLanguage = [
+        "What is the ISO language code of the language used in the below text?",
+        "Do not include any explanations and only provide the ISO language code in your response.",
+        "Text: ```%@"
+    ].joined(separator: "\n")
+
+    static let inputComponents = [
+        "You are a WooCommerce SEO and marketing expert, perform in-depth research about the product " +
+        "using the provided name, keywords, and tone, and give your response in the below JSON format.",
+        "keywords: ```%@```",
+        "tone: ```%@```"
+    ].joined(separator: "\n")
+}
+
+private extension GenerativeContentRemote {
+    private func formatExpectedJsonResponse(_ jsonResponseFormat: [String: Any]) -> String {
+        return "Your response should be in JSON format and don't send anything extra. " +
+               "Don't include the word JSON in your response:\n" +
+               (jsonResponseFormat.toJSONEncoded() ?? "")
+    }
+
+    private func generateAIProductResponseFormat(tags: [ProductTag],
+                                                 categories: [ProductCategory],
+                                                 language: String,
+                                                 tone: String,
+                                                 currencySymbol: String,
+                                                 dimensionUnit: String?,
+                                                 weightUnit: String?) -> [String: Any] {
+        let tagsPrompt: String = {
+            guard !tags.isEmpty else {
+                return "Suggest an array of the best matching tags for this product."
+            }
+            return "Given the list of available tags ```\(tags.map { $0.name }.joined(separator: ", "))```, " +
+                   "suggest an array of the best matching tags for this product. You can suggest new tags as well."
+        }()
+
+        let categoriesPrompt: String = {
+            guard !categories.isEmpty else {
+                return "Suggest an array of the best matching categories for this product."
+            }
+            return "Given the list of available categories ```\(categories.map { $0.name }.joined(separator: ", "))```, " +
+                   "suggest an array of the best matching categories for this product. You can suggest new categories as well."
+        }()
+
+        let shippingPrompt = {
+            var dict = [String: String]()
+            if let weightUnit {
+                dict["weight"] = "Guess and provide only the number in \(weightUnit)"
+            }
+            if let dimensionUnit {
+                dict["length"] = "Guess and provide only the number in \(dimensionUnit)"
+                dict["width"] = "Guess and provide only the number in \(dimensionUnit)"
+                dict["height"] = "Guess and provide only the number in \(dimensionUnit)"
+            }
+            return dict
+        }()
+
+        // swiftlint:disable line_length
+        return [
+            "names": "An array of strings, containing three different names of the product, written in the language with ISO code ```\(language)```",
+            "descriptions": "An array of strings, each containing three different product descriptions of around 100 words long each in a ```\(tone)``` tone, " +
+                            "written in the language with ISO code ```\(language)```",
+            "short_descriptions": "An array of strings, each containing three different short descriptions of the product in a ```\(tone)``` tone, " +
+                                  "written in the language with ISO code ```\(language)```",
+            "virtual": "A boolean value that shows whether the product is virtual or physical",
+            "shipping": shippingPrompt,
+            "price": "Guess the price in \(currencySymbol), do not include the currency symbol, only provide the price as a number",
+            "tags": tagsPrompt,
+            "categories": categoriesPrompt
+        ]
     }
 }

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -75,7 +75,7 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
     private var shouldUseMerchantAIAPIKey: Bool {
         // TODO: Handle case when key non-empty, but disabled
-        guard let openAIApiKey = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !openAIApiKey.isEmpty else {
+        guard let key = UserDefaults.standard.string(forKey: "AIProviderAPIKey"), !key.isEmpty else {
             return false
         }
         return true
@@ -116,10 +116,10 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
     private func generateTextUsingMerchantAPIKey(base: String,
                                                  responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
-        guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
+        guard let key = UserDefaults.standard.string(forKey: "AIProviderApiKey"), !key.isEmpty else {
             throw URLError(.userAuthenticationRequired)
         }
-        let selectedModel = UserDefaults.standard.string(forKey: "OpenAIModel") ?? "gpt-4o"
+        let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
 
         let requestBody: [String: Any] = [
             "model": selectedModel,
@@ -128,10 +128,20 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         ]
 
         let requestData = try JSONSerialization.data(withJSONObject: requestBody)
-        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+
+        var request: URLRequest
+        let selectedProvider = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
+        if selectedProvider == "OpenAI" {
+            request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        } else { // Anthropic
+            request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
+            request.setValue(key, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        }
+
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
         request.httpBody = requestData
 
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -182,11 +192,11 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
     private func identifyLanguageUsingMerchantAPIKey(string: String) async throws -> String {
 
-        guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
+        guard let key = UserDefaults.standard.string(forKey: "AIProviderAPIKey"), !key.isEmpty else {
             // TODO: If retrieved here, handle error case
             throw URLError(.userAuthenticationRequired)
         }
-        let selectedModel = UserDefaults.standard.string(forKey: "OpenAIModel") ?? "gpt-4o"
+        let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
         let prompt = """
         What is the ISO language code of the language used in the below text?
         Do not include any explanations and only provide the ISO language code in your response.
@@ -196,14 +206,23 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         let requestBody: [String: Any] = [
             "model": selectedModel,
             "messages": [["role": "user", "content": prompt]],
-            "max_tokens": 400 // TODO: Allow max_tokens. Check why 10. It used ~110 for 2 calls as per https://platform.openai.com/usage
+            "max_tokens": 400
         ]
-
         let requestData = try JSONSerialization.data(withJSONObject: requestBody)
-        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+
+        var request: URLRequest
+        let selectedProvider = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
+        if selectedProvider == "OpenAI" {
+            request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        } else { // Anthropic
+            request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
+            request.setValue(key, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        }
+
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
         request.httpBody = requestData
 
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -213,13 +232,20 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         }
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let choices = json?["choices"] as? [[String: Any]],
-              let message = choices.first?["message"] as? [String: Any],
-              let content = message["content"] as? String else {
-            throw URLError(.cannotParseResponse)
+        if selectedProvider == "OpenAI" {
+            guard let choices = json?["choices"] as? [[String: Any]],
+                  let message = choices.first?["message"] as? [String: Any],
+                  let content = message["content"] as? String else {
+                throw URLError(.cannotParseResponse)
+            }
+            return content.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else { // Anthropic
+            guard let content = json?["content"] as? [[String: Any]],
+                  let text = content.first?["text"] as? String else {
+                throw URLError(.cannotParseResponse)
+            }
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-
-        return content.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     public func generateAIProduct(siteID: Int64,
@@ -310,9 +336,10 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
                                                    weightUnit: String?,
                                                    categories: [ProductCategory],
                                                    tags: [ProductTag]) async throws -> AIProduct {
-        guard let key = UserDefaults.standard.string(forKey: "OpenAIApiKey"), !key.isEmpty else {
+        guard let key = UserDefaults.standard.string(forKey: "AIProviderAPIKey"), !key.isEmpty else {
             throw URLError(.userAuthenticationRequired)
         }
+        let selectedModel = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
 
         var inputComponents = [
             "You are a WooCommerce SEO and marketing expert, perform in-depth research about the product " +
@@ -377,16 +404,26 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         let prompt = inputComponents.joined(separator: "\n") + "\n" + expectedJsonFormat
 
         let requestBody: [String: Any] = [
-            "model": "gpt-4",
+            "model": selectedModel,
             "messages": [["role": "user", "content": prompt]],
             "max_tokens": ParameterValue.maxTokens
         ]
 
         let requestData = try JSONSerialization.data(withJSONObject: requestBody)
-        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+        
+        var request: URLRequest
+        let selectedProvider = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
+        if selectedProvider == "OpenAI" {
+            request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        } else { // Anthropic
+            request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
+            request.setValue(key, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        }
+        
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
         request.httpBody = requestData
 
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -396,10 +433,25 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
         }
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let choices = json?["choices"] as? [[String: Any]],
-              let message = choices.first?["message"] as? [String: Any],
-              let content = message["content"] as? String,
-              let data = content.data(using: .utf8),
+            
+        var contentString: String
+            
+        if selectedProvider == "OpenAI" {
+            guard let choices = json?["choices"] as? [[String: Any]],
+                  let message = choices.first?["message"] as? [String: Any],
+                  let content = message["content"] as? String else {
+                throw URLError(.cannotParseResponse)
+            }
+            contentString = content
+        } else { // Anthropic
+            guard let content = json?["content"] as? [[String: Any]],
+                  let text = content.first?["text"] as? String else {
+                throw URLError(.cannotParseResponse)
+            }
+            contentString = text
+        }
+
+        guard let data = contentString.data(using: .utf8),
               let productJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw URLError(.cannotParseResponse)
         }

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -30,6 +30,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
+                                          shouldUseMerchantAIKey: false,
                                           feature: .productDescription,
                                           responseFormat: .text)
 
@@ -48,6 +49,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
+                                          shouldUseMerchantAIKey: false,
                                           feature: .productDescription,
                                           responseFormat: .text)
 
@@ -66,6 +68,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         let generatedText = try await remote.generateText(siteID: sampleSiteID,
                                                           base: "generate a product description for wapuu pencil",
+                                                          shouldUseMerchantAIKey: false,
                                                           feature: .productDescription,
                                                           responseFormat: .text)
 
@@ -83,6 +86,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         await assertThrowsError {
             _ = try await remote.generateText(siteID: sampleSiteID,
                                               base: "generate a product description for wapuu pencil",
+                                              shouldUseMerchantAIKey: false,
                                               feature: .productDescription,
                                               responseFormat: .text)
         } errorAssert: { error in
@@ -101,6 +105,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         await assertThrowsError {
             _ = try await remote.generateText(siteID: sampleSiteID,
                                               base: "generate a product description for wapuu pencil",
+                                              shouldUseMerchantAIKey: false,
                                               feature: .productDescription,
                                               responseFormat: .text)
         } errorAssert: { error in
@@ -120,6 +125,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
+                                          shouldUseMerchantAIKey: false,
                                           feature: .productDescription,
                                           responseFormat: .text)
         // Then
@@ -128,6 +134,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
+                                          shouldUseMerchantAIKey: false,
                                           feature: .productDescription,
                                           responseFormat: .text)
 
@@ -140,6 +147,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: jetpackAIQueryPath, filename: "generative-text-invalid-token")
         _ = try? await remote.generateText(siteID: sampleSiteID,
                                            base: "generate a product description for wapuu pencil",
+                                           shouldUseMerchantAIKey: false,
                                            feature: .productDescription,
                                            responseFormat: .text)
 
@@ -159,6 +167,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
+                                          shouldUseMerchantAIKey: false,
                                           feature: .productDescription,
                                           responseFormat: .text)
         // Then
@@ -167,6 +176,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
+                                          shouldUseMerchantAIKey: false,
                                           feature: .productDescription,
                                           responseFormat: .text)
 
@@ -186,6 +196,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.identifyLanguage(siteID: sampleSiteID,
                                               string: "Woo is awesome.",
+                                              shouldUseMerchantAIKey: false,
                                               feature: .productDescription)
 
         // Then
@@ -203,6 +214,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         let language = try await remote.identifyLanguage(siteID: sampleSiteID,
                                                          string: "Woo is awesome.",
+                                                         shouldUseMerchantAIKey: false,
                                                          feature: .productDescription)
 
         // Then
@@ -219,6 +231,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         await assertThrowsError {
             _ = try await remote.identifyLanguage(siteID: sampleSiteID,
                                                   string: "Woo is awesome.",
+                                                  shouldUseMerchantAIKey: false,
                                                   feature: .productDescription)
         } errorAssert: { error in
             // Then
@@ -236,6 +249,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         await assertThrowsError {
             _ = try await remote.identifyLanguage(siteID: sampleSiteID,
                                                   string: "Woo is awesome.",
+                                                  shouldUseMerchantAIKey: false,
                                                   feature: .productDescription)
         } errorAssert: { error in
             // Then
@@ -254,6 +268,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.identifyLanguage(siteID: sampleSiteID,
                                               string: "Woo is awesome.",
+                                              shouldUseMerchantAIKey: false,
                                               feature: .productDescription)
         // Then
         XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 1)
@@ -261,6 +276,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.identifyLanguage(siteID: sampleSiteID,
                                               string: "Woo is awesome.",
+                                              shouldUseMerchantAIKey: false,
                                               feature: .productDescription)
 
         // Then
@@ -272,6 +288,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: jetpackAIQueryPath, filename: "identify-language-invalid-token")
         _ = try? await remote.identifyLanguage(siteID: sampleSiteID,
                                                string: "Woo is awesome.",
+                                               shouldUseMerchantAIKey: false,
                                                feature: .productDescription)
 
         // Then
@@ -290,6 +307,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.identifyLanguage(siteID: sampleSiteID,
                                               string: "Woo is awesome.",
+                                              shouldUseMerchantAIKey: false,
                                               feature: .productDescription)
         // Then
         XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 1)
@@ -297,6 +315,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.identifyLanguage(siteID: sampleSiteID,
                                               string: "Woo is awesome.",
+                                              shouldUseMerchantAIKey: false,
                                               feature: .productDescription)
 
         // Then
@@ -318,6 +337,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -342,6 +362,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -366,6 +387,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -390,6 +412,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -417,6 +440,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -442,6 +466,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -468,6 +493,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -492,6 +518,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                          keywords: "Crunchy, Crispy",
                                                          language: "en",
                                                          tone: "Casual",
+                                                         shouldUseMerchantAIKey: false,
                                                          currencySymbol: "INR",
                                                          dimensionUnit: "cm",
                                                          weightUnit: "kg",
@@ -525,6 +552,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                          keywords: "Crunchy, Crispy",
                                                          language: "en",
                                                          tone: "Casual",
+                                                         shouldUseMerchantAIKey: false,
                                                          currencySymbol: "INR",
                                                          dimensionUnit: "cm",
                                                          weightUnit: "kg",
@@ -548,6 +576,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                    keywords: "Crunchy, Crispy",
                                                    language: "en",
                                                    tone: "Casual",
+                                                   shouldUseMerchantAIKey: false,
                                                    currencySymbol: "INR",
                                                    dimensionUnit: "cm",
                                                    weightUnit: "kg",
@@ -572,6 +601,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                    keywords: "Crunchy, Crispy",
                                                    language: "en",
                                                    tone: "Casual",
+                                                   shouldUseMerchantAIKey: false,
                                                    currencySymbol: "INR",
                                                    dimensionUnit: "cm",
                                                    weightUnit: "kg",
@@ -597,6 +627,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -611,6 +642,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -629,6 +661,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                 keywords: "Crunchy, Crispy",
                                                 language: "en",
                                                 tone: "Casual",
+                                                shouldUseMerchantAIKey: false,
                                                 currencySymbol: "INR",
                                                 dimensionUnit: "cm",
                                                 weightUnit: "kg",
@@ -654,6 +687,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",
@@ -668,6 +702,7 @@ final class GenerativeContentRemoteTests: XCTestCase {
                                                keywords: "Crunchy, Crispy",
                                                language: "en",
                                                tone: "Casual",
+                                               shouldUseMerchantAIKey: false,
                                                currencySymbol: "INR",
                                                dimensionUnit: "cm",
                                                weightUnit: "kg",

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -12,6 +12,7 @@ extension WooAnalyticsEvent {
             case description
             case field
             case featureWordCount = "feature_word_count"
+            case aiSource = "ai_source"
         }
 
         static func entryPointDisplayed() -> WooAnalyticsEvent {
@@ -19,9 +20,9 @@ extension WooAnalyticsEvent {
                               properties: [:])
         }
 
-        static func entryPointTapped() -> WooAnalyticsEvent {
+        static func entryPointTapped(_ aiSource: AISource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIEntryPointTapped,
-                              properties: [:])
+                              properties: [Key.aiSource.rawValue: aiSource.rawValue])
         }
 
         static func productNameContinueTapped() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1088,6 +1088,7 @@ enum WooAnalyticsStat: String {
     case hubMenuSwitchStoreTapped = "hub_menu_switch_store_tapped"
     case hubMenuOptionTapped = "hub_menu_option_tapped"
     case hubMenuSettingsTapped = "hub_menu_settings_tapped"
+    case hubMenuAISettingsTapped = "hub_menu_ai_settings_tapped"
 
     // MARK: Coupons
     case couponsLoaded = "coupons_loaded"

--- a/WooCommerce/Classes/Authentication/Keychain+Entries.swift
+++ b/WooCommerce/Classes/Authentication/Keychain+Entries.swift
@@ -26,4 +26,11 @@ extension Keychain {
         get { self[WooConstants.siteCredentialPassword] }
         set { self[WooConstants.siteCredentialPassword] = newValue }
     }
+
+    /// AI Provider API key
+    ///
+    var aiProviderAPIKey: String? {
+        get { self[WooConstants.aiProviderAPIKey] }
+        set { self[WooConstants.aiProviderAPIKey] = newValue }
+    }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -33,6 +33,10 @@ public enum WooConstants {
     ///
     static let siteCredentialPassword = "siteCredentialPassword"
 
+    /// Keychain Access's Key for the AI API key entered by the merchant in AI settings
+    ///
+    static let aiProviderAPIKey = "aiProviderAPIKey"
+
     /// Keychain Access's Key for the current application password
     ///
     static let applicationPassword = "ApplicationPassword"

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct AISettingsView: View {
     @State private var AIProviderApiKey: String = UserDefaults.standard.string(forKey: "AIProviderAPIKey") ?? ""
-    @State private var selectedModel: String = UserDefaults.standard.string(forKey: "AIProviderModel") ?? "gpt-4o"
-    @State private var selectedProvider: String = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
+    @State private var selectedModel: String = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
+    @State private var selectedProvider: String = UserDefaults.standard.string(forKey: "AIProvider") ?? ""
     @State private var isEditingApiKey: Bool = false
 
     let openAIModels = [

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -12,10 +12,10 @@ struct AISettingsView: View {
         ScrollView {
             VStack {
                 HStack {
-                    Text("Provider")
-                    Picker("Select Provider", selection: $viewModel.selectedProvider) {
-                        Text("OpenAI").tag("OpenAI")
-                        Text("Anthropic").tag("Anthropic")
+                    Text(Localization.aiProvider)
+                    Picker(Localization.selectProvider, selection: $viewModel.selectedProvider) {
+                        Text(Localization.openAI).tag("OpenAI")
+                        Text(Localization.anthropic).tag("Anthropic")
                     }
                     .pickerStyle(MenuPickerStyle())
                     .onChange(of: viewModel.selectedProvider) { newValue in
@@ -24,8 +24,8 @@ struct AISettingsView: View {
                 }
 
                 HStack {
-                    Text("Models")
-                    Picker("Select Model", selection: $viewModel.selectedModel) {
+                    Text(Localization.models)
+                    Picker(Localization.selectModel, selection: $viewModel.selectedModel) {
                         ForEach(viewModel.selectedProvider == "OpenAI" ? viewModel.openAIModels : viewModel.anthropicModels, id: \.self) { model in
                             Text(model).tag(model)
                         }
@@ -35,7 +35,7 @@ struct AISettingsView: View {
 
                 Divider()
                 HStack {
-                    TextField("Enter API Key", text: $viewModel.apiKey)
+                    TextField(Localization.enterAPIKey, text: $viewModel.apiKey)
                         .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isEditingApiKey))
                         .foregroundColor(viewModel.isEditingApiKey ? .primary : .gray)
                         .disabled(!viewModel.isEditingApiKey)
@@ -48,18 +48,88 @@ struct AISettingsView: View {
                     }
 
                     Button(action: viewModel.toggleEditing) {
-                        Text(viewModel.isEditingApiKey ? "Save" : "Edit")
+                        Text(viewModel.isEditingApiKey ? Localization.save : Localization.edit)
                     }
                 }
-                Text("Enter your API key to use AI generation at public API costs.")
+                Text(Localization.apiKeyDescription)
                     .font(.caption)
             }
         }
         .padding()
-        .navigationTitle("AI Settings")
+        .navigationTitle(Localization.navigationTitle)
         .onAppear {
             viewModel.onAppear()
         }
+    }
+}
+
+private extension AISettingsView {
+    enum Localization {
+        static let navigationTitle = NSLocalizedString(
+            "aiSettings.navigationTitle",
+            value: "AI Settings",
+            comment: "Navigation title for the AI Settings screen"
+        )
+
+        static let aiProvider = NSLocalizedString(
+            "aiSettings.aiProvider",
+            value: "Provider",
+            comment: "Label for the AI provider selection in AI settings"
+        )
+
+        static let selectProvider = NSLocalizedString(
+            "aiSettings.selectProvider",
+            value: "Select Provider",
+            comment: "Accessibility label for the AI provider picker"
+        )
+
+        static let openAI = NSLocalizedString(
+            "aiSettings.openAI",
+            value: "OpenAI",
+            comment: "Label for OpenAI provider option"
+        )
+
+        static let anthropic = NSLocalizedString(
+            "aiSettings.anthropic",
+            value: "Anthropic",
+            comment: "Label for Anthropic provider option"
+        )
+
+        static let models = NSLocalizedString(
+            "aiSettings.models",
+            value: "Models",
+            comment: "Label for the AI models selection"
+        )
+
+        static let selectModel = NSLocalizedString(
+            "aiSettings.selectModel",
+            value: "Select Model",
+            comment: "Accessibility label for the AI model picker"
+        )
+
+        static let enterAPIKey = NSLocalizedString(
+            "aiSettings.enterAPIKey",
+            value: "Enter API Key",
+            comment: "Placeholder text for the API key input field"
+        )
+
+        static let save = NSLocalizedString(
+            "aiSettings.save",
+            value: "Save",
+            comment: "Button title to save API key"
+        )
+
+        static let edit = NSLocalizedString(
+            "aiSettings.edit",
+            value: "Edit",
+            comment: "Button title to edit API key"
+        )
+
+        static let apiKeyDescription = NSLocalizedString(
+            "aiSettings.apiKeyDescription",
+            value: "Enter your API key to use AI generation at public API costs.",
+            comment: "Description text explaining the purpose of the API key"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 struct AISettingsView: View {
     @State private var AIProviderApiKey: String = UserDefaults.standard.string(forKey: "AIProviderAPIKey") ?? ""
@@ -14,6 +15,11 @@ struct AISettingsView: View {
     let anthropicModels = [
         "claude-3-haiku-20240307"
     ]
+    private let viewModel: AISettingsViewModel
+    
+    init(viewModel: AISettingsViewModel) {
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         ScrollView {
@@ -126,5 +132,5 @@ struct AISettingsView: View {
 }
 
 #Preview {
-    AISettingsView()
+    AISettingsView(viewModel: AISettingsViewModel())
 }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -4,6 +4,7 @@ struct AISettingsView: View {
     @State private var AIProviderApiKey: String = UserDefaults.standard.string(forKey: "AIProviderAPIKey") ?? ""
     @State private var selectedModel: String = UserDefaults.standard.string(forKey: "AIProviderModel") ?? "gpt-4o"
     @State private var selectedProvider: String = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
+    @State private var isEditingApiKey: Bool = false
 
     let openAIModels = [
         "gpt-4o",
@@ -28,6 +29,7 @@ struct AISettingsView: View {
                         selectedModel = selectedProvider == "OpenAI" ? openAIModels.first ?? "" : anthropicModels.first ?? ""
                         UserDefaults.standard.setValue(selectedModel, forKey: "AIProviderModel")
                         UserDefaults.standard.setValue(selectedProvider, forKey: "AIProvider")
+                        logSettings()
                     }
                 }
 
@@ -39,18 +41,39 @@ struct AISettingsView: View {
                         }
                     }
                     .pickerStyle(MenuPickerStyle())
+                    .onChange(of: selectedModel) { _ in
+                        logSettings()
+                    }
                 }
 
                 Divider()
                 HStack {
                     TextField("Enter API Key", text: $AIProviderApiKey)
-                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: isEditingApiKey))
+                        .foregroundColor(isEditingApiKey ? .primary : .gray)
+                        .disabled(!isEditingApiKey)
+
+                    if !AIProviderApiKey.isEmpty {
+                        Button(action: {
+                            AIProviderApiKey = ""
+                            logSettings()
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.gray)
+                        }
+                    }
 
                     Button(action: {
-                        UserDefaults.standard.setValue(AIProviderApiKey, forKey: "AIProviderAPIKey")
-                        UserDefaults.standard.setValue(selectedModel, forKey: "AIProviderModel")
-                        UserDefaults.standard.setValue(selectedProvider, forKey: "AIProvider")
-                    }, label: { Text("Save") })
+                        if isEditingApiKey {
+                            UserDefaults.standard.setValue(AIProviderApiKey, forKey: "AIProviderAPIKey")
+                            UserDefaults.standard.setValue(selectedModel, forKey: "AIProviderModel")
+                            UserDefaults.standard.setValue(selectedProvider, forKey: "AIProvider")
+                            isEditingApiKey = false
+                        } else {
+                            isEditingApiKey = true
+                        }
+                        logSettings()
+                    }, label: { Text(isEditingApiKey ? "Save" : "Edit") })
                 }
                 Text("Enter your API key to use AI generation at public API costs.")
                     .font(.caption)
@@ -59,6 +82,12 @@ struct AISettingsView: View {
         .padding()
         .navigationTitle("AI Settings")
         .onAppear {
+            if !AIProviderApiKey.isEmpty {
+                isEditingApiKey = false
+            } else {
+                isEditingApiKey = true
+            }
+            logSettings()
             getSiteDetails()
         }
     }
@@ -75,6 +104,24 @@ struct AISettingsView: View {
             - isWooCommerceActive : \(site.isWooCommerceActive)
             - isWordPressComStore : \(site.isWordPressComStore)
             """)
+    }
+
+    private func logSettings() {
+        // TODO: Analytics
+        let maskedApiKey: String = {
+            if AIProviderApiKey.count > 8 {
+                let start = AIProviderApiKey.prefix(4)
+                let end = AIProviderApiKey.suffix(4)
+                return "\(start)****\(end)"
+            } else {
+                return "****"
+            }
+        }()
+        
+        print("AIProviderApiKey: \(maskedApiKey)")
+        print("selectedModel: \(selectedModel)")
+        print("selectedProvider: \(selectedProvider)")
+        print("isEditingApiKey: \(isEditingApiKey)")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -1,54 +1,58 @@
 import SwiftUI
 
 struct AISettingsView: View {
-    @State private var openAIApiKey: String = UserDefaults.standard.string(forKey: "OpenAIApiKey") ?? ""
-    @State private var selectedModel: String = UserDefaults.standard.string(forKey: "OpenAIModel") ?? "gpt-4o"
+    @State private var AIProviderApiKey: String = UserDefaults.standard.string(forKey: "AIProviderAPIKey") ?? ""
+    @State private var selectedModel: String = UserDefaults.standard.string(forKey: "AIProviderModel") ?? "gpt-4o"
+    @State private var selectedProvider: String = UserDefaults.standard.string(forKey: "AIProvider") ?? "OpenAI"
 
-    let availableModels = ["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"]
+    let openAIModels = [
+        "gpt-4o",
+        "gpt-4-turbo",
+        "gpt-3.5-turbo"
+    ]
+    let anthropicModels = [
+        "claude-3-haiku-20240307"
+    ]
 
     var body: some View {
         ScrollView {
             VStack {
-                Text("Models")
-                Picker("Select Model", selection: $selectedModel) {
-                    ForEach(availableModels, id: \.self) { model in
-                        Text(model).tag(model)
+                HStack {
+                    Text("Provider")
+                    Picker("Select Provider", selection: $selectedProvider) {
+                        Text("OpenAI").tag("OpenAI")
+                        Text("Anthropic").tag("Anthropic")
+                    }
+                    .pickerStyle(MenuPickerStyle())
+                    .onChange(of: selectedProvider) { _ in
+                        selectedModel = selectedProvider == "OpenAI" ? openAIModels.first ?? "" : anthropicModels.first ?? ""
+                        UserDefaults.standard.setValue(selectedModel, forKey: "AIProviderModel")
+                        UserDefaults.standard.setValue(selectedProvider, forKey: "AIProvider")
                     }
                 }
-                .pickerStyle(MenuPickerStyle())
-                .onChange(of: selectedModel) { newModel in
-                    UserDefaults.standard.setValue(newModel, forKey: "OpenAIModel")
-                }
-                Divider()
 
-                // OpenAI
                 HStack {
-                    Toggle("OpenAI API key", isOn: .constant(true))
+                    Text("Models")
+                    Picker("Select Model", selection: $selectedModel) {
+                        ForEach(selectedProvider == "OpenAI" ? openAIModels : anthropicModels, id: \.self) { model in
+                            Text(model).tag(model)
+                        }
+                    }
+                    .pickerStyle(MenuPickerStyle())
                 }
+
+                Divider()
                 HStack {
-                    TextField("Enter API Key", text: $openAIApiKey)
+                    TextField("Enter API Key", text: $AIProviderApiKey)
                         .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
 
                     Button(action: {
-                        UserDefaults.standard.setValue(openAIApiKey, forKey: "OpenAIApiKey")
+                        UserDefaults.standard.setValue(AIProviderApiKey, forKey: "AIProviderAPIKey")
+                        UserDefaults.standard.setValue(selectedModel, forKey: "AIProviderModel")
+                        UserDefaults.standard.setValue(selectedProvider, forKey: "AIProvider")
                     }, label: { Text("Save") })
                 }
-                Text("Enter your OpenAI key to use AI generation at public API costs.")
-                    .font(.caption)
-
-                // Anthropic
-                HStack {
-                    Toggle("Anthropic API key", isOn: .constant(true))
-                }
-                HStack {
-                    TextField(text: .constant("*****"), label: {
-                        EmptyView()
-                    })
-                    Button(action: {
-                        // TODO: not implemented
-                    }, label: { Text("Save") } )
-                }
-                Text("Enter your Anthropic key to use AI generation at public API costs. When used, this key will be used for all 'claude-' models.")
+                Text("Enter your API key to use AI generation at public API costs.")
                     .font(.caption)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -3,8 +3,19 @@ import Yosemite
 
 struct AISettingsView: View {
     @ObservedObject private var viewModel: AISettingsViewModel
-    // TODO: Show if current source is WPCOM/JP or Merchant key
-    private let currentAISource: String = ""
+
+    // If we're already providing AI capabilities via WPCOM or JPAI we can
+    // override API key usage
+    private var shouldUseWPCOMJPAISource: Bool {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+            return false
+        }
+        if site.isWordPressComStore || site.isAIAssistantFeatureActive {
+            return true
+        } else {
+            return false
+        }
+    }
 
     init(viewModel: AISettingsViewModel) {
         self.viewModel = viewModel
@@ -13,9 +24,22 @@ struct AISettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                Text(Localization.currentAISource(currentAISource))
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                if shouldUseWPCOMJPAISource {
+                    Text(Localization.builtInAIEnabled)
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color(.systemGray6))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color(.gray), lineWidth: 1)
+                        )
+                        .padding(.bottom, 8)
+                        .frame(width: .infinity)
+                }
 
                 HStack {
                     Text(Localization.aiProvider)
@@ -27,6 +51,13 @@ struct AISettingsView: View {
                     .onChange(of: viewModel.selectedProvider) { newValue in
                         viewModel.updateProvider(newValue)
                     }
+                    .disabled(shouldUseWPCOMJPAISource)
+                    .opacity(shouldUseWPCOMJPAISource ? 0.5 : 1.0)
+
+                    if shouldUseWPCOMJPAISource {
+                        Image(systemName: "lock.fill")
+                            .foregroundColor(.gray)
+                    }
                 }
 
                 HStack {
@@ -37,6 +68,13 @@ struct AISettingsView: View {
                         }
                     }
                     .pickerStyle(MenuPickerStyle())
+                    .disabled(shouldUseWPCOMJPAISource)
+                    .opacity(shouldUseWPCOMJPAISource ? 0.5 : 1.0)
+
+                    if shouldUseWPCOMJPAISource {
+                        Image(systemName: "lock.fill")
+                            .foregroundColor(.gray)
+                    }
                 }
 
                 Divider()
@@ -46,17 +84,27 @@ struct AISettingsView: View {
                         TextField(Localization.enterAPIKey, text: $viewModel.apiKey)
                             .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isEditingApiKey))
                             .foregroundColor(viewModel.isEditingApiKey ? .primary : .gray)
-                            .disabled(!viewModel.isEditingApiKey)
+                            .disabled(!viewModel.isEditingApiKey || shouldUseWPCOMJPAISource)
+                            .opacity(shouldUseWPCOMJPAISource ? 0.5 : 1.0)
 
                         if !viewModel.apiKey.isEmpty {
                             Button(action: viewModel.clearApiKey) {
                                 Image(systemName: "xmark.circle.fill")
                                     .foregroundColor(.gray)
                             }
+                            .disabled(shouldUseWPCOMJPAISource)
+                            .opacity(shouldUseWPCOMJPAISource ? 0.5 : 1.0)
                         }
 
                         Button(action: viewModel.toggleEditing) {
                             Text(viewModel.isEditingApiKey ? Localization.save : Localization.edit)
+                        }
+                        .disabled(shouldUseWPCOMJPAISource)
+                        .opacity(shouldUseWPCOMJPAISource ? 0.5 : 1.0)
+
+                        if shouldUseWPCOMJPAISource {
+                            Image(systemName: "lock.fill")
+                                .foregroundColor(.gray)
                         }
                     }
 
@@ -71,11 +119,15 @@ struct AISettingsView: View {
                     .foregroundColor(.secondary)
             }
             .padding()
+            .onAppear {
+                viewModel.onAppear()
+                if shouldUseWPCOMJPAISource {
+                    viewModel.selectedProvider = "OpenAI"
+                    viewModel.selectedModel = "gpt-4o"
+                }
+            }
         }
         .navigationTitle(Localization.navigationTitle)
-        .onAppear {
-            viewModel.onAppear()
-        }
     }
 }
 
@@ -145,6 +197,12 @@ private extension AISettingsView {
             "aiSettings.apiKeyDescription",
             value: "Enter your API key to use AI generation at public API costs.",
             comment: "Description text explaining the purpose of the API key"
+        )
+
+        static let builtInAIEnabled = NSLocalizedString(
+            "aiSettings.builtInAIEnabled",
+            value: "AI capabilities are already enabled for this site.",
+            comment: "Message displayed when built-in AI feature is enabled"
         )
 
         static func currentAISource(_ source: String) -> String {

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -2,14 +2,23 @@ import SwiftUI
 
 struct AISettingsView: View {
     @State private var openAIApiKey: String = UserDefaults.standard.string(forKey: "OpenAIApiKey") ?? ""
+    @State private var selectedModel: String = UserDefaults.standard.string(forKey: "OpenAIModel") ?? "gpt-4o"
+
+    let availableModels = ["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"]
 
     var body: some View {
         ScrollView {
             VStack {
                 Text("Models")
-                // TODO:
-                Text("✅ gpt-4o")
-                Text("◽️ claude-3.5-sonnet")
+                Picker("Select Model", selection: $selectedModel) {
+                    ForEach(availableModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+                .pickerStyle(MenuPickerStyle())
+                .onChange(of: selectedModel) { newModel in
+                    UserDefaults.standard.setValue(newModel, forKey: "OpenAIModel")
+                }
                 Divider()
 
                 // OpenAI
@@ -63,4 +72,8 @@ struct AISettingsView: View {
             - isWordPressComStore : \(site.isWordPressComStore)
             """)
     }
+}
+
+#Preview {
+    AISettingsView()
 }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -2,20 +2,7 @@ import SwiftUI
 import Yosemite
 
 struct AISettingsView: View {
-    @State private var AIProviderApiKey: String = UserDefaults.standard.string(forKey: "AIProviderAPIKey") ?? ""
-    @State private var selectedModel: String = UserDefaults.standard.string(forKey: "AIProviderModel") ?? ""
-    @State private var selectedProvider: String = UserDefaults.standard.string(forKey: "AIProvider") ?? ""
-    @State private var isEditingApiKey: Bool = false
-
-    let openAIModels = [
-        "gpt-4o",
-        "gpt-4-turbo",
-        "gpt-3.5-turbo"
-    ]
-    let anthropicModels = [
-        "claude-3-haiku-20240307"
-    ]
-    private let viewModel: AISettingsViewModel
+    @ObservedObject private var viewModel: AISettingsViewModel
     
     init(viewModel: AISettingsViewModel) {
         self.viewModel = viewModel
@@ -26,60 +13,43 @@ struct AISettingsView: View {
             VStack {
                 HStack {
                     Text("Provider")
-                    Picker("Select Provider", selection: $selectedProvider) {
+                    Picker("Select Provider", selection: $viewModel.selectedProvider) {
                         Text("OpenAI").tag("OpenAI")
                         Text("Anthropic").tag("Anthropic")
                     }
                     .pickerStyle(MenuPickerStyle())
-                    .onChange(of: selectedProvider) { _ in
-                        selectedModel = selectedProvider == "OpenAI" ? openAIModels.first ?? "" : anthropicModels.first ?? ""
-                        UserDefaults.standard.setValue(selectedModel, forKey: "AIProviderModel")
-                        UserDefaults.standard.setValue(selectedProvider, forKey: "AIProvider")
-                        logSettings()
+                    .onChange(of: viewModel.selectedProvider) { newValue in
+                        viewModel.updateProvider(newValue)
                     }
                 }
 
                 HStack {
                     Text("Models")
-                    Picker("Select Model", selection: $selectedModel) {
-                        ForEach(selectedProvider == "OpenAI" ? openAIModels : anthropicModels, id: \.self) { model in
+                    Picker("Select Model", selection: $viewModel.selectedModel) {
+                        ForEach(viewModel.selectedProvider == "OpenAI" ? viewModel.openAIModels : viewModel.anthropicModels, id: \.self) { model in
                             Text(model).tag(model)
                         }
                     }
                     .pickerStyle(MenuPickerStyle())
-                    .onChange(of: selectedModel) { _ in
-                        logSettings()
-                    }
                 }
 
                 Divider()
                 HStack {
-                    TextField("Enter API Key", text: $AIProviderApiKey)
-                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: isEditingApiKey))
-                        .foregroundColor(isEditingApiKey ? .primary : .gray)
-                        .disabled(!isEditingApiKey)
+                    TextField("Enter API Key", text: $viewModel.apiKey)
+                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isEditingApiKey))
+                        .foregroundColor(viewModel.isEditingApiKey ? .primary : .gray)
+                        .disabled(!viewModel.isEditingApiKey)
 
-                    if !AIProviderApiKey.isEmpty {
-                        Button(action: {
-                            AIProviderApiKey = ""
-                            logSettings()
-                        }) {
+                    if !viewModel.apiKey.isEmpty {
+                        Button(action: viewModel.clearApiKey) {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundColor(.gray)
                         }
                     }
 
-                    Button(action: {
-                        if isEditingApiKey {
-                            UserDefaults.standard.setValue(AIProviderApiKey, forKey: "AIProviderAPIKey")
-                            UserDefaults.standard.setValue(selectedModel, forKey: "AIProviderModel")
-                            UserDefaults.standard.setValue(selectedProvider, forKey: "AIProvider")
-                            isEditingApiKey = false
-                        } else {
-                            isEditingApiKey = true
-                        }
-                        logSettings()
-                    }, label: { Text(isEditingApiKey ? "Save" : "Edit") })
+                    Button(action: viewModel.toggleEditing) {
+                        Text(viewModel.isEditingApiKey ? "Save" : "Edit")
+                    }
                 }
                 Text("Enter your API key to use AI generation at public API costs.")
                     .font(.caption)
@@ -88,46 +58,8 @@ struct AISettingsView: View {
         .padding()
         .navigationTitle("AI Settings")
         .onAppear {
-            if !AIProviderApiKey.isEmpty {
-                isEditingApiKey = false
-            } else {
-                isEditingApiKey = true
-            }
-            logSettings()
-            getSiteDetails()
+            viewModel.onAppear()
         }
-    }
-
-    func getSiteDetails() {
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
-            return
-        }
-        debugPrint("""
-            🍍
-            - isAIAssistantFeatureActive : \(site.isAIAssistantFeatureActive)
-            - isJetpackThePluginInstalled : \(site.isJetpackThePluginInstalled)
-            - isJetpackConnected : \(site.isJetpackConnected)
-            - isWooCommerceActive : \(site.isWooCommerceActive)
-            - isWordPressComStore : \(site.isWordPressComStore)
-            """)
-    }
-
-    private func logSettings() {
-        // TODO: Analytics
-        let maskedApiKey: String = {
-            if AIProviderApiKey.count > 8 {
-                let start = AIProviderApiKey.prefix(4)
-                let end = AIProviderApiKey.suffix(4)
-                return "\(start)****\(end)"
-            } else {
-                return "****"
-            }
-        }()
-        
-        print("AIProviderApiKey: \(maskedApiKey)")
-        print("selectedModel: \(selectedModel)")
-        print("selectedProvider: \(selectedProvider)")
-        print("isEditingApiKey: \(isEditingApiKey)")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -81,19 +81,23 @@ struct AISettingsView: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        TextField(Localization.enterAPIKey, text: $viewModel.apiKey)
-                            .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isEditingApiKey))
-                            .foregroundColor(viewModel.isEditingApiKey ? .primary : .gray)
-                            .disabled(!viewModel.isEditingApiKey || shouldUseWPCOMJPAISource)
-                            .opacity(shouldUseWPCOMJPAISource ? 0.5 : 1.0)
+                        TextField(
+                            Localization.enterAPIKey,
+                            text: Binding(
+                                get: { viewModel.isEditingApiKey ? viewModel.apiKey : "**********" },
+                                set: { newValue in if viewModel.isEditingApiKey { viewModel.apiKey = newValue } }
+                            )
+                        )
+                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isEditingApiKey))
+                        .foregroundColor(.primary)
+                        .privacySensitive()
+                        .disabled(!viewModel.isEditingApiKey)
 
-                        if !viewModel.apiKey.isEmpty {
+                        if viewModel.isEditingApiKey, !viewModel.apiKey.isEmpty {
                             Button(action: viewModel.clearApiKey) {
                                 Image(systemName: "xmark.circle.fill")
                                     .foregroundColor(.gray)
                             }
-                            .disabled(shouldUseWPCOMJPAISource)
-                            .opacity(shouldUseWPCOMJPAISource ? 0.5 : 1.0)
                         }
 
                         Button(action: viewModel.toggleEditing) {

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -3,6 +3,8 @@ import Yosemite
 
 struct AISettingsView: View {
     @ObservedObject private var viewModel: AISettingsViewModel
+    // TODO: Show if current source is WPCOM/JP or Merchant key
+    private let currentAISource: String = ""
 
     init(viewModel: AISettingsViewModel) {
         self.viewModel = viewModel
@@ -10,7 +12,11 @@ struct AISettingsView: View {
 
     var body: some View {
         ScrollView {
-            VStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(Localization.currentAISource(currentAISource))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
                 HStack {
                     Text(Localization.aiProvider)
                     Picker(Localization.selectProvider, selection: $viewModel.selectedProvider) {
@@ -34,28 +40,38 @@ struct AISettingsView: View {
                 }
 
                 Divider()
-                HStack {
-                    TextField(Localization.enterAPIKey, text: $viewModel.apiKey)
-                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isEditingApiKey))
-                        .foregroundColor(viewModel.isEditingApiKey ? .primary : .gray)
-                        .disabled(!viewModel.isEditingApiKey)
 
-                    if !viewModel.apiKey.isEmpty {
-                        Button(action: viewModel.clearApiKey) {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundColor(.gray)
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        TextField(Localization.enterAPIKey, text: $viewModel.apiKey)
+                            .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isEditingApiKey))
+                            .foregroundColor(viewModel.isEditingApiKey ? .primary : .gray)
+                            .disabled(!viewModel.isEditingApiKey)
+
+                        if !viewModel.apiKey.isEmpty {
+                            Button(action: viewModel.clearApiKey) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.gray)
+                            }
+                        }
+
+                        Button(action: viewModel.toggleEditing) {
+                            Text(viewModel.isEditingApiKey ? Localization.save : Localization.edit)
                         }
                     }
 
-                    Button(action: viewModel.toggleEditing) {
-                        Text(viewModel.isEditingApiKey ? Localization.save : Localization.edit)
-                    }
+                    Text(Localization.apiKeyDescription)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                    Spacer()
                 }
-                Text(Localization.apiKeyDescription)
+                Text(Localization.apiKeyDisclaimer)
                     .font(.caption)
+                    .foregroundColor(.secondary)
             }
+            .padding()
         }
-        .padding()
         .navigationTitle(Localization.navigationTitle)
         .onAppear {
             viewModel.onAppear()
@@ -129,6 +145,20 @@ private extension AISettingsView {
             "aiSettings.apiKeyDescription",
             value: "Enter your API key to use AI generation at public API costs.",
             comment: "Description text explaining the purpose of the API key"
+        )
+
+        static func currentAISource(_ source: String) -> String {
+            String(format: NSLocalizedString(
+                "aiSettings.currentAISource",
+                value: "Current AI source: %@",
+                comment: "Label showing the current AI source being used. %@ shows the provider name (e.g. Jetpack)"
+            ), source)
+        }
+
+        static let apiKeyDisclaimer = NSLocalizedString(
+            "aiSettings.apiKeyDisclaimer",
+            value: "API keys open up access to potentially sensitive information. Do not share your API key with others or expose them.",
+            comment: "Warning message about keeping API keys secure"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct AISettingsView: View {
+    @State private var openAIApiKey: String = UserDefaults.standard.string(forKey: "OpenAIApiKey") ?? ""
+
+    var body: some View {
+        ScrollView {
+            VStack {
+                Text("Models")
+                // TODO:
+                Text("✅ gpt-4o")
+                Text("◽️ claude-3.5-sonnet")
+                Divider()
+
+                // OpenAI
+                HStack {
+                    Toggle("OpenAI API key", isOn: .constant(true))
+                }
+                HStack {
+                    TextField("Enter API Key", text: $openAIApiKey)
+                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+
+                    Button(action: {
+                        UserDefaults.standard.setValue(openAIApiKey, forKey: "OpenAIApiKey")
+                    }, label: { Text("Save") })
+                }
+                Text("Enter your OpenAI key to use AI generation at public API costs.")
+                    .font(.caption)
+
+                // Anthropic
+                HStack {
+                    Toggle("Anthropic API key", isOn: .constant(true))
+                }
+                HStack {
+                    TextField(text: .constant("*****"), label: {
+                        EmptyView()
+                    })
+                    Button(action: {
+                        // TODO: not implemented
+                    }, label: { Text("Save") } )
+                }
+                Text("Enter your Anthropic key to use AI generation at public API costs. When used, this key will be used for all 'claude-' models.")
+                    .font(.caption)
+            }
+        }
+        .padding()
+        .navigationTitle("AI Settings")
+        .onAppear {
+            getSiteDetails()
+        }
+    }
+
+    func getSiteDetails() {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+            return
+        }
+        debugPrint("""
+            🍍
+            - isAIAssistantFeatureActive : \(site.isAIAssistantFeatureActive)
+            - isJetpackThePluginInstalled : \(site.isJetpackThePluginInstalled)
+            - isJetpackConnected : \(site.isJetpackConnected)
+            - isWooCommerceActive : \(site.isWooCommerceActive)
+            - isWordPressComStore : \(site.isWordPressComStore)
+            """)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct AISettingsView: View {
     @ObservedObject private var viewModel: AISettingsViewModel
-    
+
     init(viewModel: AISettingsViewModel) {
         self.viewModel = viewModel
     }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
@@ -4,6 +4,7 @@ final class AISettingsViewModel: ObservableObject {
     @Published var apiKey: String
     @Published var selectedModel: String
     @Published var selectedProvider: String
+    @Published var isEditingApiKey: Bool
 
     private let defaults: UserDefaults
 
@@ -22,6 +23,13 @@ final class AISettingsViewModel: ObservableObject {
         self.apiKey = defaults.string(forKey: "AIProviderAPIKey") ?? ""
         self.selectedModel = defaults.string(forKey: "AIProviderModel") ?? ""
         self.selectedProvider = defaults.string(forKey: "AIProvider") ?? ""
+        self.isEditingApiKey = false
+    }
+
+    func onAppear() {
+        isEditingApiKey = apiKey.isEmpty
+        debug_getSiteDetails()
+        debug_logSettings()
     }
 
     func updateProvider(_ provider: String) {
@@ -30,9 +38,56 @@ final class AISettingsViewModel: ObservableObject {
         saveSettings()
     }
 
+    func clearApiKey() {
+        apiKey = ""
+        debug_logSettings()
+    }
+
+    func toggleEditing() {
+        if isEditingApiKey {
+            saveSettings()
+        }
+        isEditingApiKey.toggle()
+        debug_logSettings()
+    }
+
     private func saveSettings() {
         defaults.setValue(apiKey, forKey: "AIProviderAPIKey")
         defaults.setValue(selectedModel, forKey: "AIProviderModel")
         defaults.setValue(selectedProvider, forKey: "AIProvider")
+    }
+}
+
+// MARK: - Debug helpers
+private extension AISettingsViewModel {
+    func debug_getSiteDetails() {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+            return
+        }
+        debugPrint("""
+                🍍
+                - isAIAssistantFeatureActive : \(site.isAIAssistantFeatureActive)
+                - isJetpackThePluginInstalled : \(site.isJetpackThePluginInstalled)
+                - isJetpackConnected : \(site.isJetpackConnected)
+                - isWooCommerceActive : \(site.isWooCommerceActive)
+                - isWordPressComStore : \(site.isWordPressComStore)
+                """)
+    }
+    
+    private func debug_logSettings() {
+        let maskedApiKey: String = {
+            if apiKey.count > 8 {
+                let start = apiKey.prefix(4)
+                let end = apiKey.suffix(4)
+                return "\(start)****\(end)"
+            } else {
+                return "****"
+            }
+        }()
+        
+        print("AIProviderApiKey: \(maskedApiKey)")
+        print("selectedModel: \(selectedModel)")
+        print("selectedProvider: \(selectedProvider)")
+        print("isEditingApiKey: \(isEditingApiKey)")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
@@ -1,6 +1,9 @@
 import SwiftUI
+import KeychainAccess
 
 final class AISettingsViewModel: ObservableObject {
+    private var keychain = Keychain(service: WooConstants.keychainServiceName)
+
     @Published var apiKey: String
     @Published var selectedModel: String
     @Published var selectedProvider: String
@@ -20,7 +23,7 @@ final class AISettingsViewModel: ObservableObject {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        self.apiKey = defaults.string(forKey: "AIProviderAPIKey") ?? ""
+        self.apiKey = Keychain(service: WooConstants.keychainServiceName).aiProviderAPIKey ?? ""
         self.selectedModel = defaults.string(forKey: "AIProviderModel") ?? ""
         self.selectedProvider = defaults.string(forKey: "AIProvider") ?? ""
         self.isEditingApiKey = false
@@ -38,6 +41,7 @@ final class AISettingsViewModel: ObservableObject {
 
     func clearApiKey() {
         apiKey = ""
+        keychain.aiProviderAPIKey = nil
     }
 
     func toggleEditing() {
@@ -48,7 +52,7 @@ final class AISettingsViewModel: ObservableObject {
     }
 
     private func saveSettings() {
-        defaults.setValue(apiKey, forKey: "AIProviderAPIKey")
+        keychain.aiProviderAPIKey = apiKey
         defaults.setValue(selectedModel, forKey: "AIProviderModel")
         defaults.setValue(selectedProvider, forKey: "AIProvider")
     }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
@@ -28,8 +28,6 @@ final class AISettingsViewModel: ObservableObject {
 
     func onAppear() {
         isEditingApiKey = apiKey.isEmpty
-        debug_getSiteDetails()
-        debug_logSettings()
     }
 
     func updateProvider(_ provider: String) {
@@ -40,7 +38,6 @@ final class AISettingsViewModel: ObservableObject {
 
     func clearApiKey() {
         apiKey = ""
-        debug_logSettings()
     }
 
     func toggleEditing() {
@@ -48,46 +45,11 @@ final class AISettingsViewModel: ObservableObject {
             saveSettings()
         }
         isEditingApiKey.toggle()
-        debug_logSettings()
     }
 
     private func saveSettings() {
         defaults.setValue(apiKey, forKey: "AIProviderAPIKey")
         defaults.setValue(selectedModel, forKey: "AIProviderModel")
         defaults.setValue(selectedProvider, forKey: "AIProvider")
-    }
-}
-
-// MARK: - Debug helpers
-private extension AISettingsViewModel {
-    func debug_getSiteDetails() {
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
-            return
-        }
-        debugPrint("""
-                🍍
-                - isAIAssistantFeatureActive : \(site.isAIAssistantFeatureActive)
-                - isJetpackThePluginInstalled : \(site.isJetpackThePluginInstalled)
-                - isJetpackConnected : \(site.isJetpackConnected)
-                - isWooCommerceActive : \(site.isWooCommerceActive)
-                - isWordPressComStore : \(site.isWordPressComStore)
-                """)
-    }
-
-    private func debug_logSettings() {
-        let maskedApiKey: String = {
-            if apiKey.count > 8 {
-                let start = apiKey.prefix(4)
-                let end = apiKey.suffix(4)
-                return "\(start)****\(end)"
-            } else {
-                return "****"
-            }
-        }()
-
-        print("AIProviderApiKey: \(maskedApiKey)")
-        print("selectedModel: \(selectedModel)")
-        print("selectedProvider: \(selectedProvider)")
-        print("isEditingApiKey: \(isEditingApiKey)")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
@@ -73,7 +73,7 @@ private extension AISettingsViewModel {
                 - isWordPressComStore : \(site.isWordPressComStore)
                 """)
     }
-    
+
     private func debug_logSettings() {
         let maskedApiKey: String = {
             if apiKey.count > 8 {
@@ -84,7 +84,7 @@ private extension AISettingsViewModel {
                 return "****"
             }
         }()
-        
+
         print("AIProviderApiKey: \(maskedApiKey)")
         print("selectedModel: \(selectedModel)")
         print("selectedProvider: \(selectedProvider)")

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+final class AISettingsViewModel: ObservableObject {
+    @Published var apiKey: String
+    @Published var selectedModel: String
+    @Published var selectedProvider: String
+
+    private let defaults: UserDefaults
+
+    let openAIModels = [
+        "gpt-4o",
+        "gpt-4-turbo",
+        "gpt-3.5-turbo"
+    ]
+
+    let anthropicModels = [
+        "claude-3-haiku-20240307"
+    ]
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.apiKey = defaults.string(forKey: "AIProviderAPIKey") ?? ""
+        self.selectedModel = defaults.string(forKey: "AIProviderModel") ?? ""
+        self.selectedProvider = defaults.string(forKey: "AIProvider") ?? ""
+    }
+
+    func updateProvider(_ provider: String) {
+        selectedProvider = provider
+        selectedModel = provider == "OpenAI" ? openAIModels.first ?? "" : anthropicModels.first ?? ""
+        saveSettings()
+    }
+
+    private func saveSettings() {
+        defaults.setValue(apiKey, forKey: "AIProviderAPIKey")
+        defaults.setValue(selectedModel, forKey: "AIProviderModel")
+        defaults.setValue(selectedProvider, forKey: "AIProvider")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsViewModel.swift
@@ -4,7 +4,7 @@ import KeychainAccess
 final class AISettingsViewModel: ObservableObject {
     private var keychain = Keychain(service: WooConstants.keychainServiceName)
 
-    @Published var apiKey: String
+    @Published var apiKey: String // TODO: Make function and restrict set access
     @Published var selectedModel: String
     @Published var selectedProvider: String
     @Published var isEditingApiKey: Bool

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -183,6 +183,8 @@ private extension HubMenu {
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, selectedCampaignID: campaignID)
             case .blazeCampaignCreation:
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, startsCampaignCreationOnAppear: true)
+            case .aiSettings:
+                AISettingsView()
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -69,6 +69,8 @@ struct HubMenu: View {
             ServiceLocator.analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .menu))
         case HubMenuViewModel.PointOfSaleEntryPoint.id:
             viewModel.showsPOS = true
+        case HubMenuViewModel.AISettings.id:
+            ServiceLocator.analytics.track(.hubMenuAISettingsTapped)
         default:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -186,6 +186,7 @@ private extension HubMenu {
             case .blazeCampaignCreation:
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, startsCampaignCreationOnAppear: true)
             case .aiSettings:
+                // TODO: Pass eligibility, so we know what's the AI source
                 let viewModel = AISettingsViewModel()
                 AISettingsView(viewModel: viewModel)
             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -184,7 +184,8 @@ private extension HubMenu {
             case .blazeCampaignCreation:
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, startsCampaignCreationOnAppear: true)
             case .aiSettings:
-                AISettingsView()
+                let viewModel = AISettingsViewModel()
+                AISettingsView(viewModel: viewModel)
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -346,7 +346,7 @@ private extension HubMenuViewModel {
         var items: [HubMenuItem] = [
             Payments(iconBadge: shouldShowBadgeOnPayments ? .dot : nil)
         ]
-        
+
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey) {
             items.append(AISettings())
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -554,10 +554,10 @@ extension HubMenuViewModel {
     struct AISettings: HubMenuItem {
         static var id = "ai-settings"
 
-        let title: String = "AI"
-        let description: String = "AI enhancement"
-        let icon: UIImage = .exclamationImage
-        let iconColor: UIColor = .withColorStudio(.orange)
+        let title: String = "AI Settings"
+        let description: String = "Manage your store's AI-powered features"
+        let icon: UIImage = UIImage(systemName: "wand.and.rays.inverse")!
+        let iconColor: UIColor = .withColorStudio(.green)
         let accessibilityIdentifier: String = "menu-ai"
         let trackingOption: String = "ai"
         let iconBadge: HubMenuBadgeType?

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -94,6 +94,7 @@ final class HubMenuViewModel: ObservableObject {
     private let inboxEligibilityChecker: InboxEligibilityChecker
     private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
+    private let productCreationAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol
 
     private(set) lazy var posItemProvider: PointOfSaleItemServiceProtocol = {
         let storage = ServiceLocator.storageManager
@@ -112,6 +113,7 @@ final class HubMenuViewModel: ObservableObject {
     @Published private var isSiteEligibleForBlaze = false
     @Published private var isSiteEligibleForGoogleAds = false
     @Published private var isSiteEligibleForInbox = false
+    @Published private var isSiteEligibleForProductAICreation = false
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -150,6 +152,7 @@ final class HubMenuViewModel: ObservableObject {
          inboxEligibilityChecker: InboxEligibilityChecker = InboxEligibilityUseCase(),
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker(),
          googleAdsEligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker(),
+         productCreationAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol = ProductCreationAIEligibilityChecker(),
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.credentials = stores.sessionManager.defaultCredentials
@@ -161,6 +164,7 @@ final class HubMenuViewModel: ObservableObject {
         self.inboxEligibilityChecker = inboxEligibilityChecker
         self.blazeEligibilityChecker = blazeEligibilityChecker
         self.googleAdsEligibilityChecker = googleAdsEligibilityChecker
+        self.productCreationAIEligibilityChecker = productCreationAIEligibilityChecker
         self.cardPresentPaymentsOnboarding = CardPresentPaymentsOnboardingUseCase()
         self.posEligibilityChecker = POSEligibilityChecker(siteSettings: ServiceLocator.selectedSiteSettings,
                                                            currencySettings: ServiceLocator.currencySettings,
@@ -322,18 +326,25 @@ private extension HubMenuViewModel {
     }
 
     func setupGeneralElements() {
-        $shouldShowNewFeatureBadgeOnPayments
-            .combineLatest($isSiteEligibleForInbox,
-                           $isSiteEligibleForBlaze,
-                           $isSiteEligibleForGoogleAds)
+        let eligibilityPublisher = $isSiteEligibleForInbox
+            .combineLatest($isSiteEligibleForBlaze, $isSiteEligibleForGoogleAds)
+            .map { (inbox, blaze, googleAds) -> (Bool, Bool, Bool) in
+                return (inbox, blaze, googleAds)
+            }
+        eligibilityPublisher
+            .combineLatest($shouldShowNewFeatureBadgeOnPayments, $isSiteEligibleForProductAICreation)
             .map { [weak self] combinedResult -> [HubMenuItem] in
                 guard let self else { return [] }
-                let (shouldShowBadgeOnPayments, eligibleForInbox, eligibleForBlaze, eligibleForGoogleAds) = combinedResult
-                return createGeneralElements(
+                let ((eligibleForInbox, eligibleForBlaze, eligibleForGoogleAds),
+                     shouldShowBadgeOnPayments,
+                     eligibleForProductAICreation) = combinedResult
+
+                return self.createGeneralElements(
                     shouldShowBadgeOnPayments: shouldShowBadgeOnPayments,
                     eligibleForGoogleAds: eligibleForGoogleAds,
                     eligibleForBlaze: eligibleForBlaze,
-                    eligibleForInbox: eligibleForInbox
+                    eligibleForInbox: eligibleForInbox,
+                    eligibleForProductAICreation: eligibleForProductAICreation
                 )
             }
             .assign(to: &$generalElements)
@@ -342,12 +353,13 @@ private extension HubMenuViewModel {
     func createGeneralElements(shouldShowBadgeOnPayments: Bool,
                                eligibleForGoogleAds: Bool,
                                eligibleForBlaze: Bool,
-                               eligibleForInbox: Bool) -> [HubMenuItem] {
+                               eligibleForInbox: Bool,
+                               eligibleForProductAICreation: Bool) -> [HubMenuItem] {
         var items: [HubMenuItem] = [
             Payments(iconBadge: shouldShowBadgeOnPayments ? .dot : nil)
         ]
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey) {
+        if eligibleForProductAICreation {
             items.append(AISettings())
         }
 
@@ -429,8 +441,8 @@ private extension HubMenuViewModel {
     }
 
     func updateMenuItemEligibility(with site: Yosemite.Site) {
-
         isSiteEligibleForInbox = inboxEligibilityChecker.isEligibleForInbox(siteID: site.siteID)
+        isSiteEligibleForProductAICreation = productCreationAIEligibilityChecker.isEligible
 
         Task { @MainActor in
             isSiteEligibleForGoogleAds = await googleAdsEligibilityChecker.isSiteEligible(siteID: site.siteID)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -15,6 +15,7 @@ extension NSNotification.Name {
 
 /// Destination views that the hub menu can navigate to.
 enum HubMenuNavigationDestination: Hashable {
+    case aiSettings
     case payments
     case settings
     case blaze
@@ -345,6 +346,10 @@ private extension HubMenuViewModel {
         var items: [HubMenuItem] = [
             Payments(iconBadge: shouldShowBadgeOnPayments ? .dot : nil)
         ]
+        
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey) {
+            items.append(AISettings())
+        }
 
         if eligibleForGoogleAds {
             items.append(GoogleAds())
@@ -544,6 +549,23 @@ extension HubMenuViewModel {
         let trackingOption: String = "settings"
         let iconBadge: HubMenuBadgeType? = nil
         let navigationDestination: HubMenuNavigationDestination? = .settings
+    }
+
+    struct AISettings: HubMenuItem {
+        static var id = "ai-settings"
+
+        let title: String = "AI"
+        let description: String = "AI enhancement"
+        let icon: UIImage = .exclamationImage
+        let iconColor: UIColor = .withColorStudio(.orange)
+        let accessibilityIdentifier: String = "menu-ai"
+        let trackingOption: String = "ai"
+        let iconBadge: HubMenuBadgeType?
+        let navigationDestination: HubMenuNavigationDestination? = .aiSettings
+
+        init(iconBadge: HubMenuBadgeType? = nil) {
+            self.iconBadge = iconBadge
+        }
     }
 
     struct Payments: HubMenuItem {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -257,7 +257,7 @@ final class ProductDescriptionGenerationPreviewStores: DefaultStoresManager {
 
     override func dispatch(_ action: Action) {
         if let action = action as? ProductAction {
-            if case let .generateProductDescription(_, _, _, _, completion) = action {
+            if case let .generateProductDescription(_, _, _, _, _, completion) = action {
                 completion(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -22,7 +22,7 @@ final class ProductDescriptionGenerationHostingController: UIHostingController<P
     }
 }
 
-/// Allows the user to generate a product description using Jetpack AI given the product name and features.
+/// Allows the user to generate a product description using AI given the product name and features.
 struct ProductDescriptionGenerationView: View {
     @ObservedObject private var viewModel: ProductDescriptionGenerationViewModel
     @State private var copyTextNotice: Notice?

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -50,6 +50,10 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
     ///
     private var languageIdentifiedUsingAI: String?
 
+    private var shouldUseMerchantAIKey: Bool {
+        ProductCreationAIEligibilityChecker().aiSource == .merchant
+    }
+
     init(siteID: Int64,
          name: String,
          description: String,
@@ -118,6 +122,7 @@ private extension ProductDescriptionGenerationViewModel {
             return await withCheckedContinuation { continuation in
                 stores.dispatch(ProductAction.generateProductDescription(siteID: siteID,
                                                                          name: name,
+                                                                         shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                          features: features,
                                                                          language: language) { result in
                     continuation.resume(returning: result)
@@ -139,6 +144,7 @@ private extension ProductDescriptionGenerationViewModel {
             let language = try await withCheckedThrowingContinuation { continuation in
                 stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
                                                                string: name + " " + features,
+                                                               shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                feature: .productDescription,
                                                                completion: { result in
                     continuation.resume(with: result)

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -51,6 +51,10 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
     ///
     private var languageIdentifiedUsingAI: String?
 
+    private var shouldUseMerchantAIKey: Bool {
+        ProductCreationAIEligibilityChecker().aiSource == .merchant
+    }
+
     init(siteID: Int64,
          url: String,
          productName: String,
@@ -134,6 +138,7 @@ private extension ProductSharingMessageGenerationViewModel {
                                                                         name: productName,
                                                                         description: productDescription,
                                                                         language: language,
+                                                                        shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                         completion: { result in
                 continuation.resume(with: result)
             }))
@@ -151,6 +156,7 @@ private extension ProductSharingMessageGenerationViewModel {
             let language = try await withCheckedThrowingContinuation { continuation in
                 stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
                                                                string: productName + " " + productDescription,
+                                                               shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                feature: .productSharing,
                                                                completion: { result in
                     continuation.resume(with: result)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -206,8 +206,9 @@ private extension AddProductCoordinator {
             productTypes: productTypes,
             aiSource: aiSource,
             onAIOption: { [weak self] in
+                let trackedAiSource = self?.aiSource ?? .none
                 self?.addProductWithAIBottomSheetPresenter?.dismiss {
-                    self?.analytics.track(event: .ProductCreationAI.entryPointTapped())
+                    self?.analytics.track(event: .ProductCreationAI.entryPointTapped(trackedAiSource))
                     self?.addProductWithAIBottomSheetPresenter = nil
                     self?.startProductCreationWithAI()
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -115,7 +115,7 @@ final class AddProductCoordinator: Coordinator {
         if shouldSkipBottomSheet {
             presentProductForm(bottomSheetProductType: .simple(isVirtual: false))
         } else if shouldShowAIActionSheet {
-            presentActionSheetWithAI()
+            presentActionSheetWithAI(source: aiSource)
         } else {
             presentProductTypeBottomSheet()
         }
@@ -128,12 +128,13 @@ private extension AddProductCoordinator {
     /// Whether the action sheet with the option for product creation with AI should be presented.
     ///
     var shouldShowAIActionSheet: Bool {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey) {
-            // TODO: Needs more eligibility checks, as the flag could ne enabled, but the API key not entered, in which case they do not know what to do
-            return true
-        } else {
-            return addProductWithAIEligibilityChecker.isEligible
-        }
+        addProductWithAIEligibilityChecker.isEligible
+    }
+
+    /// The source used for AI generation based on eligibility, it could be either from WPCOM/JP or from a merchant API key
+    ///
+    var aiSource: AISource {
+        addProductWithAIEligibilityChecker.aiSource
     }
 
     /// Defines if it should skip the bottom sheet before the product form is shown.
@@ -190,7 +191,7 @@ private extension AddProductCoordinator {
 
     /// Presents an action sheet with the option to start product creation with AI
     ///
-    func presentActionSheetWithAI() {
+    func presentActionSheetWithAI(source: AISource) {
         let isEligibleForWooSubscriptionProducts = wooSubscriptionProductsEligibilityChecker.isSiteEligible()
         let productTypes: [BottomSheetProductType] = [
             .simple(isVirtual: false),
@@ -203,6 +204,7 @@ private extension AddProductCoordinator {
 
         let controller = AddProductWithAIActionSheetHostingController(
             productTypes: productTypes,
+            aiSource: aiSource,
             onAIOption: { [weak self] in
                 self?.addProductWithAIBottomSheetPresenter?.dismiss {
                     self?.analytics.track(event: .ProductCreationAI.entryPointTapped())

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -128,7 +128,11 @@ private extension AddProductCoordinator {
     /// Whether the action sheet with the option for product creation with AI should be presented.
     ///
     var shouldShowAIActionSheet: Bool {
-        addProductWithAIEligibilityChecker.isEligible
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey) {
+            return true
+        } else {
+            return addProductWithAIEligibilityChecker.isEligible
+        }
     }
 
     /// Defines if it should skip the bottom sheet before the product form is shown.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -129,6 +129,7 @@ private extension AddProductCoordinator {
     ///
     var shouldShowAIActionSheet: Bool {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey) {
+            // TODO: Needs more eligibility checks, as the flag could ne enabled, but the API key not entered, in which case they do not know what to do
             return true
         } else {
             return addProductWithAIEligibilityChecker.isEligible
@@ -220,7 +221,7 @@ private extension AddProductCoordinator {
 
         addProductWithAIBottomSheetPresenter = buildBottomSheetPresenter()
         addProductWithAIBottomSheetPresenter?.present(controller, from: navigationController)
-        analytics.track(event: .ProductCreationAI.entryPointDisplayed())
+        analytics.track(event: .ProductCreationAI.entryPointDisplayed()) // TODO: Modify analytics based on own key or a8c key
     }
 
     func startProductCreationWithAI() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/AIToneVoiceViewModel.swift
@@ -29,6 +29,7 @@ final class AIToneVoiceViewModel: ObservableObject {
 }
 
 // MARK: - AI tone helpers
+// We can use the same approach for storing the local API KEY, via UserDefaults extension
 extension UserDefaults {
     private enum Constants {
         static let defaultTone = AIToneVoice.casual

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/EntryPoint/AddProductWithAIActionSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/EntryPoint/AddProductWithAIActionSheet.swift
@@ -4,10 +4,12 @@ import SwiftUI
 ///
 final class AddProductWithAIActionSheetHostingController: UIHostingController<AddProductWithAIActionSheet> {
     init(productTypes: [BottomSheetProductType],
+         aiSource: AISource,
          onAIOption: @escaping () -> Void,
          onProductTypeOption: @escaping (BottomSheetProductType) -> Void) {
 
         let rootView = AddProductWithAIActionSheet(productTypes: productTypes,
+                                                   aiSource: aiSource,
                                                    onAIOption: onAIOption,
                                                    onProductTypeOption: onProductTypeOption)
         super.init(rootView: rootView)
@@ -28,13 +30,16 @@ struct AddProductWithAIActionSheet: View {
     @State private var isShowingManualOptions: Bool = false
 
     private let productTypes: [BottomSheetProductType]
+    private let aiSource: AISource
     private let onAIOption: () -> Void
     private let onProductTypeOption: (BottomSheetProductType) -> Void
 
     init(productTypes: [BottomSheetProductType],
+         aiSource: AISource,
          onAIOption: @escaping () -> Void,
          onProductTypeOption: @escaping (BottomSheetProductType) -> Void) {
         self.productTypes = productTypes
+        self.aiSource = aiSource
         self.onAIOption = onAIOption
         self.onProductTypeOption = onProductTypeOption
     }
@@ -70,8 +75,13 @@ struct AddProductWithAIActionSheet: View {
                     VStack(alignment: .leading, spacing: Constants.verticalSpacing) {
                         Text(Localization.CreateProductWithAI.aiTitle)
                             .bodyStyle()
-                        Text(Localization.CreateProductWithAI.aiDescription)
-                            .subheadlineStyle()
+                        if aiSource == .internal {
+                            Text(Localization.CreateProductWithAI.aiDescription)
+                                .subheadlineStyle()
+                        } else {
+                            Text(Localization.CreateProductWithAI.merchantAIDescription)
+                                .subheadlineStyle()
+                        }
                         AdaptiveStack(horizontalAlignment: .leading) {
                             Text(Localization.CreateProductWithAI.legalText)
                             Text(.init(Localization.CreateProductWithAI.learnMore))
@@ -161,6 +171,11 @@ private extension AddProductWithAIActionSheet {
                 value: "Let us generate product details for you",
                 comment: "Description of the option to add new product with AI assistance"
             )
+            static let merchantAIDescription = NSLocalizedString(
+                "addProductWithAIActionSheet.createProductWithAI.merchantAiDescription",
+                value: "Generate product details using AI. Enter your API key under Settings > AI Settings",
+                comment: "Description of the option to add new product with AI assistance"
+            )
             static let legalText = NSLocalizedString(
                 "addProductWithAIActionSheet.createProductWithAI.legalText",
                 value: "Powered by AI.",
@@ -198,6 +213,7 @@ struct AddProductWithAIActionSheet_Previews: PreviewProvider {
                 .grouped,
                 .affiliate
             ],
+            aiSource: .internal,
             onAIOption: {},
             onProductTypeOption: {_ in }
         )

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -107,6 +107,10 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         return productDescription != original
     }
 
+    private var shouldUseMerchantAIKey: Bool {
+        ProductCreationAIEligibilityChecker().aiSource == .merchant
+    }
+
     private let productFeatures: String
 
     private let siteID: Int64
@@ -199,7 +203,8 @@ final class ProductDetailPreviewViewModel: ObservableObject {
             async let language = try identifyLanguage()
             let aiTone = userDefaults.aiTone(for: siteID)
             let aiProduct = try await generateProduct(language: language,
-                                                           tone: aiTone)
+                                                      tone: aiTone,
+                                                      shouldUseMerchantAIKey: shouldUseMerchantAIKey)
             analytics.track(event: .ProductCreationAI.nameDescriptionOptionsGenerated(
                 nameCount: aiProduct.names.count,
                 shortDescriptionCount: aiProduct.shortDescriptions.count,
@@ -529,6 +534,7 @@ private extension ProductDetailPreviewViewModel {
             let language = try await withCheckedThrowingContinuation { continuation in
                 stores.dispatch(ProductAction.identifyLanguage(siteID: siteID,
                                                                string: productInfo,
+                                                               shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                feature: .productCreation,
                                                                completion: { result in
                     continuation.resume(with: result)
@@ -543,12 +549,14 @@ private extension ProductDetailPreviewViewModel {
 
     @MainActor
     func generateProduct(language: String,
-                         tone: AIToneVoice) async throws -> AIProduct {
+                         tone: AIToneVoice,
+                         shouldUseMerchantAIKey: Bool) async throws -> AIProduct {
         let existingCategories = categoryResultController.fetchedObjects
         let existingTags = tagResultController.fetchedObjects
 
         return try await generateAIProduct(language: language,
                                            tone: tone,
+                                           shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                            existingCategories: existingCategories,
                                            existingTags: existingTags)
     }
@@ -556,6 +564,7 @@ private extension ProductDetailPreviewViewModel {
     @MainActor
     func generateAIProduct(language: String,
                            tone: AIToneVoice,
+                           shouldUseMerchantAIKey: Bool,
                            existingCategories: [ProductCategory],
                            existingTags: [ProductTag]) async throws -> AIProduct {
         try await withCheckedThrowingContinuation { continuation in
@@ -564,6 +573,7 @@ private extension ProductDetailPreviewViewModel {
                                                             keywords: productFeatures,
                                                             language: language,
                                                             tone: tone.rawValue,
+                                                            shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                             currencySymbol: currency,
                                                             dimensionUnit: dimensionUnit,
                                                             weightUnit: weightUnit,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -450,10 +450,10 @@ private extension ProductDetailPreviewViewModel {
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                await self.fetchGeneralSettings()
+                await self.fetchGeneralSettings() // TODO: Double-check this doesn't conflict with own API keys if given
             }
             group.addTask {
-                await self.fetchProductSiteSettings()
+                await self.fetchProductSiteSettings() // TODO: Same as ^
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -450,10 +450,10 @@ private extension ProductDetailPreviewViewModel {
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                await self.fetchGeneralSettings() // TODO: Double-check this doesn't conflict with own API keys if given
+                await self.fetchGeneralSettings()
             }
             group.addTask {
-                await self.fetchProductSiteSettings() // TODO: Same as ^
+                await self.fetchProductSiteSettings()
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import Experiments
 
 /// Protocol for checking "add product using AI" eligibility for easier unit testing.
 protocol ProductCreationAIEligibilityCheckerProtocol {
@@ -10,9 +11,12 @@ protocol ProductCreationAIEligibilityCheckerProtocol {
 /// Checks the eligibility for the "add product using AI" feature.
 final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol {
     private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
 
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.stores = stores
+        self.featureFlagService = featureFlagService
     }
 
     var isEligible: Bool {
@@ -20,6 +24,12 @@ final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityChe
             return false
         }
 
-        return site.isWordPressComStore || site.isAIAssistantFeatureActive
+        // By default, check if we provide AI capabilities form WPCOM/JP
+        if site.isWordPressComStore || site.isAIAssistantFeatureActive {
+            return true
+        } else {
+            // As fallback, allow personal API keys usage based on feature flag:
+            return featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
@@ -9,10 +9,10 @@ protocol ProductCreationAIEligibilityCheckerProtocol {
     var aiSource: AISource { get }
 }
 
-enum AISource {
-    case none
-    case `internal`
-    case merchant
+enum AISource: String {
+    case none = "none"
+    case `internal` = "internal"
+    case merchant = "merchant"
 }
 
 /// Checks the eligibility for the "add product using AI" feature.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
@@ -6,12 +6,21 @@ import Experiments
 protocol ProductCreationAIEligibilityCheckerProtocol {
     /// Checks if the user is eligible for the "add product using AI" feature.
     var isEligible: Bool { get }
+    var aiSource: AISource { get }
+}
+
+enum AISource {
+    case none
+    case `internal`
+    case merchant
 }
 
 /// Checks the eligibility for the "add product using AI" feature.
 final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
+
+    private(set) var aiSource: AISource = .none
 
     init(stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
@@ -24,12 +33,20 @@ final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityChe
             return false
         }
 
-        // By default, check if we provide AI capabilities form WPCOM/JP
+        // By default, check first if we provide AI capabilities from WPCOM/JP
         if site.isWordPressComStore || site.isAIAssistantFeatureActive {
+            aiSource = .internal
             return true
         } else {
             // As fallback, allow personal API keys usage based on feature flag:
-            return featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey)
+            switch featureFlagService.isFeatureFlagEnabled(.allowMerchantAIAPIKey) {
+            case true:
+                aiSource = .merchant
+                return true
+            case false:
+                aiSource = .none
+                return false
+            }
         }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1564,6 +1564,7 @@
 		681BB5FE2D676061008AF8BB /* POSPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681BB5FD2D676060008AF8BB /* POSPadding.swift */; };
 		682210ED2909666600814E14 /* CustomerSearchUICommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682210EC2909666600814E14 /* CustomerSearchUICommandTests.swift */; };
 		6827140F28A3988300E6E3F6 /* DismissableNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */; };
+		682DB48F2D88230800E38449 /* AISettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682DB48E2D88230600E38449 /* AISettingsView.swift */; };
 		6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */; };
 		6832C7CC26DA5FDF00BA4088 /* LabeledTextViewTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6832C7CB26DA5FDE00BA4088 /* LabeledTextViewTableViewCell.xib */; };
 		683421642ACE9391009021D7 /* ProductDiscountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683421632ACE9391009021D7 /* ProductDiscountView.swift */; };
@@ -4727,6 +4728,7 @@
 		681BB5FD2D676060008AF8BB /* POSPadding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPadding.swift; sourceTree = "<group>"; };
 		682210EC2909666600814E14 /* CustomerSearchUICommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommandTests.swift; sourceTree = "<group>"; };
 		6827140E28A3988300E6E3F6 /* DismissableNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableNoticeView.swift; sourceTree = "<group>"; };
+		682DB48E2D88230600E38449 /* AISettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsView.swift; sourceTree = "<group>"; };
 		6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledTextViewTableViewCell.swift; sourceTree = "<group>"; };
 		6832C7CB26DA5FDE00BA4088 /* LabeledTextViewTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabeledTextViewTableViewCell.xib; sourceTree = "<group>"; };
 		683421632ACE9391009021D7 /* ProductDiscountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDiscountView.swift; sourceTree = "<group>"; };
@@ -9828,6 +9830,14 @@
 			path = Customer;
 			sourceTree = "<group>";
 		};
+		682DB48D2D8822FC00E38449 /* AI Settings */ = {
+			isa = PBXGroup;
+			children = (
+				682DB48E2D88230600E38449 /* AISettingsView.swift */,
+			);
+			path = "AI Settings";
+			sourceTree = "<group>";
+		};
 		6850C5EC2B69E6460026A93B /* Receipts */ = {
 			isa = PBXGroup;
 			children = (
@@ -10724,6 +10734,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				682DB48D2D8822FC00E38449 /* AI Settings */,
 				B626C7192876599B0083820C /* Custom Fields */,
 				86023FA82B15CA8D00A28F07 /* Themes */,
 				DED91DF72AD78A0C00CDCC53 /* Blaze */,
@@ -16115,6 +16126,7 @@
 				CCCFFC5A2934EF5E006130AF /* StatsIntervalDataParser.swift in Sources */,
 				DE5746342B4512900034B10D /* BlazeBudgetSettingView.swift in Sources */,
 				26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */,
+				682DB48F2D88230800E38449 /* AISettingsView.swift in Sources */,
 				027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */,
 				26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */,
 				DE78082D2BDF9852005D1E30 /* OrderStatsV4Interval+Chart.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1629,6 +1629,8 @@
 		68E674AB2A4DAB8C0034BA1E /* CompletedUpgradeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E674AA2A4DAB8C0034BA1E /* CompletedUpgradeView.swift */; };
 		68E674AD2A4DAC010034BA1E /* CurrentPlanDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E674AC2A4DAC010034BA1E /* CurrentPlanDetailsView.swift */; };
 		68E674AF2A4DACD50034BA1E /* UpgradeTopBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E674AE2A4DACD50034BA1E /* UpgradeTopBarView.swift */; };
+		68E7C0B42D8A707500934B04 /* AISettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E7C0B32D8A707100934B04 /* AISettingsViewModel.swift */; };
+		68E7C0B72D8A730200934B04 /* AISettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E7C0B62D8A730200934B04 /* AISettingsViewModelTests.swift */; };
 		68E952CC287536010095A23D /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CB287536010095A23D /* SafariView.swift */; };
 		68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */; };
 		68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */; };
@@ -4793,6 +4795,8 @@
 		68E674AA2A4DAB8C0034BA1E /* CompletedUpgradeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletedUpgradeView.swift; sourceTree = "<group>"; };
 		68E674AC2A4DAC010034BA1E /* CurrentPlanDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPlanDetailsView.swift; sourceTree = "<group>"; };
 		68E674AE2A4DACD50034BA1E /* UpgradeTopBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeTopBarView.swift; sourceTree = "<group>"; };
+		68E7C0B32D8A707100934B04 /* AISettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModel.swift; sourceTree = "<group>"; };
+		68E7C0B62D8A730200934B04 /* AISettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModelTests.swift; sourceTree = "<group>"; };
 		68E952CB287536010095A23D /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
 		68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderType+Manual.swift"; sourceTree = "<group>"; };
@@ -9834,6 +9838,7 @@
 			isa = PBXGroup;
 			children = (
 				682DB48E2D88230600E38449 /* AISettingsView.swift */,
+				68E7C0B32D8A707100934B04 /* AISettingsViewModel.swift */,
 			);
 			path = "AI Settings";
 			sourceTree = "<group>";
@@ -9902,6 +9907,14 @@
 				68DF5A8E2CB38F20000154C9 /* OrderCouponSectionView.swift */,
 			);
 			path = Coupons;
+			sourceTree = "<group>";
+		};
+		68E7C0B52D8A72E200934B04 /* AI Settings */ = {
+			isa = PBXGroup;
+			children = (
+				68E7C0B62D8A730200934B04 /* AISettingsViewModelTests.swift */,
+			);
+			path = "AI Settings";
 			sourceTree = "<group>";
 		};
 		68F151DF2C0DA7800082AEC8 /* Models */ = {
@@ -12838,6 +12851,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				68E7C0B52D8A72E200934B04 /* AI Settings */,
 				864059FE2C6F67A000DA04DC /* Custom Fields */,
 				86023FAB2B16D80E00A28F07 /* Themes */,
 				EE45E2C02A42C9C70085F227 /* Feature Highlight */,
@@ -16251,6 +16265,7 @@
 				267F60132A0C24D700CD1E4E /* PrivacyBannerViewController.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
 				DAAF53B82CF75701006D8880 /* WooShippingAddPackageViewModel.swift in Sources */,
+				68E7C0B42D8A707500934B04 /* AISettingsViewModel.swift in Sources */,
 				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,
 				B99B30CD2A85200D0066743D /* AddressFormViewModel.swift in Sources */,
 				205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */,
@@ -17457,6 +17472,7 @@
 				0375799D2822F9040083F2E1 /* MockCardPresentPaymentsOnboardingPresenter.swift in Sources */,
 				455800CC24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift in Sources */,
 				86EC6EB92CD0BA6A00D7D2FE /* CustomFieldEditorViewModelTests.swift in Sources */,
+				68E7C0B72D8A730200934B04 /* AISettingsViewModelTests.swift in Sources */,
 				CE86C8332CC8F9BB00B1764D /* WooShippingServiceCardViewModelTests.swift in Sources */,
 				26F92DBE2C7ECAB20074A208 /* EditOrderFormTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -23,6 +23,7 @@ final class MockFeatureFlagService: FeatureFlagService {
     var favoriteProducts: Bool
     var isProductGlobalUniqueIdentifierSupported: Bool
     var hideSitesInStorePicker: Bool
+    var allowMerchantAIAPIKey: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -44,7 +45,8 @@ final class MockFeatureFlagService: FeatureFlagService {
          viewEditCustomFieldsInProductsAndOrders: Bool = false,
          favoriteProducts: Bool = false,
          isProductGlobalUniqueIdentifierSupported: Bool = false,
-         hideSitesInStorePicker: Bool = false) {
+         hideSitesInStorePicker: Bool = false,
+         allowMerchantAIAPIKey: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -66,6 +68,7 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.favoriteProducts = favoriteProducts
         self.isProductGlobalUniqueIdentifierSupported = isProductGlobalUniqueIdentifierSupported
         self.hideSitesInStorePicker = hideSitesInStorePicker
+        self.allowMerchantAIAPIKey = allowMerchantAIAPIKey
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -112,6 +115,8 @@ final class MockFeatureFlagService: FeatureFlagService {
             return isProductGlobalUniqueIdentifierSupported
         case .hideSitesInStorePicker:
             return hideSitesInStorePicker
+        case .allowMerchantAIAPIKey:
+            return allowMerchantAIAPIKey
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductCreationAIEligibilityChecker.swift
@@ -12,4 +12,8 @@ final class MockProductCreationAIEligibilityChecker: ProductCreationAIEligibilit
     var isEligible: Bool {
         eligible
     }
+
+    var aiSource: AISource {
+        .none
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/AI Settings/AISettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/AI Settings/AISettingsViewModelTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import WooCommerce
+
+final class AISettingsViewModelTests: XCTestCase {
+    var sut: AISettingsViewModel!
+    var defaults: UserDefaults!
+    let suiteName = #file
+
+    private let testAPIKey = "test-ai-key"
+    private let testAIProvider = "test-ai-model"
+    private let testAIModel = "test-ai-provider"
+
+    let expectedOpenAIModels = [
+        "gpt-4o",
+        "gpt-4-turbo",
+        "gpt-3.5-turbo"
+    ]
+
+    let expectedAnthropicModels = [
+        "claude-3-haiku-20240307"
+    ]
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        sut = AISettingsViewModel(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_sut_when_init_then_loads_values_from_userdefaults() {
+        // Given
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail()
+        }
+        defaults.set(testAPIKey, forKey: "AIProviderAPIKey")
+        defaults.set(testAIModel, forKey: "AIProviderModel")
+        defaults.set(testAIProvider, forKey: "AIProvider")
+
+        // When
+        sut = AISettingsViewModel(defaults: defaults)
+
+        // Then
+        XCTAssertEqual(sut.apiKey, testAPIKey)
+        XCTAssertEqual(sut.selectedModel, testAIModel)
+        XCTAssertEqual(sut.selectedProvider, testAIProvider)
+    }
+
+    func test_init_should_use_empty_values_when_userdefaults_is_empty() {
+        XCTAssertEqual(sut.apiKey, "")
+        XCTAssertEqual(sut.selectedModel, "")
+        XCTAssertEqual(sut.selectedProvider, "")
+    }
+
+    func test_sut_when_init_then_has_correct_openai_models() {
+        XCTAssertEqual(sut.openAIModels, expectedOpenAIModels)
+    }
+
+    func test_sut_when_init_then_has_correct_anthropic_models() {
+        XCTAssertEqual(sut.anthropicModels, expectedAnthropicModels)
+    }
+
+    func test_sut_when_update_provider_to_openai_then_selects_first_openai_model_and_saves() {
+        // When
+        sut.updateProvider("OpenAI")
+
+        // Then
+        XCTAssertEqual(sut.selectedProvider, "OpenAI")
+        XCTAssertEqual(sut.selectedModel, expectedOpenAIModels.first)
+
+        // Verify that is saved to UserDefaults
+        XCTAssertEqual(defaults.string(forKey: "AIProvider"), "OpenAI")
+        XCTAssertEqual(defaults.string(forKey: "AIProviderModel"), expectedOpenAIModels.first)
+    }
+
+    func test_sut_when_update_provider_to_anthropic_then_selects_first_anthropic_model_and_saves() {
+        // When
+        sut.updateProvider("Anthropic")
+
+        // Then
+        XCTAssertEqual(sut.selectedProvider, "Anthropic")
+        XCTAssertEqual(sut.selectedModel, expectedAnthropicModels.first)
+
+        // And verify saved to defaults
+        XCTAssertEqual(defaults.string(forKey: "AIProvider"), "Anthropic")
+        XCTAssertEqual(defaults.string(forKey: "AIProviderModel"), expectedAnthropicModels.first)
+    }
+
+    func test_sut_when_update_provider_then_persists_all_values_to_userdefaults() {
+        // Given
+        sut.apiKey = "new-api-key"
+
+        // When
+        sut.updateProvider("OpenAI")
+
+        // Then
+        XCTAssertEqual(defaults.string(forKey: "AIProviderAPIKey"), "new-api-key")
+        XCTAssertEqual(defaults.string(forKey: "AIProviderModel"), expectedOpenAIModels.first)
+        XCTAssertEqual(defaults.string(forKey: "AIProvider"), "OpenAI")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/AI Settings/AISettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/AI Settings/AISettingsViewModelTests.swift
@@ -6,7 +6,6 @@ final class AISettingsViewModelTests: XCTestCase {
     var defaults: UserDefaults!
     let suiteName = #file
 
-    private let testAPIKey = "test-ai-key"
     private let testAIProvider = "test-ai-model"
     private let testAIModel = "test-ai-provider"
 
@@ -39,7 +38,6 @@ final class AISettingsViewModelTests: XCTestCase {
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             return XCTFail()
         }
-        defaults.set(testAPIKey, forKey: "AIProviderAPIKey")
         defaults.set(testAIModel, forKey: "AIProviderModel")
         defaults.set(testAIProvider, forKey: "AIProvider")
 
@@ -47,13 +45,11 @@ final class AISettingsViewModelTests: XCTestCase {
         sut = AISettingsViewModel(defaults: defaults)
 
         // Then
-        XCTAssertEqual(sut.apiKey, testAPIKey)
         XCTAssertEqual(sut.selectedModel, testAIModel)
         XCTAssertEqual(sut.selectedProvider, testAIProvider)
     }
 
     func test_init_should_use_empty_values_when_userdefaults_is_empty() {
-        XCTAssertEqual(sut.apiKey, "")
         XCTAssertEqual(sut.selectedModel, "")
         XCTAssertEqual(sut.selectedProvider, "")
     }
@@ -100,7 +96,6 @@ final class AISettingsViewModelTests: XCTestCase {
         sut.updateProvider("OpenAI")
 
         // Then
-        XCTAssertEqual(defaults.string(forKey: "AIProviderAPIKey"), "new-api-key")
         XCTAssertEqual(defaults.string(forKey: "AIProviderModel"), expectedOpenAIModels.first)
         XCTAssertEqual(defaults.string(forKey: "AIProvider"), "OpenAI")
     }
@@ -163,7 +158,6 @@ final class AISettingsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(sut.isEditingApiKey)
-        XCTAssertEqual(defaults.string(forKey: "AIProviderAPIKey"), "new-key")
         XCTAssertEqual(defaults.string(forKey: "AIProviderModel"), "test-model")
         XCTAssertEqual(defaults.string(forKey: "AIProvider"), "test-provider")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/AI Settings/AISettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/AI Settings/AISettingsViewModelTests.swift
@@ -104,4 +104,67 @@ final class AISettingsViewModelTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: "AIProviderModel"), expectedOpenAIModels.first)
         XCTAssertEqual(defaults.string(forKey: "AIProvider"), "OpenAI")
     }
+
+    func test_sut_when_onAppear_with_empty_apiKey_then_enables_editing() {
+        // Given
+        sut.apiKey = ""
+        sut.isEditingApiKey = false
+
+        // When
+        sut.onAppear()
+
+        // Then
+        XCTAssertTrue(sut.isEditingApiKey)
+    }
+
+    func test_sut_when_onAppear_with_apiKey_then_disables_editing() {
+        // Given
+        sut.apiKey = "some-key"
+        sut.isEditingApiKey = true
+
+        // When
+        sut.onAppear()
+
+        // Then
+        XCTAssertFalse(sut.isEditingApiKey)
+    }
+
+    func test_sut_when_clearApiKey_then_empties_apiKey() {
+        // Given
+        sut.apiKey = "some-key"
+
+        // When
+        sut.clearApiKey()
+
+        // Then
+        XCTAssertTrue(sut.apiKey.isEmpty)
+    }
+
+    func test_sut_when_toggleEditing_then_toggles_editing_state() {
+        // Given
+        sut.isEditingApiKey = false
+
+        // When
+        sut.toggleEditing()
+
+        // Then
+        XCTAssertTrue(sut.isEditingApiKey)
+    }
+
+    func test_sut_when_togglEediting_from_editing_then_saves_settings() {
+        // Given
+        sut.isEditingApiKey = true
+        sut.apiKey = "new-key"
+        sut.selectedModel = "test-model"
+        sut.selectedProvider = "test-provider"
+
+        // When
+        sut.toggleEditing()
+
+        // Then
+        XCTAssertFalse(sut.isEditingApiKey)
+        XCTAssertEqual(defaults.string(forKey: "AIProviderAPIKey"), "new-key")
+        XCTAssertEqual(defaults.string(forKey: "AIProviderModel"), "test-model")
+        XCTAssertEqual(defaults.string(forKey: "AIProvider"), "test-provider")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
@@ -209,9 +209,9 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         viewModel.name = "Fun"
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductDescription(_, _, _, _, completion):
+            case let .generateProductDescription(_, _, _, _, _, completion):
                 completion(.success("Must buy"))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:
@@ -251,9 +251,9 @@ final class ProductDescriptionGenerationViewModelTests: XCTestCase {
         viewModel.name = "Fun"
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductDescription(_, _, _, _, completion):
+            case let .generateProductDescription(_, _, _, _, _, completion):
                 completion(.success("Must buy"))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:
@@ -448,9 +448,9 @@ private extension ProductDescriptionGenerationViewModelTests {
               identifyLaunguage: Result<String, Error> = .success("en")) {
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductDescription(_, _, _, _, completion):
+            case let .generateProductDescription(_, _, _, _, _, completion):
                 completion(generatedDescription)
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(identifyLaunguage)
             default:
                 return XCTFail("Unexpected action: \(action)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModelTests.swift
@@ -44,10 +44,10 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.generationInProgress)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 XCTAssertTrue(viewModel.generationInProgress)
                 completion(.success("Check this out!"))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
             default:
                 return
@@ -72,9 +72,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success(expectedString))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
             default:
                 return
@@ -99,9 +99,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
             default:
                 return
@@ -126,7 +126,7 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
             default:
                 return
@@ -154,9 +154,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  analytics: analytics)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success("Test"))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success(expectedLanguage))
             default:
                 return
@@ -207,9 +207,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  analytics: analytics)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
             default:
                 return
@@ -240,9 +240,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  analytics: analytics)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success("Test"))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
             default:
                 return
@@ -293,9 +293,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success(expectedString))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
             default:
                 return
@@ -392,9 +392,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success(expectedString))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
             default:
                 return
@@ -422,9 +422,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success(expectedString))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
             default:
                 return
@@ -457,9 +457,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success("Must buy"))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:
@@ -495,9 +495,9 @@ final class ProductSharingMessageGenerationViewModelTests: XCTestCase {
                                                                  stores: stores)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateProductSharingMessage(_, _, _, _, _, completion):
+            case let .generateProductSharingMessage(_, _, _, _, _, _, completion):
                 completion(.success("Must buy"))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success("en"))
                 identifyLanguageRequestCounter += 1
             default:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
@@ -5,21 +5,25 @@ import XCTest
 
 final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
     private var stores: MockStoresManager!
+    private var featureFlagService: MockFeatureFlagService!
 
     override func setUp() {
         super.setUp()
         stores = MockStoresManager(sessionManager: .makeForTesting())
+        featureFlagService = MockFeatureFlagService(allowMerchantAIAPIKey: false)
     }
 
     override func tearDown() {
         stores = nil
+        featureFlagService = nil
         super.tearDown()
     }
 
     func test_isEligible_is_true_for_wpcom_store() throws {
         // Given
         updateDefaultStore(isWPCOMStore: true)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          featureFlagService: featureFlagService)
 
         // When
         let isEligible = checker.isEligible
@@ -31,7 +35,8 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
     func test_isEligible_is_false_for_non_wpcom_store() throws {
         // Given
         updateDefaultStore(isWPCOMStore: false)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          featureFlagService: featureFlagService)
         // When
         let isEligible = checker.isEligible
 
@@ -42,12 +47,41 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
     func test_isEligible_is_true_for_non_wpcom_store_when_ai_assistant_feature_is_active() throws {
         // Given
         updateDefaultStore(isWPCOMStore: false, isAIAssistantActive: true)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          featureFlagService: featureFlagService)
         // When
         let isEligible = checker.isEligible
 
         // Then
         XCTAssertTrue(isEligible)
+    }
+
+    func test_allow_merchant_ai_api_key_as_fallback_when_flag_is_true_then_isEligible() {
+        // Given
+        updateDefaultStore(isWPCOMStore: false, isAIAssistantActive: false)
+        let enabledFlag = MockFeatureFlagService(allowMerchantAIAPIKey: true)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          featureFlagService: enabledFlag)
+
+        // When
+        let isEligible = checker.isEligible
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_allow_merchant_ai_api_key_as_fallback_when_flag_is_false_then_is_not_eligible() {
+        // Given
+        updateDefaultStore(isWPCOMStore: false, isAIAssistantActive: false)
+        let disabledFlag = MockFeatureFlagService(allowMerchantAIAPIKey: false)
+        let checker = ProductCreationAIEligibilityChecker(stores: stores,
+                                                          featureFlagService: disabledFlag)
+
+        // When
+        let isEligible = checker.isEligible
+
+        // Then
+        XCTAssertFalse(isEligible)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -184,9 +184,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, _, completion):
                 completion(.success(.fake()))
-            case let .identifyLanguage(_, string, _, completion):
+            case let .identifyLanguage(_, string, _, _, completion):
                 // Then
                 XCTAssertEqual(string, productFeatures)
                 completion(.success("en"))
@@ -219,10 +219,10 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateAIProduct(_, _, _, language, _, _, _, _, _, _, completion):
+            case let .generateAIProduct(_, _, _, language, _, _, _, _, _, _, _, completion):
                 XCTAssertEqual(language, expectedLanguage)
                 completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 identifyingLanguageRequestCount += 1
                 completion(.success(expectedLanguage))
             default:
@@ -359,6 +359,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                          keywords,
                                          language,
                                          tone,
+                                         _,
                                          currencySymbol,
                                          dimensionUnit,
                                          weightUnit,
@@ -376,7 +377,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 XCTAssertEqual(categories, sampleCategories)
                 XCTAssertEqual(tags, sampleTags)
                 completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success(sampleLanguage))
             default:
                 break
@@ -405,10 +406,10 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, _, completion):
                 XCTAssertTrue(viewModel.isGeneratingDetails)
                 completion(.success(self.sampleAIProduct))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 XCTAssertTrue(viewModel.isGeneratingDetails)
                 completion(.success("en"))
             default:
@@ -444,10 +445,10 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, _, completion):
                 XCTAssertEqual(viewModel.errorState, .none)
                 completion(.failure(expectedError))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 XCTAssertEqual(viewModel.errorState, .none)
                 completion(.success("en"))
             default:
@@ -1080,10 +1081,10 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, _, completion):
                 XCTAssertFalse(viewModel.isSavingProduct)
                 completion(.success(aiProduct))
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 XCTAssertFalse(viewModel.isSavingProduct)
                 completion(.success("en"))
             case let .addProduct(_, onCompletion):
@@ -1457,13 +1458,13 @@ private extension ProductDetailPreviewViewModelTests {
                             addedProductResult: (Result<Product, ProductUpdateError>)? = nil) {
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, _, completion):
                 if let aiGeneratedProductResult {
                     completion(aiGeneratedProductResult)
                 } else {
                     completion(.success(self.sampleAIProduct))
                 }
-            case let .identifyLanguage(_, _, _, completion):
+            case let .identifyLanguage(_, _, _, _, completion):
                 completion(.success(identifiedLanguage))
             case let .addProduct(product, onCompletion):
                 if let addedProductResult {

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -130,6 +130,7 @@ public enum ProductAction: Action {
     ///
     case identifyLanguage(siteID: Int64,
                           string: String,
+                          shouldUseMerchantAIKey: Bool,
                           feature: GenerativeContentRemoteFeature,
                           completion: (Result<String, Error>) -> Void)
 
@@ -138,12 +139,14 @@ public enum ProductAction: Action {
     case generateProductName(siteID: Int64,
                              keywords: String,
                              language: String,
+                             shouldUseMerchantAIKey: Bool,
                              completion: (Result<String, Error>) -> Void)
 
     /// Generates a product description with Jetpack AI given the name and features.
     ///
     case generateProductDescription(siteID: Int64,
                                     name: String,
+                                    shouldUseMerchantAIKey: Bool,
                                     features: String,
                                     language: String,
                                     completion: (Result<String, Error>) -> Void)
@@ -155,6 +158,7 @@ public enum ProductAction: Action {
                                        name: String,
                                        description: String,
                                        language: String,
+                                       shouldUseMerchantAIKey: Bool,
                                        completion: (Result<String, Error>) -> Void)
 
     /// Generates product details (e.g. name and description) with Jetpack AI given the scanned texts from an image and optional product name .
@@ -163,6 +167,7 @@ public enum ProductAction: Action {
                                 productName: String?,
                                 scannedTexts: [String],
                                 language: String,
+                                shouldUseMerchantAIKey: Bool,
                                 completion: (Result<ProductDetailsFromScannedTexts, Error>) -> Void)
 
     /// Fetches the total number of products in the site given the site ID.
@@ -189,6 +194,7 @@ public enum ProductAction: Action {
                            keywords: String,
                            language: String,
                            tone: String,
+                           shouldUseMerchantAIKey: Bool,
                            currencySymbol: String,
                            dimensionUnit: String?,
                            weightUnit: String?,

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -116,18 +116,40 @@ public class ProductStore: Store {
             replaceProductLocally(product: product, onCompletion: onCompletion)
         case let .checkIfStoreHasProducts(siteID, status, onCompletion):
             checkIfStoreHasProducts(siteID: siteID, status: status, onCompletion: onCompletion)
-        case let .identifyLanguage(siteID, string, feature, completion):
+        case let .identifyLanguage(siteID, string, shouldUseMerchantAIKey, feature, completion):
             identifyLanguage(siteID: siteID,
-                             string: string, feature: feature,
+                             string: string,
+                             shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                             feature: feature,
                              completion: completion)
-        case let .generateProductDescription(siteID, name, features, language, completion):
-            generateProductDescription(siteID: siteID, name: name, features: features, language: language, completion: completion)
-        case let .generateProductSharingMessage(siteID, url, name, description, language, completion):
-            generateProductSharingMessage(siteID: siteID, url: url, name: name, description: description, language: language, completion: completion)
-        case let .generateProductName(siteID, keywords, language, completion):
-            generateProductName(siteID: siteID, keywords: keywords, language: language, completion: completion)
-        case let .generateProductDetails(siteID, productName, scannedTexts, language, completion):
-            generateProductDetails(siteID: siteID, productName: productName, scannedTexts: scannedTexts, language: language, completion: completion)
+        case let .generateProductDescription(siteID, name, shouldUseMerchantAIKey, features, language, completion):
+            generateProductDescription(siteID: siteID,
+                                       name: name,
+                                       shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                                       features: features,
+                                       language: language,
+                                       completion: completion)
+        case let .generateProductSharingMessage(siteID, url, name, description, language, shouldUseMerchantAIKey, completion):
+            generateProductSharingMessage(siteID: siteID,
+                                          url: url,
+                                          name: name,
+                                          description: description,
+                                          language: language,
+                                          shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                                          completion: completion)
+        case let .generateProductName(siteID, keywords, language, shouldUseMerchantAIKey, completion):
+            generateProductName(siteID: siteID,
+                                keywords: keywords,
+                                language: language,
+                                shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                                completion: completion)
+        case let .generateProductDetails(siteID, productName, scannedTexts, language, shouldUseMerchantAIKey, completion):
+            generateProductDetails(siteID: siteID,
+                                   productName: productName,
+                                   scannedTexts: scannedTexts,
+                                   language: language,
+                                   shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                                   completion: completion)
         case let .fetchNumberOfProducts(siteID, completion):
             fetchNumberOfProducts(siteID: siteID, completion: completion)
         case let .generateAIProduct(siteID,
@@ -135,6 +157,7 @@ public class ProductStore: Store {
                                     keywords,
                                     language,
                                     tone,
+                                    shouldUseMerchantAIKey,
                                     currencySymbol,
                                     dimensionUnit,
                                     weightUnit,
@@ -146,6 +169,7 @@ public class ProductStore: Store {
                               keywords: keywords,
                               language: language,
                               tone: tone,
+                              shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                               currencySymbol: currencySymbol,
                               dimensionUnit: dimensionUnit,
                               weightUnit: weightUnit,
@@ -594,12 +618,14 @@ private extension ProductStore {
 
     func identifyLanguage(siteID: Int64,
                           string: String,
+                          shouldUseMerchantAIKey: Bool,
                           feature: GenerativeContentRemoteFeature,
                           completion: @escaping (Result<String, Error>) -> Void) {
         Task { @MainActor in
             let result = await Result {
                 try await generativeContentRemote.identifyLanguage(siteID: siteID,
                                                                    string: string,
+                                                                   shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                    feature: feature)
             }
             completion(result)
@@ -608,6 +634,7 @@ private extension ProductStore {
 
     func generateProductDescription(siteID: Int64,
                                     name: String,
+                                    shouldUseMerchantAIKey: Bool,
                                     features: String,
                                     language: String,
                                     completion: @escaping (Result<String, Error>) -> Void) {
@@ -622,7 +649,11 @@ private extension ProductStore {
 
         Task { @MainActor in
             let result = await Result {
-                let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription, responseFormat: .text)
+                let description = try await generativeContentRemote.generateText(siteID: siteID,
+                                                                                 base: prompt,
+                                                                                 shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                                                                                 feature: .productDescription,
+                                                                                 responseFormat: .text)
                 return description
             }
             completion(result)
@@ -634,6 +665,7 @@ private extension ProductStore {
                                        name: String,
                                        description: String,
                                        language: String,
+                                       shouldUseMerchantAIKey: Bool,
                                        completion: @escaping (Result<String, Error>) -> Void) {
         let prompt = [
             // swiftlint:disable:next line_length
@@ -649,7 +681,11 @@ private extension ProductStore {
 
         Task { @MainActor in
             let result = await Result {
-                let message = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing, responseFormat: .text)
+                let message = try await generativeContentRemote.generateText(siteID: siteID,
+                                                                             base: prompt,
+                                                                             shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                                                                             feature: .productSharing,
+                                                                             responseFormat: .text)
                     .trimmingCharacters(in: CharacterSet(["\""]))  // Trims quotation mark
                 return message
             }
@@ -661,6 +697,7 @@ private extension ProductStore {
                                 productName: String?,
                                 scannedTexts: [String],
                                 language: String,
+                                shouldUseMerchantAIKey: Bool,
                                 completion: @escaping (Result<ProductDetailsFromScannedTexts, Error>) -> Void) {
         let keywords: [String] = {
             guard let productName else {
@@ -683,6 +720,7 @@ private extension ProductStore {
             do {
                 let jsonString = try await generativeContentRemote.generateText(siteID: siteID,
                                                                                 base: prompt,
+                                                                                shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                                 feature: .productDetailsFromScannedTexts,
                                                                                 responseFormat: .json)
                 guard let jsonData = jsonString.data(using: .utf8) else {
@@ -699,6 +737,7 @@ private extension ProductStore {
     func generateProductName(siteID: Int64,
                              keywords: String,
                              language: String,
+                             shouldUseMerchantAIKey: Bool,
                              completion: @escaping (Result<String, Error>) -> Void) {
         let prompt = [
             "You are a WooCommerce SEO and marketing expert.",
@@ -710,7 +749,11 @@ private extension ProductStore {
 
         Task { @MainActor in
             let result = await Result {
-                let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productName, responseFormat: .text)
+                let description = try await generativeContentRemote.generateText(siteID: siteID,
+                                                                                 base: prompt,
+                                                                                 shouldUseMerchantAIKey: shouldUseMerchantAIKey,
+                                                                                 feature: .productName,
+                                                                                 responseFormat: .text)
                 return description
             }
             completion(result)
@@ -733,6 +776,7 @@ private extension ProductStore {
                            keywords: String,
                            language: String,
                            tone: String,
+                           shouldUseMerchantAIKey: Bool,
                            currencySymbol: String,
                            dimensionUnit: String?,
                            weightUnit: String?,
@@ -746,6 +790,7 @@ private extension ProductStore {
                                                                                   keywords: keywords,
                                                                                   language: language,
                                                                                   tone: tone,
+                                                                                  shouldUseMerchantAIKey: shouldUseMerchantAIKey,
                                                                                   currencySymbol: currencySymbol,
                                                                                   dimensionUnit: dimensionUnit,
                                                                                   weightUnit: weightUnit,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
@@ -39,6 +39,7 @@ final class MockGenerativeContentRemote {
 extension MockGenerativeContentRemote: GenerativeContentRemoteProtocol {
     func generateText(siteID: Int64,
                       base: String,
+                      shouldUseMerchantAIKey: Bool,
                       feature: GenerativeContentRemoteFeature,
                       responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
         generateTextBase = base
@@ -53,6 +54,7 @@ extension MockGenerativeContentRemote: GenerativeContentRemoteProtocol {
 
     func identifyLanguage(siteID: Int64,
                           string: String,
+                          shouldUseMerchantAIKey: Bool,
                           feature: GenerativeContentRemoteFeature) async throws -> String {
         identifyLanguageString = string
         identifyLanguageFeature = feature
@@ -68,6 +70,7 @@ extension MockGenerativeContentRemote: GenerativeContentRemoteProtocol {
                            keywords: String,
                            language: String,
                            tone: String,
+                           shouldUseMerchantAIKey: Bool,
                            currencySymbol: String,
                            dimensionUnit: String?,
                            weightUnit: String?,

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1905,6 +1905,7 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product",
+                                                                           shouldUseMerchantAIKey: false,
                                                                            features: "Trendy",
                                                                            language: "en") { result in
                 promise(result)
@@ -1931,6 +1932,7 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product",
+                                                                           shouldUseMerchantAIKey: false,
                                                                            features: "Trendy",
                                                                            language: "en") { result in
                 promise(result)
@@ -1956,6 +1958,7 @@ final class ProductStoreTests: XCTestCase {
         waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product name",
+                                                                           shouldUseMerchantAIKey: false,
                                                                            features: "Trendy, cool, fun",
                                                                            language: "en") { _ in
                 promise(())
@@ -1983,6 +1986,7 @@ final class ProductStoreTests: XCTestCase {
         waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product name",
+                                                                           shouldUseMerchantAIKey: false,
                                                                            features: "Trendy, cool, fun",
                                                                            language: "en") { _ in
                 promise(())
@@ -2008,6 +2012,7 @@ final class ProductStoreTests: XCTestCase {
         waitFor { promise in
             productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
                                                                            name: "A product name",
+                                                                           shouldUseMerchantAIKey: false,
                                                                            features: "Trendy, cool, fun",
                                                                            language: "en") { _ in
                 promise(())
@@ -2039,7 +2044,8 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "en"
+                language: "en",
+                shouldUseMerchantAIKey: false
             ) { result in
                 promise(result)
             })
@@ -2068,7 +2074,8 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "en"
+                language: "en",
+                shouldUseMerchantAIKey: false
             ) { result in
                 promise(result)
             })
@@ -2097,7 +2104,8 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "en"
+                language: "en",
+                shouldUseMerchantAIKey: false
             ) { result in
                 promise(result)
             })
@@ -2113,7 +2121,7 @@ final class ProductStoreTests: XCTestCase {
         let expectedURL = "https://example.com"
         let expectedName = "Sample product"
         let expectedDescription = "Sample description"
-        let expectedLangugae = "en"
+        let expectedLanguage = "en"
         let generativeContentRemote = MockGenerativeContentRemote()
         generativeContentRemote.whenIdentifyingLanguage(thenReturn: .success(""))
         generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
@@ -2130,8 +2138,8 @@ final class ProductStoreTests: XCTestCase {
                 url: expectedURL,
                 name: expectedName,
                 description: expectedDescription,
-                language: expectedLangugae
-            ) { result in
+                language: expectedLanguage,
+                shouldUseMerchantAIKey: false) { result in
                 promise(())
             })
         }
@@ -2141,7 +2149,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertTrue(base.contains(expectedURL))
         XCTAssertTrue(base.contains(expectedName))
         XCTAssertTrue(base.contains(expectedDescription))
-        XCTAssertTrue(base.contains(expectedLangugae))
+        XCTAssertTrue(base.contains(expectedLanguage))
     }
 
     func test_generateProductSharingMessage_uses_correct_feature() throws {
@@ -2161,7 +2169,8 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "en"
+                language: "en",
+                shouldUseMerchantAIKey: false
             ) { result in
                 promise(())
             })
@@ -2189,7 +2198,8 @@ final class ProductStoreTests: XCTestCase {
                 url: "https://example.com",
                 name: "Sample product",
                 description: "Sample description",
-                language: "en"
+                language: "en",
+                shouldUseMerchantAIKey: false
             ) { result in
                 promise(())
             })
@@ -2217,6 +2227,7 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.identifyLanguage(siteID: self.sampleSiteID,
                                                                  string: "Woo is awesome",
+                                                                 shouldUseMerchantAIKey: false,
                                                                  feature: .productSharing) { result in
                 promise(result)
             })
@@ -2242,6 +2253,7 @@ final class ProductStoreTests: XCTestCase {
         let result = waitFor { promise in
             productStore.onAction(ProductAction.identifyLanguage(siteID: self.sampleSiteID,
                                                                  string: "Woo is awesome",
+                                                                 shouldUseMerchantAIKey: false,
                                                                  feature: .productSharing) { result in
                 promise(result)
             })
@@ -2640,7 +2652,8 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: nil,
                                                                        scannedTexts: [""],
-                                                                       language: "en") { result in
+                                                                       language: "en",
+                                                                       shouldUseMerchantAIKey: false) { result in
                 promise(result)
             })
         }
@@ -2666,7 +2679,8 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: nil,
                                                                        scannedTexts: [""],
-                                                                       language: "en") { result in
+                                                                       language: "en",
+                                                                       shouldUseMerchantAIKey: false) { result in
                 promise(result)
             })
         }
@@ -2694,7 +2708,8 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: productName,
                                                                        scannedTexts: scannedTexts,
-                                                                       language: language) { _ in
+                                                                       language: language,
+                                                                       shouldUseMerchantAIKey: false) { _ in
                 promise(())
             })
         }
@@ -2721,7 +2736,8 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: nil,
                                                                        scannedTexts: [""],
-                                                                       language: "en") { _ in
+                                                                       language: "en",
+                                                                       shouldUseMerchantAIKey: false) { _ in
                 promise(())
             })
         }
@@ -2746,7 +2762,8 @@ final class ProductStoreTests: XCTestCase {
             productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
                                                                        productName: nil,
                                                                        scannedTexts: [""],
-                                                                       language: "en") { _ in
+                                                                       language: "en",
+                                                                       shouldUseMerchantAIKey: false) { _ in
                 promise(())
             })
         }
@@ -2771,7 +2788,10 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: "iPhone 15", language: "en") { result in
+            productStore.onAction(ProductAction.generateProductName(siteID: 123,
+                                                                    keywords: "iPhone 15",
+                                                                    language: "en",
+                                                                    shouldUseMerchantAIKey: false) { result in
                 promise(result)
             })
         }
@@ -2793,7 +2813,10 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: "iPhone 15", language: "en") { result in
+            productStore.onAction(ProductAction.generateProductName(siteID: 123,
+                                                                    keywords: "iPhone 15",
+                                                                    language: "en",
+                                                                    shouldUseMerchantAIKey: false) { result in
                 promise(result)
             })
         }
@@ -2816,7 +2839,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         waitFor { promise in
-            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: keyword, language: "en") { _ in
+            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: keyword, language: "en", shouldUseMerchantAIKey: false) { _ in
                 promise(())
             })
         }
@@ -2838,7 +2861,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         waitFor { promise in
-            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: "keyword", language: "en") { _ in
+            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: "keyword", language: "en", shouldUseMerchantAIKey: false) { _ in
                 promise(())
             })
         }
@@ -2860,7 +2883,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         waitFor { promise in
-            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: "keyword", language: "en") { _ in
+            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: "keyword", language: "en", shouldUseMerchantAIKey: false) { _ in
                 promise(())
             })
         }
@@ -2929,6 +2952,7 @@ final class ProductStoreTests: XCTestCase {
                                                                   keywords: "Leather strip, silver",
                                                                   language: "en",
                                                                   tone: "Casual",
+                                                                  shouldUseMerchantAIKey: false,
                                                                   currencySymbol: "INR",
                                                                   dimensionUnit: "cm",
                                                                   weightUnit: "kg",
@@ -2960,6 +2984,7 @@ final class ProductStoreTests: XCTestCase {
                                                                   keywords: "Leather strip, silver",
                                                                   language: "en",
                                                                   tone: "Casual",
+                                                                  shouldUseMerchantAIKey: false,
                                                                   currencySymbol: "INR",
                                                                   dimensionUnit: "cm",
                                                                   weightUnit: "kg",


### PR DESCRIPTION
## Description
This PR explores allowing merchants to use their own API keys for existing WCiOS AI-powered features, like product AI creation. 

We extend the ability to use those it to all merchants by allowing them to use their own OpenAI or Anthropic API keys, which allows them to create generative products for their WooCommerce stores on demand, rather than relying on WPCOM/JPAI eligibility.

P2: pdfdoF-6LE-p2

TODO: Clean-up:
- [x] Feature flag + new `AI Settings` row + eligibility checker: https://github.com/woocommerce/woocommerce-ios/pull/15404
- [x] `AISettingsView` + ViewModel: https://github.com/woocommerce/woocommerce-ios/pull/16135
- [x] Handle key storage https://github.com/woocommerce/woocommerce-ios/pull/16136
- [x] Remote: Extract prompts from remotes https://github.com/woocommerce/woocommerce-ios/pull/16138
- [x] Remote: Use self key in generative content remotes when given https://github.com/woocommerce/woocommerce-ios/pull/16142
- [x] Hook with product creation https://github.com/woocommerce/woocommerce-ios/pull/16142
- [x] Hook KeyChain usage https://github.com/woocommerce/woocommerce-ios/pull/16150
- [ ] Analytics
- [ ] Share with HEs
- [ ] Improvement: Disable field autocapitalization
- [ ] Improvement: Move prompts from `ProductStore` to `Networking.AIRequestPrompts`
- [ ] Improvement: Add Anthropic support
- [ ] Improvement: Allow JP users to use personal key as well.
- [ ] Improvement: Identify language via tool calling (OpenAI only?)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
