### PR TITLE
HACK Week: New screen for notification settings

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,6 +95,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backgroundProductImageUpload:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .notificationSettings:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -204,4 +204,8 @@ public enum FeatureFlag: Int {
     /// Supports uploading product images in background
     ///
     case backgroundProductImageUpload
+
+    /// Supports managing notification settings from the app settings
+    ///
+    case notificationSettings
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct NotificationSettingsView: View {
+    @State private var notificationsEnabled = false
+    @State private var orderNotificationsEnabled = false
+    @State private var productReviewNotificationsEnabled = false
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle(isOn: $notificationsEnabled) {
+                    Text("All notifications")
+                }
+            } footer: {
+                Text("Including in-app reminders and remote push notifications.")
+            }
+
+            Section {
+                Toggle(isOn: $orderNotificationsEnabled) {
+                    Text("New orders")
+                }
+                .disabled(!notificationsEnabled)
+
+                Toggle(isOn: $productReviewNotificationsEnabled) {
+                    Text("Product reviews")
+                }
+                .disabled(!notificationsEnabled)
+            } header: {
+                Text("Notification types")
+            } footer: {
+                Text("Settings applied to all selected sites.")
+            }
+        }
+    }
+}
+
+#Preview {
+    NotificationSettingsView()
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -1,5 +1,20 @@
 import SwiftUI
 
+final class NotificationSettingsHostingController: UIHostingController<NotificationSettingsView> {
+    init() {
+        super.init(rootView: NotificationSettingsView())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Notification Settings"
+    }
+}
+
 struct NotificationSettingsView: View {
     @State private var notificationsEnabled = false
     @State private var orderNotificationsEnabled = false
@@ -31,6 +46,7 @@ struct NotificationSettingsView: View {
                 Text("Settings applied to all selected sites.")
             }
         }
+        .navigationTitle("Notification Settings")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -11,7 +11,7 @@ final class NotificationSettingsHostingController: UIHostingController<Notificat
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Notification Settings"
+        title = NotificationSettingsView.Localization.title
     }
 }
 
@@ -24,29 +24,69 @@ struct NotificationSettingsView: View {
         Form {
             Section {
                 Toggle(isOn: $notificationsEnabled) {
-                    Text("All notifications")
+                    Text(Localization.allNotifications)
                 }
             } footer: {
-                Text("Including in-app reminders and remote push notifications.")
+                Text(Localization.allNotificationsFooter)
             }
 
             Section {
                 Toggle(isOn: $orderNotificationsEnabled) {
-                    Text("New orders")
+                    Text(Localization.newOrders)
                 }
                 .disabled(!notificationsEnabled)
 
                 Toggle(isOn: $productReviewNotificationsEnabled) {
-                    Text("Product reviews")
+                    Text(Localization.productReviews)
                 }
                 .disabled(!notificationsEnabled)
             } header: {
-                Text("Notification types")
+                Text(Localization.notificationTypesHeader)
             } footer: {
-                Text("Settings applied to all selected sites.")
+                Text(Localization.notificationTypesFooter)
             }
         }
-        .navigationTitle("Notification Settings")
+        .navigationTitle(Localization.title)
+    }
+}
+
+extension NotificationSettingsView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "notificationSettingsView.title",
+            value: "Notification Settings",
+            comment: "Title of the notification settings view"
+        )
+        static let allNotifications = NSLocalizedString(
+            "notificationSettingsView.allNotifications",
+            value: "All notifications",
+            comment: "Label of the toggle to enable/disable all notifications on the notification settings view"
+        )
+        static let allNotificationsFooter = NSLocalizedString(
+            "notificationSettingsView.allNotificationsFooter",
+            value: "Including in-app reminders and remote push notifications.",
+            comment: "Footer of the toggle to enable/disable all notifications on the notification settings view"
+        )
+        static let newOrders = NSLocalizedString(
+            "notificationSettingsView.newOrders",
+            value: "New orders",
+            comment: "Label of the toggle to enable/disable new order notifications on the notification settings view"
+        )
+        static let productReviews = NSLocalizedString(
+            "notificationSettingsView.productReviews",
+            value: "Product reviews",
+            comment: "Label of the toggle to enable/disable product reviews notifications on the notification settings view"
+        )
+        static let notificationTypesHeader = NSLocalizedString(
+            "notificationSettingsView.notificationTypesHeader",
+            value: "Notification types",
+            comment: "Header of the notification types section on the notification settings view"
+        )
+        static let notificationTypesFooter = NSLocalizedString(
+            "notificationSettingsView.notificationTypesFooter",
+            value: "Settings applied to all selected sites.",
+            comment: "Footer of the notification types section on the notification settings view"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -156,6 +156,8 @@ private extension SettingsViewController {
             configureBetaFeatures(cell: cell)
         case let cell as BasicTableViewCell where row == .sendFeedback:
             configureSendFeedback(cell: cell)
+        case let cell as BasicTableViewCell where row == .notifications:
+            configureNotificationSettings(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
             configurePrivacy(cell: cell)
         case let cell as BasicTableViewCell where row == .about:
@@ -227,6 +229,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.storeName
+    }
+
+    func configureNotificationSettings(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = Localization.notificationSettings
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -476,6 +484,11 @@ private extension SettingsViewController {
         present(surveyNavigation, animated: true, completion: nil)
     }
 
+    func showNotificationSettings() {
+        let controller = NotificationSettingsHostingController()
+        show(controller, sender: self)
+    }
+
     func deviceSettingsWasPressed() {
         guard let targetURL = URL(string: UIApplication.openSettingsURLString) else {
             return
@@ -653,6 +666,8 @@ extension SettingsViewController: UITableViewDelegate {
             logoutWasPressed()
         case .themes:
             showThemeSettings()
+        case .notifications:
+            showNotificationSettings()
         default:
             break
         }
@@ -719,6 +734,7 @@ extension SettingsViewController {
         case sendFeedback
 
         // App Settings
+        case notifications
         case privacy
 
         // About the App
@@ -762,7 +778,7 @@ extension SettingsViewController {
                 return BasicTableViewCell.self
             case .logout, .accountSettings:
                 return BasicTableViewCell.self
-            case .privacy:
+            case .privacy, .notifications:
                 return BasicTableViewCell.self
             case .betaFeatures:
                 return BasicTableViewCell.self
@@ -851,6 +867,12 @@ private extension SettingsViewController {
         static let privacySettings = NSLocalizedString(
             "Privacy Settings",
             comment: "Navigates to Privacy Settings screen"
+        )
+
+        static let notificationSettings = NSLocalizedString(
+            "settingsViewController.notificationSettings",
+            value: "Notification Settings",
+            comment: "Navigates to the Notification Settings screen"
         )
 
         static let experimentalFeatures = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -280,10 +280,13 @@ private extension SettingsViewModel {
         let appSettingsSection: Section = {
             let rows: [Row]
             let notificationAvailable: Bool = {
+                guard stores.isAuthenticated && stores.isAuthenticatedWithoutWPCom == false else {
+                    return false
+                }
                 guard let site = stores.sessionManager.defaultSite else {
                     return false
                 }
-                return site.isJetpackThePluginInstalled && site.isJetpackConnected
+                return site.isJetpackCPConnected == false
             }()
             if notificationAvailable, featureFlagService.isFeatureFlagEnabled(.notificationSettings) {
                 rows = [.notifications, .privacy]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -279,7 +279,13 @@ private extension SettingsViewModel {
         // App Settings
         let appSettingsSection: Section = {
             let rows: [Row]
-            if featureFlagService.isFeatureFlagEnabled(.notificationSettings) {
+            let notificationAvailable: Bool = {
+                guard let site = stores.sessionManager.defaultSite else {
+                    return false
+                }
+                return site.isJetpackThePluginInstalled && site.isJetpackConnected
+            }()
+            if notificationAvailable, featureFlagService.isFeatureFlagEnabled(.notificationSettings) {
                 rows = [.notifications, .privacy]
             } else {
                 rows = [.privacy]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -277,9 +277,17 @@ private extension SettingsViewModel {
         }()
 
         // App Settings
-        let appSettingsSection = Section(title: Localization.appSettingsTitle,
-                                         rows: [.privacy],
-                                         footerHeight: UITableView.automaticDimension)
+        let appSettingsSection: Section = {
+            let rows: [Row]
+            if featureFlagService.isFeatureFlagEnabled(.notificationSettings) {
+                rows = [.notifications, .privacy]
+            } else {
+                rows = [.privacy]
+            }
+            return Section(title: Localization.appSettingsTitle,
+                           rows: rows,
+                           footerHeight: UITableView.automaticDimension)
+        }()
 
         // About the App
         let aboutTheAppSection: Section = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2680,6 +2680,7 @@
 		DE5746342B4512900034B10D /* BlazeBudgetSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */; };
 		DE5746362B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746352B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift */; };
 		DE5746382B479CB80034B10D /* BlazeBudgetSettingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746372B479CB80034B10D /* BlazeBudgetSettingViewModelTests.swift */; };
+		DE58C8A42D88226A005914DF /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58C8A32D88226A005914DF /* NotificationSettingsView.swift */; };
 		DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */; };
 		DE5FBB912A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */; };
 		DE5FBB932A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */; };
@@ -5884,6 +5885,7 @@
 		DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeBudgetSettingView.swift; sourceTree = "<group>"; };
 		DE5746352B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeBudgetSettingViewModel.swift; sourceTree = "<group>"; };
 		DE5746372B479CB80034B10D /* BlazeBudgetSettingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeBudgetSettingViewModelTests.swift; sourceTree = "<group>"; };
+		DE58C8A32D88226A005914DF /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
 		DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductNameAI.swift"; sourceTree = "<group>"; };
 		DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModelTests.swift; sourceTree = "<group>"; };
@@ -12414,6 +12416,7 @@
 		CE85FD5820F7A59E0080B73E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				DE58C8A22D882250005914DF /* NotificationSettings */,
 				DE6F997A2BE9E5CA0007B2DD /* Settings.storyboard */,
 				DEDA8DBA2B19833E0076BF0F /* Themes */,
 				DE68979D2A8F7C8C00154588 /* AccountSettings */,
@@ -13263,6 +13266,14 @@
 				DEF657A22C88540700ACD61E /* BlazeScheduleSettingView.swift */,
 			);
 			path = BudgetSetting;
+			sourceTree = "<group>";
+		};
+		DE58C8A22D882250005914DF /* NotificationSettings */ = {
+			isa = PBXGroup;
+			children = (
+				DE58C8A32D88226A005914DF /* NotificationSettingsView.swift */,
+			);
+			path = NotificationSettings;
 			sourceTree = "<group>";
 		};
 		DE63115D2AF1E16500587641 /* WPComLogin */ = {
@@ -16908,6 +16919,7 @@
 				26BCA0402C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift in Sources */,
 				DECEA4472C81778300C28C10 /* ProductImagePickerView.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
+				DE58C8A42D88226A005914DF /* NotificationSettingsView.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
 				CE755F732D4A5F9D002539F6 /* WooShippingNormalizeAddressViewModel.swift in Sources */,
 				B90D21782D15B72900ED60ED /* WooShippingCustomsFormViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -23,6 +23,7 @@ final class MockFeatureFlagService: FeatureFlagService {
     var favoriteProducts: Bool
     var isProductGlobalUniqueIdentifierSupported: Bool
     var hideSitesInStorePicker: Bool
+    var notificationSettings: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -44,7 +45,8 @@ final class MockFeatureFlagService: FeatureFlagService {
          viewEditCustomFieldsInProductsAndOrders: Bool = false,
          favoriteProducts: Bool = false,
          isProductGlobalUniqueIdentifierSupported: Bool = false,
-         hideSitesInStorePicker: Bool = false) {
+         hideSitesInStorePicker: Bool = false,
+         notificationSettings: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -66,6 +68,7 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.favoriteProducts = favoriteProducts
         self.isProductGlobalUniqueIdentifierSupported = isProductGlobalUniqueIdentifierSupported
         self.hideSitesInStorePicker = hideSitesInStorePicker
+        self.notificationSettings = notificationSettings
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -112,6 +115,8 @@ final class MockFeatureFlagService: FeatureFlagService {
             return isProductGlobalUniqueIdentifierSupported
         case .hideSitesInStorePicker:
             return hideSitesInStorePicker
+        case .notificationSettings:
+            return notificationSettings
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -313,6 +313,61 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.whatsNew) })
     }
 
+    func test_sections_does_not_contain_notifications_row_when_feature_flag_is_disabled() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(notificationSettings: false)
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+    }
+
+    func test_sections_does_not_contain_notifications_row_when_user_is_authenticated_without_WPCom() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(notificationSettings: true)
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+    }
+
+    func test_sections_does_not_contain_notifications_row_when_site_is_JCP() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(notificationSettings: true)
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+    }
+
+    func test_sections_does_not_contain_notifications_row_for_Jetpack_site_and_user_is_authenticated_with_WPCom() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(notificationSettings: true)
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+    }
 }
 
 private final class MockSettingsPresenter: SettingsViewPresenter {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15371 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new screen for notification settings:
- New feature flag for the new screen.
- New UI for the new screen - functionalities will be added in a subsequent PR.
- Navigation from the Settings screen to the new screen.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
**TC1: With feature flag on**
1. Log in to a test store with the Jetpack plugin installed and connected.
2. Switch to the Hub menu tab and select Settings.
3. Confirm that there is a new row in the App Settings section named Notification Settings.
4. Tap the new row and confirm that a new screen for Notification Settings is displayed.
5. Switch to a JCP store and confirm that the notification settings row is not available on the Settings screen.
6. Log in to a test store with no Jetpack (or log in to a self-hosted store with site credentials).
7. Confirm that the notification settings row is not available on the Settings screen.

**TC2: With feature flag off**
Repeat steps 1-4 in the previous test case and confirm that the notification settings row is not available on the Settings screen


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested the above test cases on simulator iPhone 16 Pro iOS 18.2 and confirmed the expectations.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/16c1c84d-d91e-44f7-a2c7-92cdc910c57c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.