### PR TITLE
Disable `review_status` in CodeRabbit config.

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
   request_changes_workflow: false
   high_level_summary: false
   poem: false
-  review_status: true
+  review_status: false
   commit_status: false
   sequence_diagrams: true
   changed_files_summary: true


### PR DESCRIPTION
To hide CodeRabbit comment on every PR