### PR TITLE
ReadMe: Add git-lfs to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,26 @@
 
     We use Ruby to manage the third party dependencies and other tools and automation.
 
-2. Clone project in the folder of your preference
+3. Ensure you have [git-lfs]([url](https://git-lfs.com/)) installed.
+
+   You can install it via homebrew or visit [git-lfs]([url](https://git-lfs.com/)) for other installation methods.
+   ```bash
+   brew install git-lfs
+   ```
+
+4. Clone project in the folder of your preference
 
     ```bash
     git clone https://github.com/woocommerce/woocommerce-ios.git
     ````
 
-3. Enter the project directory
+5. Enter the project directory
 
     ```bash
     cd woocommerce-ios
     ```
 
-4. Install the third party dependencies and tools required to run the project.
+6. Install the third party dependencies and tools required to run the project.
 
 
     ```bash
@@ -55,7 +62,7 @@
 
     This command installs the required tools like [CocoaPods](https://cocoapods.org/). And then it installs the iOS project dependencies using CocoaPods.
 
-5. Open the project by double clicking on `WooCommerce.xcworkspace` file, or launching Xcode and choose File > Open and browse to `WooCommerce.xcworkspace`
+7. Open the project by double clicking on `WooCommerce.xcworkspace` file, or launching Xcode and choose File > Open and browse to `WooCommerce.xcworkspace`
 
 ### Credentials for External Contributors
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@
 
     We use Ruby to manage the third party dependencies and other tools and automation.
 
-3. Ensure you have [git-lfs]([url](https://git-lfs.com/)) installed.
+3. Ensure you have [git-lfs](https://git-lfs.com/) installed.
 
-   You can install it via homebrew or visit [git-lfs]([url](https://git-lfs.com/)) for other installation methods.
+   You can install it via homebrew or visit [git-lfs](https://git-lfs.com/)) for other installation methods.
    ```bash
    brew install git-lfs
    ```


### PR DESCRIPTION


## Description

When not having git-lfs installed git clone fails with
```
Cloning into 'woocommerce-ios'...
remote: Enumerating objects: 8114, done.
remote: Counting objects: 100% (8114/8114), done.
remote: Compressing objects: 100% (6576/6576), done.
remote: Total 8114 (delta 2118), reused 3660 (delta 1048), pack-reused 0 (from 0)
Receiving objects: 100% (8114/8114), 54.01 MiB | 16.65 MiB/s, done.
Resolving deltas: 100% (2118/2118), done.
git-lfs filter-process: git-lfs: command not found
fatal: the remote end hung up unexpectedly
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'
```

## Steps to reproduce
Call git clone when not having git-lfs installed.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
