### PR TITLE
HACK Week: Show site list on notification settings screen for configurations

### DIFF
--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -208,6 +208,10 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
     }
 }
 
+extension Site: Identifiable {
+    public var id: Int64 { siteID }
+}
+
 public extension Site {
     /// Whether the site is connected to Jetpack with Jetpack Connection Package, and not with Jetpack-the-plugin.
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -89,17 +89,17 @@ private extension NotificationSettingsView {
 
             Section {
                 ForEach(viewModel.sites) { site in
-                    siteRow(for: site)
+                    detailRow(for: site)
                 }
             } header: {
-                Text(Localization.siteListSectionHeader)
+                Text(Localization.storeListSectionHeader)
             } footer: {
-                Text(Localization.siteListSectionFooter)
+                Text(Localization.storeListSectionFooter)
             }
         }
     }
 
-    func siteRow(for site: Site) -> some View {
+    func detailRow(for site: Site) -> some View {
         Button(action: {
             selectedSite = site
         }) {
@@ -169,15 +169,15 @@ extension NotificationSettingsView {
             value: "Including reminders and remote push notifications.",
             comment: "Footer of the notifications section on the notification settings view"
         )
-        static let siteListSectionHeader = NSLocalizedString(
-            "notificationSettingsView.siteListSectionHeader",
-            value: "Your sites",
-            comment: "Header of the site list section on the notification settings view"
+        static let storeListSectionHeader = NSLocalizedString(
+            "notificationSettingsView.storeListSectionHeader",
+            value: "Your stores",
+            comment: "Header of the store list section on the notification settings view"
         )
-        static let siteListSectionFooter = NSLocalizedString(
-            "notificationSettingsView.siteListSectionFooter",
+        static let storeListSectionFooter = NSLocalizedString(
+            "notificationSettingsView.storeListSectionFooter",
             value: "Customize your notification preferences for each store.",
-            comment: "Footer of the site list section on the notification settings view"
+            comment: "Footer of the store list section on the notification settings view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -18,6 +18,7 @@ final class NotificationSettingsHostingController: UIHostingController<Notificat
 
 struct NotificationSettingsView: View {
     @StateObject private var viewModel: NotificationSettingsViewModel
+    @State private var selectedSite: Site?
 
     init() {
         self._viewModel = StateObject(wrappedValue: NotificationSettingsViewModel())
@@ -26,7 +27,7 @@ struct NotificationSettingsView: View {
     var body: some View {
         Group {
             if viewModel.notificationsEnabled {
-                notificationTypesForm
+                siteList
             } else {
                 notificationsDisabledView
             }
@@ -34,6 +35,9 @@ struct NotificationSettingsView: View {
         .navigationTitle(Localization.title)
         .task {
             await viewModel.synchronizeSites()
+        }
+        .sheet(item: $selectedSite) { site in
+            SiteNotificationSettingsView(siteTitle: site.name)
         }
     }
 }
@@ -63,7 +67,7 @@ private extension NotificationSettingsView {
         .padding(.horizontal)
     }
 
-    var notificationTypesForm: some View {
+    var siteList: some View {
         List {
             Section {
                 HStack {
@@ -80,7 +84,7 @@ private extension NotificationSettingsView {
             }
 
             Section {
-                ForEach(viewModel.sites, id: \.siteID) { site in
+                ForEach(viewModel.sites) { site in
                     siteRow(for: site)
                 }
             } header: {
@@ -93,7 +97,7 @@ private extension NotificationSettingsView {
 
     func siteRow(for site: Site) -> some View {
         Button(action: {
-            // TODO
+            selectedSite = site
         }) {
             HStack(spacing: Layout.contentSpacing) {
                 VStack(alignment: .leading) {
@@ -110,6 +114,7 @@ private extension NotificationSettingsView {
                 Image(systemName: "chevron.forward")
                     .secondaryBodyStyle()
             }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
@@ -160,15 +165,15 @@ extension NotificationSettingsView {
             value: "Including reminders and remote push notifications.",
             comment: "Footer of the notifications section on the notification settings view"
         )
-        static let newOrders = NSLocalizedString(
-            "notificationSettingsView.newOrders",
-            value: "New orders",
-            comment: "Label of the toggle to enable/disable new order notifications on the notification settings view"
+        static let siteListSectionHeader = NSLocalizedString(
+            "notificationSettingsView.siteListSectionHeader",
+            value: "Your sites",
+            comment: "Header of the site list section on the notification settings view"
         )
-        static let productReviews = NSLocalizedString(
-            "notificationSettingsView.productReviews",
-            value: "Product reviews",
-            comment: "Label of the toggle to enable/disable product reviews notifications on the notification settings view"
+        static let siteListSectionFooter = NSLocalizedString(
+            "notificationSettingsView.siteListSectionFooter",
+            value: "Customize your notification preferences for new orders and product reviews.",
+            comment: "Footer of the site list section on the notification settings view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -176,7 +176,7 @@ extension NotificationSettingsView {
         )
         static let siteListSectionFooter = NSLocalizedString(
             "notificationSettingsView.siteListSectionFooter",
-            value: "Customize your notification preferences for new orders and product reviews.",
+            value: "Customize your notification preferences for each store.",
             comment: "Footer of the site list section on the notification settings view"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import struct Yosemite.Site
 
 final class NotificationSettingsHostingController: UIHostingController<NotificationSettingsView> {
     init() {
@@ -31,6 +32,9 @@ struct NotificationSettingsView: View {
             }
         }
         .navigationTitle(Localization.title)
+        .task {
+            await viewModel.synchronizeSites()
+        }
     }
 }
 
@@ -60,7 +64,7 @@ private extension NotificationSettingsView {
     }
 
     var notificationTypesForm: some View {
-        Form {
+        List {
             Section {
                 HStack {
                     Text(Localization.notificationsEnabled)
@@ -74,19 +78,40 @@ private extension NotificationSettingsView {
             } footer: {
                 Text(Localization.notificationsFooter)
             }
+
             Section {
-                Toggle(isOn: $viewModel.orderNotificationsEnabled) {
-                    Text(Localization.newOrders)
-                }
-                Toggle(isOn: $viewModel.productReviewNotificationsEnabled) {
-                    Text(Localization.productReviews)
+                ForEach(viewModel.sites, id: \.siteID) { site in
+                    siteRow(for: site)
                 }
             } header: {
-                Text(Localization.notificationTypesHeader)
+                Text("Your sites")
             } footer: {
-                Text(Localization.notificationTypesFooter)
+                Text("Customize your notification preferences for new orders and product reviews.")
             }
         }
+    }
+
+    func siteRow(for site: Site) -> some View {
+        Button(action: {
+            // TODO
+        }) {
+            HStack(spacing: Layout.contentSpacing) {
+                VStack(alignment: .leading) {
+                    Text(site.name)
+                        .bodyStyle()
+                    Text(site.url)
+                        .foregroundStyle(Color.secondary)
+                        .captionStyle()
+                }
+                .multilineTextAlignment(.leading)
+
+                Spacer()
+
+                Image(systemName: "chevron.forward")
+                    .secondaryBodyStyle()
+            }
+        }
+        .buttonStyle(.plain)
     }
 
     func openSettingsApp() async {
@@ -144,16 +169,6 @@ extension NotificationSettingsView {
             "notificationSettingsView.productReviews",
             value: "Product reviews",
             comment: "Label of the toggle to enable/disable product reviews notifications on the notification settings view"
-        )
-        static let notificationTypesHeader = NSLocalizedString(
-            "notificationSettingsView.notificationTypesHeader",
-            value: "Notification types",
-            comment: "Header of the notification types section on the notification settings view"
-        )
-        static let notificationTypesFooter = NSLocalizedString(
-            "notificationSettingsView.notificationTypesFooter",
-            value: "Settings applied to all selected sites.",
-            comment: "Footer of the notification types section on the notification settings view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -27,7 +27,7 @@ struct NotificationSettingsView: View {
     var body: some View {
         Group {
             if viewModel.notificationsEnabled {
-                siteList
+                notificationSettings
             } else {
                 notificationsDisabledView
             }
@@ -67,7 +67,7 @@ private extension NotificationSettingsView {
         .padding(.horizontal)
     }
 
-    var siteList: some View {
+    var notificationSettings: some View {
         List {
             Section {
                 HStack {
@@ -88,9 +88,9 @@ private extension NotificationSettingsView {
                     siteRow(for: site)
                 }
             } header: {
-                Text("Your sites")
+                Text(Localization.siteListSectionHeader)
             } footer: {
-                Text("Customize your notification preferences for new orders and product reviews.")
+                Text(Localization.siteListSectionFooter)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -98,19 +98,3 @@ private extension NotificationSettingsViewModel {
         sites = siteResultsController.fetchedObjects
     }
 }
-
-private extension NotificationSettingsViewModel {
-    func observeAppState() {
-        // Observe when the app becomes active.
-        appStateSubscription = NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .sink { [weak self] _ in
-                self?.updateNotificationStateIfNeeded()
-            }
-    }
-
-    func updateNotificationStateIfNeeded() {
-        Task {
-            await checkNotificationPermission()
-        }
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -1,5 +1,7 @@
 import Combine
 import UIKit
+import Yosemite
+import protocol Storage.StorageManagerType
 
 /// View model for `NotificationSettingsView`
 final class NotificationSettingsViewModel: ObservableObject {
@@ -8,10 +10,27 @@ final class NotificationSettingsViewModel: ObservableObject {
     @Published var productReviewNotificationsEnabled = false
 
     private let notificationCenter: UserNotificationsCenterAdapter
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
+
     private var appStateSubscription: AnyCancellable?
 
-    init(notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current()) {
+    /// ResultsController: Loads Sites from the Storage Layer.
+    ///
+    private lazy var siteResultsController: ResultsController<StorageSite> = {
+        let predicate = NSPredicate(format: "isWooCommerceActive == YES")
+        let nameDescriptor = NSSortDescriptor(keyPath: \StorageSite.name, ascending: true)
+        return ResultsController(storageManager: storageManager,
+                                 matching: predicate,
+                                 sortedBy: [nameDescriptor])
+    }()
+
+    init(notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.notificationCenter = notificationCenter
+        self.stores = stores
+        self.storageManager = storageManager
 
         observeAppState()
         updateNotificationStateIfNeeded()
@@ -48,5 +67,14 @@ private extension NotificationSettingsViewModel {
             }
         }
         notificationsEnabled = isEnabled
+    }
+
+    @MainActor
+    func synchronizeSites(selectedSiteID: Int64?) async {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(AccountAction.synchronizeSites(selectedSiteID: selectedSiteID) { _ in
+                continuation.resume()
+            })
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -6,8 +6,7 @@ import protocol Storage.StorageManagerType
 /// View model for `NotificationSettingsView`
 final class NotificationSettingsViewModel: ObservableObject {
     @Published private(set) var notificationsEnabled = false
-    @Published var orderNotificationsEnabled = false
-    @Published var productReviewNotificationsEnabled = false
+    @Published private(set) var sites: [Site] = []
 
     private let notificationCenter: UserNotificationsCenterAdapter
     private let stores: StoresManager
@@ -34,6 +33,16 @@ final class NotificationSettingsViewModel: ObservableObject {
 
         observeAppState()
         updateNotificationStateIfNeeded()
+        configureResultsController()
+    }
+
+    @MainActor
+    func synchronizeSites() async {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(AccountAction.synchronizeSites(selectedSiteID: nil) { _ in
+                continuation.resume()
+            })
+        }
     }
 }
 
@@ -52,6 +61,26 @@ private extension NotificationSettingsViewModel {
         }
     }
 
+    func configureResultsController() {
+        siteResultsController.onDidChangeContent = { [weak self] in
+            self?.updateSiteList()
+        }
+        siteResultsController.onDidResetContent = { [weak self] in
+            self?.updateSiteList()
+        }
+
+        do {
+            try siteResultsController.performFetch()
+            updateSiteList()
+        } catch {
+            ServiceLocator.crashLogging.logError(error)
+        }
+    }
+
+    func updateSiteList() {
+        sites = siteResultsController.fetchedObjects
+    }
+
     @MainActor
     func checkNotificationPermission() async {
         let isEnabled = await withCheckedContinuation { continuation in
@@ -67,14 +96,5 @@ private extension NotificationSettingsViewModel {
             }
         }
         notificationsEnabled = isEnabled
-    }
-
-    @MainActor
-    func synchronizeSites(selectedSiteID: Int64?) async {
-        await withCheckedContinuation { continuation in
-            stores.dispatch(AccountAction.synchronizeSites(selectedSiteID: selectedSiteID) { _ in
-                continuation.resume()
-            })
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct SiteNotificationSettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var orderNotificationsEnabled = false
+    @State private var productReviewNotificationsEnabled = false
+
+    private let siteTitle: String
+
+    init(siteTitle: String) {
+        self.siteTitle = siteTitle
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Toggle(isOn: $orderNotificationsEnabled) {
+                        Text(Localization.newOrders)
+                    }
+                    Toggle(isOn: $productReviewNotificationsEnabled) {
+                        Text(Localization.productReviews)
+                    }
+                } header: {
+                    Text(Localization.notificationTypesHeader)
+                } footer: {
+                    Text(Localization.notificationTypesFooter)
+                }
+            }
+            .navigationTitle(siteTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.save) {
+                        // TODO
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension SiteNotificationSettingsView {
+    enum Localization {
+        static let cancel = NSLocalizedString(
+            "siteNotificationSettingsView.cancel",
+            value: "Cancel",
+            comment: "Button to dismiss the site notification settings view"
+        )
+        static let save = NSLocalizedString(
+            "siteNotificationSettingsView.save",
+            value: "Save",
+            comment: "Button to save the settings on the site notification settings view"
+        )
+        static let notificationTypesHeader = NSLocalizedString(
+            "siteNotificationSettingsView.notificationTypesHeader",
+            value: "Notification types",
+            comment: "Header of the notification types section on the site notification settings view"
+        )
+        static let notificationTypesFooter = NSLocalizedString(
+            "siteNotificationSettingsView.notificationTypesFooter",
+            value: "Settings for push notifications that appear on your mobile device.",
+            comment: "Footer of the notification types section on the site notification settings view"
+        )
+        static let newOrders = NSLocalizedString(
+            "siteNotificationSettingsView.newOrders",
+            value: "New orders",
+            comment: "Label of the toggle to enable/disable new order notifications on the site notification settings view"
+        )
+        static let productReviews = NSLocalizedString(
+            "siteNotificationSettingsView.productReviews",
+            value: "Product reviews",
+            comment: "Label of the toggle to enable/disable product reviews notifications on the site notification settings view"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
@@ -23,12 +23,12 @@ struct SiteNotificationSettingsView: View {
                         Text(Localization.productReviews)
                     }
                 } header: {
-                    Text(Localization.notificationTypesHeader)
+                    Text(siteTitle)
                 } footer: {
                     Text(Localization.notificationTypesFooter)
                 }
             }
-            .navigationTitle(siteTitle)
+            .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -59,8 +59,8 @@ private extension SiteNotificationSettingsView {
             value: "Save",
             comment: "Button to save the settings on the site notification settings view"
         )
-        static let notificationTypesHeader = NSLocalizedString(
-            "siteNotificationSettingsView.notificationTypesHeader",
+        static let title = NSLocalizedString(
+            "siteNotificationSettingsView.title",
             value: "Notification types",
             comment: "Header of the notification types section on the site notification settings view"
         )

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2683,6 +2683,7 @@
 		DE58C8A42D88226A005914DF /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58C8A32D88226A005914DF /* NotificationSettingsView.swift */; };
 		DE58C8A62D8928CF005914DF /* NotificationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58C8A52D8928C8005914DF /* NotificationSettingsViewModel.swift */; };
 		DE58D0042D8A6F85005914DF /* NotificationSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58D0032D8A6F85005914DF /* NotificationSettingsViewModelTests.swift */; };
+		DE58D0062D8A9F45005914DF /* SiteNotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58D0052D8A9F45005914DF /* SiteNotificationSettingsView.swift */; };
 		DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */; };
 		DE5FBB912A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */; };
 		DE5FBB932A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */; };
@@ -5890,6 +5891,7 @@
 		DE58C8A32D88226A005914DF /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
 		DE58C8A52D8928C8005914DF /* NotificationSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsViewModel.swift; sourceTree = "<group>"; };
 		DE58D0032D8A6F85005914DF /* NotificationSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsViewModelTests.swift; sourceTree = "<group>"; };
+		DE58D0052D8A9F45005914DF /* SiteNotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteNotificationSettingsView.swift; sourceTree = "<group>"; };
 		DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductNameAI.swift"; sourceTree = "<group>"; };
 		DE5FBB902A9EF25A0072FB35 /* WooPaymentSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentSetupWebViewModelTests.swift; sourceTree = "<group>"; };
@@ -13277,6 +13279,7 @@
 			isa = PBXGroup;
 			children = (
 				DE58C8A32D88226A005914DF /* NotificationSettingsView.swift */,
+				DE58D0052D8A9F45005914DF /* SiteNotificationSettingsView.swift */,
 				DE58C8A52D8928C8005914DF /* NotificationSettingsViewModel.swift */,
 			);
 			path = NotificationSettings;
@@ -16817,6 +16820,7 @@
 				02B1AA6729A4709400D54FCB /* FilterTabBar.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				015D99AA2C58C780001D7186 /* PointOfSaleCardPresentPaymentLayout.swift in Sources */,
+				DE58D0062D8A9F45005914DF /* SiteNotificationSettingsView.swift in Sources */,
 				DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */,
 				EE505DE12B3D321A006E3323 /* BlazeLearnHowView.swift in Sources */,
 				03582BE2299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
@@ -1,5 +1,6 @@
 import UserNotifications
 import Testing
+import Yosemite
 @testable import WooCommerce
 
 struct NotificationSettingsViewModelTests {
@@ -34,5 +35,67 @@ struct NotificationSettingsViewModelTests {
 
         // Then
         #expect(viewModel.notificationsEnabled == true)
+    }
+
+    @MainActor
+    @Test func sites_include_storage_data_if_syncing_fails() async {
+        // Given
+        let storageManager = MockStorageManager()
+        let testSite1 = Site.fake().copy(siteID: 123, name: "Miffy", isWooCommerceActive: true)
+        let testSite2 = Site.fake().copy(siteID: 243, name: "Matsui", isWooCommerceActive: true)
+        let testSite3 = Site.fake().copy(siteID: 233, name: "Kitty", isWooCommerceActive: false)
+        storageManager.insertSampleSite(readOnlySite: testSite1)
+        storageManager.insertSampleSite(readOnlySite: testSite2)
+        storageManager.insertSampleSite(readOnlySite: testSite3)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let notificationCenter = MockUserNotificationsCenterAdapter()
+
+        let viewModel = NotificationSettingsViewModel(notificationCenter: notificationCenter,
+                                                      stores: stores,
+                                                      storageManager: storageManager)
+
+        // When
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                onCompletion(.failure(NSError(domain: "test", code: 500)))
+            default:
+                break
+            }
+        }
+        await viewModel.synchronizeSites()
+
+        // Then
+        #expect(viewModel.sites == [testSite2, testSite1])
+    }
+
+    @MainActor
+    @Test func sites_is_updated_when_syncing_succeeds() async throws {
+        // Given
+        let storageManager = MockStorageManager()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let notificationCenter = MockUserNotificationsCenterAdapter()
+
+        let viewModel = NotificationSettingsViewModel(notificationCenter: notificationCenter,
+                                                      stores: stores,
+                                                      storageManager: storageManager)
+
+        // When
+        let testSite4 = Site.fake().copy(siteID: 11, name: "Lala", isWooCommerceActive: true)
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                storageManager.insertSampleSite(readOnlySite: testSite4)
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+        await viewModel.synchronizeSites()
+        try await Task.sleep(nanoseconds: 200) // workaround to wait for update
+
+        // Then
+        #expect(viewModel.sites == [testSite4])
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15371 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the notification settings screen to include a list of connected stores, and tapping on each store navigates to a separate screen for configuring notification preferences.

Functionalities for the notification type settings will be added in a separate PR.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Pre-requisite: Build and run the app on a physical device as this feature requires push notification permission.
1. Log in to a Jetpack store with a WPCom account.
2. Navigate to Hub Menu tab > Settings > Notification Settings.
3. Confirm that the screen displays a list of connected stores.
4. Tap on any of the stores and confirm that a new screen is displayed with options to toggle notifications for new orders and product reviews.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on iPhone 16 Pro iOS 18.3 and confirmed the test case above.
Unit tests have been added to verify the loading of the site list.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Notification Settings | Site Settings 
--- | ---
<img src="https://github.com/user-attachments/assets/054f1ce6-f50d-4cad-9897-41ff873893f2" width=320 /> | <img src="https://github.com/user-attachments/assets/2bc4ac1f-4375-4a39-89d5-6036d6d7c954" width=320 /> 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
