### PR TITLE
[Woo POS] Experiment: Scan QR to Pay

### DIFF
--- a/Networking/Networking/Remote/FeatureFlagRemote.swift
+++ b/Networking/Networking/Remote/FeatureFlagRemote.swift
@@ -30,7 +30,7 @@ public enum RemoteFeatureFlag: Decodable {
     case storeCreationCompleteNotification
     case hardcodedPlanUpgradeDetailsMilestone1AreAccurate
     case pointOfSale
-    case pointOfSaleScanToPayOnly
+    case pointOfSaleOnlyScanToPay
 
     init?(rawValue: String) {
         switch rawValue {
@@ -40,8 +40,8 @@ public enum RemoteFeatureFlag: Decodable {
             self = .hardcodedPlanUpgradeDetailsMilestone1AreAccurate
         case "woo_pos":
             self = .pointOfSale
-        case "woo_pos_scan_to_pay_only":
-            self = .pointOfSaleScanToPayOnly
+        case "woo_pos_only_scan_to_pay":
+            self = .pointOfSaleOnlyScanToPay
         default:
             return nil
         }

--- a/Networking/Networking/Remote/FeatureFlagRemote.swift
+++ b/Networking/Networking/Remote/FeatureFlagRemote.swift
@@ -30,6 +30,7 @@ public enum RemoteFeatureFlag: Decodable {
     case storeCreationCompleteNotification
     case hardcodedPlanUpgradeDetailsMilestone1AreAccurate
     case pointOfSale
+    case pointOfSaleScanToPayOnly
 
     init?(rawValue: String) {
         switch rawValue {
@@ -39,6 +40,8 @@ public enum RemoteFeatureFlag: Decodable {
             self = .hardcodedPlanUpgradeDetailsMilestone1AreAccurate
         case "woo_pos":
             self = .pointOfSale
+        case "woo_pos_scan_to_pay_only":
+            self = .pointOfSaleScanToPayOnly
         default:
             return nil
         }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -4,6 +4,7 @@ import protocol Yosemite.StoresManager
 import protocol Yosemite.POSOrderServiceProtocol
 import protocol Yosemite.POSReceiptServiceProtocol
 import struct Yosemite.Order
+import enum Yosemite.OrderStatusEnum
 import struct Yosemite.PaymentGateway
 import struct Yosemite.POSCartItem
 import enum Yosemite.OrderAction
@@ -31,6 +32,7 @@ protocol PointOfSaleOrderControllerProtocol {
     func sendReceipt(recipientEmail: String) async throws
     func clearOrder()
     func collectCashPayment() async throws
+    func collectScanPayment() async throws
 }
 
 @available(iOS 17.0, *)
@@ -163,6 +165,42 @@ protocol PointOfSaleOrderControllerProtocol {
             stores.dispatch(action)
         }
     }
+
+    /// Initiates scan-to-pay flow and monitors order status until completion
+    @MainActor
+    func collectScanPayment() async throws {
+        do {
+            order = try await updateOrderStatus(.pending)
+        } catch {
+            throw ScanToPayError.updateStatusFailure
+        }
+
+        guard let siteID = stores.sessionManager.defaultStoreID,
+              let order = order else {
+            throw PointOfSaleOrderControllerError.noOrder
+        }
+
+        try Task.checkCancellation()
+
+        while true {
+            do {
+                let updatedOrder = try await retrieveOrder(siteID: siteID, orderID: order.orderID)
+
+                if updatedOrder.status == .processing {
+                    Task {
+                        try? await updateOrderStatus(.completed)
+                    }
+                    self.celebrate()
+                    return
+                }
+            } catch {
+                throw ScanToPayError.observationFailure
+            }
+
+            try await Task.sleep(for: .seconds(5))
+            try Task.checkCancellation()
+        }
+    }
 }
 
 @available(iOS 17.0, *)
@@ -247,5 +285,53 @@ extension PointOfSaleOrderController {
     enum PointOfSaleOrderControllerError: Error {
         case noSiteID
         case noOrder
+    }
+}
+
+// MARK: - Scan to Pay
+
+enum ScanToPayError: Error {
+    case updateStatusFailure
+    case observationFailure
+}
+
+@available(iOS 17.0, *)
+private extension PointOfSaleOrderController {
+    @MainActor
+    func updateOrderStatus(_ status: OrderStatusEnum) async throws -> Order {
+        guard let siteID = stores.sessionManager.defaultStoreID else {
+            throw PointOfSaleOrderControllerError.noSiteID
+        }
+        guard let order = order else {
+            throw PointOfSaleOrderControllerError.noOrder
+        }
+
+        let fieldsToUpdate: [OrderUpdateField] = [.status]
+        let updatedOrder = order.copy(status: status)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let action = OrderAction.updateOrder(siteID: siteID,
+                                                 order: updatedOrder,
+                                                 giftCard: nil,
+                                                 fields: fieldsToUpdate,
+                                                 onCompletion: { result in
+                continuation.resume(with: result)
+            })
+            stores.dispatch(action)
+        }
+    }
+
+    @MainActor
+    func retrieveOrder(siteID: Int64, orderID: Int64) async throws -> Order {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = OrderAction.retrieveOrderRemotely(
+                siteID: siteID,
+                orderID: orderID,
+                onCompletion: { result in
+                    continuation.resume(with: result)
+                }
+            )
+            stores.dispatch(action)
+        }
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -65,6 +65,7 @@ protocol PointOfSaleAggregateModelProtocol {
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
+    private var eligibilityChecker: POSEligibilityCheckerProtocol
 
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
@@ -78,12 +79,14 @@ protocol PointOfSaleAggregateModelProtocol {
          orderController: PointOfSaleOrderControllerProtocol,
          analytics: Analytics = ServiceLocator.analytics,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
+         eligibilityChecker: POSEligibilityCheckerProtocol = POSEligibilityChecker(),
          paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.itemsController = itemsController
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderController = orderController
         self.analytics = analytics
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
+        self.eligibilityChecker = eligibilityChecker
         self.paymentState = paymentState
         publishCardReaderConnectionStatus()
         publishPaymentMessages()
@@ -218,6 +221,7 @@ extension PointOfSaleAggregateModel {
     /// Note that any scheduled payments are cancelled by `cancelReaderPreparation`
     /// e.g. when the TotalsView goes offscreen.
     private func startPaymentWhenCardReaderConnected() async {
+        paymentState = .card(.idle)
         guard case .connected = cardReaderConnectionStatus else {
             return startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
                 .filter { status in
@@ -481,8 +485,11 @@ extension PointOfSaleAggregateModel {
         })
         trackOrderSyncState(syncOrderResult)
 
-//        await startPaymentWhenCardReaderConnected()
-        paymentState = .scan(.waitingForScan)
+        if eligibilityChecker.isOnlyScanToPayEnabled {
+            startScanToPay()
+        } else {
+            await startPaymentWhenCardReaderConnected()
+        }
     }
 }
 
@@ -531,6 +538,7 @@ extension PointOfSaleAggregateModel {
     }
 
     func startScanToPay() {
+        paymentState = .scan(.waitingForScan)
         stopScanToPay()
 
         scanToPayTask = Task { @MainActor [weak self] in

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -71,6 +71,8 @@ protocol PointOfSaleAggregateModelProtocol {
 
     private var cancellables: Set<AnyCancellable> = []
 
+    private var scanToPayTask: Task<Void, Never>?
+
     init(itemsController: PointOfSaleItemsControllerProtocol,
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderController: PointOfSaleOrderControllerProtocol,
@@ -263,10 +265,7 @@ extension PointOfSaleAggregateModel {
     @MainActor
     func cancelCashPayment() async {
         analytics.track(.pointOfSaleBackToCheckoutFromCashTapped)
-        paymentState = .card(.idle)
-        if case .connected = cardReaderConnectionStatus {
-            await collectCardPayment()
-        }
+        await checkOut()
     }
 
     private func cashPaymentSuccess() {
@@ -481,7 +480,9 @@ extension PointOfSaleAggregateModel {
             await self?.checkOut()
         })
         trackOrderSyncState(syncOrderResult)
-        await startPaymentWhenCardReaderConnected()
+
+//        await startPaymentWhenCardReaderConnected()
+        paymentState = .scan(.waitingForScan)
     }
 }
 
@@ -515,5 +516,44 @@ extension PointOfSaleAggregateModel {
 private extension PointOfSaleAggregateModel {
     enum Constants {
         static let initialPage: Int = 1
+    }
+}
+
+// MARK: - Scan to Pay
+
+@available(iOS 17.0, *)
+extension PointOfSaleAggregateModel {
+    var paymentURL: URL? {
+        if case .loaded(_, let order) = internalOrderState {
+            return order.paymentURL
+        }
+        return nil
+    }
+
+    func startScanToPay() {
+        stopScanToPay()
+
+        scanToPayTask = Task { @MainActor [weak self] in
+            do {
+                let _ = try await self?.orderController.collectScanPayment()
+                self?.paymentState = .scan(.paymentSuccess)
+            } catch is CancellationError {
+                DDLogInfo("Scan to Pay cancelled")
+                return
+            } catch is ScanToPayError {
+                try? await Task.sleep(for: .seconds(5))
+                if self?.scanToPayTask?.isCancelled == false {
+                    DDLogError("Scan to Pay failed, restarting.")
+                    self?.startScanToPay()
+                }
+            } catch {
+                DDLogError("Scan to Pay failed: \(error)")
+            }
+        }
+    }
+
+    func stopScanToPay() {
+        scanToPayTask?.cancel()
+        scanToPayTask = nil
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -539,7 +539,7 @@ extension PointOfSaleAggregateModel {
     }
 
     var isCardPaymentAvailable: Bool {
-        return eligibilityChecker.isOnlyScanToPayEnabled
+        return !eligibilityChecker.isOnlyScanToPayEnabled
     }
 
     func startScanToPay() {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -221,7 +221,6 @@ extension PointOfSaleAggregateModel {
     /// Note that any scheduled payments are cancelled by `cancelReaderPreparation`
     /// e.g. when the TotalsView goes offscreen.
     private func startPaymentWhenCardReaderConnected() async {
-        paymentState = .card(.idle)
         guard case .connected = cardReaderConnectionStatus else {
             return startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
                 .filter { status in
@@ -485,10 +484,12 @@ extension PointOfSaleAggregateModel {
         })
         trackOrderSyncState(syncOrderResult)
 
-        if eligibilityChecker.isOnlyScanToPayEnabled {
-            startScanToPay()
-        } else {
+        if isCardPaymentAvailable {
+            paymentState = .card(.idle)
             await startPaymentWhenCardReaderConnected()
+        } else {
+            paymentState = .scan(.waitingForScan)
+            startScanToPay()
         }
     }
 }
@@ -537,8 +538,11 @@ extension PointOfSaleAggregateModel {
         return nil
     }
 
+    var isCardPaymentAvailable: Bool {
+        return eligibilityChecker.isOnlyScanToPayEnabled
+    }
+
     func startScanToPay() {
-        paymentState = .scan(.waitingForScan)
         stopScanToPay()
 
         scanToPayTask = Task { @MainActor [weak self] in

--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentMethod.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentMethod.swift
@@ -3,4 +3,5 @@ import Foundation
 enum PointOfSalePaymentMethod {
     case card
     case cash
+    case scan
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
@@ -3,6 +3,7 @@ import Foundation
 enum PointOfSalePaymentState: Equatable {
     case card(PointOfSaleCardPaymentState)
     case cash(PointOfSaleCashPaymentState)
+    case scan(PointOfSaleScanPaymentState)
 }
 
 enum PointOfSaleCardPaymentState: Equatable {
@@ -18,6 +19,11 @@ enum PointOfSaleCardPaymentState: Equatable {
 
 enum PointOfSaleCashPaymentState: Equatable {
     case collectingCash
+    case paymentSuccess
+}
+
+enum PointOfSaleScanPaymentState: Equatable {
+    case waitingForScan
     case paymentSuccess
 }
 
@@ -69,6 +75,13 @@ extension PointOfSalePaymentState {
             return false
         case .cash:
             return true
+        case .scan(let scanPaymentState):
+            switch scanPaymentState {
+            case .waitingForScan:
+                return false
+            case .paymentSuccess:
+                return true
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSalePaymentSuccessViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSalePaymentSuccessViewModel.swift
@@ -34,6 +34,13 @@ private extension PointOfSalePaymentSuccessViewModel {
             comment: "Message shown to users when payment is made. %1$@ is a placeholder for the order " +
             " total, e.g $10.50. Please include %1$@ in your formatted string"
         )
+
+        static let messageScan = NSLocalizedString(
+            "pointOfSale.paymentSuccessful.message.scan.1",
+            value: "A payment of %1$@ was successfully made.",
+            comment: "Message shown to users when payment is made by scanning QR code. %1$@ is a placeholder for the order " +
+            " total, e.g $10.50. Please include %1$@ in your formatted string"
+        )
     }
 }
 
@@ -42,9 +49,10 @@ private extension PointOfSalePaymentMethod {
         switch self {
         case .card:
             return PointOfSalePaymentSuccessViewModel.Localization.messageCard
-
         case .cash:
             return PointOfSalePaymentSuccessViewModel.Localization.messageCash
+        case .scan:
+            return PointOfSalePaymentSuccessViewModel.Localization.messageScan
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -68,6 +68,7 @@ struct POSFloatingControlView: View {
                 .cornerRadius(Constants.cornerRadius)
                 .disabled(posModel.paymentState.shownFullScreen)
                 .disabled(horizontalSizeClass != .regular)
+                .disabled(!posModel.isCardPaymentAvailable)
         }
         .frame(height: Constants.size)
         .background(Color.clear)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -11,18 +11,21 @@ struct PointOfSaleEntryPointView: View {
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderController: PointOfSaleOrderControllerProtocol
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
+    private let posEligibilityChecker: POSEligibilityCheckerProtocol
 
     init(itemsController: PointOfSaleItemsControllerProtocol,
          onPointOfSaleModeActiveStateChange: @escaping ((Bool) -> Void),
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderController: PointOfSaleOrderControllerProtocol,
-         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking) {
+         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
+        posEligibilityChecker: POSEligibilityCheckerProtocol) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
 
         self.itemsController = itemsController
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderController = orderController
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
+        self.posEligibilityChecker = posEligibilityChecker
     }
 
     var body: some View {
@@ -42,7 +45,8 @@ struct PointOfSaleEntryPointView: View {
                 itemsController: itemsController,
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker)
+                collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+                eligibilityChecker: posEligibilityChecker)
         }
         .environmentObject(posModalManager)
         .onAppear {
@@ -63,6 +67,7 @@ struct PointOfSaleEntryPointView: View {
                               onPointOfSaleModeActiveStateChange: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
                               orderController: PointOfSalePreviewOrderController(),
-                              collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+                              collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+                              posEligibilityChecker: POSEligibilityChecker())
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleScanToPayView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleScanToPayView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+@available(iOS 17.0, *)
+struct PointOfSaleScanToPayView: View {
+    @Environment(PointOfSaleAggregateModel.self) private var posModel
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    var body: some View {
+        VStack(alignment: .center, spacing: POSSpacing.medium) {
+            if let qrCodeImage = ScanToPayViewModel(paymentURL: posModel.paymentURL).generateQRCodeImage() {
+                Text(ScanToPayView.Localization.title)
+                    .font(.posHeadingBold)
+                    .dynamicTypeSize(...DynamicTypeSize.large)
+                Image(uiImage: qrCodeImage)
+                    .interpolation(.none)
+                    .resizable()
+                .buttonStyle(PrimaryButtonStyle())
+                .aspectRatio(1, contentMode: .fit)
+                .frame(minWidth: 250, minHeight: 250)
+                .layoutPriority(1)
+                .padding(dynamicTypeSize.isAccessibilitySize ? 0 : POSPadding.large)
+            }
+        }
+        .padding(.top, dynamicTypeSize.isAccessibilitySize ? 0 : POSPadding.large)
+        .onAppear {
+            posModel.startScanToPay()
+        }
+        .onDisappear() {
+            posModel.stopScanToPay()
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleScanToPayView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleScanToPayView.swift
@@ -22,9 +22,6 @@ struct PointOfSaleScanToPayView: View {
             }
         }
         .padding(.top, dynamicTypeSize.isAccessibilitySize ? 0 : POSPadding.large)
-        .onAppear {
-            posModel.startScanToPay()
-        }
         .onDisappear() {
             posModel.stopScanToPay()
         }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -252,6 +252,18 @@ private extension TotalsView {
                                              paymentMethod: .cash)))
                 }
             }
+        case .scan(let scanPaymentState):
+            switch scanPaymentState {
+            case .waitingForScan:
+                PointOfSaleScanToPayView()
+            case .paymentSuccess:
+                if case .loaded(let total) = posModel.orderState {
+                    PointOfSaleCardPresentPaymentInLineMessage(
+                        messageType: .paymentSuccess(
+                            viewModel: .init(formattedOrderTotal: total.orderTotal,
+                                             paymentMethod: .scan)))
+                }
+            }
         }
     }
 }
@@ -299,6 +311,8 @@ private extension TotalsView {
                 return posModel.cardPresentPaymentInlineMessage != nil
             case .cash:
                 return true
+            case .scan:
+                return true
             }
         case .disconnected:
             // Since the reader is disconnected, this will show the "Connect your reader" CTA button view.
@@ -341,6 +355,19 @@ private extension TotalsView {
         case .cash(let cashPaymentState):
             switch cashPaymentState {
             case .collectingCash:
+                return PaymentViewLayout(backgroundColor: backgroundColor,
+                                         topPadding: POSPadding.none,
+                                         bottomPadding: nil,
+                                         sidePadding: POSPadding.none)
+            case .paymentSuccess:
+                return PaymentViewLayout(backgroundColor: backgroundColor,
+                                         topPadding: POSPadding.none,
+                                         bottomPadding: POSPadding.none,
+                                         sidePadding: POSPadding.none)
+            }
+        case .scan(let scanPaymentState):
+            switch scanPaymentState {
+            case .waitingForScan:
                 return PaymentViewLayout(backgroundColor: backgroundColor,
                                          topPadding: POSPadding.none,
                                          bottomPadding: nil,

--- a/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
+++ b/WooCommerce/Classes/POS/Utils/PointOfSalePreviewOrderController.swift
@@ -21,5 +21,7 @@ class PointOfSalePreviewOrderController: PointOfSaleOrderControllerProtocol {
     func clearOrder() { }
 
     func collectCashPayment() async throws {}
+
+    func collectScanPayment() async throws {}
 }
 #endif

--- a/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
@@ -39,6 +39,13 @@ private extension PointOfSalePaymentState {
             }
         case .cash:
             return false
+        case .scan(let scanPaymentState):
+            switch scanPaymentState {
+            case .waitingForScan:
+                return true
+            case .paymentSuccess:
+                return false
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
@@ -81,7 +81,7 @@ final class TotalsViewHelper {
 
     func shouldApplyPadding(paymentState: PointOfSalePaymentState) -> Bool {
         switch paymentState {
-        case .card(.cardPaymentSuccessful), .cash(.paymentSuccess), .cash(.collectingCash), .card(.paymentError):
+        case .card(.cardPaymentSuccessful), .cash(.paymentSuccess), .scan(.paymentSuccess), .cash(.collectingCash), .card(.paymentError):
             return false
         default:
             return true

--- a/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
@@ -18,6 +18,13 @@ final class TotalsViewHelper {
             }
         case .cash:
             return false
+        case .scan(let scanPaymentState):
+            switch scanPaymentState {
+            case .waitingForScan:
+                return true
+            case .paymentSuccess:
+                return false
+            }
         }
     }
 
@@ -43,8 +50,15 @@ final class TotalsViewHelper {
     func shouldShowCollectCashPaymentButton(orderState: PointOfSaleOrderState,
                                             paymentState: PointOfSalePaymentState,
                                             cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus) -> Bool {
-        guard orderState != .syncing,
-              case .card(let cardState) = paymentState else {
+        guard orderState != .syncing else {
+            return false
+        }
+
+        if case .scan(let scanState) = paymentState {
+            return scanState == .waitingForScan
+        }
+
+        guard case .card(let cardState) = paymentState else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -28,10 +28,17 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
         }
 
         return Publishers.CombineLatest3(isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled, isPointOfSaleOnlyScanToPayEnabled)
-            .filter { [weak self] _ in
-                self?.isEligibleFromSiteChecks ?? false
+            .map { [weak self] isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled, isPointOfSaleOnlyScanToPayEnabled -> Bool in
+                guard let self else {
+                    return false
+                }
+
+                guard isWooCommerceVersionSupported else {
+                    return false
+                }
+
+                return (isPointOfSaleFeatureFlagEnabled && isEligibleFromSiteChecks) || isPointOfSaleOnlyScanToPayEnabled
             }
-            .map { $0 && ($1 || $2) }
             .eraseToAnyPublisher()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -12,6 +12,8 @@ import enum Yosemite.FeatureFlagAction
 protocol POSEligibilityCheckerProtocol {
     /// As POS eligibility can change from site settings and card payment onboarding state, it's recommended to observe the eligibility value.
     var isEligible: AnyPublisher<Bool, Never> { get }
+    /// Experiment: Specific mercants that operate outside eligible markets may only have QR Scan to Pay enabled
+    var isOnlyScanToPayEnabled: Bool { get }
 }
 
 /// Determines whether the POS entry point can be shown based on the selected store and feature gates.
@@ -25,11 +27,11 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
                 .eraseToAnyPublisher()
         }
 
-        return Publishers.CombineLatest(isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled)
+        return Publishers.CombineLatest3(isWooCommerceVersionSupported, isPointOfSaleFeatureFlagEnabled, isPointOfSaleOnlyScanToPayEnabled)
             .filter { [weak self] _ in
                 self?.isEligibleFromSiteChecks ?? false
             }
-            .map { $0 && $1 }
+            .map { $0 && ($1 || $2) }
             .eraseToAnyPublisher()
     }
 
@@ -38,6 +40,7 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
     private let currencySettings: CurrencySettings
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
+    var isOnlyScanToPayEnabled: Bool = false
 
     init(userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
          siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
@@ -119,6 +122,26 @@ private extension POSEligibilityChecker {
                 return false
         }
     }
+}
+
+private extension POSEligibilityChecker {
+    var isPointOfSaleOnlyScanToPayEnabled: AnyPublisher<Bool, Never> {
+        // Experimental feature
+        // Only whitelisted accounts in WPCOM have the woo_pos_only_scan_to_pay remote feature flag enabled. These can be found at D159901-code
+        Future<Bool, Never> { [weak self] promise in
+            guard let self else {
+                promise(.success(false))
+                return
+            }
+            let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(.pointOfSaleOnlyScanToPay, defaultValue: false, completion: { [weak self] result in
+                self?.isOnlyScanToPayEnabled = result
+                return promise(.success(result))
+            })
+            self.stores.dispatch(action)
+        }
+        .eraseToAnyPublisher()
+    }
+
 }
 
 private extension POSEligibilityChecker {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -46,7 +46,8 @@ struct HubMenu: View {
                             cardPresentPaymentService: cardPresentPaymentService,
                             orderController: PointOfSaleOrderController(orderService: orderService,
                                                                         receiptService: receiptService),
-                            collectOrderPaymentAnalyticsTracker: viewModel.collectOrderPaymentAnalyticsTracker)
+                            collectOrderPaymentAnalyticsTracker: viewModel.collectOrderPaymentAnalyticsTracker,
+                            posEligibilityChecker: viewModel.posEligibilityChecker)
                     } else {
                         // TODO: When we have a singleton for the card payment service, this should not be required.
                         Text("Error creating card payment service")

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -89,10 +89,10 @@ final class HubMenuViewModel: ObservableObject {
     private let featureFlagService: FeatureFlagService
     private let generalAppSettings: GeneralAppSettingsStorage
     private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
-    private let posEligibilityChecker: POSEligibilityCheckerProtocol
     private let inboxEligibilityChecker: InboxEligibilityChecker
     private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
+    let posEligibilityChecker: POSEligibilityCheckerProtocol
 
     private(set) lazy var posItemProvider: PointOfSaleItemServiceProtocol = {
         let storage = ServiceLocator.storageManager

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		019630B42D01DB4800219D80 /* TapToPayAwarenessMomentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B32D01DB4000219D80 /* TapToPayAwarenessMomentView.swift */; };
 		019630B62D02018C00219D80 /* TapToPayAwarenessMomentDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B52D02018400219D80 /* TapToPayAwarenessMomentDeterminer.swift */; };
 		019630B82D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B72D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift */; };
+		019A953E2D89D5BF00ABBB71 /* PointOfSaleScanToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A953D2D89D5B800ABBB71 /* PointOfSaleScanToPayView.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
 		01ADC1382C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */; };
 		01B744E22D2FCA1400AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B744E12D2FCA1300AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift */; };
@@ -3278,6 +3279,7 @@
 		019630B32D01DB4000219D80 /* TapToPayAwarenessMomentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentView.swift; sourceTree = "<group>"; };
 		019630B52D02018400219D80 /* TapToPayAwarenessMomentDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentDeterminer.swift; sourceTree = "<group>"; };
 		019630B72D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentDeterminerTests.swift; sourceTree = "<group>"; };
+		019A953D2D89D5B800ABBB71 /* PointOfSaleScanToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleScanToPayView.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift; sourceTree = "<group>"; };
 		01B744E12D2FCA1300AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationBackgroundSynchronizerFactory.swift; sourceTree = "<group>"; };
@@ -7216,6 +7218,7 @@
 				026826B02BF59E170036F959 /* CardReaderConnection */,
 				014BD4B62C64E26B0011A66E /* Order Messages */,
 				02B1914A2CCF278100CF38C9 /* Payments Onboarding */,
+				019A953D2D89D5B800ABBB71 /* PointOfSaleScanToPayView.swift */,
 				026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */,
 				68A345632D029E09002EE324 /* PaymentButtons.swift */,
 				026826A52BF59DF60036F959 /* PointOfSaleDashboardView.swift */,
@@ -16462,6 +16465,7 @@
 				68B6F22B2ADE7ED500D171FC /* TooltipView.swift in Sources */,
 				02EAF5BE29FA04750058071C /* ProductDescriptionGenerationView.swift in Sources */,
 				CEEF74252B99EF1200B03948 /* RevenueReportCardViewModel.swift in Sources */,
+				019A953E2D89D5BF00ABBB71 /* PointOfSaleScanToPayView.swift in Sources */,
 				CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
 				2677B559299F322300862180 /* SupportForm+Presentation.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
@@ -34,4 +34,6 @@ private final class MockPOSEligibilityChecker: POSEligibilityCheckerProtocol {
     var isEligible: AnyPublisher<Bool, Never> {
         $isEligibleValue.eraseToAnyPublisher()
     }
+
+    var isOnlyScanToPayEnabled: Bool = false
 }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -8,6 +8,7 @@ import struct Yosemite.OrderItem
 import enum Yosemite.OrderAction
 import class WooFoundation.CurrencySettings
 import protocol WooFoundation.Analytics
+import enum Yosemite.OrderStatusEnum
 
 struct PointOfSaleOrderControllerTests {
     let mockOrderService = MockPOSOrderService()
@@ -362,6 +363,63 @@ struct PointOfSaleOrderControllerTests {
         } else {
             #expect(Bool(false), "Expected sync failure but got \(result)")
         }
+    }
+
+    @MainActor
+    @available(iOS 17.0, *)
+    @Test func collectScanPayment_when_processing_detected_then_succeeds() async throws {
+        // Given
+        let sampleSiteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.sessionManager.setStoreId(sampleSiteID)
+        let mockPaymentCelebration = MockPaymentCaptureCelebration()
+
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService,
+                                             stores: mockStores,
+                                             celebration: mockPaymentCelebration)
+
+        let orderItem = OrderItem.fake()
+        let initialOrder = Order.fake().copy(items: [orderItem])
+        mockOrderService.orderToReturn = initialOrder
+        await sut.syncOrder(for: [makeItem()], retryHandler: {})
+
+        var orderStatusUpdates: [OrderStatusEnum] = []
+        var retrievedOrder: Order? = nil
+
+        // When
+        let result: Bool = await withCheckedContinuation { continuation in
+            mockStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, _, fields, onCompletion):
+                    if fields.contains(.status) {
+                        orderStatusUpdates.append(order.status)
+                        onCompletion(.success(order))
+                    }
+                case let .retrieveOrderRemotely(_, _, onCompletion):
+                    if retrievedOrder == nil {
+                        retrievedOrder = initialOrder.copy(status: .processing)
+                        onCompletion(.success(retrievedOrder!))
+                    }
+                default:
+                    #expect(Bool(false), "Unexpected action \(action)")
+                }
+            }
+
+            Task {
+                do {
+                    try await sut.collectScanPayment()
+                    continuation.resume(returning: true)
+                } catch {
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+
+        // Then
+        #expect(result == true)
+        #expect(orderStatusUpdates == [.pending, .completed])
+        #expect(mockPaymentCelebration.celebrationWasCalled)
     }
 
     struct AnalyticsTests {

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderController.swift
@@ -9,6 +9,8 @@ final class MockPointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
         // no-op
     }
 
+    func collectScanPayment() async throws {}
+
     var orderStatePublisher: AnyPublisher<PointOfSaleInternalOrderState, Never> {
         $orderState.eraseToAnyPublisher()
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -213,8 +213,10 @@ private extension POSEligibilityCheckerTests {
     func accountWhitelistedInBackend(_ isAllowed: Bool = false) {
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case .isRemoteFeatureFlagEnabled(_, _, completion: let completion):
+            case .isRemoteFeatureFlagEnabled(.pointOfSale, _, completion: let completion):
                 completion(isAllowed)
+            case .isRemoteFeatureFlagEnabled(_, _, completion: let completion):
+                completion(false)
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

Context: p91TBi-d5g-p2#comment-14097

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Experimenting with the idea of showing Scan QR to Pay to selective merchants when card reader payment is not available.

## Solution

1. Created `PointOfSaleScanToPayView`, reusing logic from existing `ScanToPayView` of showing QR code
2. Created `collectScanPayment` in `PointOfSaleOrderController` which sets the order to `pending` and observes for `processing` status every 5 seconds.
3. Aggregate model sets the POS in success state if `collectScanPayment` completes, or cancels the task if the screen is closed
4. Added remoteFeatureFlag. If it's enabled for specific merchants, then POS option is shown in the menu but only `.scan` payment option is available.

The most questionable part of the solution is calling `retrieveOrder` every 5 seconds while the QR code is presented. However, it may be acceptable for an experimental feature that may be used only by a couple of merchants. We could rethink it if we decided to expland.

### Further Improvements to consider

#### auto_draft

To make the solution more reliable, we need to reset the order state to auto_draft when going back to edit an order. This makes the payment page unavailable until we open the payment view again and stops customers from paying while the order is still being edited.

#### Customer address

Context: pdfdoF-6K9-p2

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Before testing: Set `defaultValue: treu` for `isRemoteFeatureFlagEnabled(.pointOfSale` in `POSEligibilityChecker` (line 104)

1. Open the Woo app (feel free to use a site that is a non-supported country)
2. Open POS
3. Add products
4. Check out
6. Confirm QR code appears
7. Come back, notice "Scan to pay canceled" in the console
8. Check out again
9. Scan the code and pay
10. Confirm success view appears

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/030d07a9-f94b-4bbf-9062-3beefa215243


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.