### PR TITLE
HACK Week: Integrate loading notification settings

### DIFF
--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -46,6 +46,31 @@ public extension NotificationSettings {
         enum CodingKeys: String, CodingKey {
             case blogID = "blog_id"
             case devices
+            case device
+        }
+
+        public init(blogID: Int64, devices: [Device]) {
+            self.blogID = blogID
+            self.devices = devices
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(blogID, forKey: .blogID)
+            try container.encode(devices, forKey: .devices)
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container: KeyedDecodingContainer<NotificationSettings.Blog.CodingKeys> = try decoder.container(keyedBy: NotificationSettings.Blog.CodingKeys.self)
+            self.blogID = try container.decode(Int64.self, forKey: NotificationSettings.Blog.CodingKeys.blogID)
+            self.devices = try {
+                if let array = try container.decodeIfPresent([NotificationSettings.Device].self, forKey: NotificationSettings.Blog.CodingKeys.devices) {
+                    return array
+                } else if let device = try container.decodeIfPresent(NotificationSettings.Device.self, forKey: NotificationSettings.Blog.CodingKeys.device) {
+                    return [device]
+                }
+                return []
+            }()
         }
     }
 

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Notification settings for a user
 ///
-public struct NotificationSettings: Equatable, Encodable {
+public struct NotificationSettings: Equatable, Codable {
 
     /// Settings for different blogs connected to the user.
     public let blogs: [Blog]
@@ -36,7 +36,7 @@ public struct NotificationSettings: Equatable, Encodable {
 
 public extension NotificationSettings {
     /// Notification settings for a blog
-    struct Blog: Equatable, Encodable {
+    struct Blog: Equatable, Codable {
         /// ID of the blog
         public let blogID: Int64
 
@@ -50,7 +50,7 @@ public extension NotificationSettings {
     }
 
     /// Notification settings for a device
-    struct Device: Equatable, Encodable {
+    struct Device: Equatable, Codable {
         /// Unique ID of the device
         public let deviceID: Int64
 

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -16,8 +16,8 @@ public protocol AccountRemoteProtocol {
     func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void)
     func loadUsernameSuggestions(from text: String) async throws -> [String]
 
-    func loadNotificationSettings() async throws -> NotificationSettings
-    
+    func loadNotificationSettings(deviceID: Int64) async throws -> NotificationSettings
+
     func updateNotificationSettings(with settings: NotificationSettings) async throws
 
     /// Creates a WPCOM account with the given email and password.
@@ -149,9 +149,10 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
         return suggestions
     }
 
-    public func loadNotificationSettings() async throws -> NotificationSettings {
+    public func loadNotificationSettings(deviceID: Int64) async throws -> NotificationSettings {
         let path = Path.notificationSettings
-        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path)
+        let parameters = [ParameterKey.deviceID: deviceID]
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)
         return try await enqueue(request)
     }
 
@@ -211,6 +212,7 @@ private extension AccountRemote {
 
     enum ParameterKey {
         static let name = "name"
+        static let deviceID = "device_id"
     }
 
     enum Path {

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -16,6 +16,8 @@ public protocol AccountRemoteProtocol {
     func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void)
     func loadUsernameSuggestions(from text: String) async throws -> [String]
 
+    func loadNotificationSettings() async throws -> NotificationSettings
+    
     func updateNotificationSettings(with settings: NotificationSettings) async throws
 
     /// Creates a WPCOM account with the given email and password.
@@ -145,6 +147,12 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
         let suggestions = result["suggestions"] ?? []
 
         return suggestions
+    }
+
+    public func loadNotificationSettings() async throws -> NotificationSettings {
+        let path = Path.notificationSettings
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path)
+        return try await enqueue(request)
     }
 
     public func updateNotificationSettings(with settings: NotificationSettings) async throws {

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -333,4 +333,41 @@ final class AccountRemoteTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedError, errorCaught as? NetworkError)
     }
+
+    func test_loadNotificationSettings_succeeds_on_request_success() async throws {
+        // Given
+        let remote = AccountRemote(network: network)
+        let deviceID: Int64 = 664
+        network.simulateResponse(requestUrlSuffix: "me/notifications/settings",
+                                 filename: "load-notification-settings-success")
+
+        // When
+        let notificationSettings = try await remote.loadNotificationSettings(deviceID: deviceID)
+
+        // Then
+        let expectedResult = NotificationSettings(blogs: [
+            .init(blogID: 113, devices: [.init(deviceID: deviceID, newComment: true, storeOrder: true)]),
+            .init(blogID: 72, devices: [.init(deviceID: deviceID, newComment: false, storeOrder: true)])
+        ])
+        XCTAssertEqual(notificationSettings, expectedResult)
+    }
+
+    func test_loadNotificationSettings_relays_error_on_request_failure() async {
+        // Given
+        let remote = AccountRemote(network: network)
+        let deviceID: Int64 = 664
+        let expectedError = NetworkError.timeout()
+        network.simulateError(requestUrlSuffix: "me/notifications/settings", error: expectedError)
+
+        // When
+        var errorCaught: Error?
+        do {
+            _ = try await remote.loadNotificationSettings(deviceID: deviceID)
+        } catch {
+            errorCaught = error
+        }
+
+        // Then
+        XCTAssertEqual(expectedError, errorCaught as? NetworkError)
+    }
 }

--- a/Networking/NetworkingTests/Responses/load-notification-settings-success.json
+++ b/Networking/NetworkingTests/Responses/load-notification-settings-success.json
@@ -1,0 +1,84 @@
+{
+    "blogs": [
+        {
+            "blog_id": 113,
+            "timeline": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "email": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "device": {
+                "device_id": 664,
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            }
+        },
+        {
+            "blog_id": 72,
+            "timeline": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "email": {
+                "new_comment": true,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            },
+            "device": {
+                "device_id": 664,
+                "new_comment": false,
+                "comment_like": true,
+                "post_like": true,
+                "follow": true,
+                "achievement": true,
+                "mentions": true,
+                "scheduled_publicize": true,
+                "store_order": true,
+                "blogging_prompt": false,
+                "draft_post_prompt": true
+            }
+        }
+    ]
+}

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -15,6 +15,7 @@ public enum AccountAction: Action {
     case synchronizeSitesAndReturnSelectedSiteInfo(siteAddress: String, onCompletion: (Result<Site, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
+    case loadNotificationSettings(deviceID: Int64, onCompletion: (Result<NotificationSettings, Error>) -> Void)
     case updateNotificationSettings(notificationSettings: NotificationSettings, onCompletion: (Result<Void, Error>) -> Void)
     case closeAccount(onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -56,6 +56,8 @@ public class AccountStore: Store {
             synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
         case .updateAccountSettings(let userID, let tracksOptOut, let onCompletion):
             updateAccountSettings(userID: userID, tracksOptOut: tracksOptOut, onCompletion: onCompletion)
+        case let .loadNotificationSettings(deviceID, onCompletion):
+            loadNotificationSettings(deviceID: deviceID, onCompletion: onCompletion)
         case .updateNotificationSettings(let notificationSettings, let onCompletion):
             updateNotificationSettings(notificationSettings: notificationSettings, onCompletion: onCompletion)
         case .closeAccount(let onCompletion):
@@ -220,6 +222,17 @@ private extension AccountStore {
             case .success:
                 onCompletion(.success(()))
             case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func loadNotificationSettings(deviceID: Int64, onCompletion: @escaping (Result<NotificationSettings, Error>) -> Void) {
+        Task {
+            do {
+                let settings = try await remote.loadNotificationSettings(deviceID: deviceID)
+                onCompletion(.success(settings))
+            } catch {
                 onCompletion(.failure(error))
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -22,6 +22,9 @@ final class MockAccountRemote {
     /// The results to return based on the given site ID in `loadUsernameSuggestions`.
     private var loadUsernameSuggestionsResult: Result<[String], Error>?
 
+    /// Returns the value when `getNotificationSettings` is called
+    private var loadNotificationSettingsResult: Result<NotificationSettings, Error>?
+
     /// Returns the value when `updateNotificationSettings` is called.
     private var updateNotificationSettingsResult: Result<Void, Error> = .success(())
 
@@ -73,6 +76,7 @@ extension MockAccountRemote {
 // MARK: - AccountRemoteProtocol
 
 extension MockAccountRemote: AccountRemoteProtocol {
+    
     func loadAccount(completion: @escaping (Result<Account, Error>) -> Void) {
         // no-op
     }
@@ -120,6 +124,14 @@ extension MockAccountRemote: AccountRemoteProtocol {
             throw NetworkError.notFound()
         }
 
+        return try result.get()
+    }
+
+    func loadNotificationSettings() async throws -> NotificationSettings {
+        guard let result = loadNotificationSettingsResult else {
+            XCTFail("Could not find result for loading notification settings.")
+            throw NetworkError.notFound()
+        }
         return try result.get()
     }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -63,6 +63,10 @@ final class MockAccountRemote {
     func whenUpdatingNotificationSettings(thenReturn result: Result<Void, Error>) {
         updateNotificationSettingsResult = result
     }
+
+    func whenLoadingNotificationSettings(thenReturn result: Result<NotificationSettings, Error>) {
+        loadNotificationSettingsResult = result
+    }
 }
 
 extension MockAccountRemote {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -76,7 +76,6 @@ extension MockAccountRemote {
 // MARK: - AccountRemoteProtocol
 
 extension MockAccountRemote: AccountRemoteProtocol {
-    
     func loadAccount(completion: @escaping (Result<Account, Error>) -> Void) {
         // no-op
     }
@@ -127,7 +126,7 @@ extension MockAccountRemote: AccountRemoteProtocol {
         return try result.get()
     }
 
-    func loadNotificationSettings() async throws -> NotificationSettings {
+    func loadNotificationSettings(deviceID: Int64) async throws -> NotificationSettings {
         guard let result = loadNotificationSettingsResult else {
             XCTFail("Could not find result for loading notification settings.")
             throw NetworkError.notFound()

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -934,6 +934,60 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as NSError?, error)
     }
+
+    // MARK: - loadNotificationSettings
+
+    func test_loadNotificationSettings_returns_success_upon_success() throws {
+        // Given
+        let network = MockNetwork()
+        let accountRemote = MockAccountRemote()
+        let deviceID: Int64 = 115
+        let settings = NotificationSettings(blogs: [
+            .init(blogID: 113, devices: [.init(deviceID: deviceID, newComment: true, storeOrder: true)]),
+            .init(blogID: 72, devices: [.init(deviceID: deviceID, newComment: false, storeOrder: true)])
+        ])
+        accountRemote.whenLoadingNotificationSettings(thenReturn: .success(settings))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: accountRemote)
+
+        // When
+        let result: Result<NotificationSettings, Error> = waitFor { promise in
+            let action = AccountAction.loadNotificationSettings(deviceID: deviceID) { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(try result.get(), settings)
+    }
+
+    func test_loadNotificationSettings_relays_error_upon_failure() {
+        // Given
+        let network = MockNetwork()
+        let accountRemote = MockAccountRemote()
+        let error = NSError(domain: "notifications", code: 33)
+        accountRemote.whenLoadingNotificationSettings(thenReturn: .failure(error))
+        let accountStore = AccountStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: accountRemote)
+
+        // When
+        let result: Result<NotificationSettings, Error> = waitFor { promise in
+            let action = AccountAction.loadNotificationSettings(deviceID: 11) { result in
+                promise(result)
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as NSError?, error)
+    }
 }
 
 // MARK: - Private Methods


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15371 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR integrates the endpoint to load notification settings to the Networking and Yosemite layers.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
The endpoint will be used in a subsequent PR, so just CI passing is sufficient.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Unit tests have been added to verify integration in the Networking and Yosemite layers.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
