### PR TITLE
HACK Week: Load and update site settings

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -96,7 +96,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .backgroundProductImageUpload:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .notificationSettings:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1311,6 +1311,51 @@ extension Networking.NoteRange {
     }
 }
 
+extension Networking.NotificationSettings {
+    public func copy(
+        blogs: CopiableProp<[NotificationSettings.Blog]> = .copy
+    ) -> Networking.NotificationSettings {
+        let blogs = blogs ?? self.blogs
+
+        return Networking.NotificationSettings(
+            blogs: blogs
+        )
+    }
+}
+
+extension Networking.NotificationSettings.Blog {
+    public func copy(
+        blogID: CopiableProp<Int64> = .copy,
+        devices: CopiableProp<[NotificationSettings.Device]> = .copy
+    ) -> Networking.NotificationSettings.Blog {
+        let blogID = blogID ?? self.blogID
+        let devices = devices ?? self.devices
+
+        return Networking.NotificationSettings.Blog(
+            blogID: blogID,
+            devices: devices
+        )
+    }
+}
+
+extension Networking.NotificationSettings.Device {
+    public func copy(
+        deviceID: CopiableProp<Int64> = .copy,
+        newComment: CopiableProp<Bool> = .copy,
+        storeOrder: CopiableProp<Bool> = .copy
+    ) -> Networking.NotificationSettings.Device {
+        let deviceID = deviceID ?? self.deviceID
+        let newComment = newComment ?? self.newComment
+        let storeOrder = storeOrder ?? self.storeOrder
+
+        return Networking.NotificationSettings.Device(
+            deviceID: deviceID,
+            newComment: newComment,
+            storeOrder: storeOrder
+        )
+    }
+}
+
 extension Networking.Order {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -77,7 +77,7 @@ public extension NotificationSettings {
 
     /// Notification settings for a device
     struct Device: Equatable, Codable, GeneratedCopiable {
-        
+
         /// Unique ID of the device
         public let deviceID: Int64
 

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -87,6 +87,11 @@ public extension NotificationSettings {
         /// Whether a notification should be sent when there is a new order on the store.
         public let storeOrder: Bool
 
+        public init(deviceID: Int64, newComment: Bool, storeOrder: Bool) {
+            self.deviceID = deviceID
+            self.newComment = newComment
+            self.storeOrder = storeOrder
+        }
 
         enum CodingKeys: String, CodingKey {
             case deviceID = "device_id"

--- a/Networking/Networking/Model/NotificationSettings.swift
+++ b/Networking/Networking/Model/NotificationSettings.swift
@@ -1,8 +1,9 @@
 import Foundation
+import Codegen
 
 /// Notification settings for a user
 ///
-public struct NotificationSettings: Equatable, Codable {
+public struct NotificationSettings: Equatable, Codable, GeneratedCopiable {
 
     /// Settings for different blogs connected to the user.
     public let blogs: [Blog]
@@ -36,7 +37,7 @@ public struct NotificationSettings: Equatable, Codable {
 
 public extension NotificationSettings {
     /// Notification settings for a blog
-    struct Blog: Equatable, Codable {
+    struct Blog: Equatable, Codable, GeneratedCopiable {
         /// ID of the blog
         public let blogID: Int64
 
@@ -75,7 +76,8 @@ public extension NotificationSettings {
     }
 
     /// Notification settings for a device
-    struct Device: Equatable, Codable {
+    struct Device: Equatable, Codable, GeneratedCopiable {
+        
         /// Unique ID of the device
         public let deviceID: Int64
 
@@ -84,6 +86,7 @@ public extension NotificationSettings {
 
         /// Whether a notification should be sent when there is a new order on the store.
         public let storeOrder: Bool
+
 
         enum CodingKeys: String, CodingKey {
             case deviceID = "device_id"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [internal] Assign `siteID` and `productID` to image product upload statuses. [https://github.com/woocommerce/woocommerce-ios/pull/15196]
 - [*] Payments: Improved payment views' adaptability to larger accessibility font sizes [https://github.com/woocommerce/woocommerce-ios/pull/15328].
 - [internal] Add site related properties to crowdsignal surveys. [https://github.com/woocommerce/woocommerce-ios/pull/15353]
+- [**] Notification settings are now available for configuring notifications for each store. [https://github.com/woocommerce/woocommerce-ios/pull/15386]
 
 21.9
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -335,10 +335,18 @@ enum WooAnalyticsStat: String {
     case settingsThirdPartyLearnMoreTapped = "privacy_settings_third_party_tracking_info_link_tapped"
     case settingsLicensesLinkTapped = "settings_about_open_source_licenses_link_tapped"
     case settingsAboutLinkTapped = "settings_about_woocommerce_link_tapped"
+    case settingsNotificationSettingsTapped = "settings_notification_settings_tapped"
 
     case settingsLogoutTapped = "settings_logout_button_tapped"
     case settingsLogoutConfirmation = "settings_logout_confirmation_dialog_result"
     case settingsWereHiringTapped = "settings_we_are_hiring_button_tapped"
+
+    // MARK: Notification Settings
+    //
+    case notificationSettingsUpdateButtonTapped = "notification_settings_update_button_tapped"
+    case notificationSettingsSaveButtonTapped = "notification_settings_save_button_tapped"
+    case notificationSettingsSavingSuccess = "notification_settings_saving_success"
+    case notificationSettingsSavingFailed = "notification_settings_saving_failed"
 
     // MARK: Domain Settings
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -78,6 +78,7 @@ struct NotificationSettingsView: View {
                 saveSettings()
             }
         }
+        .notice($viewModel.notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import struct Yosemite.Site
+import struct Yosemite.NotificationSettings
 
 final class NotificationSettingsHostingController: UIHostingController<NotificationSettingsView> {
     init() {
@@ -59,12 +60,10 @@ struct NotificationSettingsView: View {
             }
         }
         .sheet(item: $selectedSite) { site in
-            if let setting = viewModel.siteSettings?.blogs.first(where: { $0.blogID == site.siteID }),
-               let deviceID = viewModel.currentDeviceID,
-               let device = setting.devices.first(where: { $0.deviceID == Int64(deviceID) }) {
+            if let setting = viewModel.loadSetting(for: site) {
                 SiteNotificationSettingsView(siteTitle: site.name,
-                                             ordersNotificationsEnabled: device.storeOrder,
-                                             productReviewsNotificationsEnabled: device.newComment,
+                                             ordersNotificationsEnabled: setting.storeOrder,
+                                             productReviewsNotificationsEnabled: setting.newComment,
                                              completionHandler: { newOrder, productReviews in
                     viewModel.updateSettings(siteID: site.siteID,
                                              ordersNotificationsEnabled: newOrder,
@@ -157,9 +156,11 @@ private extension NotificationSettingsView {
                 VStack(alignment: .leading) {
                     Text(site.name)
                         .bodyStyle()
-                    Text(site.url)
-                        .foregroundStyle(Color.secondary)
-                        .captionStyle()
+                    if let setting = viewModel.loadSetting(for: site) {
+                        Text(description(for: setting))
+                            .foregroundStyle(Color.secondary)
+                            .captionStyle()
+                    }
                 }
                 .multilineTextAlignment(.leading)
 
@@ -188,6 +189,19 @@ private extension NotificationSettingsView {
             } catch {
                 savingSettingsFailed = true
             }
+        }
+    }
+
+    func description(for settings: NotificationSettings.Device) -> String {
+        switch (settings.storeOrder, settings.newComment) {
+        case (true, true):
+            [Localization.newOrders, Localization.productReviews].joined(separator: ", ")
+        case (true, false):
+            Localization.newOrders
+        case (false, true):
+            Localization.productReviews
+        case (false, false):
+            Localization.off
         }
     }
 }
@@ -263,6 +277,21 @@ extension NotificationSettingsView {
             "notificationSettingsView.errorSavingSiteSettings",
             value: "Unable to save notification settings",
             comment: "Error message when saving site settings fails on the notification settings view"
+        )
+        static let newOrders = NSLocalizedString(
+            "notificationSettingsView.newOrders",
+            value: "New orders",
+            comment: "Label indicating that new orders notifications are enabled for a site on the notification settings view"
+        )
+        static let productReviews = NSLocalizedString(
+            "notificationSettingsView.productReviews",
+            value: "Product reviews",
+            comment: "Label indicating that product reviews notifications are enabled for a site on the notification settings view"
+        )
+        static let off = NSLocalizedString(
+            "notificationSettingsView.off",
+            value: "Off",
+            comment: "Label indicating that notifications are disabled for a site on the notification settings view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -131,8 +131,7 @@ private extension NotificationSettingsView {
 
             Section {
                 if viewModel.isLoadingSiteSettings {
-                    ProgressView()
-                        .progressViewStyle(.circular)
+                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
                         .frame(maxWidth: .infinity)
                 } else if viewModel.siteSettings != nil {
                     ForEach(viewModel.sites) { site in
@@ -144,7 +143,7 @@ private extension NotificationSettingsView {
             } footer: {
                 Text(Localization.storeListSectionFooter)
             }
-            .renderedIf(viewModel.currentDeviceID != nil && viewModel.loadingSiteSettingsFailed == false)
+            .renderedIf(viewModel.shouldShowSiteList)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -36,6 +36,14 @@ struct NotificationSettingsView: View {
             }
         }
         .navigationTitle(Localization.title)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    //  TODO
+                }
+                .disabled(viewModel.hasSiteSettingsChanges == false)
+            }
+        }
         .task {
             await viewModel.checkNotificationPermission()
             if viewModel.currentDeviceID != nil {
@@ -50,8 +58,10 @@ struct NotificationSettingsView: View {
                 SiteNotificationSettingsView(siteTitle: site.name,
                                              ordersNotificationsEnabled: device.storeOrder,
                                              productReviewsNotificationsEnabled: device.newComment,
-                                             completionHandler: { _, _ in
-                    // TODO
+                                             completionHandler: { newOrder, productReviews in
+                    viewModel.updateSettings(siteID: site.siteID,
+                                             ordersNotificationsEnabled: newOrder,
+                                             productReviewsNotificationsEnabled: productReviews)
                 })
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -60,10 +60,10 @@ struct NotificationSettingsView: View {
             }
         }
         .sheet(item: $selectedSite) { site in
-            if let setting = viewModel.loadSetting(for: site) {
+            if let settings = viewModel.loadSettings(for: site) {
                 SiteNotificationSettingsView(siteTitle: site.name,
-                                             ordersNotificationsEnabled: setting.storeOrder,
-                                             productReviewsNotificationsEnabled: setting.newComment,
+                                             ordersNotificationsEnabled: settings.storeOrder,
+                                             productReviewsNotificationsEnabled: settings.newComment,
                                              completionHandler: { newOrder, productReviews in
                     viewModel.updateSettings(siteID: site.siteID,
                                              ordersNotificationsEnabled: newOrder,
@@ -156,8 +156,8 @@ private extension NotificationSettingsView {
                 VStack(alignment: .leading) {
                     Text(site.name)
                         .bodyStyle()
-                    if let setting = viewModel.loadSetting(for: site) {
-                        Text(description(for: setting))
+                    if let settings = viewModel.loadSettings(for: site) {
+                        Text(description(for: settings))
                             .foregroundStyle(Color.secondary)
                             .captionStyle()
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -20,7 +20,6 @@ final class NotificationSettingsHostingController: UIHostingController<Notificat
 struct NotificationSettingsView: View {
     @StateObject private var viewModel: NotificationSettingsViewModel
     @State private var selectedSite: Site?
-    @State private var savingSettingsFailed = false
 
     init() {
         self._viewModel = StateObject(wrappedValue: NotificationSettingsViewModel())
@@ -71,10 +70,18 @@ struct NotificationSettingsView: View {
                 })
             }
         }
-        .alert(Localization.errorSavingSiteSettings, isPresented: $savingSettingsFailed) {
+        .alert(Localization.errorSavingSiteSettings, isPresented: $viewModel.savingSiteSettingsFailed) {
             Button(Localization.cancel, role: .cancel) {}
             Button(Localization.retry) {
                 saveSettings()
+            }
+        }
+        .alert(Localization.errorLoadingSiteSettings, isPresented: $viewModel.loadingSiteSettingsFailed) {
+            Button(Localization.cancel, role: .cancel) {}
+            Button(Localization.retry) {
+                Task {
+                    await viewModel.retrieveNotificationSettings()
+                }
             }
         }
         .notice($viewModel.notice)
@@ -127,13 +134,6 @@ private extension NotificationSettingsView {
                     ProgressView()
                         .progressViewStyle(.circular)
                         .frame(maxWidth: .infinity)
-                } else if case .loadingFailed = viewModel.loadingSiteSettingsError {
-                    Text(Localization.errorLoadingSiteSettings)
-                    Button(Localization.retry) {
-                        Task {
-                            await viewModel.retrieveNotificationSettings()
-                        }
-                    }
                 } else if viewModel.siteSettings != nil {
                     ForEach(viewModel.sites) { site in
                         detailRow(for: site)
@@ -144,7 +144,7 @@ private extension NotificationSettingsView {
             } footer: {
                 Text(Localization.storeListSectionFooter)
             }
-            .renderedIf(viewModel.currentDeviceID != nil)
+            .renderedIf(viewModel.currentDeviceID != nil && viewModel.loadingSiteSettingsFailed == false)
         }
     }
 
@@ -183,12 +183,8 @@ private extension NotificationSettingsView {
     }
 
     func saveSettings() {
-        Task { @MainActor in
-            do {
-                try await viewModel.saveSettings()
-            } catch {
-                savingSettingsFailed = true
-            }
+        Task {
+            await viewModel.saveSettings()
         }
     }
 
@@ -255,7 +251,7 @@ extension NotificationSettingsView {
         )
         static let errorLoadingSiteSettings = NSLocalizedString(
             "notificationSettingsView.errorLoadingSiteSettings",
-            value: "We're unable to load notification settings for your stores.",
+            value: "Unable to load notification settings for your stores.",
             comment: "Error message when loading site settings fails on the notification settings view"
         )
         static let retry = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -44,7 +44,16 @@ struct NotificationSettingsView: View {
             }
         }
         .sheet(item: $selectedSite) { site in
-            SiteNotificationSettingsView(siteTitle: site.name)
+            if let setting = viewModel.siteSettings?.blogs.first(where: { $0.blogID == site.siteID }),
+               let deviceID = viewModel.currentDeviceID,
+               let device = setting.devices.first(where: { $0.deviceID == Int64(deviceID) }) {
+                SiteNotificationSettingsView(siteTitle: site.name,
+                                             ordersNotificationsEnabled: device.storeOrder,
+                                             productReviewsNotificationsEnabled: device.newComment,
+                                             completionHandler: { _, _ in
+                    // TODO
+                })
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -19,6 +19,7 @@ final class NotificationSettingsHostingController: UIHostingController<Notificat
 struct NotificationSettingsView: View {
     @StateObject private var viewModel: NotificationSettingsViewModel
     @State private var selectedSite: Site?
+    @State private var savingSettingsFailed = false
 
     init() {
         self._viewModel = StateObject(wrappedValue: NotificationSettingsViewModel())
@@ -38,8 +39,14 @@ struct NotificationSettingsView: View {
         .navigationTitle(Localization.title)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button("Save") {
-                    //  TODO
+                Button {
+                    saveSettings()
+                } label: {
+                    if viewModel.isSavingSettings {
+                        ProgressView().progressViewStyle(.circular)
+                    } else {
+                        Text(Localization.save)
+                    }
                 }
                 .disabled(viewModel.hasSiteSettingsChanges == false)
             }
@@ -63,6 +70,12 @@ struct NotificationSettingsView: View {
                                              ordersNotificationsEnabled: newOrder,
                                              productReviewsNotificationsEnabled: productReviews)
                 })
+            }
+        }
+        .alert(Localization.errorSavingSiteSettings, isPresented: $savingSettingsFailed) {
+            Button(Localization.cancel, role: .cancel) {}
+            Button(Localization.retry) {
+                saveSettings()
             }
         }
     }
@@ -166,6 +179,16 @@ private extension NotificationSettingsView {
         // Ask the system to open that URL.
         await UIApplication.shared.open(url)
     }
+
+    func saveSettings() {
+        Task { @MainActor in
+            do {
+                try await viewModel.saveSettings()
+            } catch {
+                savingSettingsFailed = true
+            }
+        }
+    }
 }
 
 extension NotificationSettingsView {
@@ -224,6 +247,21 @@ extension NotificationSettingsView {
             "notificationSettingsView.retry",
             value: "Try again",
             comment: "Button to reload site settings on the notification settings view"
+        )
+        static let save = NSLocalizedString(
+            "notificationSettingsView.save",
+            value: "Save",
+            comment: "Button to save site settings on the notification settings view"
+        )
+        static let cancel = NSLocalizedString(
+            "notificationSettingsView.cancel",
+            value: "Cancel",
+            comment: "Button to cancel saving site settings on the notification settings view"
+        )
+        static let errorSavingSiteSettings = NSLocalizedString(
+            "notificationSettingsView.errorSavingSiteSettings",
+            value: "Unable to save notification settings",
+            comment: "Error message when saving site settings fails on the notification settings view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsView.swift
@@ -38,7 +38,10 @@ struct NotificationSettingsView: View {
         .navigationTitle(Localization.title)
         .task {
             await viewModel.checkNotificationPermission()
-            await viewModel.synchronizeSites()
+            if viewModel.currentDeviceID != nil {
+                await viewModel.retrieveNotificationSettings()
+                await viewModel.synchronizeSites()
+            }
         }
         .sheet(item: $selectedSite) { site in
             SiteNotificationSettingsView(siteTitle: site.name)
@@ -88,14 +91,28 @@ private extension NotificationSettingsView {
             }
 
             Section {
-                ForEach(viewModel.sites) { site in
-                    detailRow(for: site)
+                if viewModel.isLoadingSiteSettings {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .frame(maxWidth: .infinity)
+                } else if case .loadingFailed = viewModel.loadingSiteSettingsError {
+                    Text(Localization.errorLoadingSiteSettings)
+                    Button(Localization.retry) {
+                        Task {
+                            await viewModel.retrieveNotificationSettings()
+                        }
+                    }
+                } else if viewModel.siteSettings != nil {
+                    ForEach(viewModel.sites) { site in
+                        detailRow(for: site)
+                    }
                 }
             } header: {
                 Text(Localization.storeListSectionHeader)
             } footer: {
                 Text(Localization.storeListSectionFooter)
             }
+            .renderedIf(viewModel.currentDeviceID != nil)
         }
     }
 
@@ -178,6 +195,16 @@ extension NotificationSettingsView {
             "notificationSettingsView.storeListSectionFooter",
             value: "Customize your notification preferences for each store.",
             comment: "Footer of the store list section on the notification settings view"
+        )
+        static let errorLoadingSiteSettings = NSLocalizedString(
+            "notificationSettingsView.errorLoadingSiteSettings",
+            value: "We're unable to load notification settings for your stores.",
+            comment: "Error message when loading site settings fails on the notification settings view"
+        )
+        static let retry = NSLocalizedString(
+            "notificationSettingsView.retry",
+            value: "Try again",
+            comment: "Button to reload site settings on the notification settings view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -11,6 +11,8 @@ final class NotificationSettingsViewModel: ObservableObject {
     @Published private(set) var loadingSiteSettingsError: SiteSettingsError?
     @Published private(set) var siteSettings: NotificationSettings?
 
+    @Published private(set) var isSavingSettings = false
+
     var hasSiteSettingsChanges: Bool {
         siteSettings != initialSiteSettings
     }
@@ -124,6 +126,27 @@ final class NotificationSettingsViewModel: ObservableObject {
         }
 
         self.siteSettings = NotificationSettings(blogs: updatedBlogs)
+    }
+
+    @MainActor
+    func saveSettings() async throws {
+        guard let siteSettings else {
+            return
+        }
+        isSavingSettings = true
+        do {
+            try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings) { result in
+                    continuation.resume(with: result)
+                })
+            }
+            isSavingSettings = false
+            initialSiteSettings = siteSettings // to ensure that checking for changes works
+        } catch {
+            DDLogError("⛔️ Error saving notification settings: \(error)")
+            isSavingSettings = false
+            throw error
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import UIKit
 import Yosemite
+import WooFoundation
 import protocol Storage.StorageManagerType
 
 /// View model for `NotificationSettingsView`
@@ -22,6 +23,7 @@ final class NotificationSettingsViewModel: ObservableObject {
     private let notificationCenter: UserNotificationsCenterAdapter
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private let analytics: Analytics
 
     let currentDeviceID: String?
 
@@ -42,11 +44,13 @@ final class NotificationSettingsViewModel: ObservableObject {
     init(notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         pushNotificationManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+         pushNotificationManager: PushNotesManager = ServiceLocator.pushNotesManager,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.notificationCenter = notificationCenter
         self.stores = stores
         self.storageManager = storageManager
         self.currentDeviceID = pushNotificationManager.deviceID
+        self.analytics = analytics
 
         observeAppState()
         updateNotificationStateIfNeeded()
@@ -118,6 +122,8 @@ final class NotificationSettingsViewModel: ObservableObject {
             return
         }
 
+        analytics.track(.notificationSettingsUpdateButtonTapped)
+
         var updatedBlogs: [NotificationSettings.Blog] = []
         for blog in siteSettings.blogs {
             if blog.blogID == siteID {
@@ -144,6 +150,7 @@ final class NotificationSettingsViewModel: ObservableObject {
         guard let siteSettings else {
             return
         }
+        analytics.track(.notificationSettingsSaveButtonTapped)
         isSavingSettings = true
         do {
             try await withCheckedThrowingContinuation { continuation in
@@ -154,9 +161,11 @@ final class NotificationSettingsViewModel: ObservableObject {
             isSavingSettings = false
             initialSiteSettings = siteSettings // to ensure that checking for changes works
             notice = Notice(title: Localization.successNotice)
+            analytics.track(.notificationSettingsSavingSuccess)
         } catch {
             DDLogError("⛔️ Error saving notification settings: \(error)")
             isSavingSettings = false
+            analytics.track(.notificationSettingsSavingFailed, withError: error)
             throw error
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -9,12 +9,14 @@ final class NotificationSettingsViewModel: ObservableObject {
     @Published private(set) var notificationsEnabled: Bool?
     @Published private(set) var sites: [Site] = []
     @Published private(set) var isLoadingSiteSettings = true
-    @Published private(set) var loadingSiteSettingsError: SiteSettingsError?
     @Published private(set) var siteSettings: NotificationSettings?
 
     @Published private(set) var isSavingSettings = false
 
     @Published var notice: Notice?
+
+    @Published var loadingSiteSettingsFailed = false
+    @Published var savingSiteSettingsFailed = false
 
     var hasSiteSettingsChanges: Bool {
         siteSettings != initialSiteSettings
@@ -86,10 +88,9 @@ final class NotificationSettingsViewModel: ObservableObject {
     @MainActor
     func retrieveNotificationSettings() async {
         guard let currentDeviceID, let id = Int64(currentDeviceID) else {
-            loadingSiteSettingsError = SiteSettingsError.deviceNotAvailable
             return
         }
-        loadingSiteSettingsError = nil
+        loadingSiteSettingsFailed = false
         isLoadingSiteSettings = true
         do {
             siteSettings = try await withCheckedThrowingContinuation { continuation in
@@ -100,7 +101,7 @@ final class NotificationSettingsViewModel: ObservableObject {
             initialSiteSettings = siteSettings
         } catch {
             DDLogError("⛔️ Error retrieving notification settings: \(error)")
-            loadingSiteSettingsError = .loadingFailed
+            loadingSiteSettingsFailed = true
         }
         isLoadingSiteSettings = false
     }
@@ -146,11 +147,12 @@ final class NotificationSettingsViewModel: ObservableObject {
     }
 
     @MainActor
-    func saveSettings() async throws {
+    func saveSettings() async {
         guard let siteSettings else {
             return
         }
         analytics.track(.notificationSettingsSaveButtonTapped)
+        savingSiteSettingsFailed = false
         isSavingSettings = true
         do {
             try await withCheckedThrowingContinuation { continuation in
@@ -158,16 +160,15 @@ final class NotificationSettingsViewModel: ObservableObject {
                     continuation.resume(with: result)
                 })
             }
-            isSavingSettings = false
             initialSiteSettings = siteSettings // to ensure that checking for changes works
             notice = Notice(title: Localization.successNotice)
             analytics.track(.notificationSettingsSavingSuccess)
         } catch {
             DDLogError("⛔️ Error saving notification settings: \(error)")
-            isSavingSettings = false
+            savingSiteSettingsFailed = true
             analytics.track(.notificationSettingsSavingFailed, withError: error)
-            throw error
         }
+        isSavingSettings = false
     }
 }
 
@@ -208,11 +209,6 @@ private extension NotificationSettingsViewModel {
 }
 
 extension NotificationSettingsViewModel {
-    enum SiteSettingsError: Error {
-        case deviceNotAvailable
-        case loadingFailed
-    }
-
     enum Localization {
         static let successNotice = NSLocalizedString(
             "notificationSettingsViewModel.successNotice",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -96,7 +96,7 @@ final class NotificationSettingsViewModel: ObservableObject {
             initialSiteSettings = siteSettings
         } catch {
             DDLogError("⛔️ Error retrieving notification settings: \(error)")
-            loadingSiteSettingsError = .loadingFailed(error: error)
+            loadingSiteSettingsError = .loadingFailed
         }
         isLoadingSiteSettings = false
     }
@@ -201,7 +201,7 @@ private extension NotificationSettingsViewModel {
 extension NotificationSettingsViewModel {
     enum SiteSettingsError: Error {
         case deviceNotAvailable
-        case loadingFailed(error: Error)
+        case loadingFailed
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -13,6 +13,8 @@ final class NotificationSettingsViewModel: ObservableObject {
 
     @Published private(set) var isSavingSettings = false
 
+    @Published var notice: Notice?
+
     var hasSiteSettingsChanges: Bool {
         siteSettings != initialSiteSettings
     }
@@ -142,6 +144,7 @@ final class NotificationSettingsViewModel: ObservableObject {
             }
             isSavingSettings = false
             initialSiteSettings = siteSettings // to ensure that checking for changes works
+            notice = Notice(title: Localization.successNotice)
         } catch {
             DDLogError("⛔️ Error saving notification settings: \(error)")
             isSavingSettings = false
@@ -190,5 +193,13 @@ extension NotificationSettingsViewModel {
     enum SiteSettingsError: Error {
         case deviceNotAvailable
         case loadingFailed(error: Error)
+    }
+
+    enum Localization {
+        static let successNotice = NSLocalizedString(
+            "notificationSettingsViewModel.successNotice",
+            value: "Settings saved!",
+            comment: "Notice displayed when saving notification settings succeeds."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -7,10 +7,16 @@ import protocol Storage.StorageManagerType
 final class NotificationSettingsViewModel: ObservableObject {
     @Published private(set) var notificationsEnabled: Bool?
     @Published private(set) var sites: [Site] = []
+    @Published private(set) var isLoadingSiteSettings = true
+    @Published private(set) var loadingSiteSettingsError: SiteSettingsError?
 
     private let notificationCenter: UserNotificationsCenterAdapter
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+
+    let currentDeviceID: String?
+
+    private(set) var siteSettings: NotificationSettings?
 
     private var appStateSubscription: AnyCancellable?
 
@@ -26,10 +32,12 @@ final class NotificationSettingsViewModel: ObservableObject {
 
     init(notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
          stores: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         pushNotificationManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.notificationCenter = notificationCenter
         self.stores = stores
         self.storageManager = storageManager
+        self.currentDeviceID = pushNotificationManager.deviceID
 
         observeAppState()
         updateNotificationStateIfNeeded()
@@ -60,6 +68,27 @@ final class NotificationSettingsViewModel: ObservableObject {
                 continuation.resume()
             })
         }
+    }
+
+    @MainActor
+    func retrieveNotificationSettings() async {
+        guard let currentDeviceID, let id = Int64(currentDeviceID) else {
+            loadingSiteSettingsError = SiteSettingsError.deviceNotAvailable
+            return
+        }
+        loadingSiteSettingsError = nil
+        isLoadingSiteSettings = true
+        do {
+            siteSettings = try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(AccountAction.loadNotificationSettings(deviceID: id) { result in
+                    continuation.resume(with: result)
+                })
+            }
+        } catch {
+            DDLogError("⛔️ Error retrieving notification settings: \(error)")
+            loadingSiteSettingsError = .loadingFailed(error: error)
+        }
+        isLoadingSiteSettings = false
     }
 }
 
@@ -96,5 +125,12 @@ private extension NotificationSettingsViewModel {
 
     func updateSiteList() {
         sites = siteResultsController.fetchedObjects
+    }
+}
+
+extension NotificationSettingsViewModel {
+    enum SiteSettingsError: Error {
+        case deviceNotAvailable
+        case loadingFailed(error: Error)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -101,6 +101,15 @@ final class NotificationSettingsViewModel: ObservableObject {
         isLoadingSiteSettings = false
     }
 
+    func loadSetting(for site: Site) -> NotificationSettings.Device? {
+        if let setting = siteSettings?.blogs.first(where: { $0.blogID == site.siteID }),
+           let deviceID = currentDeviceID,
+           let device = setting.devices.first(where: { $0.deviceID == Int64(deviceID) }) {
+            return device
+        }
+        return nil
+    }
+
     func updateSettings(siteID: Int64,
                         ordersNotificationsEnabled: Bool,
                         productReviewsNotificationsEnabled: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -22,6 +22,13 @@ final class NotificationSettingsViewModel: ObservableObject {
         siteSettings != initialSiteSettings
     }
 
+    var shouldShowSiteList: Bool {
+        guard currentDeviceID != nil else {
+            return false
+        }
+        return isLoadingSiteSettings || siteSettings != nil
+    }
+
     private let notificationCenter: UserNotificationsCenterAdapter
     private let stores: StoresManager
     private let storageManager: StorageManagerType
@@ -55,7 +62,6 @@ final class NotificationSettingsViewModel: ObservableObject {
         self.analytics = analytics
 
         observeAppState()
-        updateNotificationStateIfNeeded()
         configureResultsController()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -101,7 +101,7 @@ final class NotificationSettingsViewModel: ObservableObject {
         isLoadingSiteSettings = false
     }
 
-    func loadSetting(for site: Site) -> NotificationSettings.Device? {
+    func loadSettings(for site: Site) -> NotificationSettings.Device? {
         if let setting = siteSettings?.blogs.first(where: { $0.blogID == site.siteID }),
            let deviceID = currentDeviceID,
            let device = setting.devices.first(where: { $0.deviceID == Int64(deviceID) }) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -9,6 +9,11 @@ final class NotificationSettingsViewModel: ObservableObject {
     @Published private(set) var sites: [Site] = []
     @Published private(set) var isLoadingSiteSettings = true
     @Published private(set) var loadingSiteSettingsError: SiteSettingsError?
+    @Published private(set) var siteSettings: NotificationSettings?
+
+    var hasSiteSettingsChanges: Bool {
+        siteSettings != initialSiteSettings
+    }
 
     private let notificationCenter: UserNotificationsCenterAdapter
     private let stores: StoresManager
@@ -16,9 +21,9 @@ final class NotificationSettingsViewModel: ObservableObject {
 
     let currentDeviceID: String?
 
-    private(set) var siteSettings: NotificationSettings?
-
     private var appStateSubscription: AnyCancellable?
+
+    private var initialSiteSettings: NotificationSettings?
 
     /// ResultsController: Loads Sites from the Storage Layer.
     ///
@@ -84,11 +89,41 @@ final class NotificationSettingsViewModel: ObservableObject {
                     continuation.resume(with: result)
                 })
             }
+            initialSiteSettings = siteSettings
         } catch {
             DDLogError("⛔️ Error retrieving notification settings: \(error)")
             loadingSiteSettingsError = .loadingFailed(error: error)
         }
         isLoadingSiteSettings = false
+    }
+
+    func updateSettings(siteID: Int64,
+                        ordersNotificationsEnabled: Bool,
+                        productReviewsNotificationsEnabled: Bool) {
+        guard let siteSettings,
+              let currentDeviceID else {
+            return
+        }
+
+        var updatedBlogs: [NotificationSettings.Blog] = []
+        for blog in siteSettings.blogs {
+            if blog.blogID == siteID {
+                var updatedDevices: [NotificationSettings.Device] = []
+                for device in blog.devices {
+                    if device.deviceID == Int64(currentDeviceID) {
+                        updatedDevices.append(device.copy(newComment: productReviewsNotificationsEnabled,
+                                                          storeOrder: ordersNotificationsEnabled))
+                    } else {
+                        updatedDevices.append(device)
+                    }
+                }
+                updatedBlogs.append(blog.copy(devices: updatedDevices))
+            } else {
+                updatedBlogs.append(blog)
+            }
+        }
+
+        self.siteSettings = NotificationSettings(blogs: updatedBlogs)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
@@ -10,6 +10,12 @@ struct SiteNotificationSettingsView: View {
 
     private let siteTitle: String
     private let completionHandler: CompletionCallback
+    private let initialValues: (newOrders: Bool, productReviews: Bool)
+
+    var hasChanges: Bool {
+        initialValues.newOrders != orderNotificationsEnabled ||
+        initialValues.productReviews != productReviewsNotificationsEnabled
+    }
 
     init(siteTitle: String,
          ordersNotificationsEnabled: Bool,
@@ -19,6 +25,7 @@ struct SiteNotificationSettingsView: View {
         self.orderNotificationsEnabled = ordersNotificationsEnabled
         self.productReviewsNotificationsEnabled = productReviewsNotificationsEnabled
         self.completionHandler = completionHandler
+        self.initialValues = (ordersNotificationsEnabled, productReviewsNotificationsEnabled)
     }
 
     var body: some View {
@@ -47,10 +54,11 @@ struct SiteNotificationSettingsView: View {
                 }
 
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.done) {
+                    Button(Localization.update) {
                         completionHandler(orderNotificationsEnabled, productReviewsNotificationsEnabled)
                         dismiss()
                     }
+                    .disabled(hasChanges == false)
                 }
             }
         }
@@ -64,9 +72,9 @@ private extension SiteNotificationSettingsView {
             value: "Cancel",
             comment: "Button to dismiss the site notification settings view"
         )
-        static let done = NSLocalizedString(
-            "siteNotificationSettingsView.done",
-            value: "Done",
+        static let update = NSLocalizedString(
+            "siteNotificationSettingsView.update",
+            value: "Update",
             comment: "Button to confirm the settings on the site notification settings view"
         )
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
@@ -47,8 +47,9 @@ struct SiteNotificationSettingsView: View {
                 }
 
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.save) {
+                    Button(Localization.done) {
                         completionHandler(orderNotificationsEnabled, productReviewsNotificationsEnabled)
+                        dismiss()
                     }
                 }
             }
@@ -63,10 +64,10 @@ private extension SiteNotificationSettingsView {
             value: "Cancel",
             comment: "Button to dismiss the site notification settings view"
         )
-        static let save = NSLocalizedString(
-            "siteNotificationSettingsView.save",
-            value: "Save",
-            comment: "Button to save the settings on the site notification settings view"
+        static let done = NSLocalizedString(
+            "siteNotificationSettingsView.done",
+            value: "Done",
+            comment: "Button to confirm the settings on the site notification settings view"
         )
         static let title = NSLocalizedString(
             "siteNotificationSettingsView.title",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/SiteNotificationSettingsView.swift
@@ -3,13 +3,22 @@ import SwiftUI
 struct SiteNotificationSettingsView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @State private var orderNotificationsEnabled = false
-    @State private var productReviewNotificationsEnabled = false
+    @State private var orderNotificationsEnabled: Bool
+    @State private var productReviewsNotificationsEnabled: Bool
+
+    typealias CompletionCallback = (_ orderNotificationsEnabled: Bool, _ productReviewsNotificationsEnabled: Bool) -> Void
 
     private let siteTitle: String
+    private let completionHandler: CompletionCallback
 
-    init(siteTitle: String) {
+    init(siteTitle: String,
+         ordersNotificationsEnabled: Bool,
+         productReviewsNotificationsEnabled: Bool,
+         completionHandler: @escaping CompletionCallback) {
         self.siteTitle = siteTitle
+        self.orderNotificationsEnabled = ordersNotificationsEnabled
+        self.productReviewsNotificationsEnabled = productReviewsNotificationsEnabled
+        self.completionHandler = completionHandler
     }
 
     var body: some View {
@@ -19,7 +28,7 @@ struct SiteNotificationSettingsView: View {
                     Toggle(isOn: $orderNotificationsEnabled) {
                         Text(Localization.newOrders)
                     }
-                    Toggle(isOn: $productReviewNotificationsEnabled) {
+                    Toggle(isOn: $productReviewsNotificationsEnabled) {
                         Text(Localization.productReviews)
                     }
                 } header: {
@@ -39,7 +48,7 @@ struct SiteNotificationSettingsView: View {
 
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Localization.save) {
-                        // TODO
+                        completionHandler(orderNotificationsEnabled, productReviewsNotificationsEnabled)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -485,6 +485,7 @@ private extension SettingsViewController {
     }
 
     func showNotificationSettings() {
+        ServiceLocator.analytics.track(.settingsNotificationSettingsTapped)
         let controller = NotificationSettingsHostingController()
         show(controller, sender: self)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
@@ -98,4 +98,69 @@ struct NotificationSettingsViewModelTests {
         // Then
         #expect(viewModel.sites == [testSite4])
     }
+
+    @Test func retrieveNotificationSettings_returns_error_when_device_id_is_unavailable() async throws {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager()
+        let viewModel = NotificationSettingsViewModel(pushNotificationManager: pushNotificationManager)
+
+        // When
+        await viewModel.retrieveNotificationSettings()
+
+        // Then
+        let error = try #require(viewModel.loadingSiteSettingsError)
+        #expect(error == .deviceNotAvailable)
+    }
+
+    @MainActor
+    @Test func retrieveNotificationSettings_updates_settings_when_succeeds() async throws {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
+
+        // When
+        let expectedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)])
+        ])
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(expectedSettings))
+            default:
+                break
+            }
+        }
+        await viewModel.retrieveNotificationSettings()
+
+        // Then
+        let settings = try #require(viewModel.siteSettings)
+        #expect(settings == expectedSettings)
+    }
+
+    @MainActor
+    @Test func retrieveNotificationSettings_updates_error_when_fails() async throws {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
+
+        // When
+        let expectedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)])
+        ])
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.failure(NSError(domain: "Test", code: 400)))
+            default:
+                break
+            }
+        }
+        await viewModel.retrieveNotificationSettings()
+
+        // Then
+        let error = try #require(viewModel.loadingSiteSettingsError)
+        #expect(error == .loadingFailed)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
@@ -99,7 +99,7 @@ struct NotificationSettingsViewModelTests {
         #expect(viewModel.sites == [testSite4])
     }
 
-    @Test func retrieveNotificationSettings_returns_error_when_device_id_is_unavailable() async throws {
+    @Test func retrieveNotificationSettings_does_not_return_error_when_device_id_is_unavailable() async throws {
         // Given
         let pushNotificationManager = MockPushNotificationsManager()
         let viewModel = NotificationSettingsViewModel(pushNotificationManager: pushNotificationManager)
@@ -108,7 +108,8 @@ struct NotificationSettingsViewModelTests {
         await viewModel.retrieveNotificationSettings()
 
         // Then
-        #expect(viewModel.loadingSiteSettingsError == .deviceNotAvailable)
+        #expect(viewModel.loadingSiteSettingsFailed == false)
+        #expect(viewModel.siteSettings == nil)
     }
 
     @MainActor
@@ -137,7 +138,7 @@ struct NotificationSettingsViewModelTests {
     }
 
     @MainActor
-    @Test func retrieveNotificationSettings_updates_error_when_fails() async throws {
+    @Test func retrieveNotificationSettings_returns_error_when_fails() async throws {
         // Given
         let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -155,7 +156,7 @@ struct NotificationSettingsViewModelTests {
         await viewModel.retrieveNotificationSettings()
 
         // Then
-        #expect(viewModel.loadingSiteSettingsError == .loadingFailed)
+        #expect(viewModel.loadingSiteSettingsFailed == true)
     }
 
     @MainActor
@@ -219,7 +220,7 @@ struct NotificationSettingsViewModelTests {
     }
 
     @MainActor
-    @Test func saveSettings_updates_notice_when_succeeds() async throws {
+    @Test func saveSettings_updates_notice_when_succeeds() async {
         // Given
         let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -244,14 +245,14 @@ struct NotificationSettingsViewModelTests {
         // When
         await viewModel.retrieveNotificationSettings()
         viewModel.updateSettings(siteID: 136, ordersNotificationsEnabled: false, productReviewsNotificationsEnabled: false)
-        try await viewModel.saveSettings()
+        await viewModel.saveSettings()
 
         // Then
         #expect(viewModel.notice != nil)
     }
 
     @MainActor
-    @Test func saveSettings_throws_error_when_fails() async throws {
+    @Test func saveSettings_throws_error_when_fails() async {
         // Given
         let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -276,15 +277,15 @@ struct NotificationSettingsViewModelTests {
         await viewModel.retrieveNotificationSettings()
         viewModel.updateSettings(siteID: 136, ordersNotificationsEnabled: false, productReviewsNotificationsEnabled: false)
 
+        // When
+        await viewModel.saveSettings()
+
         // Then
-        await #expect(throws: expectedError) {
-            // When
-            try await viewModel.saveSettings()
-        }
+        #expect(viewModel.savingSiteSettingsFailed == true)
     }
 
     @MainActor
-    @Test func hasSiteSettingsChanges_returns_correctly() async throws {
+    @Test func hasSiteSettingsChanges_returns_correctly() async {
         // Given
         let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -314,7 +315,7 @@ struct NotificationSettingsViewModelTests {
         #expect(viewModel.hasSiteSettingsChanges == true)
 
         // When
-        try await viewModel.saveSettings()
+        await viewModel.saveSettings()
         #expect(viewModel.hasSiteSettingsChanges == false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
@@ -108,8 +108,7 @@ struct NotificationSettingsViewModelTests {
         await viewModel.retrieveNotificationSettings()
 
         // Then
-        let error = try #require(viewModel.loadingSiteSettingsError)
-        #expect(error == .deviceNotAvailable)
+        #expect(viewModel.loadingSiteSettingsError == .deviceNotAvailable)
     }
 
     @MainActor
@@ -134,8 +133,7 @@ struct NotificationSettingsViewModelTests {
         await viewModel.retrieveNotificationSettings()
 
         // Then
-        let settings = try #require(viewModel.siteSettings)
-        #expect(settings == expectedSettings)
+        #expect(viewModel.siteSettings == expectedSettings)
     }
 
     @MainActor
@@ -146,9 +144,6 @@ struct NotificationSettingsViewModelTests {
         let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
 
         // When
-        let expectedSettings = NotificationSettings(blogs: [
-            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)])
-        ])
         stores.whenReceivingAction(ofType: AccountAction.self) { action in
             switch action {
             case let .loadNotificationSettings(_, onCompletion):
@@ -160,7 +155,166 @@ struct NotificationSettingsViewModelTests {
         await viewModel.retrieveNotificationSettings()
 
         // Then
-        let error = try #require(viewModel.loadingSiteSettingsError)
-        #expect(error == .loadingFailed)
+        #expect(viewModel.loadingSiteSettingsError == .loadingFailed)
+    }
+
+    @MainActor
+    @Test func loadSettings_returns_correct_settings_for_given_site() async {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
+
+        let expectedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)]),
+            .init(blogID: 136, devices: [.init(deviceID: 132, newComment: true, storeOrder: true)])
+        ])
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(expectedSettings))
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.retrieveNotificationSettings()
+        let settings = viewModel.loadSettings(for: Site.fake().copy(siteID: 136))
+
+        // Then
+        #expect(settings == expectedSettings.blogs[1].devices[0])
+    }
+
+    @MainActor
+    @Test func updateSettings_updates_current_settings_correctly() async {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
+
+        let expectedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)]),
+            .init(blogID: 136, devices: [.init(deviceID: 132, newComment: true, storeOrder: true)])
+        ])
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(expectedSettings))
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.retrieveNotificationSettings()
+        viewModel.updateSettings(siteID: 136, ordersNotificationsEnabled: false, productReviewsNotificationsEnabled: false)
+
+        // Then
+        let updatedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)]),
+            .init(blogID: 136, devices: [.init(deviceID: 132, newComment: false, storeOrder: false)])
+        ])
+        #expect(viewModel.siteSettings == updatedSettings)
+    }
+
+    @MainActor
+    @Test func saveSettings_updates_notice_when_succeeds() async throws {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
+        #expect(viewModel.notice == nil)
+
+        let expectedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)]),
+            .init(blogID: 136, devices: [.init(deviceID: 132, newComment: true, storeOrder: true)])
+        ])
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(expectedSettings))
+            case let .updateNotificationSettings(_, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.retrieveNotificationSettings()
+        viewModel.updateSettings(siteID: 136, ordersNotificationsEnabled: false, productReviewsNotificationsEnabled: false)
+        try await viewModel.saveSettings()
+
+        // Then
+        #expect(viewModel.notice != nil)
+    }
+
+    @MainActor
+    @Test func saveSettings_throws_error_when_fails() async throws {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
+
+        let expectedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)]),
+            .init(blogID: 136, devices: [.init(deviceID: 132, newComment: true, storeOrder: true)])
+        ])
+        let expectedError = NSError(domain: "Test", code: 400)
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(expectedSettings))
+            case let .updateNotificationSettings(_, onCompletion):
+                onCompletion(.failure(expectedError))
+            default:
+                break
+            }
+        }
+
+        await viewModel.retrieveNotificationSettings()
+        viewModel.updateSettings(siteID: 136, ordersNotificationsEnabled: false, productReviewsNotificationsEnabled: false)
+
+        // Then
+        await #expect(throws: expectedError) {
+            // When
+            try await viewModel.saveSettings()
+        }
+    }
+
+    @MainActor
+    @Test func hasSiteSettingsChanges_returns_correctly() async throws {
+        // Given
+        let pushNotificationManager = MockPushNotificationsManager(mockedDeviceID: "132")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = NotificationSettingsViewModel(stores: stores, pushNotificationManager: pushNotificationManager)
+        #expect(viewModel.hasSiteSettingsChanges == false)
+
+        let expectedSettings = NotificationSettings(blogs: [
+            .init(blogID: 134, devices: [.init(deviceID: 132, newComment: true, storeOrder: false)]),
+            .init(blogID: 136, devices: [.init(deviceID: 132, newComment: true, storeOrder: true)])
+        ])
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(expectedSettings))
+            case let .updateNotificationSettings(_, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.retrieveNotificationSettings()
+        viewModel.updateSettings(siteID: 136, ordersNotificationsEnabled: false, productReviewsNotificationsEnabled: false)
+
+        // Then
+        #expect(viewModel.hasSiteSettingsChanges == true)
+
+        // When
+        try await viewModel.saveSettings()
+        #expect(viewModel.hasSiteSettingsChanges == false)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15371 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR wraps up the notification settings screen by enabling users to configure notification settings for their stores. Changes include:
- Load notification settings for connected sites upon loading the screen.
- Updated the site list to display the notification settings.
- Added the Save button to let users save any changes.
- Error handling and tracking.
- Enabled feature flag for the feature to be available in production.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Pre-requisite: Build and run the app on a physical device because the feature requires notification permission.

### TC1: Loading notification settings
1. Log in to a Jetpack store while authenticated with WPCom.
2. Navigate to Hub Menu > Settings > Notification Settings. Confirm that `settings_notification_settings_tapped` is tracked in Xcode console.
3. Confirm that the screen shows a loading indicator initially and then displays the list of connected stores with their relative notification settings.
4. Tap on any store and confirm that the Notification types screen displays the correct settings states.
5. Navigate back to the Settings screen and disconnect the Internet connection. 
6. Select Notification settings and confirm that the error state is displayed with a retry button after the request times out.

### TC2: Updating notification settings
1. Log in to a Jetpack store while authenticated with WPCom.
2. Navigate to Hub Menu > Settings > Notification Settings. Confirm that `settings_notification_settings_tapped` is tracked in Xcode console.
3. Tap on any store on the store list and toggle any settings then tap Done. Confirm that `notification_settings_update_button_tapped` is tracked in Xcode console.
4. Confirm that the Save button is now enabled. The new settings should also be reflected on the store list.
5. Tap the Save button and confirm that `notification_settings_save_button_tapped` is tracked. 
6. After completion, a notice is displayed indicating the success and the Save button is disabled again. Confirm that `notification_settings_saving_success` is tracked.
7. Repeat step 3 then disconnect the Internet connection.
8. When the request times out, confirm that `notification_settings_saving_failed` is tracked with the error details. An alert should be displayed for the error with a button to retry.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested the above test cases on iPhone 16 Pro iOS 18.3.
Unit tests have also been added to confirm the functionalities.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Store list | Loading | Loading failed | Updating failed | Updating success
--- | ---- | --- | --- | ---
![IMG_7038](https://github.com/user-attachments/assets/02098a50-50e7-47b1-8464-909e096ae786) | ![IMG_7039](https://github.com/user-attachments/assets/509c3d90-4cc7-42b4-9807-aca5155ab4f7) | ![IMG_7045](https://github.com/user-attachments/assets/40646650-cdac-4281-b704-a6d9d50765b5) | ![IMG_7041](https://github.com/user-attachments/assets/1dcf9fe0-a7df-4730-bcc0-a8c0900b7b33) | ![IMG_7043](https://github.com/user-attachments/assets/b5707158-38f1-4598-9ae3-364585e2f2f9)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
