### PR TITLE
Disable 'Add Discount' product button if the order is loading

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -343,7 +343,7 @@ private extension CollapsibleProductRowCard {
                     onAddDiscount(viewModel.id)
                 }
                 .buttonStyle(PlusButtonStyle())
-                .disabled(shouldDisallowDiscounts)
+                .disabled(shouldDisallowDiscounts || isLoading)
             } else {
                 HStack {
                     Button(action: {
@@ -357,6 +357,7 @@ private extension CollapsibleProductRowCard {
                                 .frame(width: Layout.iconSize, height: Layout.iconSize)
                         }
                     })
+                    .disabled(isLoading)
                     Spacer()
                     if let discountLabel = viewModel.discountLabel {
                         Text(minusSign + discountLabel)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15295
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When Add Discount is tapped while the order is loading, the order totals are not loaded to calculate the base price and discount correctly.

The main issue is `discountConfiguration` being `nil` when the order is loading. It is created in `EditableOrderViewModel.addProductDiscountConfiguration` which explicitly returns `nil` if the order is not synced. It is then used in `ProductDiscountViewModel` to calculate `baseAmountForDiscountPercentage` = `discountConfiguration?.baseAmountForDiscountPercentage ?? .zero`.

## Solution

Disable `Add Discount` if the order is loading

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Orders
2. Add Order
3. Select and add product
4. Expand the product cart
5. Increase the quantity
6. Confirm 'Add Discount' cannot be tapped while the order totals are loading
7. After totals are loaded tap 'Add Discount'
8. Confirm totals are shown

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Order loading starts with the delay so there's a split second where 'Add Discount' can be tapped and then new order totals load in the background. If this the case, percentage discount is calculated using the previous order total.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.