### PR TITLE
HACK Week: Add entry point to connectivity tool from Settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Product Form: Fix crash related to picking photos [https://github.com/woocommerce/woocommerce-ios/pull/15275]
 - [internal] Assign `siteID` and `productID` to image product upload statuses. [https://github.com/woocommerce/woocommerce-ios/pull/15196]
 - [*] Payments: Improved payment views' adaptability to larger accessibility font sizes [https://github.com/woocommerce/woocommerce-ios/pull/15328].
+- [*] Added an entry point to Troubleshoot Connection from the Settings screen. [https://github.com/woocommerce/woocommerce-ios/pull/15391]
 - [internal] Add site related properties to crowdsignal surveys. [https://github.com/woocommerce/woocommerce-ios/pull/15353]
 
 21.9

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
@@ -20,6 +20,10 @@ extension WooAnalyticsEvent {
             .init(statName: .ordersListTopBannerTroubleshootTapped, properties: [:])
         }
 
+        static func settingsTroubleshootTapped() -> WooAnalyticsEvent {
+            .init(statName: .settingsTroubleshootConnectionTapped, properties: [:])
+        }
+
         static func requestResponse(test: Test, success: Bool, timeTaken: Double) -> WooAnalyticsEvent {
             .init(statName: .connectivityToolRequestResponse,
                   properties: [

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -321,6 +321,7 @@ enum WooAnalyticsStat: String {
     case settingsSelectedStoreTapped = "settings_selected_site_tapped"
     case settingsContactSupportTapped = "main_menu_contact_support_tapped"
     case settingsDomainsTapped = "settings_domains_tapped"
+    case settingsTroubleshootConnectionTapped = "settings_troubleshoot_connection_tapped"
 
     case settingsBetaFeaturesButtonTapped = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled = "settings_beta_features_products_toggled"

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -103,6 +103,8 @@ struct ConnectivityTool: View {
             .padding()
         }
         .background(Color(uiColor: .listBackground))
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
@@ -112,6 +114,11 @@ private extension ConnectivityTool {
                                                 comment: "Subtitle on the connectivity tool screen")
         static let contactSupport = NSLocalizedString("Contact Support",
                                                       comment: "Contact support button in the connectivity tool screen")
+        static let title = NSLocalizedString(
+            "connectivityTool.title",
+            value: "Troubleshoot Connection",
+            comment: "Screen title for the connectivity tool"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -144,6 +144,8 @@ private extension SettingsViewController {
             configureWooCommmerceDetails(cell: cell)
         case let cell as BasicTableViewCell where row == .domain:
             configureDomain(cell: cell)
+        case let cell as BasicTableViewCell where row == .connectivity:
+            configureConnectivity(cell: cell)
         case let cell as BasicTableViewCell where row == .installJetpack:
             configureInstallJetpack(cell: cell)
         case let cell as BasicTableViewCell where row == .themes:
@@ -211,6 +213,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.domain
+    }
+
+    func configureConnectivity(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = Localization.connectivity
     }
 
     func configureInstallJetpack(cell: BasicTableViewCell) {
@@ -489,6 +497,11 @@ private extension SettingsViewController {
         show(controller, sender: self)
     }
 
+    func showConnectivityTool() {
+        let controller = ConnectivityToolViewController()
+        show(controller, sender: self)
+    }
+
     func deviceSettingsWasPressed() {
         guard let targetURL = URL(string: UIApplication.openSettingsURLString) else {
             return
@@ -668,6 +681,8 @@ extension SettingsViewController: UITableViewDelegate {
             showThemeSettings()
         case .notifications:
             showNotificationSettings()
+        case .connectivity:
+            showConnectivityTool()
         default:
             break
         }
@@ -727,6 +742,7 @@ extension SettingsViewController {
         case installJetpack
         case storeName
         case themes
+        case connectivity
 
         // Help & Feedback
         case support
@@ -772,7 +788,7 @@ extension SettingsViewController {
                 return HostingTableViewCell<PluginDetailsRowContent>.self
             case .support:
                 return BasicTableViewCell.self
-            case .domain:
+            case .domain, .connectivity:
                 return BasicTableViewCell.self
             case .installJetpack:
                 return BasicTableViewCell.self
@@ -846,6 +862,12 @@ private extension SettingsViewController {
         static let domain = NSLocalizedString(
             "Domains",
             comment: "Navigates to domain settings screen."
+        )
+
+        static let connectivity = NSLocalizedString(
+            "settingsViewController.connectivity",
+            value: "Troubleshoot Connection",
+            comment: "Navigates to connectivity test screen."
         )
 
         static let installJetpack = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -498,6 +498,7 @@ private extension SettingsViewController {
     }
 
     func showConnectivityTool() {
+        ServiceLocator.analytics.track(event: .ConnectivityTool.settingsTroubleshootTapped())
         let controller = ConnectivityToolViewController()
         show(controller, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -214,6 +214,12 @@ private extension SettingsViewModel {
                 rows.append(.domain)
             }
 
+            if stores.isAuthenticated,
+               stores.isAuthenticatedWithoutWPCom == false,
+               stores.sessionManager.defaultSite?.isWordPressComStore == false {
+                rows.append(.connectivity)
+            }
+
             guard rows.isNotEmpty else {
                 return nil
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -355,7 +355,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
     }
 
-    func test_sections_does_not_contain_notifications_row_for_Jetpack_site_and_user_is_authenticated_with_WPCom() {
+    func test_sections_contains_notifications_row_for_Jetpack_site_and_user_is_authenticated_with_WPCom() {
         // Given
         let featureFlagService = MockFeatureFlagService(notificationSettings: true)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
@@ -367,6 +367,42 @@ final class SettingsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+    }
+
+    func test_sections_does_not_contain_connectivity_row_for_wpcom_site() {
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
+    }
+
+    func test_sections_does_not_contain_connectivity_row_if_user_authenticated_without_wpcom() {
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: false)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
+    }
+
+    func test_sections_contains_connectivity_row_if_user_authenticated_with_wpcom_to_non_wpcom_site() {
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: false)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15390 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To support users with self-hosted Jetpack sites troubleshooting their sites' connection, this PR adds an entry point to the connectivity tool from the Settings screen.

This entry point is available only for self-hosted sites and when users are authenticated with a WPCom account. WPCom sites connection are handled automatically so no troubleshooting is needed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a self-hosted store using site credentials.
2. Navigate to Hub Menu > Settings. Confirm that there's no entry point to Troubleshoot Connection in the Configure section.
3. Log out and back in to a WPCom store.
4. Repeat step 2 and confirm that there's no entry point to Troubleshoot Connection either.
5. Switch to a self-hosted store while authenticated with a WPCom.
6. Confirm that there's an entry point to Troubleshoot Connection on the Settings screen. 
7. Tap on the row and confirm that `settings_troubleshoot_connection_tapped` is tracked.
8. Confirm that the troubleshooting works correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed the test cases above.
Unit tests have been added to verify the logic for the entry point availability.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7444d6ac-4442-44f2-9b06-778b6bcc86dd



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
