### PR TITLE
Shipping Labels: Handle HAZMAT category selection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -11,9 +11,13 @@ struct WooShippingHazmatDetailView: View {
 
     @State private var isShowingCategoryList = false
 
-    init(selectedCategory: ShippingLabelHazmatCategory?) {
+    private let selectionHandler: (ShippingLabelHazmatCategory?) -> Void
+
+    init(selectedCategory: ShippingLabelHazmatCategory?,
+         selectionHandler: @escaping (ShippingLabelHazmatCategory?) -> Void) {
         self.isHazardous = selectedCategory != nil
         self.selectedCategory = selectedCategory
+        self.selectionHandler = selectionHandler
     }
 
     var body: some View {
@@ -66,7 +70,8 @@ struct WooShippingHazmatDetailView: View {
             .sheet(isPresented: $isShowingCategoryList) {
                 WooShippingHazmatCategoryList(selectedItem: selectedCategory,
                                               selectionHandler: { category in
-                    // TODO: dismiss view
+                    selectionHandler(category)
+                    dismiss()
                 })
             }
         }
@@ -178,5 +183,5 @@ private extension WooShippingHazmatDetailView {
 }
 
 #Preview {
-    WooShippingHazmatDetailView(selectedCategory: .airEligibleEthanol)
+    WooShippingHazmatDetailView(selectedCategory: .airEligibleEthanol, selectionHandler: { _ in })
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -11,8 +11,8 @@ struct WooShippingHazmatDetailView: View {
 
     @State private var isShowingCategoryList = false
 
-    init(isHazardous: Bool, selectedCategory: ShippingLabelHazmatCategory?) {
-        self.isHazardous = isHazardous
+    init(selectedCategory: ShippingLabelHazmatCategory?) {
+        self.isHazardous = selectedCategory != nil
         self.selectedCategory = selectedCategory
     }
 
@@ -29,6 +29,7 @@ struct WooShippingHazmatDetailView: View {
                     Toggle(isOn: $isHazardous) {
                         Text(Localization.toggleLabel)
                     }
+                    .tint(Color.accentColor)
 
                     Button(Localization.selectCategory) {
                         isShowingCategoryList = true
@@ -177,6 +178,5 @@ private extension WooShippingHazmatDetailView {
 }
 
 #Preview {
-    WooShippingHazmatDetailView(isHazardous: true,
-                                selectedCategory: .airEligibleEthanol)
+    WooShippingHazmatDetailView(selectedCategory: .airEligibleEthanol)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -4,16 +4,15 @@ struct WooShippingHazmatRow: View {
     /// Whether the interactions (navigation/setting selection) are enabled.
     private let enabled: Bool
 
-    @Binding private var isHazardous: Bool
+    private let isHazardous: Bool
 
     @Binding private var selectedCategory: ShippingLabelHazmatCategory?
 
     @State private var isShowingDetailView = false
 
-    init(isHazardous: Binding<Bool>,
-         selectedCategory: Binding<ShippingLabelHazmatCategory?>,
+    init(selectedCategory: Binding<ShippingLabelHazmatCategory?>,
          enabled: Bool) {
-        self._isHazardous = isHazardous
+        isHazardous = selectedCategory.wrappedValue != nil
         self._selectedCategory = selectedCategory
         self.enabled = enabled
     }
@@ -37,8 +36,7 @@ struct WooShippingHazmatRow: View {
         .buttonStyle(.plain)
         .disabled(!enabled)
         .sheet(isPresented: $isShowingDetailView) {
-            WooShippingHazmatDetailView(isHazardous: isHazardous,
-                                        selectedCategory: selectedCategory)
+            WooShippingHazmatDetailView(selectedCategory: selectedCategory)
         }
     }
 }
@@ -67,8 +65,7 @@ private extension WooShippingHazmatRow {
 }
 
 #Preview {
-    WooShippingHazmatRow(isHazardous: .constant(false),
-                         selectedCategory: .constant(nil),
+    WooShippingHazmatRow(selectedCategory: .constant(nil),
                          enabled: true)
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -18,23 +18,38 @@ struct WooShippingHazmatRow: View {
     }
 
     var body: some View {
-        Button(action: {
-            isShowingDetailView = true
-        }) {
-            AdaptiveStack {
-                Text(Localization.hazmatLabel)
-                    .bodyStyle()
-                Spacer()
-                Text(isHazardous ? Localization.yes : Localization.no)
-                    .secondaryBodyStyle()
-                Image(uiImage: .chevronImage)
-                    .secondaryBodyStyle()
-                    .renderedIf(enabled)
+        VStack {
+            Button(action: {
+                isShowingDetailView = true
+            }) {
+                AdaptiveStack {
+                    Text(Localization.hazmatLabel)
+                        .bodyStyle()
+                    Spacer()
+                    Text(isHazardous ? Localization.yes : Localization.no)
+                        .secondaryBodyStyle()
+                    Image(uiImage: .chevronImage)
+                        .secondaryBodyStyle()
+                        .renderedIf(enabled)
+                }
             }
-            .padding(.vertical, Layout.verticalPadding)
+            .buttonStyle(.plain)
+            .disabled(!enabled)
+
+            if let category = selectedCategory {
+                Text(category.localizedName)
+                    .captionStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
+                    .padding(Layout.categoryPadding)
+                    .background(
+                        Color(.quaternarySystemFill)
+                            .clipShape(RoundedRectangle(cornerSize: .init(width: Layout.backgroundRadius,
+                                                                          height: Layout.backgroundRadius)))
+                    )
+            }
         }
-        .buttonStyle(.plain)
-        .disabled(!enabled)
+        .padding(.vertical, Layout.verticalPadding)
         .sheet(isPresented: $isShowingDetailView) {
             WooShippingHazmatDetailView(selectedCategory: selectedCategory) { selectedCategory in
                 self.selectedCategory = selectedCategory
@@ -48,6 +63,7 @@ private extension WooShippingHazmatRow {
     enum Layout {
         static let backgroundRadius: CGFloat = 8
         static let verticalPadding: CGFloat = 24
+        static let categoryPadding: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -4,15 +4,12 @@ struct WooShippingHazmatRow: View {
     /// Whether the interactions (navigation/setting selection) are enabled.
     private let enabled: Bool
 
-    @State private var isHazardous: Bool
-
     @Binding private var selectedCategory: ShippingLabelHazmatCategory?
 
     @State private var isShowingDetailView = false
 
     init(selectedCategory: Binding<ShippingLabelHazmatCategory?>,
          enabled: Bool) {
-        isHazardous = selectedCategory.wrappedValue != nil
         self._selectedCategory = selectedCategory
         self.enabled = enabled
     }
@@ -26,7 +23,7 @@ struct WooShippingHazmatRow: View {
                     Text(Localization.hazmatLabel)
                         .bodyStyle()
                     Spacer()
-                    Text(isHazardous ? Localization.yes : Localization.no)
+                    Text(selectedCategory != nil ? Localization.yes : Localization.no)
                         .secondaryBodyStyle()
                     Image(uiImage: .chevronImage)
                         .secondaryBodyStyle()
@@ -53,7 +50,6 @@ struct WooShippingHazmatRow: View {
         .sheet(isPresented: $isShowingDetailView) {
             WooShippingHazmatDetailView(selectedCategory: selectedCategory) { selectedCategory in
                 self.selectedCategory = selectedCategory
-                isHazardous = selectedCategory != nil
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -4,7 +4,7 @@ struct WooShippingHazmatRow: View {
     /// Whether the interactions (navigation/setting selection) are enabled.
     private let enabled: Bool
 
-    private let isHazardous: Bool
+    @State private var isHazardous: Bool
 
     @Binding private var selectedCategory: ShippingLabelHazmatCategory?
 
@@ -36,7 +36,10 @@ struct WooShippingHazmatRow: View {
         .buttonStyle(.plain)
         .disabled(!enabled)
         .sheet(isPresented: $isShowingDetailView) {
-            WooShippingHazmatDetailView(selectedCategory: selectedCategory)
+            WooShippingHazmatDetailView(selectedCategory: selectedCategory) { selectedCategory in
+                self.selectedCategory = selectedCategory
+                isHazardous = selectedCategory != nil
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -110,8 +110,7 @@ private extension WooShippingCreateLabelsView {
 
                 WooShippingItems(viewModel: viewModel.items)
 
-                WooShippingHazmatRow(isHazardous: $viewModel.containsHazardousMaterials,
-                                     selectedCategory: $viewModel.hazmatCategory,
+                WooShippingHazmatRow(selectedCategory: $viewModel.hazmatCategory,
                                      enabled: !viewModel.canViewLabel)
 
                 WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -60,7 +60,7 @@ struct WooShippingCreateLabelsView: View {
                 }
             }
             .safeAreaInset(edge: .bottom) {
-                if viewModel.state == .ready {
+                if viewModel.state == .ready && viewModel.hazmatNotice == nil {
                     expandableBottomSheet
                 }
             }
@@ -92,6 +92,7 @@ struct WooShippingCreateLabelsView: View {
                 WooShippingCustomsForm(viewModel: viewModel.customsFormViewModel)
             }
             .notice($viewModel.labelPurchaseErrorNotice, autoDismiss: false)
+            .notice($viewModel.hazmatNotice)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -21,7 +21,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private var subscriptions: Set<AnyCancellable> = []
     private var debounceDuration: Double = 1
 
-    @Published var containsHazardousMaterials = false
     @Published var hazmatCategory: ShippingLabelHazmatCategory?
 
     @Published var labelPurchaseErrorNotice: Notice?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -573,7 +573,9 @@ private extension WooShippingCreateLabelsViewModel {
 
     func observeHAZMATChanges() {
         $hazmatCategory
-            .scan((nil, nil)) { (previous: (current: ShippingLabelHazmatCategory?, previous: ShippingLabelHazmatCategory?),
+            .dropFirst()
+            .scan((nil, nil)) { (previous: (current: ShippingLabelHazmatCategory?,
+                                            previous: ShippingLabelHazmatCategory?),
                                  newValue: ShippingLabelHazmatCategory?) in
                 return (current: newValue, previous: previous.current)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -650,7 +650,7 @@ private extension WooShippingCreateLabelsViewModel {
                                      height: Double(packageData.height) ?? 0,
                                      weight: weight,
                                      isLetter: WooShippingPackageType(rawValue: packageData.packageType) == .envelope,
-                                     hazmatCategory: nil, // Hazmat support will be added in a future milestone
+                                     hazmatCategory: hazmatCategory?.rawValue,
                                      customsForm: customsForm)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -22,6 +22,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private var debounceDuration: Double = 1
 
     @Published var hazmatCategory: ShippingLabelHazmatCategory?
+    @Published var hazmatNotice: Notice?
 
     @Published var labelPurchaseErrorNotice: Notice?
 
@@ -228,6 +229,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         observeSelectedPackage()
         observeForLabelRates()
         observeForCustomsForm()
+        observeHAZMATChanges()
         Task {
             await loadRequiredData()
         }
@@ -569,6 +571,21 @@ private extension WooShippingCreateLabelsViewModel {
             .store(in: &subscriptions)
     }
 
+    func observeHAZMATChanges() {
+        $hazmatCategory
+            .scan((nil, nil)) { (previous: (current: ShippingLabelHazmatCategory?, previous: ShippingLabelHazmatCategory?),
+                                 newValue: ShippingLabelHazmatCategory?) in
+                return (current: newValue, previous: previous.current)
+            }
+            .map { [weak self] (newValue, oldValue) in
+                let noticeTitle = newValue != nil ? Localization.hazmatSet : Localization.hazmatRemoved
+                return Notice(title: noticeTitle, actionTitle: Localization.undo, actionHandler: {
+                    self?.hazmatCategory = oldValue
+                })
+            }
+            .assign(to: &$hazmatNotice)
+    }
+
     func observeForCustomsForm() {
         $selectedOriginAddress.combineLatest($destinationAddress)
             .map { (originAddress, destinationAddress) -> Bool in
@@ -695,6 +712,24 @@ private extension WooShippingCreateLabelsViewModel {
                                                    value: "Retry",
                                                    comment: "Button to retry label purchase when an error occurs")
         }
+
+        static let hazmatSet = NSLocalizedString(
+            "wooShipping.createLabels.hazmatSet",
+            value: "Hazardous materials category set",
+            comment: "Notice when a hazardous materials category is set on the shipping label creation screen"
+        )
+
+        static let hazmatRemoved = NSLocalizedString(
+            "wooShipping.createLabels.hazmatRemoved",
+            value: "Remove hazardous materials category",
+            comment: "Notice when a hazardous materials category is removed on the shipping label creation screen"
+        )
+
+        static let undo = NSLocalizedString(
+            "wooShipping.createLabels.undo",
+            value: "Undo",
+            comment: "Button to undo a change on the shipping label creation screen"
+        )
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -743,6 +743,41 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isPurchasingLabel)
     }
 
+    func test_purchaseLabel_sets_hazmat_category_correctly() {
+        // Given
+        var encodedHazmat: [String: Any]?
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(shippingAddress: Address.fake()),
+                                                         selectedOriginAddress: WooShippingOriginAddress.fake(),
+                                                         selectedPackage: samplePackageData(),
+                                                         selectedRate: sampleSelectedRate(),
+                                                         stores: stores)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .purchaseShippingLabel(_, _, _, _, package, _, _, _, completion):
+                encodedHazmat = package.encodedHazmat()
+                completion(.success(ShippingLabel.fake()))
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success([]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadPackages, .loadOriginAddresses, .verifyDestinationAddress, .loadConfig:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.hazmatCategory = .class3
+        viewModel.purchaseLabel()
+
+        // Then
+        let shipmentDetails = encodedHazmat?["shipment_0"] as? [String: Any]
+        XCTAssertEqual(shipmentDetails?["isHazmat"] as? Bool, true)
+        XCTAssertEqual(shipmentDetails?["category"] as? String, ShippingLabelHazmatCategory.class3.rawValue)
+    }
+
     func test_selectPackage_sets_selectedPackage_with_package_data() {
         // Given
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -924,6 +924,20 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(viewModel.addressToEdit)
     }
+
+    func test_hazmatNotice_is_updated_after_setting_new_hazmat_category() {
+        // Given
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake())
+        XCTAssertNil(viewModel.hazmatNotice)
+
+        // When
+        viewModel.hazmatCategory = .class1
+
+        // Then
+        waitUntil {
+            viewModel.hazmatNotice != nil
+        }
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15315 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the UI and logic to support handling HAZMAT category selection:
- Dismiss the HAZMAT detail views upon category selection.
- Updated the HAZMAT row when a category is selected.
- Display a notice when a category is selected/removed.
- Send the selected category to label purchase.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with Woo Shipping plugin set up.
2. Open a completed order with at least one physical product > select Create shipping label.
3. Select the HAZMAT, toggle the switch to enable it, and select a category.
4. Upon category selection, confirm that the HAZMAT detail view is dismissed and the purchase form shows the correct category and state for HAZMAT.
5. Confirm that a notice is displayed regarding the new category. The bottom sheet is hidden temporarily while the notice is present.
6. Tap Undo on the notice and confirm that the previous state of the HAZMAT row is restored.
7. Follow the steps to complete the purchase. When the purchase completes, confirm that the correct HAZMAT category is displayed for the purchased label.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed the above tests in both light and dark modes.
Unit tests have also been added to confirm the selection of HAZMAT categories.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/1874c648-ca1a-4d62-b1c7-82c738a12403




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.