### PR TITLE
Shipping Label: Edit and remove HAZMAT category

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -101,6 +101,11 @@ struct WooShippingHazmatDetailView: View {
                     dismiss()
                 })
             }
+            .onChange(of: isHazardous) { newValue in
+                if newValue == false {
+                    selectedCategory = nil
+                }
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -94,17 +94,24 @@ struct WooShippingHazmatDetailView: View {
                 }
                 .toolbarBackground(Color.clear, for: .navigationBar)
             }
+            .safeAreaInset(edge: .bottom) {
+                VStack {
+                    Button(Localization.save) {
+                        selectionHandler(nil)
+                        dismiss()
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .padding(Constants.verticalSpacing)
+                }
+                .background(Color(.systemBackground))
+                .renderedIf(selectedCategory != nil && isHazardous == false)
+            }
             .sheet(isPresented: $isShowingCategoryList) {
                 WooShippingHazmatCategoryList(selectedItem: selectedCategory,
                                               selectionHandler: { category in
                     selectionHandler(category)
                     dismiss()
                 })
-            }
-            .onChange(of: isHazardous) { newValue in
-                if newValue == false {
-                    selectedCategory = nil
-                }
             }
         }
     }
@@ -191,6 +198,11 @@ private extension WooShippingHazmatDetailView {
             "wooShippingHazmatDetailView.category",
             value: "Category",
             comment: "Label for the existing category on the HAZMAT detail view in the shipping label creation flow"
+        )
+        static let save = NSLocalizedString(
+            "wooShippingHazmatDetailView.save",
+            value: "Save",
+            comment: "Button to confirm selection on the HAZMAT detail view in the shipping label creation flow"
         )
         static let detailLine1 = NSLocalizedString(
             "wooShippingHazmatDetailView.detailLine1",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatDetailView.swift
@@ -35,11 +35,38 @@ struct WooShippingHazmatDetailView: View {
                     }
                     .tint(Color.accentColor)
 
-                    Button(Localization.selectCategory) {
-                        isShowingCategoryList = true
+                    if isHazardous {
+                        if let selectedCategory {
+                            HStack {
+                                Text(Localization.category)
+                                    .headlineStyle()
+                                Spacer()
+                                Button {
+                                    isShowingCategoryList = true
+                                } label: {
+                                    Image(systemName: "pencil")
+                                }
+                                .buttonStyle(.plain)
+                                .font(.body)
+                                .foregroundStyle(Color.accentColor)
+                            }
+
+                            Text(selectedCategory.localizedName)
+                                .font(.body)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .multilineTextAlignment(.leading)
+                                .padding(Constants.verticalSpacing)
+                                .background(
+                                    Color(.quaternarySystemFill)
+                                        .clipShape(RoundedRectangle(cornerSize: Constants.cornerSize))
+                                )
+                        } else {
+                            Button(Localization.selectCategory) {
+                                isShowingCategoryList = true
+                            }
+                            .buttonStyle(PrimaryButtonStyle())
+                        }
                     }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .renderedIf(isHazardous)
 
                     Divider()
 
@@ -128,6 +155,7 @@ private extension WooShippingHazmatDetailView {
 private extension WooShippingHazmatDetailView {
     enum Constants {
         static let verticalSpacing: CGFloat = 16
+        static let cornerSize = CGSize(width: 8, height: 8)
         static let hazmatURL = "https://www.usps.com/hazmat"
         static let searchToolURL = "https://pe.usps.com/hazmat/index"
         static let DHLExpressName = "DHL Express"
@@ -153,6 +181,11 @@ private extension WooShippingHazmatDetailView {
             "wooShippingHazmatDetailView.selectCategory",
             value: "Select Category",
             comment: "Button to select hazardous material category on the HAZMAT detail view in the shipping label creation flow"
+        )
+        static let category = NSLocalizedString(
+            "wooShippingHazmatDetailView.category",
+            value: "Category",
+            comment: "Label for the existing category on the HAZMAT detail view in the shipping label creation flow"
         )
         static let detailLine1 = NSLocalizedString(
             "wooShippingHazmatDetailView.detailLine1",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15316 
Also closes #15317 
Also closes #15311 

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR wraps up the HAZMAT functionality of the new shipping label flow:
- Updated the HAZMAT detail view to display the currently selected category.
- Added a button to save selection when disabling HAZMAT after selecting a category.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with Woo Shipping plugin set up.
2. Select a completed order with at least one physical product.
3. Select Create shipping label > tap the HAZMAT row.
4. Switch on HAZMAT then select any category.
5. Tap the HAZMAT row again then confirm that the selected category is displayed correctly.
6. Tap the pencil button and select a different category. Confirm that the HAZMAT detail view is dismissed and the new category is displayed on the creation form.
7. Tap the HAZMAT row again then turn off HAZMAT using the toggle.
8. Confirm that the Save button shows up at the bottom. Tap the button.
9. Confirm that the HAZMAT detail view is dismissed and the creation form shows that no HAZMAT category is set. Confirm that the correct notice is displayed in this case.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirm the above test cases.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/4e8bc48e-21f3-4d93-ba69-a950e3ed63d2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.