### PR TITLE
[Shipping Labels] Split shipments instructions notice

### DIFF
--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -380,7 +380,9 @@ private extension UNMutableNotificationContent {
     convenience init(notice: Notice) {
         self.init()
 
-        title = notice.notificationInfo?.title ?? notice.title
+        if let title = notice.notificationInfo?.title ?? notice.title {
+            self.title = title
+        }
 
         if let body = notice.notificationInfo?.body {
             self.body = body

--- a/WooCommerce/Classes/Tools/Notices/Notice.swift
+++ b/WooCommerce/Classes/Tools/Notices/Notice.swift
@@ -9,7 +9,7 @@ struct Notice {
 
     /// The title that contains the reason for the notice
     ///
-    let title: String
+    let title: String?
 
     /// An optional subtitle that contains a secondary description of the reason for the notice
     ///
@@ -34,7 +34,6 @@ struct Notice {
     /// An optional handler closure that will be called when the action button is tapped, if you've provided an action title
     ///
     let actionHandler: (() -> Void)?
-
 
     /// Designated Initializer
     ///
@@ -63,5 +62,43 @@ extension Notice: Equatable {
             lhs.feedbackType == rhs.feedbackType &&
             lhs.notificationInfo?.identifier == rhs.notificationInfo?.identifier &&
             lhs.actionTitle == rhs.actionTitle
+    }
+}
+
+/// Convenience initializers to init without  a`title`
+/// These initializers  help to ensure that at least one of title/subtitle/message is non-nil.
+///
+extension Notice {
+    /// To init using `subtitle` and/or `message`
+    ///
+    init(subtitle: String,
+         message: String? = nil,
+         feedbackType: UINotificationFeedbackGenerator.FeedbackType? = nil,
+         notificationInfo: NoticeNotificationInfo? = nil,
+         actionTitle: String? = nil,
+         actionHandler: ((() -> Void))? = nil) {
+        self.title = nil
+        self.subtitle = subtitle
+        self.message = message
+        self.feedbackType = feedbackType
+        self.notificationInfo = notificationInfo
+        self.actionTitle = actionTitle
+        self.actionHandler = actionHandler
+    }
+
+    /// To init using only `message`
+    ///
+    init(message: String,
+         feedbackType: UINotificationFeedbackGenerator.FeedbackType? = nil,
+         notificationInfo: NoticeNotificationInfo? = nil,
+         actionTitle: String? = nil,
+         actionHandler: ((() -> Void))? = nil) {
+        self.title = nil
+        self.subtitle = nil
+        self.message = message
+        self.feedbackType = feedbackType
+        self.notificationInfo = notificationInfo
+        self.actionTitle = actionTitle
+        self.actionHandler = actionHandler
     }
 }

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -83,7 +83,7 @@ struct NoticeModifier: ViewModifier {
                             }
                             if let message = notice.message {
                                 HStack {
-                                    Text(message)
+                                    BoldableTextView(message)
                                     Spacer()
                                 }
                                 .font(Constants.messageFont)

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -64,13 +64,15 @@ struct NoticeModifier: ViewModifier {
                     Spacer()
                     HStack(spacing: 0.0) {
                         VStack {
-                            HStack {
-                                Text(notice.title)
-                                    .lineLimit(notice.message.isNilOrEmpty ? 0 : 2)
-                                Spacer()
+                            if let title = notice.title {
+                                HStack {
+                                    Text(title)
+                                        .lineLimit(notice.message.isNilOrEmpty ? 0 : 2)
+                                    Spacer()
+                                }
+                                .font(Constants.titleFont)
+                                .foregroundColor(Constants.titleColor)
                             }
-                            .font(Constants.titleFont)
-                            .foregroundColor(Constants.titleColor)
                             if let subtitle = notice.subtitle {
                                 HStack {
                                     Text(subtitle)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentCardViewModel.swift
@@ -12,6 +12,8 @@ final class CollapsibleShipmentCardViewModel: ObservableObject, Identifiable {
     /// Child shipment rows, if the shipment has more than one quantity
     let childShipmentRows: [SelectableShipmentRowViewModel]
 
+    var onSelectionChange: (() -> Void)?
+
     init(parentShipmentId: String,
          childShipmentIds: [String],
          item: ShippingLabelPackageItem,
@@ -47,6 +49,7 @@ private extension CollapsibleShipmentCardViewModel {
             guard let self else { return }
 
             childShipmentRows.forEach({ $0.setSelected(row.selected) })
+            onSelectionChange?()
         }
 
         childShipmentRows.forEach({
@@ -54,6 +57,7 @@ private extension CollapsibleShipmentCardViewModel {
                 guard let self else { return }
 
                 mainShipmentRow.setSelected(false)
+                onSelectionChange?()
             }
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentCardViewModel.swift
@@ -14,6 +14,16 @@ final class CollapsibleShipmentCardViewModel: ObservableObject, Identifiable {
 
     var onSelectionChange: (() -> Void)?
 
+    var hasSelectedAnItem: Bool {
+        if mainShipmentRow.selected {
+            return true
+        }
+
+        return childShipmentRows
+            .filter { $0.selected }
+            .isNotEmpty
+    }
+
     init(parentShipmentId: String,
          childShipmentIds: [String],
          item: ShippingLabelPackageItem,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -4,7 +4,7 @@ import Yosemite
 struct WooShippingSplitShipmentsDetailView: View {
     @Environment(\.dismiss) private var dismiss
 
-    let viewModel: WooShippingSplitShipmentsViewModel
+    @ObservedObject var viewModel: WooShippingSplitShipmentsViewModel
 
     var body: some View {
         NavigationView {
@@ -40,6 +40,10 @@ struct WooShippingSplitShipmentsDetailView: View {
                     }
                 }
             }
+        }
+        .notice($viewModel.instructionsNotice, autoDismiss: false)
+        .onAppear {
+            viewModel.onAppear()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -26,9 +26,9 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         "\(itemsWeightLabel) • \(itemsPriceLabel)"
     }
 
-    @Published var selectedItemIDs: [String: [String]] = [:]
-
     let shipmentCardViewModels: [CollapsibleShipmentCardViewModel]
+
+    @Published var instructionsNotice: Notice?
 
     init(order: Order,
          config: WooShippingConfig,
@@ -70,6 +70,11 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         }()
 
         configureSectionHeader()
+        configureSelectionCallback()
+    }
+
+    func onAppear() {
+        showInstructionsNotice()
     }
 
     func selectAll() {
@@ -80,6 +85,22 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
 }
 
 private extension WooShippingSplitShipmentsViewModel {
+
+    func showInstructionsNotice() {
+        if hasSelectedAnItem() == false {
+            instructionsNotice = Notice(message: Localization.SelectionInstructionsNotice.message,
+                                        feedbackType: .success,
+                                        actionTitle: Localization.SelectionInstructionsNotice.dismiss) { [weak self] in
+                self?.instructionsNotice = nil
+            }
+        }
+    }
+
+
+    func hasSelectedAnItem() -> Bool {
+        shipmentCardViewModels.map({ $0.hasSelectedAnItem }).contains(where: { $0 })
+    }
+
     /// Configures the labels in the section header.
     ///
     func configureSectionHeader() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -85,6 +85,13 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
 }
 
 private extension WooShippingSplitShipmentsViewModel {
+    func configureSelectionCallback() {
+        shipmentCardViewModels.forEach { viewModel in
+            viewModel.onSelectionChange = { [weak self] in
+                self?.checkSelectionAndHideInstructions()
+            }
+        }
+    }
 
     func showInstructionsNotice() {
         if hasSelectedAnItem() == false {
@@ -96,6 +103,11 @@ private extension WooShippingSplitShipmentsViewModel {
         }
     }
 
+    func checkSelectionAndHideInstructions() {
+        if hasSelectedAnItem() {
+            instructionsNotice = nil
+        }
+    }
 
     func hasSelectedAnItem() -> Bool {
         shipmentCardViewModels.map({ $0.hasSelectedAnItem }).contains(where: { $0 })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -110,7 +110,7 @@ private extension WooShippingSplitShipmentsViewModel {
     }
 
     func hasSelectedAnItem() -> Bool {
-        shipmentCardViewModels.map({ $0.hasSelectedAnItem }).contains(where: { $0 })
+        shipmentCardViewModels.contains(where: { $0.hasSelectedAnItem })
     }
 
     /// Configures the labels in the section header.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -113,6 +113,16 @@ private extension WooShippingSplitShipmentsViewModel {
 // MARK: Constants
 private extension WooShippingSplitShipmentsViewModel {
     enum Localization {
+        enum SelectionInstructionsNotice {
+            static let message = NSLocalizedString("wooShipping.createLabels.splitShipment.SelectionInstructionsNotice.message",
+                                                   value: "To split, select the items, and tap **move to new shipment** when the toolbar appears.",
+                                                   comment: "Instructions to ask customer to select items to split during shipping label creation."
+                                                   + " The content inside two double asterisks **...** denote bolded text.")
+
+            static let dismiss = NSLocalizedString("wooShipping.createLabels.splitShipment.SelectionInstructionsNotice.dismiss",
+                                                   value: "Dismiss",
+                                                   comment: "Label of the button to dismiss the instructions notice in split shipments flow.")
+        }
         static func itemsCount(_ count: Decimal) -> String {
             return String.pluralize(count, singular: Localization.itemsCountSingularFormat, plural: Localization.itemsCountPluralFormat)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -104,7 +104,7 @@ private extension WooShippingCreateLabelsView {
                     WooShippingPostPurchaseView(viewModel: postPurchase)
                 }
 
-                if let splitShipmentsViewModel = viewModel.splitShipmentsViewModel {
+                if !viewModel.canViewLabel, let splitShipmentsViewModel = viewModel.splitShipmentsViewModel {
                     WooShippingSplitShipmentsRow(viewModel: splitShipmentsViewModel)
                 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/Epilogue/SwitchStoreNoticePresenterTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Epilogue/SwitchStoreNoticePresenterTests.swift
@@ -66,7 +66,8 @@ final class SwitchStoreNoticePresenterTests: XCTestCase {
         XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
 
         let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
-        assertThat(notice.title, contains: siteName)
+        let title = try XCTUnwrap(notice.title)
+        assertThat(title, contains: siteName)
         let expectedTitle = String.localizedStringWithFormat(SwitchStoreNoticePresenter.Localization.titleFormat, site.name)
         XCTAssertEqual(notice.title, expectedTitle)
     }
@@ -92,7 +93,8 @@ final class SwitchStoreNoticePresenterTests: XCTestCase {
         XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
 
         let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
-        assertThat(notice.title, contains: siteName)
+        let title = try XCTUnwrap(notice.title)
+        assertThat(title, contains: siteName)
         let expectedTitle = String.localizedStringWithFormat(SwitchStoreNoticePresenter.Localization.titleFormat, site.name)
         XCTAssertEqual(notice.title, expectedTitle)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15305
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Starts showing the instructions notice in the split shipments flow.


Changes
- Alter `Notice` to work without a `title`. 
- Use `BoldableTextView` in Notice for showing markdown message.
- Show instructions notice if there is no selection made in split shipments screen.
- Shows "Split shipments" view only if a shipping label has not been purchased. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
1. Create an order with multiple products and different quantities for each product.
1. Enter a valid shipping address for the order.
1. Open the order detail page. 
1. Tap "Create shipping label".
1. Tap "Split shipments".
1. Validate that you see a notice with instructions to select items to split into shipments. Design - bsLNrhmi2xQZB4C0TzjmHB-fi-942_42236
1. Selecting any item should make that instructions notice disappear. 


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested that the instructions notices is displayed as described above. 


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

#### Purchased a shipping label

| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/7ab3caa7-31d1-4cd1-bf12-d41893e61f69) | ![After](https://github.com/user-attachments/assets/e5536b2b-bcbb-4806-afbb-4ff298bfb0f3) | 


#### Notice for instructions


https://github.com/user-attachments/assets/91a2d316-c836-4a7e-83b9-2a78208b4370



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.