### PR TITLE
[Woo POS] Coupons: Send coupon(s) in order creation request 

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -5,7 +5,9 @@ import protocol Yosemite.POSOrderServiceProtocol
 import protocol Yosemite.POSReceiptServiceProtocol
 import struct Yosemite.Order
 import struct Yosemite.PaymentGateway
+import struct Yosemite.POSCart
 import struct Yosemite.POSCartItem
+import struct Yosemite.POSCartCouponItem
 import enum Yosemite.OrderAction
 import enum Yosemite.OrderUpdateField
 import class WooFoundation.CurrencyFormatter
@@ -65,11 +67,9 @@ protocol PointOfSaleOrderControllerProtocol {
     @MainActor @discardableResult
     func syncOrder(for cart: Cart,
                    retryHandler: @escaping () async -> Void) async -> Result<SyncOrderState, Error> {
-        let posCartItems = cart.items.map {
-            POSCartItem(item: $0.item, quantity: Decimal($0.quantity))
-        }
+        let posCart = POSCart(cart: cart)
 
-        guard !orderState.isSyncing, !posCartItems.matches(order: order) else {
+        guard !orderState.isSyncing, !posCart.items.matches(order: order) else {
             return .success(.orderNotChanged)
         }
 
@@ -77,7 +77,7 @@ protocol PointOfSaleOrderControllerProtocol {
         let isNewOrder = order == nil
 
         do {
-            let syncedOrder = try await orderService.syncOrder(cart: posCartItems,
+            let syncedOrder = try await orderService.syncOrder(cart: posCart,
                                                                order: order,
                                                                currency: storeCurrency)
             self.order = syncedOrder
@@ -247,5 +247,15 @@ extension PointOfSaleOrderController {
     enum PointOfSaleOrderControllerError: Error {
         case noSiteID
         case noOrder
+    }
+}
+
+// MARK: - Mapping
+
+private extension POSCart {
+    init(cart: Cart) {
+        let items = cart.items.map { POSCartItem(item: $0.item, quantity: Decimal($0.quantity)) }
+        let coupons = cart.coupons.map { POSCartCouponItem(code: $0.code) }
+        self.init(items: items, coupons: coupons)
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -69,7 +69,7 @@ protocol PointOfSaleOrderControllerProtocol {
                    retryHandler: @escaping () async -> Void) async -> Result<SyncOrderState, Error> {
         let posCart = POSCart(cart: cart)
 
-        guard !orderState.isSyncing, !posCart.items.matches(order: order) else {
+        guard !orderState.isSyncing, !posCart.matches(order: order) else {
             return .success(.orderNotChanged)
         }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -7,7 +7,7 @@ import struct Yosemite.Order
 import struct Yosemite.PaymentGateway
 import struct Yosemite.POSCart
 import struct Yosemite.POSCartItem
-import struct Yosemite.POSCartCouponItem
+import struct Yosemite.POSCoupon
 import enum Yosemite.OrderAction
 import enum Yosemite.OrderUpdateField
 import class WooFoundation.CurrencyFormatter
@@ -255,7 +255,7 @@ extension PointOfSaleOrderController {
 private extension POSCart {
     init(cart: Cart) {
         let items = cart.items.map { POSCartItem(item: $0.item, quantity: Decimal($0.quantity)) }
-        let coupons = cart.coupons.map { POSCartCouponItem(code: $0.code) }
+        let coupons = cart.coupons.map { POSCoupon(id: $0.id, code: $0.code) }
         self.init(items: items, coupons: coupons)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -17,7 +17,7 @@ struct CartView: View {
     @State private var shouldShowItemImages: Bool = false
 
     private var shouldShowCoupons: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale) && posModel.cart.coupons.isNotEmpty
     }
 
     var body: some View {

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -380,6 +380,8 @@ struct PointOfSaleOrderControllerTests {
         // Initial sync to set up the order
         await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
 
+        mockOrderService.syncOrderWasCalled = false
+
         // When - sync with same items and coupons
         await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
 
@@ -402,6 +404,8 @@ struct PointOfSaleOrderControllerTests {
         // Initial sync
         await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: initialCouponCode)]), retryHandler: {})
 
+        mockOrderService.syncOrderWasCalled = false
+
         // When - sync with same items but different coupon
         await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: "DIFFERENT20")]), retryHandler: {})
 
@@ -423,6 +427,8 @@ struct PointOfSaleOrderControllerTests {
 
         // Initial sync with coupon
         await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
+
+        mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items but no coupons
         await sut.syncOrder(for: .init(items: [cartItem], coupons: []), retryHandler: {})

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -5,6 +5,7 @@ import Foundation
 @testable import WooCommerce
 import struct Yosemite.Order
 import struct Yosemite.OrderItem
+import struct Yosemite.OrderCouponLine
 import enum Yosemite.OrderAction
 import class WooFoundation.CurrencySettings
 import protocol WooFoundation.Analytics
@@ -362,6 +363,72 @@ struct PointOfSaleOrderControllerTests {
         } else {
             #expect(Bool(false), "Expected sync failure but got \(result)")
         }
+    }
+
+    @available(iOS 17.0, *)
+    @Test func syncOrder_with_cart_matching_order_and_coupons_doesnt_call_orderService() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
+        let orderItem = OrderItem.fake().copy(quantity: 1)
+        let couponCode = "SAVE10"
+        let coupon = OrderCouponLine.fake().copy(code: couponCode)
+        let fakeOrder = Order.fake().copy(items: [orderItem], coupons: [coupon])
+        let cartItem = makeItem(orderItemsToMatch: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
+
+        // Initial sync to set up the order
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
+
+        // When - sync with same items and coupons
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
+
+        // Then
+        #expect(mockOrderService.syncOrderWasCalled == false)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func syncOrder_with_matching_items_but_different_coupons_calls_orderService() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
+        let orderItem = OrderItem.fake().copy(quantity: 1)
+        let initialCouponCode = "SAVE10"
+        let initialCoupon = OrderCouponLine.fake().copy(code: initialCouponCode)
+        let fakeOrder = Order.fake().copy(items: [orderItem], coupons: [initialCoupon])
+        let cartItem = makeItem(orderItemsToMatch: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
+
+        // Initial sync
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: initialCouponCode)]), retryHandler: {})
+
+        // When - sync with same items but different coupon
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: "DIFFERENT20")]), retryHandler: {})
+
+        // Then
+        #expect(mockOrderService.syncOrderWasCalled == true)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func syncOrder_with_matching_items_but_removed_coupon_calls_orderService() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptService: mockReceiptService)
+        let orderItem = OrderItem.fake().copy(quantity: 1)
+        let couponCode = "SAVE10"
+        let coupon = OrderCouponLine.fake().copy(code: couponCode)
+        let fakeOrder = Order.fake().copy(items: [orderItem], coupons: [coupon])
+        let cartItem = makeItem(orderItemsToMatch: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
+
+        // Initial sync with coupon
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
+
+        // When - sync with same items but no coupons
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: []), retryHandler: {})
+
+        // Then
+        #expect(mockOrderService.syncOrderWasCalled == true)
     }
 
     struct AnalyticsTests {

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
@@ -10,7 +10,7 @@ class MockPOSOrderService: POSOrderServiceProtocol {
     var updateOrderWasCalled = false
     var spySyncOrderCurrency: CurrencyCode?
 
-    func syncOrder(cart: [Yosemite.POSCartItem],
+    func syncOrder(cart: Yosemite.POSCart,
                    order: Yosemite.Order?,
                    currency: CurrencyCode) async throws -> Yosemite.Order {
         syncOrderWasCalled = true

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0139C2B02D91D1C600C78FDE /* POSCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0139C2AF2D91D1C400C78FDE /* POSCart.swift */; };
 		016EFCAE2C4155650016BDAA /* OrderItem+BasePrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EFCAD2C4155650016BDAA /* OrderItem+BasePrice.swift */; };
 		016EFCB02C41559D0016BDAA /* OrderItem+BasePriceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EFCAF2C41559D0016BDAA /* OrderItem+BasePriceTests.swift */; };
 		0202B690238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B68F238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift */; };
@@ -551,6 +552,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0139C2AF2D91D1C400C78FDE /* POSCart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCart.swift; sourceTree = "<group>"; };
 		016EFCAD2C4155650016BDAA /* OrderItem+BasePrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItem+BasePrice.swift"; sourceTree = "<group>"; };
 		016EFCAF2C41559D0016BDAA /* OrderItem+BasePriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItem+BasePriceTests.swift"; sourceTree = "<group>"; };
 		0202B68F238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFeatureSwitchPListWrapper.swift; sourceTree = "<group>"; };
@@ -2119,6 +2121,7 @@
 		DA3F0E1A2C218EE200B8C2F8 /* POS */ = {
 			isa = PBXGroup;
 			children = (
+				0139C2AF2D91D1C400C78FDE /* POSCart.swift */,
 				DA3F0E1B2C218EF100B8C2F8 /* POSOrderService.swift */,
 				68A70DD12D0BF6F30013B807 /* POSReceiptService.swift */,
 			);
@@ -2653,6 +2656,7 @@
 				E109876C284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift in Sources */,
 				03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */,
 				7499936420EFBC1B00CF01CD /* OrderNoteAction.swift in Sources */,
+				0139C2B02D91D1C600C78FDE /* POSCart.swift in Sources */,
 				7455D4692141B59E00FA8C1F /* TopEarnerStatsItem+ReadOnlyConvertible.swift in Sources */,
 				D8C11A5222DF2DA200D4A88D /* StatsActionV4.swift in Sources */,
 				6889089F28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite/Tools/POS/POSCart.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSCart.swift
@@ -31,8 +31,14 @@ public struct POSCartCouponItem {
     }
 }
 
+public extension POSCart {
+    func matches(order: Order?) -> Bool {
+        return items.matches(order: order) && coupons.matches(order: order)
+    }
+}
+
 extension [POSCartItem] {
-    public func matches(order: Order?) -> Bool {
+    func matches(order: Order?) -> Bool {
         guard let order else {
             return self.isEmpty
         }
@@ -92,5 +98,17 @@ extension [POSCartItem] {
         }
 
         return output
+    }
+}
+
+extension [POSCartCouponItem] {
+    func matches(order: Order?) -> Bool {
+        guard let order else {
+            return self.isEmpty
+        }
+
+        let orderCoupons = Set(order.coupons.map(\.code))
+        let cartCoupons = Set(self.map(\.code))
+        return orderCoupons == cartCoupons
     }
 }

--- a/Yosemite/Yosemite/Tools/POS/POSCart.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSCart.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// POSCart is different from the Cart in the POS app layer.
+/// - The POS cart UI might show the cart items differently from how they appear in an order in wp-admin.
+
+public struct POSCart {
+    public let items: [POSCartItem]
+    public let coupons: [POSCartCouponItem]
+
+    public init(items: [POSCartItem] = [], coupons: [POSCartCouponItem] = []) {
+        self.items = items
+        self.coupons = coupons
+    }
+}
+
+public struct POSCartItem {
+    public let item: POSOrderableItem
+    public let quantity: Decimal
+
+    public init(item: POSOrderableItem, quantity: Decimal) {
+        self.item = item
+        self.quantity = quantity
+    }
+}
+
+public struct POSCartCouponItem {
+    public let code: String
+
+    public init(code: String) {
+        self.code = code
+    }
+}
+
+extension [POSCartItem] {
+    public func matches(order: Order?) -> Bool {
+        guard let order else {
+            return self.isEmpty
+        }
+
+        let consolidatedCartItems = self.reduce(into: [POSCartItem]()) { partialResult, nextItem in
+            if let matchingIndex = partialResult.firstIndex(where: { $0.item.isEqual(to: nextItem.item) }) {
+                let itemToUpdate = partialResult[matchingIndex]
+                partialResult[matchingIndex] = POSCartItem(item: itemToUpdate.item, quantity: itemToUpdate.quantity + nextItem.quantity)
+            } else {
+                partialResult.append(nextItem)
+            }
+        }
+
+        let consolidatedOrderItems = order.items.reduce(into: [OrderItem]()) { partialResult, nextItem in
+            if let matchingIndex = partialResult.firstIndex(where: { $0.productID == nextItem.productID && $0.variationID == nextItem.variationID }) {
+                let itemToUpdate = partialResult[matchingIndex]
+                partialResult[matchingIndex] = itemToUpdate.copy(quantity: itemToUpdate.quantity + nextItem.quantity)
+            } else {
+                partialResult.append(nextItem)
+            }
+        }
+
+        guard consolidatedCartItems.count == consolidatedOrderItems.count else {
+            return false
+        }
+
+        for cartItem in consolidatedCartItems {
+            guard consolidatedOrderItems.contains(where: { orderItem in
+                cartItem.item.matches(orderItem: orderItem) && cartItem.quantity == orderItem.quantity
+            }) else {
+                return false
+            }
+        }
+        return true
+    }
+
+    func createGroupedOrderSyncProductInputs() -> [OrderSyncProductInput.ProductType: OrderSyncProductInput] {
+        let orderSyncProductInputs = self.map { $0.item.toOrderSyncProductInput(quantity: $0.quantity) }
+
+        // Group items by their `product`, which is actually a `ProductType` enum, representing a product or variation,
+        // with an associated value for the underlying item.
+        let groupedItems = Dictionary(grouping: orderSyncProductInputs, by: { $0.product })
+
+        // Convert each group into a single `OrderSyncProductInput`
+        let output = groupedItems.compactMapValues { items -> OrderSyncProductInput? in
+            guard let firstItem = items.first else { return nil }
+
+            // Aggregate the quantity for this item
+            let totalQuantity = items.reduce(Decimal(0)) { $0 + $1.quantity }
+
+            // Return a copy of the first item, with the aggregate quantity
+            return OrderSyncProductInput(product: firstItem.product,
+                                         quantity: totalQuantity,
+                                         discount: firstItem.discount,
+                                         baseSubtotal: firstItem.baseSubtotal,
+                                         bundleConfiguration: firstItem.bundleConfiguration)
+        }
+
+        return output
+    }
+}

--- a/Yosemite/Yosemite/Tools/POS/POSCart.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSCart.swift
@@ -5,9 +5,9 @@ import Foundation
 
 public struct POSCart {
     public let items: [POSCartItem]
-    public let coupons: [POSCartCouponItem]
+    public let coupons: [POSCoupon]
 
-    public init(items: [POSCartItem] = [], coupons: [POSCartCouponItem] = []) {
+    public init(items: [POSCartItem] = [], coupons: [POSCoupon] = []) {
         self.items = items
         self.coupons = coupons
     }
@@ -20,14 +20,6 @@ public struct POSCartItem {
     public init(item: POSOrderableItem, quantity: Decimal) {
         self.item = item
         self.quantity = quantity
-    }
-}
-
-public struct POSCartCouponItem {
-    public let code: String
-
-    public init(code: String) {
-        self.code = code
     }
 }
 
@@ -101,7 +93,7 @@ extension [POSCartItem] {
     }
 }
 
-extension [POSCartCouponItem] {
+extension [POSCoupon] {
     func matches(order: Order?) -> Bool {
         guard let order else {
             return self.isEmpty

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -98,7 +98,7 @@ private extension POSOrderService {
         return order
     }
 
-    func updateCoupons(_ coupons: [POSCartCouponItem], on order: Order) -> Order {
+    func updateCoupons(_ coupons: [POSCoupon], on order: Order) -> Order {
         // Get coupon codes from cart
         let cartCouponCodes = Set(coupons.map { $0.code })
 

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -3,89 +3,13 @@ import Networking
 import class WooFoundation.CurrencyFormatter
 import enum WooFoundation.CurrencyCode
 
-/// POSCartItem is different from the CartItem in the POS app layer.
-/// - The POS cart UI might show the cart items differently from how they appear in an order in wp-admin.
-public struct POSCartItem {
-    let item: POSOrderableItem
-    let quantity: Decimal
-
-    public init(item: POSOrderableItem, quantity: Decimal) {
-        self.item = item
-        self.quantity = quantity
-    }
-}
-
-extension [POSCartItem] {
-    public func matches(order: Order?) -> Bool {
-        guard let order else {
-            return self.isEmpty
-        }
-
-        let consolidatedCartItems = self.reduce(into: [POSCartItem]()) { partialResult, nextItem in
-            if let matchingIndex = partialResult.firstIndex(where: { $0.item.isEqual(to: nextItem.item) }) {
-                let itemToUpdate = partialResult[matchingIndex]
-                partialResult[matchingIndex] = POSCartItem(item: itemToUpdate.item, quantity: itemToUpdate.quantity + nextItem.quantity)
-            } else {
-                partialResult.append(nextItem)
-            }
-        }
-
-        let consolidatedOrderItems = order.items.reduce(into: [OrderItem]()) { partialResult, nextItem in
-            if let matchingIndex = partialResult.firstIndex(where: { $0.productID == nextItem.productID && $0.variationID == nextItem.variationID }) {
-                let itemToUpdate = partialResult[matchingIndex]
-                partialResult[matchingIndex] = itemToUpdate.copy(quantity: itemToUpdate.quantity + nextItem.quantity)
-            } else {
-                partialResult.append(nextItem)
-            }
-        }
-
-        guard consolidatedCartItems.count == consolidatedOrderItems.count else {
-            return false
-        }
-
-        for cartItem in consolidatedCartItems {
-            guard consolidatedOrderItems.contains(where: { orderItem in
-                cartItem.item.matches(orderItem: orderItem) && cartItem.quantity == orderItem.quantity
-            }) else {
-                return false
-            }
-        }
-        return true
-    }
-
-    func createGroupedOrderSyncProductInputs() -> [OrderSyncProductInput.ProductType: OrderSyncProductInput] {
-        let orderSyncProductInputs = self.map { $0.item.toOrderSyncProductInput(quantity: $0.quantity) }
-
-        // Group items by their `product`, which is actually a `ProductType` enum, representing a product or variation,
-        // with an associated value for the underlying item.
-        let groupedItems = Dictionary(grouping: orderSyncProductInputs, by: { $0.product })
-
-        // Convert each group into a single `OrderSyncProductInput`
-        let output = groupedItems.compactMapValues { items -> OrderSyncProductInput? in
-            guard let firstItem = items.first else { return nil }
-
-            // Aggregate the quantity for this item
-            let totalQuantity = items.reduce(Decimal(0)) { $0 + $1.quantity }
-
-            // Return a copy of the first item, with the aggregate quantity
-            return OrderSyncProductInput(product: firstItem.product,
-                                         quantity: totalQuantity,
-                                         discount: firstItem.discount,
-                                         baseSubtotal: firstItem.baseSubtotal,
-                                         bundleConfiguration: firstItem.bundleConfiguration)
-        }
-
-        return output
-    }
-}
-
 public protocol POSOrderServiceProtocol {
     /// Syncs order based on the cart.
     /// - Parameters:
-    ///   - cart: Cart with optional items (product & quantity).
+    ///   - cart: Cart with different types of items and quantities.
     ///   - order: Optional latest remotely synced order. Nil when syncing order for the first time.
     /// - Returns: Order from the remote sync.
-    func syncOrder(cart: [POSCartItem], order: Order?, currency: CurrencyCode) async throws -> Order
+    func syncOrder(cart: POSCart, order: Order?, currency: CurrencyCode) async throws -> Order
     func updatePOSOrder(order: Order, recipientEmail: String) async throws
 }
 
@@ -111,13 +35,13 @@ public final class POSOrderService: POSOrderServiceProtocol {
 
     // MARK: - Protocol conformance
 
-    public func syncOrder(cart: [POSCartItem],
+    public func syncOrder(cart: POSCart,
                           order posOrder: Order?,
                           currency: CurrencyCode) async throws -> Order {
         let initialOrder: Order = posOrder ?? OrderFactory.newOrder(currency: currency)
             .copy(siteID: siteID,
                   status: .autoDraft)
-        let order = updateOrder(initialOrder, cart: cart).sanitizingLocalItems()
+        let order = updateOrder(initialOrder, cartItems: cart.items).sanitizingLocalItems()
         let syncedOrder: Order
         if posOrder != nil {
             syncedOrder = try await ordersRemote.updatePOSOrder(siteID: siteID, order: order, fields: [.items])
@@ -158,20 +82,18 @@ private struct POSOrderSyncProductType: OrderSyncProductTypeProtocol, Hashable {
 }
 
 private extension POSOrderService {
-    func updateOrder(_ order: Order, cart: [POSCartItem]) -> Order {
+    func updateOrder(_ order: Order, cartItems: [POSCartItem]) -> Order {
         // Removes all existing items by setting quantity to 0.
         let itemsToRemove = order.items.compactMap {
             Self.removalProductInput(item: $0)
         }
 
         // Adds items from the latest cart grouping by item.
-        let itemsToAdd = cart.createGroupedOrderSyncProductInputs().values
+        let itemsToAdd = cartItems.createGroupedOrderSyncProductInputs().values
         let itemsToSync = itemsToRemove + itemsToAdd
 
         return ProductInputTransformer.updateMultipleItems(with: itemsToSync, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
     }
-
-
 
     /// Creates a new `OrderSyncProductInput` type meant to remove an existing item from `OrderSynchronizer`
     ///

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -41,12 +41,12 @@ public final class POSOrderService: POSOrderServiceProtocol {
         let initialOrder: Order = posOrder ?? OrderFactory.newOrder(currency: currency)
             .copy(siteID: siteID,
                   status: .autoDraft)
-        let order = updateOrder(initialOrder, cartItems: cart.items).sanitizingLocalItems()
+        let order = updateOrder(initialOrder, cart: cart).sanitizingLocalItems()
         let syncedOrder: Order
         if posOrder != nil {
-            syncedOrder = try await ordersRemote.updatePOSOrder(siteID: siteID, order: order, fields: [.items])
+            syncedOrder = try await ordersRemote.updatePOSOrder(siteID: siteID, order: order, fields: [.items, .couponLines])
         } else {
-            syncedOrder = try await ordersRemote.createPOSOrder(siteID: siteID, order: order, fields: [.items, .status, .currency])
+            syncedOrder = try await ordersRemote.createPOSOrder(siteID: siteID, order: order, fields: [.items, .status, .currency, .couponLines])
         }
         return syncedOrder
     }
@@ -82,17 +82,39 @@ private struct POSOrderSyncProductType: OrderSyncProductTypeProtocol, Hashable {
 }
 
 private extension POSOrderService {
-    func updateOrder(_ order: Order, cartItems: [POSCartItem]) -> Order {
+    func updateOrder(_ order: Order, cart: POSCart) -> Order {
         // Removes all existing items by setting quantity to 0.
         let itemsToRemove = order.items.compactMap {
             Self.removalProductInput(item: $0)
         }
 
         // Adds items from the latest cart grouping by item.
-        let itemsToAdd = cartItems.createGroupedOrderSyncProductInputs().values
+        let itemsToAdd = cart.items.createGroupedOrderSyncProductInputs().values
         let itemsToSync = itemsToRemove + itemsToAdd
 
-        return ProductInputTransformer.updateMultipleItems(with: itemsToSync, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
+        var order = ProductInputTransformer.updateMultipleItems(with: itemsToSync, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
+        order = updateCoupons(cart.coupons, on: order)
+
+        return order
+    }
+
+    func updateCoupons(_ coupons: [POSCartCouponItem], on order: Order) -> Order {
+        // Get coupon codes from cart
+        let cartCouponCodes = Set(coupons.map { $0.code })
+
+        // Keep existing coupons that are still in the cart
+        let remainingCoupons = order.coupons.filter { orderCoupon in
+            cartCouponCodes.contains(orderCoupon.code)
+        }
+
+        // Find new coupons that need to be added (in cart but not in order)
+        let existingCouponCodes = Set(order.coupons.map { $0.code })
+        let newCoupons = coupons
+            .filter { !existingCouponCodes.contains($0.code) }
+            .map { OrderFactory.newOrderCouponLine(code: $0.code) }
+
+        // Update order with remaining + new coupons
+        return order.copy(coupons: remainingCoupons + newCoupons)
     }
 
     /// Creates a new `OrderSyncProductInput` type meant to remove an existing item from `OrderSynchronizer`

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -18,7 +18,7 @@ struct POSOrderServiceTests {
         // Given
 
         // When
-        _ = try await sut.syncOrder(cart: [], order: nil, currency: .USD)
+        _ = try await sut.syncOrder(cart: .init(), order: nil, currency: .USD)
 
         // Then
         #expect(mockOrdersRemote.createPOSOrderCalled == true)
@@ -29,7 +29,7 @@ struct POSOrderServiceTests {
         // Given
 
         // When
-        _ = try await sut.syncOrder(cart: [], order: nil, currency: .EUR)
+        _ = try await sut.syncOrder(cart: .init(), order: nil, currency: .EUR)
 
         // Then
         #expect(mockOrdersRemote.spyCreatePOSOrder?.currency.uppercased() == "EUR")
@@ -43,7 +43,7 @@ struct POSOrderServiceTests {
         let order = Order.fake().copy(siteID: 123, orderID: 456, currency: "JPY")
 
         // When
-        _ = try await sut.syncOrder(cart: [], order: order, currency: .JPY)
+        _ = try await sut.syncOrder(cart: .init(), order: order, currency: .JPY)
 
         // Then
         #expect(mockOrdersRemote.updatePOSOrderCalled == true)
@@ -56,7 +56,7 @@ struct POSOrderServiceTests {
         let order = Order.fake().copy(siteID: 123, orderID: 456, currency: "USD")
 
         // When
-        _ = try await sut.syncOrder(cart: [], order: order, currency: .JPY)
+        _ = try await sut.syncOrder(cart: .init(), order: order, currency: .JPY)
 
         // Then
         #expect(mockOrdersRemote.updatePOSOrderCalled == true)
@@ -71,10 +71,10 @@ struct POSOrderServiceTests {
         let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems)
 
         // When
-        let cart: [POSCartItem] = [
+        let cart = POSCart(items: [
             makePOSCartItem(productID: 100, quantity: 2),
             makePOSCartItem(productID: 102, quantity: 1)
-        ]
+        ])
         _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
 
         // Then
@@ -93,9 +93,9 @@ struct POSOrderServiceTests {
         let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems)
 
         // When
-        let cart: [POSCartItem] = [
+        let cart = POSCart(items: [
             makePOSCartItem(productID: 102, quantity: 1)
-        ]
+        ])
         _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
 
         // Then
@@ -122,10 +122,10 @@ struct POSOrderServiceTests {
         let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems)
 
         // When
-        let cart: [POSCartItem] = [
+        let cart = POSCart(items: [
             makePOSCartItem(productID: 100, quantity: 1),
             makePOSCartItem(productID: 102, quantity: 5)
-        ]
+        ])
         _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
 
         // Then
@@ -142,10 +142,10 @@ private func makePOSCartItem(
     quantity: Decimal) -> POSCartItem {
         return POSCartItem(
             item: POSSimpleProduct(id: UUID(),
-                             name: "",
-                             formattedPrice: "",
-                             productID: productID,
-                             price: ""),
+                                   name: "",
+                                   formattedPrice: "",
+                                   productID: productID,
+                                   price: ""),
             quantity: quantity
         )
     }

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -144,7 +144,7 @@ struct POSOrderServiceTests {
         // When
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
-            coupons: [.init(code: "SAVE10")]
+            coupons: [.init(id: UUID(), code: "SAVE10")]
         )
         _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
 
@@ -186,9 +186,9 @@ struct POSOrderServiceTests {
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
             coupons: [
-                .init(code: "KEEP1"),
-                .init(code: "NEW1"),
-                .init(code: "NEW2")
+                .init(id: UUID(), code: "KEEP1"),
+                .init(id: UUID(), code: "NEW1"),
+                .init(id: UUID(), code: "NEW2")
             ]
         )
         _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
@@ -220,7 +220,7 @@ struct POSOrderServiceTests {
         // When
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
-            coupons: [.init(code: "KEEP1")] // Same coupon in cart
+            coupons: [.init(id: UUID(), code: "KEEP1")] // Same coupon in cart
         )
         _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
 

--- a/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -135,6 +135,101 @@ struct POSOrderServiceTests {
             item.productID == 102 && item.quantity == 5
         }), "Item for product 102 should be added")
     }
+
+    @Test func syncOrder_after_adding_coupon_to_cart_adds_it_to_the_order() async throws {
+        // Given
+        let orderItems = [OrderItem.fake().copy(itemID: 1, name: "Item 1", productID: 100, quantity: 1)]
+        let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems, coupons: [])
+
+        // When
+        let cart = POSCart(
+            items: [makePOSCartItem(productID: 100, quantity: 1)],
+            coupons: [.init(code: "SAVE10")]
+        )
+        _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
+
+        // Then
+        let updatedOrderCoupons = try #require(mockOrdersRemote.spyUpdatePOSOrder?.coupons)
+        #expect(updatedOrderCoupons.count == 1)
+        #expect(updatedOrderCoupons.first?.code == "SAVE10")
+    }
+
+    @Test func syncOrder_after_removing_coupon_from_cart_removes_it_from_the_order() async throws {
+        // Given
+        let orderItems = [OrderItem.fake().copy(itemID: 1, name: "Item 1", productID: 100, quantity: 1)]
+        let existingCoupons = [OrderCouponLine.fake().copy(code: "SAVE10")]
+        let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems, coupons: existingCoupons)
+
+        // When
+        let cart = POSCart(
+            items: [makePOSCartItem(productID: 100, quantity: 1)],
+            coupons: [] // Empty coupons in cart
+        )
+        _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
+
+        // Then
+        let updatedOrderCoupons = try #require(mockOrdersRemote.spyUpdatePOSOrder?.coupons)
+        #expect(updatedOrderCoupons.isEmpty)
+    }
+
+    @Test func syncOrder_with_multiple_coupons_handles_mixed_changes() async throws {
+        // Given
+        let orderItems = [OrderItem.fake().copy(itemID: 1, name: "Item 1", productID: 100, quantity: 1)]
+        let existingCoupons = [
+            OrderCouponLine.fake().copy(code: "REMOVE1"),
+            OrderCouponLine.fake().copy(code: "KEEP1"),
+            OrderCouponLine.fake().copy(code: "REMOVE2")
+        ]
+        let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems, coupons: existingCoupons)
+
+        // When
+        let cart = POSCart(
+            items: [makePOSCartItem(productID: 100, quantity: 1)],
+            coupons: [
+                .init(code: "KEEP1"),
+                .init(code: "NEW1"),
+                .init(code: "NEW2")
+            ]
+        )
+        _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
+
+        // Then
+        let updatedOrderCoupons = try #require(mockOrdersRemote.spyUpdatePOSOrder?.coupons)
+
+        // Verify kept coupon
+        #expect(updatedOrderCoupons.contains(where: { $0.code == "KEEP1" }))
+
+        // Verify removed coupons
+        #expect(!updatedOrderCoupons.contains(where: { $0.code == "REMOVE1" }))
+        #expect(!updatedOrderCoupons.contains(where: { $0.code == "REMOVE2" }))
+
+        // Verify new coupons
+        #expect(updatedOrderCoupons.contains(where: { $0.code == "NEW1" }))
+        #expect(updatedOrderCoupons.contains(where: { $0.code == "NEW2" }))
+
+        // Verify total count
+        #expect(updatedOrderCoupons.count == 3)
+    }
+
+    @Test func syncOrder_with_unchanged_coupons_preserves_existing_coupon_data() async throws {
+        // Given
+        let orderItems = [OrderItem.fake().copy(itemID: 1, name: "Item 1", productID: 100, quantity: 1)]
+        let existingCoupon = OrderCouponLine.fake().copy(code: "KEEP1", discount: "10.00")
+        let order = Order.fake().copy(siteID: 123, orderID: 456, items: orderItems, coupons: [existingCoupon])
+
+        // When
+        let cart = POSCart(
+            items: [makePOSCartItem(productID: 100, quantity: 1)],
+            coupons: [.init(code: "KEEP1")] // Same coupon in cart
+        )
+        _ = try await sut.syncOrder(cart: cart, order: order, currency: .USD)
+
+        // Then
+        let updatedOrderCoupons = try #require(mockOrdersRemote.spyUpdatePOSOrder?.coupons)
+        #expect(updatedOrderCoupons.count == 1)
+        #expect(updatedOrderCoupons.first?.code == "KEEP1")
+        #expect(updatedOrderCoupons.first?.discount == "10.00", "Existing coupon data should be preserved")
+    }
 }
 
 private func makePOSCartItem(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15331
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Send coupons in the order creation request.

I decided not to change anything in how we do things and just follow the patterns.

1. Expanded `POSCartItem` with `POSCart` (Similar to what I did with `CartItem` and `Cart`)
2. Added a simple matcher for coupons to check if the same coupons already exist on order and used in `PointOfSaleOrderController`
3. Updated `POSOrderService` to send `.couponLines` together with an order


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### New functionality

Before testing, update  addToCart` method in `PointOfSaleAggregateModel` to add a valid coupon with an item, for example:

```
    func addToCart(_ item: POSItem) {
        trackCustomerInteractionStarted()
        cart.add(POSItem.coupon(.init(id: UUID(), code: "10_valid")))
        cart.add(item)
    }
```

Confirm that order loads and coupon is applied. Proper error handling is out of scope.

### Regression

- Check that making order without coupons continues to work
- Check that coming back from checkout and returning continues to use cached order state

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 11 M2 Simulator, both new functionality and regression.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Applying Coupons

https://github.com/user-attachments/assets/0e2828f6-958f-4adc-aaf6-07ee53dd83d1

### Errors

For now any coupon validation error appears like this - it will be improved in other PRs

![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-03-25 at 12 07 27](https://github.com/user-attachments/assets/a2b7d1b6-69b9-435e-997e-90a3e16eb3c2)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.