### PR TITLE
[Woo POS] Coupons: Sync from remote

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -372,6 +372,23 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     }
 }
 
+extension CouponsRemote {
+    public func loadAllCoupons(for siteID: Int64,
+                               pageNumber: Int = CouponsRemote.Default.pageNumber,
+                               pageSize: Int = CouponsRemote.Default.pageSize) async throws -> [Coupon] {
+        try await withCheckedThrowingContinuation { continuation in
+            loadAllCoupons(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { result in
+                switch result {
+                case .success(let coupons):
+                    continuation.resume(returning: coupons)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Constants
 //
 public extension CouponsRemote {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -48,22 +48,8 @@ private extension PointOfSaleCouponsController {
             itemsViewState = ItemsViewState(containerState: .content,
                                             itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
                                                               itemStates: [:]))
-
-            await syncCoupons()
         } catch {
             debugPrint(error)
         }
-    }
-
-    @MainActor
-    func syncCoupons() async {
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            return
-        }
-        let action = CouponAction.synchronizeCoupons(siteID: siteID,
-                                                     pageNumber: 1,
-                                                     pageSize: 25,
-                                                     onCompletion: { _ in })
-        ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -1,5 +1,6 @@
 import Observation
 import enum Yosemite.POSItem
+import enum Yosemite.CouponAction
 import protocol Yosemite.PointOfSaleItemServiceProtocol
 
 @available(iOS 17.0, *)
@@ -47,8 +48,22 @@ private extension PointOfSaleCouponsController {
             itemsViewState = ItemsViewState(containerState: .content,
                                             itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
                                                               itemStates: [:]))
+
+            await syncCoupons()
         } catch {
             debugPrint(error)
         }
+    }
+
+    @MainActor
+    func syncCoupons() async {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            return
+        }
+        let action = CouponAction.synchronizeCoupons(siteID: siteID,
+                                                     pageNumber: 1,
+                                                     pageSize: 25,
+                                                     onCompletion: { _ in })
+        ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -108,10 +108,12 @@ final class HubMenuViewModel: ObservableObject {
     private(set) lazy var posCouponProvider: PointOfSaleItemServiceProtocol = {
         let storage = ServiceLocator.storageManager
         let currencySettings = ServiceLocator.currencySettings
+        let stores = ServiceLocator.stores
 
         return PointOfSaleCouponService(siteID: siteID,
                                         currencySettings: currencySettings,
                                         credentials: credentials,
+                                        stores: stores,
                                         storage: storage)
     }()
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -1,7 +1,6 @@
 import protocol Networking.Network
 import protocol Networking.ProductVariationsRemoteProtocol
-import class Networking.ProductsRemote
-import class Networking.ProductVariationsRemote
+import class Networking.CouponsRemote
 import class Networking.AlamofireNetwork
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
@@ -10,8 +9,7 @@ import Storage
 public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
     private var siteID: Int64
     private let currencyFormatter: CurrencyFormatter
-    private let productsRemote: ProductsRemote
-    private let variationRemote: ProductVariationsRemoteProtocol
+    private let couponsRemote: CouponsRemote
     private let storage: StorageManagerType?
 
     public init(siteID: Int64,
@@ -20,8 +18,7 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
                 storage: StorageManagerType? = nil) {
         self.siteID = siteID
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        self.productsRemote = ProductsRemote(network: network)
-        self.variationRemote = ProductVariationsRemote(network: network)
+        self.couponsRemote = CouponsRemote(network: network)
         self.storage = storage
     }
 
@@ -38,26 +35,36 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
     // TODO:
     // gh-15326 - Return PagedItems<POSItem> instead.
     @MainActor
-    public func providePointOfSaleCoupons() -> [POSItem] {
+    public func providePointOfSaleCoupons() async -> [POSItem] {
         guard let storage = storage else {
             return []
         }
-        let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
-                                          ascending: false)
-
-        let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
-                                                                matching: predicate,
-                                                                sortedBy: [descriptor])
-
+// #2 Remote
         do {
-            try resultsController.performFetch()
-            let storeCoupons = resultsController.fetchedObjects
-            return mapCouponsToPOSItems(coupons: storeCoupons)
+            let remoteCoupons = try await couponsRemote.loadAllCoupons(for: siteID)
+            return mapCouponsToPOSItems(coupons: remoteCoupons)
         } catch {
             debugPrint(error)
             return []
         }
+
+// #1 Storage
+//        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+//        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
+//                                          ascending: false)
+//
+//        let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
+//                                                                matching: predicate,
+//                                                                sortedBy: [descriptor])
+//
+//        do {
+//            try resultsController.performFetch()
+//            let storeCoupons = resultsController.fetchedObjects
+//            return mapCouponsToPOSItems(coupons: storeCoupons)
+//        } catch {
+//            debugPrint(error)
+//            return []
+//        }
     }
 
     private func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
@@ -73,7 +80,7 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
 
     @MainActor
     public func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
-        let coupons = providePointOfSaleCoupons()
+        let coupons = await providePointOfSaleCoupons()
         return .init(items: coupons, hasMorePages: false)
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -78,19 +78,37 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
     public func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
         let coupons = await providePointOfSaleCoupons()
 
-        syncCouponsFromRemote(pageNumber: pageNumber)
-
-        return .init(items: coupons, hasMorePages: false)
+        if !coupons.isEmpty {
+            // Fire-and-forget sync
+            Task.detached {
+                await self.syncCouponsFromRemote(pageNumber: pageNumber)
+            }
+            return .init(items: coupons, hasMorePages: false)
+        } else {
+            // Wait for the sync to complete
+            await syncCouponsFromRemote(pageNumber: pageNumber)
+            let refreshedCoupons = await providePointOfSaleCoupons()
+            return .init(items: refreshedCoupons, hasMorePages: false)
+        }
     }
 
-    private func syncCouponsFromRemote(pageNumber: Int) {
+    private func syncCouponsFromRemote(pageNumber: Int) async {
         guard let stores = stores else {
             return
         }
-        let action = CouponAction.synchronizeCoupons(siteID: siteID,
-                                                             pageNumber: pageNumber,
-                                                             pageSize: 25,
-                                                             onCompletion: { _ in })
-        stores.dispatch(action)
+
+        await withCheckedContinuation { continuation in
+            let action = CouponAction.synchronizeCoupons(
+                siteID: siteID,
+                pageNumber: pageNumber,
+                pageSize: 25,
+                onCompletion: { _ in
+                    continuation.resume()
+                }
+            )
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
+        }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -10,25 +10,30 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
     private var siteID: Int64
     private let currencyFormatter: CurrencyFormatter
     private let couponsRemote: CouponsRemote
+    private let stores: StoresManager?
     private let storage: StorageManagerType?
 
     public init(siteID: Int64,
                 currencySettings: CurrencySettings,
                 network: Network,
+                stores: StoresManager? = nil,
                 storage: StorageManagerType? = nil) {
         self.siteID = siteID
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.couponsRemote = CouponsRemote(network: network)
+        self.stores = stores
         self.storage = storage
     }
 
     public convenience init(siteID: Int64,
                             currencySettings: CurrencySettings,
                             credentials: Credentials?,
+                            stores: StoresManager,
                             storage: StorageManagerType) {
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
                   network: AlamofireNetwork(credentials: credentials),
+                  stores: stores,
                   storage: storage)
     }
 
@@ -72,6 +77,20 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
     @MainActor
     public func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
         let coupons = await providePointOfSaleCoupons()
+
+        syncCouponsFromRemote(pageNumber: pageNumber)
+
         return .init(items: coupons, hasMorePages: false)
+    }
+
+    private func syncCouponsFromRemote(pageNumber: Int) {
+        guard let stores = stores else {
+            return
+        }
+        let action = CouponAction.synchronizeCoupons(siteID: siteID,
+                                                             pageNumber: pageNumber,
+                                                             pageSize: 25,
+                                                             onCompletion: { _ in })
+        stores.dispatch(action)
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -39,32 +39,30 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
         guard let storage = storage else {
             return []
         }
-// #2 Remote
+
         do {
             let remoteCoupons = try await couponsRemote.loadAllCoupons(for: siteID)
             return mapCouponsToPOSItems(coupons: remoteCoupons)
         } catch {
-            debugPrint(error)
-            return []
-        }
+            debugPrint("Failed to load coupons from remote:", error)
 
-// #1 Storage
-//        let predicate = NSPredicate(format: "siteID == %lld", siteID)
-//        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
-//                                          ascending: false)
-//
-//        let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
-//                                                                matching: predicate,
-//                                                                sortedBy: [descriptor])
-//
-//        do {
-//            try resultsController.performFetch()
-//            let storeCoupons = resultsController.fetchedObjects
-//            return mapCouponsToPOSItems(coupons: storeCoupons)
-//        } catch {
-//            debugPrint(error)
-//            return []
-//        }
+            // Fetch from storage as remote fallback
+            let predicate = NSPredicate(format: "siteID == %lld", siteID)
+            let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
+                                              ascending: false)
+
+            let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
+                                                                     matching: predicate,
+                                                                     sortedBy: [descriptor])
+            do {
+                try resultsController.performFetch()
+                let storeCoupons = resultsController.fetchedObjects
+                return mapCouponsToPOSItems(coupons: storeCoupons)
+            } catch {
+                debugPrint("Failed to load coupons from storage:", error)
+                return []
+            }
+        }
     }
 
     private func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -40,28 +40,21 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
             return []
         }
 
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
+                                          ascending: false)
+
+        let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
+                                                                 matching: predicate,
+                                                                 sortedBy: [descriptor])
+
         do {
-            let remoteCoupons = try await couponsRemote.loadAllCoupons(for: siteID)
-            return mapCouponsToPOSItems(coupons: remoteCoupons)
+            try resultsController.performFetch()
+            let storageCoupons = resultsController.fetchedObjects
+            return mapCouponsToPOSItems(coupons: storageCoupons)
         } catch {
-            debugPrint("Failed to load coupons from remote:", error)
-
-            // Fetch from storage as remote fallback
-            let predicate = NSPredicate(format: "siteID == %lld", siteID)
-            let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
-                                              ascending: false)
-
-            let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
-                                                                     matching: predicate,
-                                                                     sortedBy: [descriptor])
-            do {
-                try resultsController.performFetch()
-                let storeCoupons = resultsController.fetchedObjects
-                return mapCouponsToPOSItems(coupons: storeCoupons)
-            } catch {
-                debugPrint("Failed to load coupons from storage:", error)
-                return []
-            }
+            debugPrint("Failed to load coupons from storage:", error)
+            return []
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15324 

## Description
This PR adds the ability to fetch coupons from remote to the coupons service. First, we attempt to fetch from the remote. If this fails, we'll attempt to fetch from storage. If fails, we just return an empty list of coupons (for the moment)

We might change the fetching strategy, for now it seemed adequate to attempt remote first and local storage later.

https://github.com/user-attachments/assets/475d3894-4cfb-44e8-b32b-82f3d5d9ba4f

## Testing information
- On POS, tap the `coupons` button
- Observe the loading screen and coupons being loaded from remote
- Stop the app and throw an error from `CouponsRemote.loadAllCoupons()`:
```
    public func loadAllCoupons(for siteID: Int64,
                               pageNumber: Int = CouponsRemote.Default.pageNumber,
                               pageSize: Int = CouponsRemote.Default.pageSize) async throws -> [Coupon] {
        throw NSError(domain: "oops", code: -1)
        try await withCheckedThrowingContinuation { continuation in
   ...
    }
```
- Observe that we'll still load coupons, but this time they come from the storage fallback:
```
"Failed to load coupons from remote:" Error Domain=oops Code=-1 "(null)"
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
