### PR TITLE
Shipping Labels: Show notice after moving items between shipments 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
@@ -50,6 +50,7 @@ private extension MoveToShipmentNotice {
                 Text(Localization.moveToNewShipment)
                     .font(.subheadline)
                     .fontWeight(.semibold)
+                    .multilineTextAlignment(.trailing)
             }
             .foregroundColor(Color(.accent))
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
@@ -82,8 +82,8 @@ private extension MoveToShipmentNotice {
     }
 }
 
-private extension MoveToShipmentNotice {
-    enum Layout {
+extension MoveToShipmentNotice {
+    private enum Layout {
         static let horizontalPadding: CGFloat = 16
         static let verticalPadding: CGFloat = 22
         static let horizontalSpacing: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -73,9 +73,21 @@ private extension WooShippingSplitShipmentsDetailView {
     var noticeStack: some View {
         VStack(spacing: Layout.contentPadding) {
             if let message = viewModel.instructions {
-                InstructionsSnackbar(message: message) {
+                MessageSnackBar(message: message, verticalAlignment: .top, icon: {
+                    EmptyView()
+                }, actionHandler: {
                     viewModel.dismissInstructions()
-                }
+                })
+            }
+
+            if let completionMessage = viewModel.movingCompletionMessage {
+                MessageSnackBar(message: completionMessage, actionTitle: Localization.undo, icon: {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.headline)
+                        .foregroundStyle(Color(.withColorStudio(.green, shade: .shade20)))
+                }, actionHandler: {
+                    viewModel.undoMovingItems()
+                })
             }
 
             if let moveTo = viewModel.moveToNoticeViewModel {
@@ -87,12 +99,20 @@ private extension WooShippingSplitShipmentsDetailView {
     }
 }
 
-private struct InstructionsSnackbar: View {
+private struct MessageSnackBar<IconContent: View>: View {
     let message: String
+    var actionTitle: String?
+    var verticalAlignment: VerticalAlignment = .center
+    let icon: (() -> IconContent)
     let actionHandler: () -> Void
 
+    private let hSpacing: CGFloat = 8
+    private let shadowColorOpacity: CGFloat = 0.16
+
     var body: some View {
-        HStack(alignment: .top, spacing: Layout.hSpacing) {
+        HStack(alignment: verticalAlignment, spacing: hSpacing) {
+            icon()
+
             BoldableTextView(message)
                 .foregroundStyle(Color(.textInverted))
 
@@ -101,23 +121,23 @@ private struct InstructionsSnackbar: View {
             Button {
                 actionHandler()
             } label: {
-                Image(systemName: "xmark")
-                    .foregroundStyle(Color(.withColorStudio(.gray)))
+                if let actionTitle {
+                    Text(actionTitle)
+                        .font(.headline)
+                } else {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(Color(.withColorStudio(.gray)))
+                }
             }
         }
         .padding(WooShippingSplitShipmentsDetailView.Layout.contentPadding)
         .background {
             RoundedRectangle(cornerRadius: WooShippingSplitShipmentsDetailView.Layout.cornerRadius)
                 .fill(Color(.text))
-                .shadow(color: Color(.text).opacity(Layout.shadowColorOpacity),
+                .shadow(color: Color(.text).opacity(shadowColorOpacity),
                         radius: WooShippingSplitShipmentsDetailView.Layout.shadowRadius,
                         y: WooShippingSplitShipmentsDetailView.Layout.shadowYOffset)
         }
-    }
-
-    private enum Layout {
-        static let hSpacing: CGFloat = 8
-        static let shadowColorOpacity: CGFloat = 0.16
     }
 }
 
@@ -151,6 +171,11 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
             "wooShippingSplitShipmentsDetailView.done",
             value: "Done",
             comment: "Button to save split shipment configurations in the shipping label creation flow"
+        )
+        static let undo = NSLocalizedString(
+            "wooShippingSplitShipmentsDetailView.undo",
+            value: "Undo",
+            comment: "Button to revert moving items between shipments in the shipping label creation flow"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -100,7 +100,7 @@ private extension WooShippingSplitShipmentsDetailView {
 }
 
 private struct MessageSnackBar<IconContent: View>: View {
-    let message: String
+    let message: AttributedString
     var actionTitle: String?
     var verticalAlignment: VerticalAlignment = .center
     let icon: (() -> IconContent)
@@ -113,8 +113,7 @@ private struct MessageSnackBar<IconContent: View>: View {
         HStack(alignment: verticalAlignment, spacing: hSpacing) {
             icon()
 
-            BoldableTextView(message)
-                .foregroundStyle(Color(.textInverted))
+            Text(message)
 
             Spacer()
 
@@ -124,6 +123,8 @@ private struct MessageSnackBar<IconContent: View>: View {
                 if let actionTitle {
                     Text(actionTitle)
                         .font(.headline)
+                        .foregroundStyle(Color(UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade30),
+                                                       dark: .withColorStudio(.wooCommercePurple, shade: .shade40))))
                 } else {
                     Image(systemName: "xmark")
                         .foregroundStyle(Color(.withColorStudio(.gray)))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -51,10 +51,10 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
 
     @Published private(set) var moveToNoticeViewModel: MoveToShipmentNoticeViewModel?
 
-    @Published private(set) var instructions: String?
+    @Published private(set) var instructions: AttributedString?
     private var dismissedInstructions: Bool = false
 
-    @Published private(set) var movingCompletionMessage: String?
+    @Published private(set) var movingCompletionMessage: AttributedString?
     private var undoMovingItemsHandler: (() -> Void)?
 
     init(order: Order,
@@ -189,7 +189,16 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         let displayedShipmentIndex = (updatedShipmentIndex ?? 0) + 1
         let shipmentLabel = String.localizedStringWithFormat(Localization.shipmentFormat, displayedShipmentIndex)
         withAnimation {
-            movingCompletionMessage = String.localizedStringWithFormat(Localization.movingCompletionFormat, itemsCount, shipmentLabel)
+            movingCompletionMessage = {
+                let moveToNewShipmentTitle = MoveToShipmentNotice.Localization.moveToNewShipment.lowercased()
+                let content = String.localizedStringWithFormat(Localization.movingCompletionFormat, itemsCount, shipmentLabel)
+
+                var attributedText = AttributedString(content)
+                attributedText.font = .headline
+                attributedText.foregroundColor = Color(.textInverted)
+
+                return attributedText
+            }()
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + Constants.movingCompletionNoticeDuration) {
             withAnimation {
@@ -215,9 +224,26 @@ private extension WooShippingSplitShipmentsViewModel {
     }
 
     func showInstructionsNotice() {
-        if !dismissedInstructions {
-            instructions = Localization.SelectionInstructionsNotice.message
+        guard dismissedInstructions == false else {
+            return
         }
+        instructions = {
+            let moveToNewShipmentTitle = MoveToShipmentNotice.Localization.moveToNewShipment
+            let content = String.localizedStringWithFormat(Localization.SelectionInstructionsNotice.message, moveToNewShipmentTitle)
+
+            var attributedText = AttributedString(content)
+            attributedText.font = .body
+            attributedText.foregroundColor = Color(.textInverted)
+
+            if let range = attributedText.range(of: moveToNewShipmentTitle) {
+                let textStyleContainer = AttributeContainer()
+                    .font(.body.weight(.semibold))
+                    .foregroundColor(Color(.textInverted))
+                attributedText[range].setAttributes(textStyleContainer)
+            }
+
+            return attributedText
+        }()
     }
 
     func updateMoveToNotice() {
@@ -284,14 +310,13 @@ private extension WooShippingSplitShipmentsViewModel {
 
     enum Localization {
         enum SelectionInstructionsNotice {
-            static let message = NSLocalizedString("wooShipping.createLabels.splitShipment.SelectionInstructionsNotice.message",
-                                                   value: "To split, select the items, and tap **move to new shipment** when the toolbar appears.",
-                                                   comment: "Instructions to ask customer to select items to split during shipping label creation."
-                                                   + " The content inside two double asterisks **...** denote bolded text.")
+            static let message = NSLocalizedString(
+                "wooShipping.createLabels.splitShipment.SelectionInstructionsNotice.message",
+                value: "To split, select the items, and tap %1$@ when the toolbar appears.",
+                comment: "Instructions to ask customer to select items to split during shipping label creation. " +
+                "The placeholder is title of a button to move items to a new shipment ."
+            )
 
-            static let dismiss = NSLocalizedString("wooShipping.createLabels.splitShipment.SelectionInstructionsNotice.dismiss",
-                                                   value: "Dismiss",
-                                                   comment: "Label of the button to dismiss the instructions notice in split shipments flow.")
         }
         static func itemsCount(_ count: Decimal) -> String {
             return String.pluralize(count, singular: Localization.itemsCountSingularFormat, plural: Localization.itemsCountPluralFormat)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -54,6 +54,8 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     @Published private(set) var instructions: String?
     private var dismissedInstructions: Bool = false
 
+    @Published private(set) var movingCompletionMessage: String?
+    private var undoMovingItemsHandler: (() -> Void)?
 
     init(order: Order,
          config: WooShippingConfig,
@@ -96,6 +98,15 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         moveToNoticeViewModel = nil
         instructions = nil
 
+        // Step 0: keep the details before changes to revert changes when undo is selected
+        let initialShipments = shipments
+        let currentIndex = selectedShipmentIndex ?? 0
+        undoMovingItemsHandler = { [weak self] in
+            guard let self else { return }
+            shipments = initialShipments
+            selectedShipmentIndex = currentIndex
+        }
+
         // Step 1: Split items
         var newShipment = Shipment()
         var movedItems = [CollapsibleShipmentItemCardViewModel]()
@@ -124,7 +135,6 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         }
 
         // Step 2: Update the current shipment
-        let currentIndex = selectedShipmentIndex ?? 0
         shipments[currentIndex] = newShipment
 
         // Step 3: Add new or update existing shipment

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -138,9 +138,15 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         shipments[currentIndex] = newShipment
 
         // Step 3: Add new or update existing shipment
+        let totalItemsMoved = movedItems
+            .map { $0.packageItem.quantity }
+            .reduce(0, +)
+        var updatedShipmentIndex: Int?
+
         switch destination {
         case .newShipment:
             shipments.append(movedItems)
+            updatedShipmentIndex = shipments.count - 1
 
         case .existingShipment(let index):
             var updatedShipment = Shipment()
@@ -164,6 +170,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
             // Add the rest of the new items to the shipment
             updatedShipment.append(contentsOf: movedItems)
             shipments[index] = updatedShipment
+            updatedShipmentIndex = index
         }
 
         // Step 4: Remove the current shipment if it's empty.
@@ -176,6 +183,25 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         }
         configureSelectionCallback()
         configureSectionHeader()
+
+        // Step 5: Trigger notice for moving completion.
+        let itemsCount = Localization.itemsCount(totalItemsMoved)
+        let displayedShipmentIndex = (updatedShipmentIndex ?? 0) + 1
+        let shipmentLabel = String.localizedStringWithFormat(Localization.shipmentFormat, displayedShipmentIndex)
+        withAnimation {
+            movingCompletionMessage = String.localizedStringWithFormat(Localization.movingCompletionFormat, itemsCount, shipmentLabel)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.movingCompletionNoticeDuration) {
+            withAnimation {
+                self.movingCompletionMessage = nil
+            }
+            self.undoMovingItemsHandler = nil
+        }
+    }
+
+    func undoMovingItems() {
+        undoMovingItemsHandler?()
+        movingCompletionMessage = nil
     }
 }
 
@@ -252,6 +278,10 @@ private extension WooShippingSplitShipmentsViewModel {
 
 // MARK: Constants
 private extension WooShippingSplitShipmentsViewModel {
+    enum Constants {
+        static let movingCompletionNoticeDuration: Double = 3 // seconds
+    }
+
     enum Localization {
         enum SelectionInstructionsNotice {
             static let message = NSLocalizedString("wooShipping.createLabels.splitShipment.SelectionInstructionsNotice.message",
@@ -276,6 +306,14 @@ private extension WooShippingSplitShipmentsViewModel {
             "wooShipping.createLabels.splitShipment.shipmentFormat",
             value: "Shipment %1$d",
             comment: "Label for a shipment during shipping label creation. The placeholder is the index of the shipment. Reads like: 'Shipment 1'"
+        )
+
+        static let movingCompletionFormat = NSLocalizedString(
+            "wooShipping.createLabels.splitShipment.movingCompletionFormat",
+            value: "Moved %1$@ to %2$@",
+            comment: "Message to be displayed after moving items between shipments in the shipping label creation flow. " +
+            "The placeholders are the number of items and shipment index respectively. " +
+            "Reads as: 'Moved 3 items to Shipment 2'."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -190,7 +190,6 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         let shipmentLabel = String.localizedStringWithFormat(Localization.shipmentFormat, displayedShipmentIndex)
         withAnimation {
             movingCompletionMessage = {
-                let moveToNewShipmentTitle = MoveToShipmentNotice.Localization.moveToNewShipment.lowercased()
                 let content = String.localizedStringWithFormat(Localization.movingCompletionFormat, itemsCount, shipmentLabel)
 
                 var attributedText = AttributedString(content)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -407,6 +407,66 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.topTabItems.count, 2)
     }
+
+    func test_movingCompletionMessage_is_set_upon_moving_items_and_cleared_upon_tapping_undo() {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: WooShippingConfig.fake(),
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+        XCTAssertNil(viewModel.movingCompletionMessage)
+
+        // When
+        viewModel.shipments.first?.first?.childItemRows.first?.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+
+        // Then
+        XCTAssertNotNil(viewModel.movingCompletionMessage)
+
+        // When
+        viewModel.undoMovingItems()
+
+        // Then
+        XCTAssertNil(viewModel.movingCompletionMessage)
+    }
+
+    func test_shipments_are_reverted_upon_tapping_undo() {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: WooShippingConfig.fake(),
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        viewModel.shipments.first?.first?.mainItemRow.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+
+        // Confidence checks
+        XCTAssertEqual(viewModel.shipments.count, 2)
+        XCTAssertEqual(viewModel.shipments[0].count, 1)
+        XCTAssertEqual(viewModel.shipments[0][0].packageItem.productOrVariationID, items[1].productOrVariationID)
+        XCTAssertEqual(viewModel.shipments[0][0].packageItem.quantity, 1)
+        XCTAssertEqual(viewModel.shipments[1].count, 1)
+        XCTAssertEqual(viewModel.shipments[1][0].packageItem.productOrVariationID, items[0].productOrVariationID)
+        XCTAssertEqual(viewModel.shipments[1][0].packageItem.quantity, 2)
+
+        // When
+        viewModel.undoMovingItems()
+
+        // Then
+        XCTAssertEqual(viewModel.shipments.count, 1)
+
+        XCTAssertEqual(viewModel.shipments[0].count, 2)
+        XCTAssertEqual(viewModel.shipments[0][0].packageItem.productOrVariationID, items[0].productOrVariationID)
+        XCTAssertEqual(viewModel.shipments[0][0].packageItem.quantity, 2)
+        XCTAssertEqual(viewModel.shipments[0][1].packageItem.productOrVariationID, items[1].productOrVariationID)
+        XCTAssertEqual(viewModel.shipments[0][1].packageItem.quantity, 1)
+    }
 }
 
 private extension WooShippingSplitShipmentsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15307 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a notice for when moving items between shipments is completed. Changes include:
- Updated the snack bar to support the instructions and the new notice. The snack bar now uses an `AttributedString` to handle more flexible font styles.
- Updated the moving items logic to trigger a notice upon completion and support the undo option.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with the Woo Shipping plugin set up.
2. Open a completed order with multiple physical products of different quantities.
3. Select Create shipping label > Split shipments.
4. Confirm that the instruction notice still looks good.
5. Move items between shipments and confirm that there's a notice displayed upon completion for each time.
6. Try the Undo button and confirm that changes are reverted.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed the above test cases.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Dark mode | Light mode
--- | ---
<img src="https://github.com/user-attachments/assets/1af227f2-1022-42a6-97ca-43eb9eab8370" width=320 /> | <img src="https://github.com/user-attachments/assets/045fd3ca-cb1f-4cb4-8b10-a8280b1d2d67" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.