### PR TITLE
Shipping Labels: Fix issue updating tab view upon merging shipments

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -119,16 +119,18 @@ struct WooCarrierPackagesSelectionView: View {
                 emptyStateView
             }
 
-            WooCarrierPackagesView(carrierTab: viewModel.selectedCarrierTab,
-                                   selectedPackageId: $viewModel.selectedCarriersPackageId,
-                                   starredPackages: $viewModel.starredCarriersPackages,
-                                   tapAction: { packageID in
-                viewModel.selectedCarriersPackageId = viewModel.selectedCarriersPackageId == packageID ? nil : packageID
-            }, starAction: { packageID in
-                viewModel.starUnstarPackage(packageID, carrierID: viewModel.selectedCarrierTab.carrier.rawValue)
-            }, onRefresh: {
-                await viewModel.loadPackages()
-            })
+            if let selectedCarrierTab = viewModel.selectedCarrierTab {
+                WooCarrierPackagesView(carrierTab: selectedCarrierTab,
+                                       selectedPackageId: $viewModel.selectedCarriersPackageId,
+                                       starredPackages: $viewModel.starredCarriersPackages,
+                                       tapAction: { packageID in
+                    viewModel.selectedCarriersPackageId = viewModel.selectedCarriersPackageId == packageID ? nil : packageID
+                }, starAction: { packageID in
+                    viewModel.starUnstarPackage(packageID, carrierID: selectedCarrierTab.carrier.rawValue)
+                }, onRefresh: {
+                    await viewModel.loadPackages()
+                })
+            }
             Spacer()
             Divider()
             Button(selectionButtonText) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -98,7 +98,7 @@ struct WooCarrierPackagesSelectionView: View {
         VStack(spacing: 0) {
             if viewModel.selectedCarriersTabIndex != nil, viewModel.carrierTabs.isNotEmpty {
                 TopTabView(tabs: viewModel.carrierTabs,
-                           showContent: .constant(false),
+                           showContent: false,
                            selectedTabIndex: $viewModel.selectedCarriersTabIndex,
                            tabsContainerHorizontalPadding: nil,
                            selectedStateColor: Color.accentColor,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -96,7 +96,7 @@ struct WooCarrierPackagesSelectionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if viewModel.selectedCarriersTabIndex != nil, viewModel.carrierTabs.isNotEmpty {
+            if viewModel.carrierTabs.isNotEmpty {
                 TopTabView(tabs: viewModel.carrierTabs,
                            showContent: false,
                            selectedTabIndex: $viewModel.selectedCarriersTabIndex,
@@ -119,18 +119,16 @@ struct WooCarrierPackagesSelectionView: View {
                 emptyStateView
             }
 
-            if let selectedCarrierTab = viewModel.selectedCarrierTab {
-                WooCarrierPackagesView(carrierTab: selectedCarrierTab,
-                                       selectedPackageId: $viewModel.selectedCarriersPackageId,
-                                       starredPackages: $viewModel.starredCarriersPackages,
-                                       tapAction: { packageID in
-                    viewModel.selectedCarriersPackageId = viewModel.selectedCarriersPackageId == packageID ? nil : packageID
-                }, starAction: { packageID in
-                    viewModel.starUnstarPackage(packageID, carrierID: selectedCarrierTab.carrier.rawValue)
-                }, onRefresh: {
-                    await viewModel.loadPackages()
-                })
-            }
+            WooCarrierPackagesView(carrierTab: viewModel.selectedCarrierTab,
+                                   selectedPackageId: $viewModel.selectedCarriersPackageId,
+                                   starredPackages: $viewModel.starredCarriersPackages,
+                                   tapAction: { packageID in
+                viewModel.selectedCarriersPackageId = viewModel.selectedCarriersPackageId == packageID ? nil : packageID
+            }, starAction: { packageID in
+                viewModel.starUnstarPackage(packageID, carrierID: viewModel.selectedCarrierTab.carrier.rawValue)
+            }, onRefresh: {
+                await viewModel.loadPackages()
+            })
             Spacer()
             Divider()
             Button(selectionButtonText) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -82,8 +82,8 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     @Published var starredCarriersPackages: Set<String> = []
     @Published private(set) var carrierTabs: [TopTabItem<EmptyView>] = []
     private var allPredefinedOptions: [WooShippingCarrierPredefinedOptions] = []
-    var selectedCarrierTab: WooShippingCarrierPackages {
-        carrierPackages[selectedCarriersTabIndex]
+    var selectedCarrierTab: WooShippingCarrierPackages? {
+        carrierPackages[safe: selectedCarriersTabIndex]
     }
     var selectedCarriersPackage: WooShippingPackageDataRepresentable? {
         guard let selectedCarriersPackageId else { return nil }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -77,15 +77,13 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     // MARK: - carrier
 
     @Published private(set) var carrierPackages: [WooShippingCarrierPackages] = []
-    @Published var selectedCarriersTabIndex: Int? = nil
+    @Published var selectedCarriersTabIndex = 0
     @Published var selectedCarriersPackageId: String? = nil
     @Published var starredCarriersPackages: Set<String> = []
     @Published private(set) var carrierTabs: [TopTabItem<EmptyView>] = []
     private var allPredefinedOptions: [WooShippingCarrierPredefinedOptions] = []
-    var selectedCarrierTab: WooShippingCarrierPackages? {
-        guard let selectedCarriersTabIndex else { return nil }
-
-        return carrierPackages[selectedCarriersTabIndex]
+    var selectedCarrierTab: WooShippingCarrierPackages {
+        carrierPackages[selectedCarriersTabIndex]
     }
     var selectedCarriersPackage: WooShippingPackageDataRepresentable? {
         guard let selectedCarriersPackageId else { return nil }
@@ -207,17 +205,6 @@ final class WooShippingAddPackageViewModel: ObservableObject {
                 selectedPackageType = predefinedSavedPackages.contains(where: { $0.id == previousSelectedPackage.id }) ? .saved : .carrier
             case .custom:
                 selectedPackageType = customSavedPackages.contains(where: { $0.id == previousSelectedPackage.id }) ? .saved : .custom
-            }
-        }
-
-        if selectedCarriersTabIndex == nil {
-            // Select the carriers tab matching the previous selected carriers package, if it is the currently selected package
-            if let previousSelectedPackage, selectedCarriersPackageId == previousSelectedPackage.id {
-                selectedCarriersTabIndex = carrierPackages.firstIndex { carrierTab in
-                    return carrierTab.carrier.rawValue == previousSelectedPackage.source.sourceID
-                }
-            } else {
-                selectedCarriersTabIndex = carrierPackages.isEmpty ? nil : 0
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -11,7 +11,7 @@ struct WooShippingSplitShipmentsDetailView: View {
             VStack {
                 if viewModel.shipments.count > 1 {
                     TopTabView(tabs: viewModel.topTabItems,
-                               showContent: .constant(false),
+                               showContent: false,
                                selectedTabIndex: $viewModel.selectedShipmentIndex,
                                tabsContainerHorizontalPadding: nil,
                                selectedStateColor: .accentColor,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -14,7 +14,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
 
     @Published private(set) var shipments: [Shipment]
 
-    @Published var selectedShipmentIndex: Int? = 0 {
+    @Published var selectedShipmentIndex = 0 {
         didSet {
             configureSectionHeader()
             configureSelectionCallback()
@@ -45,8 +45,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     }
 
     var currentShipment: [CollapsibleShipmentItemCardViewModel] {
-        let index = selectedShipmentIndex ?? 0
-        return shipments[index]
+        shipments[selectedShipmentIndex]
     }
 
     @Published private(set) var moveToNoticeViewModel: MoveToShipmentNoticeViewModel?
@@ -100,7 +99,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
 
         // Step 0: keep the details before changes to revert changes when undo is selected
         let initialShipments = shipments
-        let currentIndex = selectedShipmentIndex ?? 0
+        let currentIndex = selectedShipmentIndex
         undoMovingItemsHandler = { [weak self] in
             guard let self else { return }
             shipments = initialShipments
@@ -246,7 +245,7 @@ private extension WooShippingSplitShipmentsViewModel {
     }
 
     func updateMoveToNotice() {
-        let currentIndex = selectedShipmentIndex ?? 0
+        let currentIndex = selectedShipmentIndex
         let selectedItemsCount = currentShipment
             .map(\.numberOfSelectedItems)
             .reduce(0, +)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -25,7 +25,8 @@ struct TopTabView<Content: View>: View {
     @State private var contentSize: CGSize = .zero
 
     @Binding var showTabs: Bool
-    @Binding var showContent: Bool
+    private let showContent: Bool
+
     @Binding var selectedTabIndex: Int?
 
     let tabs: [TopTabItem<Content>]
@@ -54,7 +55,7 @@ struct TopTabView<Content: View>: View {
 
     init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
-         showContent: Binding<Bool> = .constant(true),
+         showContent: Bool = true,
          selectedTabIndex: Binding<Int?> = .constant(nil),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
@@ -67,7 +68,7 @@ struct TopTabView<Content: View>: View {
          tabItemContentVerticalPadding: CGFloat? = nil) {
         self.tabs = tabs
         self._showTabs = showTabs
-        self._showContent = showContent
+        self.showContent = showContent
         self._selectedTabIndex = selectedTabIndex
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
@@ -379,7 +380,7 @@ struct ContentView_Previews: PreviewProvider {
             .preferredColorScheme(.dark)
             .previewDisplayName("Carrier Packages Dark Style")
         TopTabView(tabs: carrierTabs,
-                   showContent: .constant(false),
+                   showContent: false,
                    tabsContainerHorizontalPadding: nil,
                    unselectedStateColor: .secondary,
                    selectedTabIndicatorHeight: 3.0,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -18,7 +18,7 @@ struct TopTabItem<Content: View> {
 }
 
 struct TopTabView<Content: View>: View {
-    @State private var selectedTab = 0
+    @Binding private var selectedTab: Int
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
     @GestureState private var dragState: DragState = .inactive
@@ -26,8 +26,6 @@ struct TopTabView<Content: View>: View {
 
     @Binding var showTabs: Bool
     private let showContent: Bool
-
-    @Binding var selectedTabIndex: Int?
 
     let tabs: [TopTabItem<Content>]
 
@@ -56,7 +54,7 @@ struct TopTabView<Content: View>: View {
     init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
          showContent: Bool = true,
-         selectedTabIndex: Binding<Int?> = .constant(nil),
+         selectedTabIndex: Binding<Int> = .constant(0),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
@@ -69,7 +67,7 @@ struct TopTabView<Content: View>: View {
         self.tabs = tabs
         self._showTabs = showTabs
         self.showContent = showContent
-        self._selectedTabIndex = selectedTabIndex
+        self._selectedTab = selectedTabIndex
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
         self.selectedStateColor = selectedStateColor
@@ -131,13 +129,7 @@ struct TopTabView<Content: View>: View {
                                                 }
                                             }
                                         })
-                                }
-                                .onAppear {
-                                    selectedTab = selectedTabIndex ?? 0
-                                    scrollViewProxy.scrollTo(selectedTab, anchor: .center)
-                                    underlineOffset = calculateOffset(index: selectedTab)
-                                }
-                            }
+                                }                            }
                             .padding(.horizontal, tabPadding)
                             .overlay(
                                 Rectangle()
@@ -148,15 +140,7 @@ struct TopTabView<Content: View>: View {
                                 alignment: .bottomLeading
                             )
                             .onChange(of: selectedTab, perform: { newSelectedTab in
-                                let animate = selectedTabIndex != newSelectedTab
-                                selectedTabIndex = newSelectedTab
-                                if animate {
-                                    withAnimation {
-                                        scrollViewProxy.scrollTo(newSelectedTab, anchor: .center)
-                                        underlineOffset = calculateOffset(index: newSelectedTab)
-                                    }
-                                }
-                                else {
+                                withAnimation {
                                     scrollViewProxy.scrollTo(newSelectedTab, anchor: .center)
                                     underlineOffset = calculateOffset(index: newSelectedTab)
                                 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -129,7 +129,8 @@ struct TopTabView<Content: View>: View {
                                                 }
                                             }
                                         })
-                                }                            }
+                                }
+                            }
                             .padding(.horizontal, tabPadding)
                             .overlay(
                                 Rectangle()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -23,7 +23,7 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.selectedSavedPackage)
 
         XCTAssertEqual(viewModel.carrierPackages.count, 0)
-        XCTAssertEqual(viewModel.selectedCarriersTabIndex, nil)
+        XCTAssertEqual(viewModel.selectedCarriersTabIndex, 0)
         XCTAssertEqual(viewModel.selectedCarriersPackageId, nil)
         XCTAssertEqual(viewModel.starredCarriersPackages.count, 0)
         XCTAssertEqual(viewModel.carrierTabs.count, 0)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15310
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When testing merging shipments, I found that the tab view doesn't update the selected tab when the empty shipment is removed:


https://github.com/user-attachments/assets/0f37e700-a22d-4218-9877-b1acca66031e

This was caused by the messy use of `selectedTabIndex` - the new changes to this binding was not updated to the tab view.

This PR fixes this by removing the code smell in the tab view:
- Unified `selectedTabIndex` with the existing `selectedTab` in tab view to simplify the state management for the view.
- Removed the unnecessary binding for `showContents` as there is no state management required for this.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with Woo Shipping set up.
2. Open a completed order with multiple physical products with different quantities.
3. Select Create shipping label > Split shipments.
4. Move items to create at least 3 different shipments.
5. Open the last shipment and move all items to an existing shipment.
6. Confirm that the tab view automatically switches to the last shipment after the empty shipment is removed.

Regression test: 
1. On the shipping label creation form, tap Select a package.
2. Switch to the Carrier tab.
3. Confirm that the tabs for different carriers are displayed correctly.
4. Switching between the tabs and confirm that there's no issue.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Confirmed the above test cases in simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/493fc9ff-f469-4c80-9f3b-4683c2a74bc5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.