### PR TITLE
Shipping Labels: Handle merging shipments

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -6,6 +6,9 @@ struct WooShippingSplitShipmentsDetailView: View {
 
     @ObservedObject var viewModel: WooShippingSplitShipmentsViewModel
 
+    @State private var showingMergeAllSheet = false
+    @State private var showingRemovalSheet = false
+
     var body: some View {
         NavigationView {
             VStack {
@@ -58,6 +61,9 @@ struct WooShippingSplitShipmentsDetailView: View {
         .onAppear {
             viewModel.onAppear()
         }
+        .sheet(isPresented: $showingMergeAllSheet) {
+            mergeAllUnfulfilledSheet
+        }
     }
 }
 
@@ -96,7 +102,7 @@ private extension WooShippingSplitShipmentsDetailView {
             }
             Divider()
             Button(Localization.mergeAll) {
-                viewModel.mergeAllUnfulfilledShipments()
+                showingMergeAllSheet = true
             }
         } label: {
             Image(systemName: "ellipsis")
@@ -130,6 +136,35 @@ private extension WooShippingSplitShipmentsDetailView {
                 })
             }
         }
+    }
+
+    var mergeAllUnfulfilledSheet: some View {
+        ScrollableVStack(alignment: .leading, spacing: Layout.contentPadding) {
+            Text(Localization.MergeAllUnfulfilledSheet.title)
+                .font(.title3)
+                .bold()
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top)
+
+            Text(Localization.MergeAllUnfulfilledSheet.description)
+                .font(.subheadline)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
+            Button(Localization.MergeAllUnfulfilledSheet.confirmCTA) {
+                viewModel.mergeAllUnfulfilledShipments()
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(Localization.cancel) {
+                showingMergeAllSheet = false
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+        .presentationDetents([.medium, .large])
     }
 }
 
@@ -213,6 +248,11 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
             value: "Undo",
             comment: "Button to revert moving items between shipments in the shipping label creation flow"
         )
+        static let cancel = NSLocalizedString(
+            "wooShippingSplitShipmentsDetailView.cancel",
+            value: "Cancel",
+            comment: "Button to dismiss a sheet in the shipping label creation flow"
+        )
         static let removeShipmentFormat = NSLocalizedString(
             "wooShippingSplitShipmentsDetailView.removeShipmentFormat",
             value: "Remove %1$@",
@@ -224,6 +264,24 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
             value: "Merge all unfulfilled",
             comment: "Button to merge all unfulfilled shipments in the shipping label creation flow."
         )
+
+        enum MergeAllUnfulfilledSheet {
+            static let title = NSLocalizedString(
+                "wooShippingSplitShipmentsDetailView.mergeAllUnfulfilledSheet.title",
+                value: "Merge all unfulfilled shipments",
+                comment: "Title of the merge all unfulfilled shipments sheet in the shipping label creation flow."
+            )
+            static let description = NSLocalizedString(
+                "wooShippingSplitShipmentsDetailView.mergeAllUnfulfilledSheet.description",
+                value: "This will remove all unfulfilled split shipments and move all items into one shipment",
+                comment: "Message on the merge all unfulfilled shipments sheet in the shipping label creation flow."
+            )
+            static let confirmCTA = NSLocalizedString(
+                "wooShippingSplitShipmentsDetailView.mergeAllUnfulfilledSheet.confirmCTA",
+                value: "Merge all shipments",
+                comment: "Button to confirm merging all unfulfilled shipments sheet in the shipping label creation flow."
+            )
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -144,13 +144,11 @@ private extension WooShippingSplitShipmentsDetailView {
                 .font(.title3)
                 .bold()
                 .multilineTextAlignment(.leading)
-                .fixedSize(horizontal: false, vertical: true)
                 .padding(.top)
 
             Text(Localization.MergeAllUnfulfilledSheet.description)
                 .font(.subheadline)
                 .multilineTextAlignment(.leading)
-                .fixedSize(horizontal: false, vertical: true)
 
             Spacer()
 
@@ -164,7 +162,7 @@ private extension WooShippingSplitShipmentsDetailView {
             }
             .buttonStyle(SecondaryButtonStyle())
         }
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.fraction(0.4), .medium, .large])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -83,12 +83,24 @@ private extension WooShippingSplitShipmentsDetailView {
                     .renderedIf(viewModel.selectedShipmentIndex < viewModel.topTabItems.count - 1)
             }
 
-            Button {
-                // TODO: show delete menu
-            } label: {
-                Image(systemName: "ellipsis")
-                    .padding()
+            removeShipmentMenu
+        }
+    }
+
+    var removeShipmentMenu: some View {
+        Menu {
+            ForEach(viewModel.topTabItems, id: \.name) { tab in
+                Button(String.localizedStringWithFormat(Localization.removeShipmentFormat, tab.name.lowercased())) {
+                    // TODO
+                }
             }
+            Divider()
+            Button(Localization.mergeAll) {
+                // TODO
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .padding()
         }
     }
 
@@ -200,6 +212,17 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
             "wooShippingSplitShipmentsDetailView.undo",
             value: "Undo",
             comment: "Button to revert moving items between shipments in the shipping label creation flow"
+        )
+        static let removeShipmentFormat = NSLocalizedString(
+            "wooShippingSplitShipmentsDetailView.removeShipmentFormat",
+            value: "Remove %1$@",
+            comment: "Button to remove a shipment in the shipping label creation flow. " +
+            "The placeholder is the name of a shipment. Reads as: 'Remove shipment 1'."
+        )
+        static let mergeAll = NSLocalizedString(
+            "wooShippingSplitShipmentsDetailView.mergeAll",
+            value: "Merge all unfulfilled"",
+            comment: "Button to merge all unfulfilled shipments in the shipping label creation flow."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -7,7 +7,6 @@ struct WooShippingSplitShipmentsDetailView: View {
     @ObservedObject var viewModel: WooShippingSplitShipmentsViewModel
 
     @State private var showingMergeAllSheet = false
-    @State private var showingRemovalSheet = false
 
     var body: some View {
         NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -153,6 +153,7 @@ private extension WooShippingSplitShipmentsDetailView {
 
             Button(Localization.MergeAllUnfulfilledSheet.confirmCTA) {
                 viewModel.mergeAllUnfulfilledShipments()
+                showingMergeAllSheet = false
             }
             .buttonStyle(PrimaryButtonStyle())
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -96,7 +96,7 @@ private extension WooShippingSplitShipmentsDetailView {
             }
             Divider()
             Button(Localization.mergeAll) {
-                // TODO
+                viewModel.mergeAllUnfulfilledShipments()
             }
         } label: {
             Image(systemName: "ellipsis")
@@ -221,7 +221,7 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
         )
         static let mergeAll = NSLocalizedString(
             "wooShippingSplitShipmentsDetailView.mergeAll",
-            value: "Merge all unfulfilled"",
+            value: "Merge all unfulfilled",
             comment: "Button to merge all unfulfilled shipments in the shipping label creation flow."
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -10,18 +10,10 @@ struct WooShippingSplitShipmentsDetailView: View {
         NavigationView {
             VStack {
                 if viewModel.shipments.count > 1 {
-                    TopTabView(tabs: viewModel.topTabItems,
-                               showContent: false,
-                               selectedTabIndex: $viewModel.selectedShipmentIndex,
-                               tabsContainerHorizontalPadding: nil,
-                               selectedStateColor: .accentColor,
-                               unselectedStateColor: .secondary,
-                               selectedTabIndicatorHeight: Layout.selectedTabIndicatorHeight,
-                               tabPadding: Layout.tabPadding,
-                               tabsNameFont: Font.subheadline.bold(),
-                               tabsIconSize: nil,
-                               tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
-                               tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
+                    VStack(spacing: 0) {
+                        topTabView
+                        Divider()
+                    }
                 }
 
                 ScrollView {
@@ -70,6 +62,36 @@ struct WooShippingSplitShipmentsDetailView: View {
 }
 
 private extension WooShippingSplitShipmentsDetailView {
+    var topTabView: some View {
+        HStack(spacing: 0) {
+            TopTabView(tabs: viewModel.topTabItems,
+                       showContent: false,
+                       showDividerBelowTabs: false,
+                       selectedTabIndex: $viewModel.selectedShipmentIndex,
+                       tabsContainerHorizontalPadding: nil,
+                       selectedStateColor: .accentColor,
+                       unselectedStateColor: .secondary,
+                       selectedTabIndicatorHeight: Layout.selectedTabIndicatorHeight,
+                       tabPadding: Layout.tabPadding,
+                       tabsNameFont: Font.subheadline.bold(),
+                       tabsIconSize: nil,
+                       tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
+                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
+            .overlay(alignment: .trailing) {
+                LinearGradient(gradient: Gradient(colors: [.clear, Color(.basicBackground)]), startPoint: .leading, endPoint: .center)
+                    .frame(width: Layout.gradientViewWidth)
+                    .renderedIf(viewModel.selectedShipmentIndex < viewModel.topTabItems.count - 1)
+            }
+
+            Button {
+                // TODO: show delete menu
+            } label: {
+                Image(systemName: "ellipsis")
+                    .padding()
+            }
+        }
+    }
+
     var noticeStack: some View {
         VStack(spacing: Layout.contentPadding) {
             if let message = viewModel.instructions {
@@ -155,6 +177,7 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
         static let tabItemContentHorizontalPadding: CGFloat = 16.0
         static let tabItemContentVerticalPadding: CGFloat = 9.0
         static let cornerRadius: CGFloat = 8
+        static let gradientViewWidth: CGFloat = 32
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -210,6 +210,31 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         undoMovingItemsHandler?()
         movingCompletionMessage = nil
     }
+
+    func mergeAllUnfulfilledShipments() {
+        var mergedShipment = Shipment()
+
+        // TODO-15440: check for fulfilled shipments and remove them from the list.
+        shipments.forEach { shipment in
+            for item in shipment {
+                let matchingItemIndex = mergedShipment.firstIndex(where: {
+                    $0.packageItem.productOrVariationID == item.packageItem.productOrVariationID
+                })
+                if let matchingItemIndex {
+                    // Merge the quantity if the same item is merged to the shipment
+                    let updatedQuantity = item.packageItem.quantity + mergedShipment[matchingItemIndex].packageItem.quantity
+                    let updatedItem = ShippingLabelPackageItem(copy: item.packageItem, quantity: updatedQuantity)
+                    mergedShipment[matchingItemIndex] = CollapsibleShipmentItemCardViewModel(item: updatedItem, currency: order.currency)
+                } else {
+                    // Keep the item as-is
+                    mergedShipment.append(item)
+                }
+            }
+        }
+
+        shipments = [mergedShipment]
+        selectedShipmentIndex = 0
+    }
 }
 
 private extension WooShippingSplitShipmentsViewModel {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -25,7 +25,9 @@ struct TopTabView<Content: View>: View {
     @State private var contentSize: CGSize = .zero
 
     @Binding var showTabs: Bool
+
     private let showContent: Bool
+    private let showDividerBelowTabs: Bool
 
     let tabs: [TopTabItem<Content>]
 
@@ -54,6 +56,7 @@ struct TopTabView<Content: View>: View {
     init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
          showContent: Bool = true,
+         showDividerBelowTabs: Bool = true,
          selectedTabIndex: Binding<Int> = .constant(0),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
@@ -67,6 +70,7 @@ struct TopTabView<Content: View>: View {
         self.tabs = tabs
         self._showTabs = showTabs
         self.showContent = showContent
+        self.showDividerBelowTabs = showDividerBelowTabs
         self._selectedTab = selectedTabIndex
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
@@ -151,6 +155,7 @@ struct TopTabView<Content: View>: View {
                     }
                 }
                 Divider()
+                    .renderedIf(showDividerBelowTabs)
             }
 
             if showContent {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -467,6 +467,42 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shipments[0][1].packageItem.productOrVariationID, items[1].productOrVariationID)
         XCTAssertEqual(viewModel.shipments[0][1].packageItem.quantity, 1)
     }
+
+    // MARK: - `mergeAllUnfulfilledShipments`
+
+    func test_mergeAllUnfulfilledShipments_updates_shipments_correctly() {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1),
+                     sampleItem(id: 3, weight: 4, value: 5, quantity: 3)]
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: WooShippingConfig.fake(),
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        // Moving items to 2 new shipments
+        viewModel.shipments.first?.last?.childItemRows.first?.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+        viewModel.shipments.first?.last?.childItemRows.last?.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+
+        // Confidence checks
+        XCTAssertEqual(viewModel.shipments.count, 3)
+
+        // When
+        viewModel.mergeAllUnfulfilledShipments()
+
+        // Then
+        XCTAssertEqual(viewModel.shipments.count, 1)
+        XCTAssertEqual(viewModel.shipments[0].count, 3)
+        XCTAssertEqual(viewModel.shipments[0][0].packageItem.productOrVariationID, items[0].productOrVariationID)
+        XCTAssertEqual(viewModel.shipments[0][0].packageItem.quantity, 2)
+        XCTAssertEqual(viewModel.shipments[0][1].packageItem.productOrVariationID, items[1].productOrVariationID)
+        XCTAssertEqual(viewModel.shipments[0][1].packageItem.quantity, 1)
+        XCTAssertEqual(viewModel.shipments[0][2].packageItem.productOrVariationID, items[2].productOrVariationID)
+        XCTAssertEqual(viewModel.shipments[0][2].packageItem.quantity, 3)
+    }
 }
 
 private extension WooShippingSplitShipmentsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #15310
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the split shipment detail screen to support removing and merging shipments:
- Added a new ellipsis button on the right side of the top tab bar.
- Added a gradient to partially hide the bar title labels when scrolling.
- Added a menu show options to remove shipments or merge all.
- Added a sheet to confirm merging all shipments.
- Added implementation to merge all shipments.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with Woo Shipping plugin set up.
2. Open a completed order with more than one physical product with different quantities.
3. Select Create shipping label > Split shipments.
4. Move items to different shipments.
5. Confirm that there's an ellipsis button on the right of the tab bar.
6. Confirm that there's a gradient next to the ellipsis button if there are 3 or more shipments.
7. Tap the ellipsis button and confirm that a menu is displayed with options to remove or merge shipments.
8. Select Merge all unfulfilled and confirm that a sheet is displayed to confirm the decision.
9. Select Merge all shipments and confirm that all items are merged into one single shipment.

Implementation for removing shipments will be handled in a subsequent PR.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested the above test cases in simulator iPhone 16 Pro iOS 18.2 with different font sizes.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f21219d8-ba14-40fc-a6f3-db8269246d65



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
