### PR TITLE
[Woo POS] Coupons: Display coupon discount in cart – Dummy UI

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -174,7 +174,8 @@ private extension PointOfSaleOrderController {
                                       currency: order.currency) ?? "",
             orderTotal: formattedPrice(order.total, currency: order.currency) ?? "",
             taxTotal: formattedPrice(order.totalTax, currency: order.currency) ?? "",
-            orderTotalDecimal: totalsCalculator.orderTotal.decimalValue)
+            orderTotalDecimal: totalsCalculator.orderTotal.decimalValue,
+            couponsTotals: couponsTotals(order))
     }
 
     func formattedPrice(_ price: String?, currency: String?) -> String? {
@@ -182,6 +183,15 @@ private extension PointOfSaleOrderController {
             return nil
         }
         return currencyFormatter.formatAmount(price, with: currency)
+    }
+
+    func couponsTotals(_ order: Order) -> [PointOfSaleCouponTotal] {
+        return order.coupons.compactMap { coupon in
+            PointOfSaleCouponTotal(
+                code: coupon.code,
+                total: formattedPrice(coupon.discount, currency: order.currency) ?? ""
+            )
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleOrderTotals.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleOrderTotals.swift
@@ -7,4 +7,23 @@ struct PointOfSaleOrderTotals: Equatable {
     let orderTotal: String
     let taxTotal: String
     let orderTotalDecimal: Decimal
+    let couponsTotals: [PointOfSaleCouponTotal]
+
+    init(cartTotal: String,
+         orderTotal: String,
+         taxTotal: String,
+         orderTotalDecimal: Decimal,
+         couponsTotals: [PointOfSaleCouponTotal] = []
+    ) {
+        self.cartTotal = cartTotal
+        self.orderTotal = orderTotal
+        self.taxTotal = taxTotal
+        self.orderTotalDecimal = orderTotalDecimal
+        self.couponsTotals = couponsTotals
+    }
+}
+
+struct PointOfSaleCouponTotal: Equatable {
+    let code: String
+    let total: String
 }

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -277,6 +277,9 @@ private extension CartView {
         VStack {
             ForEach(posModel.cart.coupons, id: \.id) { couponItem in
                 CouponRowView(couponItem: couponItem,
+                              couponRowState: viewHelper.couponRowState(orderStage: posModel.orderStage,
+                                                                        orderState: posModel.orderState,
+                                                                        couponItem: couponItem),
                               onItemRemoveTapped: posModel.orderStage == .building ? {
                     posModel.remove(cartCouponItem: couponItem)
                 } : nil)

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -2,12 +2,14 @@ import SwiftUI
 
 struct CouponRowView: View {
     private let couponItem: CartCouponItem
+    private let couponRowState: CouponRowState?
     private let onItemRemoveTapped: (() -> Void)?
 
     @ScaledMetric private var scale: CGFloat = 1.0
 
-    init(couponItem: CartCouponItem, onItemRemoveTapped: (() -> Void)? = nil) {
+    init(couponItem: CartCouponItem, couponRowState: CouponRowState? = nil, onItemRemoveTapped: (() -> Void)? = nil) {
         self.couponItem = couponItem
+        self.couponRowState = couponRowState
         self.onItemRemoveTapped = onItemRemoveTapped
     }
 
@@ -22,11 +24,29 @@ struct CouponRowView: View {
                 }
                 .frame(width: Constants.couponCardSize, height: Constants.couponCardSize)
 
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
                 Text(couponItem.code)
                     .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
                     .font(Constants.itemTitleFont)
+
+                switch couponRowState {
+                case .valid(let couponTotal):
+                    Text("-\(couponTotal.total)")
+                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .font(Constants.itemPriceFont)
+                case .idle, .none:
+                    EmptyView()
+                case .invalid:
+                    Text("Invalid coupon")
+                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .font(Constants.itemPriceFont)
+                case .validating:
+                    Text("Validating...")
+                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .font(Constants.itemPriceFont)
+                }
             }
+            .animation(.default, value: couponRowState)
             .frame(maxWidth: .infinity, alignment: .leading)
 
             if let onItemRemoveTapped {
@@ -54,12 +74,14 @@ private extension CouponRowView {
         static let horizontalElementSpacing: CGFloat = POSSpacing.medium
         static let cardContentHorizontalPadding: CGFloat = POSPadding.medium
         static let itemTitleFont: POSFontStyle = .posBodySmallBold
+        static let itemTitleAndPriceSpacing: CGFloat = POSSpacing.xSmall
+        static let itemPriceFont: POSFontStyle = .posBodySmallRegular()
     }
 }
 
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview(traits: .sizeThatFitsLayout) {
-    CouponRowView(couponItem: CartCouponItem(id: UUID(), code: "10-Discount")) {}
+    CouponRowView(couponItem: CartCouponItem(id: UUID(), code: "10-Discount"), couponRowState: .idle) {}
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -13,6 +13,10 @@ struct CouponRowView: View {
         self.onItemRemoveTapped = onItemRemoveTapped
     }
 
+    private var dynamicSpacing: CGFloat {
+        Constants.itemTitleAndPriceSpacing * (1 / scale)
+    }
+
     var body: some View {
         HStack(spacing: Constants.horizontalElementSpacing) {
             Rectangle()
@@ -24,7 +28,7 @@ struct CouponRowView: View {
                 }
                 .frame(width: Constants.couponCardSize, height: Constants.couponCardSize)
 
-            VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
+            VStack(alignment: .leading, spacing: dynamicSpacing) {
                 Text(couponItem.code)
                     .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
                     .font(Constants.itemTitleFont)

--- a/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
@@ -42,3 +42,40 @@ private extension PointOfSalePaymentState {
         }
     }
 }
+
+// MARK: - Coupons
+
+enum CouponRowState: Equatable {
+    case idle
+    case validating
+    case valid(PointOfSaleCouponTotal)
+    case invalid
+}
+
+extension CartViewHelper {
+    func couponRowState(
+        orderStage: PointOfSaleOrderStage,
+        orderState: PointOfSaleOrderState,
+        couponItem: CartCouponItem
+    ) -> CouponRowState {
+        guard orderStage == .finalizing else {
+            return .idle
+        }
+
+        switch orderState {
+        case .syncing:
+            return .validating
+        case .loaded(let totals):
+            if let couponTotal = totals.couponsTotals
+                .first(where: { $0.code == couponItem.code }) {
+                    return .valid(couponTotal)
+                } else {
+                    return .idle
+                }
+        case .error(.invalidCoupon, _):
+            return .invalid
+        default:
+            return .idle
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
@@ -106,7 +106,6 @@ struct CartViewHelperTests {
         let coupon = CartCouponItem(id: UUID(), code: "TEST10")
 
         // When, Then
-
         #expect(sut.couponRowState(orderStage: .finalizing,
                                    orderState: .syncing,
                                    couponItem: coupon) == .validating)

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
@@ -85,6 +85,86 @@ struct CartViewHelperTests {
     @Test func shouldShowClearCartButton_items_in_cart_and_finalizing_false() async throws {
         #expect(sut.shouldShowClearCartButton(cart: .init(items: [makeItem()]), orderStage: .finalizing) == false)
     }
+
+    @Test func couponRowState_building_stage_returns_idle() async throws {
+        // Given
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+        let orderState = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00",
+            orderTotalDecimal: 12.0))
+
+        // When, Then
+        #expect(sut.couponRowState(orderStage: .building,
+                                   orderState: orderState,
+                                   couponItem: coupon) == .idle)
+    }
+
+    @Test func couponRowState_finalizing_and_syncing_returns_validating() async throws {
+        // Given
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+
+        // When, Then
+
+        #expect(sut.couponRowState(orderStage: .finalizing,
+                                   orderState: .syncing,
+                                   couponItem: coupon) == .validating)
+    }
+
+    @Test func couponRowState_finalizing_and_loaded_with_matching_coupon_returns_valid() async throws {
+        // Given
+        let couponCode = "TEST10"
+        let coupon = CartCouponItem(id: UUID(), code: couponCode)
+        let couponTotal = PointOfSaleCouponTotal(code: couponCode, total: "10.00")
+        let orderTotals = PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00",
+            orderTotalDecimal: 12.0,
+            couponsTotals: [couponTotal])
+
+        // When, Then
+        #expect(sut.couponRowState(orderStage: .finalizing,
+                                   orderState: .loaded(orderTotals),
+                                   couponItem: coupon) == .valid(couponTotal))
+    }
+
+    @Test func couponRowState_finalizing_and_loaded_with_no_matching_coupon_returns_idle() async throws {
+        // Given
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+        let orderTotals = PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00",
+            orderTotalDecimal: 12.0,
+            couponsTotals: [])
+
+        // When, Then
+        #expect(sut.couponRowState(orderStage: .finalizing,
+                                   orderState: .loaded(orderTotals),
+                                   couponItem: coupon) == .idle)
+    }
+
+    @Test func couponRowState_finalizing_and_invalid_coupon_error_returns_invalid() async throws {
+        // Given
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+
+        // When, Then
+        #expect(sut.couponRowState(orderStage: .finalizing,
+                                   orderState: .error(.invalidCoupon("Invalid coupon"), {}),
+                                   couponItem: coupon) == .invalid)
+    }
+
+    @Test func couponRowState_finalizing_and_other_error_returns_idle() async throws {
+        // Given
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+
+        // When, Then
+        #expect(sut.couponRowState(orderStage: .finalizing,
+                                   orderState: .error(.other("Some other error"), {}),
+                                   couponItem: coupon) == .idle)
+    }
 }
 
 private func makeItem() -> CartItem {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15334
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adding a structure to display coupon discounts in the cart with a dummy UI. It's not yet clear how the UI will look, but I added the ability that we will need to have one way or another:

- Show discount on a coupon
- Show validation status on a coupon - invalid / validating

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites: Enable `enableCouponsInPointOfSale` to `true`

### Valid Coupon

1. Open POS
2. Add Product
3. Add Valid Coupon
4. Check out
5. Confirm "Validating..." is shown on the coupon while the order is loading
6. Confirm discount is shown on the coupon when order is loaded

### Invalid Coupon

1. Open POS
2. Add Product
3. Add Valid Coupon
4. Check out
5. Confirm "Validating..." is shown on the coupon while the order is loading
6. Confirm "Invalid coupon" is shown on the coupon when order sync fails

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Additionally, tested that the changes do not affect cases without the feature flag.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/034b3505-6507-4c78-9e0c-c0655ff66236

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.