### PR TITLE
[Woo POS] Show Location Permissions notice and error in Point of Sale

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -364,6 +364,17 @@ extension StripeCardReaderService: CardReaderService {
                     self.processPayment(intent: intent)
                 }
                 .map(PaymentIntent.init(intent:))
+                .mapError { [weak self] error in
+                    if case CardReaderServiceError.paymentMethodCollection = error {
+                        // This is supposed to happen in `collectPaymentMethod(intent:)` when there's an error.
+                        // However when retrying some errors, `Terminal.shared.collectPaymentMethod` calls our
+                        // completion handler before it returns the payment cancellable which gets put in this property.
+                        // Nilling it here as well prevents future cancellations from never returning and making the UI
+                        // unresponsive, which can happen in `cancelPaymentIntent`.
+                        self?.paymentCancellable = nil
+                    }
+                    return error
+                }
                 .eraseToAnyPublisher()
         case .requiresConfirmation:
             return processPayment(intent: activePaymentIntent)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 - [*] Order Creation: Fixed an issue where order recalculation would stop working after canceling a confirmation with unsaved changes [https://github.com/woocommerce/woocommerce-ios/pull/15392].
 - [internal] POS: Always create a new order during the checkout [https://github.com/woocommerce/woocommerce-ios/pull/15427].
 - [internal] Improve data fetching in Order Details, to avoid I/O performance on the main thread. [https://github.com/woocommerce/woocommerce-ios/pull/14999]
-- [internal] POS: Show location pre-alert and error during reader connection [
+- [internal] POS: Show location pre-alert and error during reader connection [https://github.com/woocommerce/woocommerce-ios/pull/15456].
 
 22.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Order Creation: Fixed an issue where order recalculation would stop working after canceling a confirmation with unsaved changes [https://github.com/woocommerce/woocommerce-ios/pull/15392].
 - [internal] POS: Always create a new order during the checkout [https://github.com/woocommerce/woocommerce-ios/pull/15427].
 - [internal] Improve data fetching in Order Details, to avoid I/O performance on the main thread. [https://github.com/woocommerce/woocommerce-ios/pull/14999]
+- [internal] POS: Show location pre-alert and error during reader connection [
 
 22.0
 -----

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
@@ -108,7 +108,7 @@ struct CardPresentPaymentBluetoothReaderConnectionAlertsProvider: BluetoothReade
         .locationRequestPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .locationRequired(dismiss: dismiss)
+    func locationRequired(cancel: @escaping () -> Void) -> CardPresentPaymentEventDetails {
+        .locationRequired(cancel: cancel)
     }
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
@@ -108,8 +108,7 @@ struct CardPresentPaymentBluetoothReaderConnectionAlertsProvider: BluetoothReade
         .locationRequestPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void,
-                          skip: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .locationRequired(dismiss: dismiss, skip: skip)
+    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentEventDetails {
+        .locationRequired(dismiss: dismiss)
     }
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -161,8 +161,8 @@ private extension CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
             done()
         case .locationRequestPreAlert:
             return
-        case .locationRequired(let dismiss):
-            dismiss()
+        case .locationRequired(let cancel):
+            cancel()
         }
     }
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -161,7 +161,7 @@ private extension CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
             done()
         case .locationRequestPreAlert:
             return
-        case .locationRequired(let dismiss, _):
+        case .locationRequired(let dismiss):
             dismiss()
         }
     }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
@@ -56,5 +56,5 @@ enum CardPresentPaymentEventDetails {
     case validatingOrder(cancelPayment: () -> Void)
 
     case locationRequestPreAlert(requestPermission: () -> Void)
-    case locationRequired(dismiss: () -> Void)
+    case locationRequired(cancel: () -> Void)
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
@@ -56,6 +56,5 @@ enum CardPresentPaymentEventDetails {
     case validatingOrder(cancelPayment: () -> Void)
 
     case locationRequestPreAlert(requestPermission: () -> Void)
-    case locationRequired(dismiss: () -> Void,
-                          skip: () -> Void)
+    case locationRequired(dismiss: () -> Void)
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift
@@ -82,8 +82,7 @@ struct CardPresentPaymentTapToPayReaderConnectionAlertsProvider: CardReaderConne
         .locationRequestPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void,
-                          skip: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .locationRequired(dismiss: dismiss, skip: skip)
+    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentEventDetails {
+        .locationRequired(dismiss: dismiss)
     }
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift
@@ -82,7 +82,7 @@ struct CardPresentPaymentTapToPayReaderConnectionAlertsProvider: CardReaderConne
         .locationRequestPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .locationRequired(dismiss: dismiss)
+    func locationRequired(cancel: @escaping () -> Void) -> CardPresentPaymentEventDetails {
+        .locationRequired(cancel: cancel)
     }
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -60,6 +60,11 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
                 self?.readerConnectionStatusSubject.send(.cancellingConnection)
                 endSearch()
             })))
+        case .locationRequired(let cancel):
+            paymentEventSubject.send(.show(eventDetails: .locationRequired(cancel: { [weak self] in
+                self?.readerConnectionStatusSubject.send(.cancellingConnection)
+                cancel()
+            })))
         default:
             paymentEventSubject.send(.show(eventDetails: eventDetails))
         }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -24,6 +24,7 @@ enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
     case connectingFailedChargeReader(viewModel: PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel)
     case connectingFailedUpdateAddress(viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel)
     case connectingFailedUpdatePostalCode(viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel)
+    case connectingFailedLocationRequired(viewModel: PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel)
     case connectionSuccess(viewModel: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel)
 
     var onDismiss: (() -> Void)? {
@@ -62,6 +63,8 @@ enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
         case .connectingFailedUpdateAddress(let viewModel):
             return viewModel.cancelButtonViewModel.actionHandler
         case .connectingFailedUpdatePostalCode(let viewModel):
+            return viewModel.cancelButtonViewModel.actionHandler
+        case .connectingFailedLocationRequired(viewModel: let viewModel):
             return viewModel.cancelButtonViewModel.actionHandler
         case .connectionSuccess(let viewModel):
             return viewModel.buttonViewModel.actionHandler

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -19,6 +19,7 @@ enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
     case updateFailedNonRetryable(viewModel: PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel)
     case updateFailedLowBattery(viewModel: PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel)
     case connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel)
+    case connectingLocationPreAlert(viewModel: PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel)
     case connectingFailed(viewModel: PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel)
     case connectingFailedNonRetryable(viewModel: PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel)
     case connectingFailedChargeReader(viewModel: PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel)
@@ -53,6 +54,8 @@ enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
         case .updateFailedLowBattery(let viewModel):
             return viewModel.cancelButtonViewModel.actionHandler
         case .connectingToReader:
+            return nil
+        case .connectingLocationPreAlert:
             return nil
         case .connectingFailed(let viewModel):
             return viewModel.cancelButtonViewModel.actionHandler

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel: Hashable {
+    let title = Localization.title
+    let subtitle = Localization.subtitle
+    let imageName = PointOfSaleAssets.readerLocation.imageName
+
+    let primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
+
+    init(cancelSearchAction: @escaping () -> Void) {
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelSearchAction)
+        self.primaryButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.openSettings,
+            actionHandler: {
+                guard let targetURL = URL(string: UIApplication.openSettingsURLString) else {
+                    return
+                }
+                UIApplication.shared.open(targetURL)
+            })
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingFailedLocationRequired.title",
+            value: "Enable location services to allow payments",
+            comment: "A title explaining the requirement of location services for making a payment"
+        )
+
+        static let subtitle = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingFailedLocationRequired.subtitle",
+            value: "Location services permission is required to reduce fraud, prevent disputes, and ensure secure payments.",
+            comment: "A subtitle explaining why location services are needed to make a payment"
+        )
+
+        static let openSettings = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingFailedLocationRequired.openSettings.button.title",
+            value: "Open Device Settings",
+            comment: "Opens iOS's Device Settings for the app to access location services"
+        )
+
+        static let cancel = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingFailedLocationRequired.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails due to " +
+            "location permissions not being granted. This also cancels searching."
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel: Hashable {
+    let title = Localization.title
+    let subtitle = Localization.subtitle
+    let detail = Localization.settings
+    let imageName = PointOfSaleAssets.readerLocation.imageName
+
+    let primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel
+
+    init(requestPermissionAction: @escaping () -> Void) {
+        self.primaryButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.continueButtonTitle,
+            actionHandler: requestPermissionAction)
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingLocationPreAlert.title",
+            value: "Enable location services to allow payments",
+            comment: "A title explaining the requirement of location services for making a payment"
+        )
+
+        static let subtitle = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingLocationPreAlert.subtitle",
+            value: "Location services permission is required to reduce fraud, prevent disputes, and ensure secure payments.",
+            comment: "A subtitle explaining why location services are needed to make a payment"
+        )
+
+        static let settings = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingLocationPreAlert.settingsNotice",
+            value: "You can change this option later in the Settings app.",
+            comment: "A notice at the bottom explaining that location services can be changed in the Settings app later"
+        )
+
+        static let continueButtonTitle = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.connectingLocationPreAlert.continue.button.title",
+            value: "Continue",
+            comment: "A title for CTA to present native location permission alert"
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -246,10 +246,10 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
             /// Not-yet supported types
         case .selectSearchType:
             return nil
-            /// Immediately request location permission until POS view is created, showing `Connecting to reader` underneath.
         case .locationRequestPreAlert(let requestPermission):
-            requestPermission()
-            self = .alert(.connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel()))
+            self = .alert(.connectingLocationPreAlert(
+                viewModel: PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel(
+                    requestPermissionAction: requestPermission)))
         case .locationRequired(let cancel):
             self = .alert(.connectingFailedLocationRequired(
                 viewModel: PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -250,10 +250,10 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
         case .locationRequestPreAlert(let requestPermission):
             requestPermission()
             self = .alert(.connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel()))
-            /// Skip location required step and rely on error during the payment process until POS view is created, showing `Connecting to reader` underneath.
         case .locationRequired(let cancel):
-            cancel()
-            self = .alert(.connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel()))
+            self = .alert(.connectingFailedLocationRequired(
+                viewModel: PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel(
+                    cancelSearchAction: cancel)))
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -251,8 +251,8 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
             requestPermission()
             self = .alert(.connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel()))
             /// Skip location required step and rely on error during the payment process until POS view is created, showing `Connecting to reader` underneath.
-        case .locationRequired(_, let skip):
-            skip()
+        case .locationRequired(let cancel):
+            cancel()
             self = .alert(.connectingToReader(viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel()))
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -253,7 +253,10 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
         case .locationRequired(let cancel):
             self = .alert(.connectingFailedLocationRequired(
                 viewModel: PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel(
-                    cancelSearchAction: cancel)))
+                    cancelSearchAction: {
+                        cancel()
+                        dependencies.dismissReaderConnectionModal()
+                    })))
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView: View {
+    let viewModel: PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel
+    let animation: POSCardPresentPaymentAlertAnimation
+
+    var body: some View {
+        VStack(spacing: PointOfSaleReaderConnectionModalLayout.contentButtonSpacing) {
+            VStack(spacing: PointOfSaleReaderConnectionModalLayout.imageTextSpacing) {
+                Image(decorative: viewModel.imageName)
+                    .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
+
+                VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
+                    Text(viewModel.title)
+                        .font(POSFontStyle.posHeadingBold)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityAddTraits(.isHeader)
+                        .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
+
+                    Text(viewModel.subtitle)
+                        .font(POSFontStyle.posBodyLargeRegular())
+                        .fixedSize(horizontal: false, vertical: true)
+                        .matchedGeometryEffect(id: animation.contentTransitionId, in: animation.namespace, properties: .position)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .scrollVerticallyIfNeeded()
+
+            Button(viewModel.primaryButtonViewModel.title,
+                   action: viewModel.primaryButtonViewModel.actionHandler)
+            .buttonStyle(POSFilledButtonStyle(size: .normal))
+            .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
+        }
+        .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.cancelButtonViewModel.title)
+        .multilineTextAlignment(.center)
+        .accessibilityElement(children: .contain)
+    }
+}
+
+#Preview {
+    @Namespace var namespace
+    PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView(
+        viewModel: PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel(cancelSearchAction: {}),
+        animation: .init(namespace: namespace)
+    )
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentConnectingLocationPreAlertView: View {
+    let viewModel: PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel
+    let animation: POSCardPresentPaymentAlertAnimation
+
+    var body: some View {
+        VStack(spacing: PointOfSaleReaderConnectionModalLayout.contentButtonSpacing) {
+            VStack(spacing: PointOfSaleReaderConnectionModalLayout.imageTextSpacing) {
+                Image(decorative: viewModel.imageName)
+                    .matchedGeometryEffect(id: animation.iconTransitionId, in: animation.namespace, properties: .position)
+
+                VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
+                    Text(viewModel.title)
+                        .font(POSFontStyle.posHeadingBold)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityAddTraits(.isHeader)
+                        .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
+
+                    VStack(spacing: PointOfSaleReaderConnectionModalLayout.textSpacing) {
+                        Text(viewModel.subtitle)
+                            .font(POSFontStyle.posBodyLargeRegular())
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text(viewModel.detail)
+                            .font(POSFontStyle.posBodyLargeRegular())
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .matchedGeometryEffect(id: animation.contentTransitionId, in: animation.namespace, properties: .position)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .scrollVerticallyIfNeeded()
+
+            Button(viewModel.primaryButtonViewModel.title,
+                   action: viewModel.primaryButtonViewModel.actionHandler)
+            .buttonStyle(POSFilledButtonStyle(size: .normal))
+            .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
+        }
+        .multilineTextAlignment(.center)
+        .accessibilityElement(children: .contain)
+    }
+}
+
+#Preview {
+    @Namespace var namespace
+    PointOfSaleCardPresentPaymentConnectingLocationPreAlertView(
+        viewModel: PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel(requestPermissionAction: {}),
+        animation: .init(namespace: namespace)
+    )
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
@@ -49,6 +49,8 @@ struct PointOfSaleCardPresentPaymentAlert: View {
             PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView(viewModel: alertViewModel, animation: animation)
         case .connectingFailedUpdatePostalCode(let alertViewModel):
             PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView(viewModel: alertViewModel, animation: animation)
+        case .connectingFailedLocationRequired(viewModel: let viewModel):
+            PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView(viewModel: viewModel, animation: animation)
         case .connectionSuccess(let alertViewModel):
             PointOfSaleCardPresentPaymentConnectionSuccessAlertView(viewModel: alertViewModel, animation: animation)
         }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
@@ -49,6 +49,8 @@ struct PointOfSaleCardPresentPaymentAlert: View {
             PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView(viewModel: alertViewModel, animation: animation)
         case .connectingFailedUpdatePostalCode(let alertViewModel):
             PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView(viewModel: alertViewModel, animation: animation)
+        case .connectingLocationPreAlert(let alertViewModel):
+            PointOfSaleCardPresentPaymentConnectingLocationPreAlertView(viewModel: alertViewModel, animation: animation)
         case .connectingFailedLocationRequired(viewModel: let viewModel):
             PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView(viewModel: viewModel, animation: animation)
         case .connectionSuccess(let alertViewModel):

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleAssets.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleAssets.swift
@@ -10,6 +10,7 @@ enum PointOfSaleAssets: CaseIterable {
     case readerConnectionLowBattery
     case readerConnectionSuccess
     case readerDisconnected
+    case readerLocation
     case shoppingBags
     case successCheck
 
@@ -33,6 +34,8 @@ enum PointOfSaleAssets: CaseIterable {
             "pos-reader-connection-complete"
         case .readerDisconnected:
             "pos-reader-disconnected"
+        case .readerLocation:
+            "location"
         case .shoppingBags:
             "shopping-bags"
         case .successCheck:

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalLocationRequired.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalLocationRequired.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Modal presented when location permission is denied
 ///
 final class CardPresentModalLocationRequired: CardPresentPaymentsModalViewModel {
-    private let dismiss: () -> Void
+    private let cancel: () -> Void
 
     let textMode: PaymentsModalTextMode = .fullInfo
     let actionsMode: PaymentsModalActionsMode = .twoAction
@@ -19,8 +19,8 @@ final class CardPresentModalLocationRequired: CardPresentPaymentsModalViewModel 
         return topTitle + (bottomTitle ?? "")
     }
 
-    init(dismiss: @escaping () -> Void) {
-        self.dismiss = dismiss
+    init(cancel: @escaping () -> Void) {
+        self.cancel = cancel
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -32,7 +32,7 @@ final class CardPresentModalLocationRequired: CardPresentPaymentsModalViewModel 
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
         viewController?.dismiss(animated: true)
-        dismiss()
+        cancel()
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {}

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -535,11 +535,6 @@ private extension CardReaderConnectionController {
                     guard let self else { return }
                     locationService.stopObservingPermissionChanges()
                     state = .cancel(.locationPermissionDenied)
-                },
-                skip: { [weak self] in
-                    guard let self else { return }
-                    locationService.stopObservingPermissionChanges()
-                    state = .connectToReader
                 }
             ))
         case .notDetermined:

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -531,7 +531,7 @@ private extension CardReaderConnectionController {
             analyticsTracker.cardReaderLocationPermissionRequiredShown()
             observePermissionChanges()
             alertsPresenter.present(viewModel: alertsProvider.locationRequired(
-                dismiss: { [weak self] in
+                cancel: { [weak self] in
                     guard let self else { return }
                     locationService.stopObservingPermissionChanges()
                     state = .cancel(.locationPermissionDenied)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
@@ -372,7 +372,7 @@ private extension TapToPayCardReaderConnectionController {
             analyticsTracker.cardReaderLocationPermissionRequiredShown()
             observePermissionChanges()
             alertsPresenter.present(viewModel: alertsProvider.locationRequired(
-                dismiss: { [weak self] in
+                cancel: { [weak self] in
                     guard let self else { return }
                     locationService.stopObservingPermissionChanges()
                     state = .cancel(.locationPermissionDenied)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
@@ -376,11 +376,6 @@ private extension TapToPayCardReaderConnectionController {
                     guard let self else { return }
                     locationService.stopObservingPermissionChanges()
                     state = .cancel(.locationPermissionDenied)
-                },
-                skip: { [weak self] in
-                    guard let self else { return }
-                    locationService.stopObservingPermissionChanges()
-                    state = .connectToReader
                 }
             ))
         case .notDetermined:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -90,7 +90,7 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
         CardPresentModalLocationPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalLocationRequired(dismiss: dismiss)
+    func locationRequired(cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalLocationRequired(cancel: cancel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -90,8 +90,7 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
         CardPresentModalLocationPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void,
-                          skip: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalLocationRequired(dismiss: dismiss)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -65,10 +65,9 @@ protocol CardReaderConnectionAlertsProviding<AlertDetails> {
     func locationRequestPreAlert(requestPermission: @escaping () -> Void) -> AlertDetails
 
     /// Shows a modal requiring location permissions to proceed
-    /// Skip callback is provided in case the alert presenter wants to skip the location requirement
+    /// Dismissal will cancel the connection and payment flow.
     ///
-    func locationRequired(dismiss: @escaping () -> Void,
-                          skip: @escaping () -> Void) -> AlertDetails
+    func locationRequired(dismiss: @escaping () -> Void) -> AlertDetails
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -65,9 +65,9 @@ protocol CardReaderConnectionAlertsProviding<AlertDetails> {
     func locationRequestPreAlert(requestPermission: @escaping () -> Void) -> AlertDetails
 
     /// Shows a modal requiring location permissions to proceed
-    /// Dismissal will cancel the connection and payment flow.
+    /// Cancellation will cancel the connection and payment flow.
     ///
-    func locationRequired(dismiss: @escaping () -> Void) -> AlertDetails
+    func locationRequired(cancel: @escaping () -> Void) -> AlertDetails
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPayReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPayReaderConnectionAlertsProvider.swift
@@ -73,7 +73,7 @@ struct TapToPayReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidi
         CardPresentModalLocationPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalLocationRequired(dismiss: dismiss)
+    func locationRequired(cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalLocationRequired(cancel: cancel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPayReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPayReaderConnectionAlertsProvider.swift
@@ -73,8 +73,7 @@ struct TapToPayReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidi
         CardPresentModalLocationPreAlert(requestPermission: requestPermission)
     }
 
-    func locationRequired(dismiss: @escaping () -> Void,
-                          skip: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+    func locationRequired(dismiss: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalLocationRequired(dismiss: dismiss)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -866,6 +866,8 @@
 		2084B7AC2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */; };
 		2084B7AE2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7AD2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift */; };
 		208628742D48E4CB003F45DC /* TotalsViewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208628732D48E4CB003F45DC /* TotalsViewHelperTests.swift */; };
+		20886D3D2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20886D3C2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift */; };
+		20886D3F2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20886D3E2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift */; };
 		20897C9E2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20897C9D2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift */; };
 		209566252D4CF00100977124 /* PointOfSalePaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209566242D4CF00100977124 /* PointOfSalePaymentMethod.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift */; };
@@ -4107,6 +4109,8 @@
 		2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift; sourceTree = "<group>"; };
 		2084B7AD2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift; sourceTree = "<group>"; };
 		208628732D48E4CB003F45DC /* TotalsViewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewHelperTests.swift; sourceTree = "<group>"; };
+		20886D3C2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift; sourceTree = "<group>"; };
+		20886D3E2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift; sourceTree = "<group>"; };
 		20897C9D2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleUnsupportedWidthView.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		209566242D4CF00100977124 /* PointOfSalePaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePaymentMethod.swift; sourceTree = "<group>"; };
@@ -8234,6 +8238,7 @@
 				026826B72BF59E400036F959 /* PointOfSaleCardPresentPaymentConnectingFailedView.swift */,
 				203163B42C1C5EB2001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift */,
 				203163BA2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */,
+				20886D3E2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift */,
 				203163B62C1C5EDF001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift */,
 				026826BB2BF59E410036F959 /* PointOfSaleCardPresentPaymentFoundReaderView.swift */,
 				0220F4942C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift */,
@@ -8274,6 +8279,7 @@
 				205B7EC42C19FC4F00D14A36 /* PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift */,
 				203163AE2C1C5C6B001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift */,
 				203163B02C1C5C87001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift */,
+				20886D3C2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift */,
 				203163AC2C1C5C54001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift */,
 				203163B22C1C5DAC001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift */,
 				205B7EBE2C19FBCA00D14A36 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift */,
@@ -16001,6 +16007,7 @@
 				451A04EA2386D28300E368C9 /* ProductImagesHeaderViewModel.swift in Sources */,
 				02307924258731B2008EADEE /* PrintShippingLabelViewModel.swift in Sources */,
 				D843D5D92248EE91001BFA55 /* ManualTrackingViewModel.swift in Sources */,
+				20886D3D2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift in Sources */,
 				204CB8102C10BB88000C9773 /* CardPresentPaymentPreviewService.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
 				035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */,
@@ -16156,6 +16163,7 @@
 				039298C82A45EE3900F393D5 /* MyStoreRoute.swift in Sources */,
 				0221121E288973C20028F0AF /* LocalNotification.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
+				20886D3F2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift in Sources */,
 				CEAEB75A2CD0F9A300C3E117 /* WooShippingPostPurchaseView.swift in Sources */,
 				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -868,6 +868,8 @@
 		208628742D48E4CB003F45DC /* TotalsViewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208628732D48E4CB003F45DC /* TotalsViewHelperTests.swift */; };
 		20886D3D2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20886D3C2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift */; };
 		20886D3F2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20886D3E2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift */; };
+		2088784B2D96E98000F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2088784A2D96E98000F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift */; };
+		2088784D2D96EA3900F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2088784C2D96EA3900F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift */; };
 		20897C9E2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20897C9D2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift */; };
 		209566252D4CF00100977124 /* PointOfSalePaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209566242D4CF00100977124 /* PointOfSalePaymentMethod.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift */; };
@@ -4111,6 +4113,8 @@
 		208628732D48E4CB003F45DC /* TotalsViewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewHelperTests.swift; sourceTree = "<group>"; };
 		20886D3C2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift; sourceTree = "<group>"; };
 		20886D3E2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift; sourceTree = "<group>"; };
+		2088784A2D96E98000F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift; sourceTree = "<group>"; };
+		2088784C2D96EA3900F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift; sourceTree = "<group>"; };
 		20897C9D2D4A68C5008AD16C /* PointOfSaleUnsupportedWidthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleUnsupportedWidthView.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		209566242D4CF00100977124 /* PointOfSalePaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePaymentMethod.swift; sourceTree = "<group>"; };
@@ -8239,6 +8243,7 @@
 				203163B42C1C5EB2001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift */,
 				203163BA2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */,
 				20886D3E2D96E5EA00F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift */,
+				2088784A2D96E98000F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift */,
 				203163B62C1C5EDF001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift */,
 				026826BB2BF59E410036F959 /* PointOfSaleCardPresentPaymentFoundReaderView.swift */,
 				0220F4942C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift */,
@@ -8280,6 +8285,7 @@
 				203163AE2C1C5C6B001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift */,
 				203163B02C1C5C87001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift */,
 				20886D3C2D96E0F900F7AE03 /* PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel.swift */,
+				2088784C2D96EA3900F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift */,
 				203163AC2C1C5C54001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift */,
 				203163B22C1C5DAC001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift */,
 				205B7EBE2C19FBCA00D14A36 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift */,
@@ -15773,6 +15779,7 @@
 				77E53EB8250E6A4E003D385F /* ProductDownloadListViewController.swift in Sources */,
 				26CE6F392B7E71AA008DB858 /* ConnectivityTool.swift in Sources */,
 				020EF5EB2A8C7105009D2169 /* SiteSnapshotTracker.swift in Sources */,
+				2088784B2D96E98000F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift in Sources */,
 				029106C02BE3349500C2248B /* OrderCustomerSectionViewModel.swift in Sources */,
 				E1325EFB28FD544E00EC9B2A /* InAppPurchasesDebugView.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
@@ -15973,6 +15980,7 @@
 				02BBD6E529A2678100243BE2 /* StoreOnboardingView.swift in Sources */,
 				02784A03238B8BC800BDD6A8 /* UIView+Border.swift in Sources */,
 				CE1CCB402056F21C000EE3AC /* Style.swift in Sources */,
+				2088784D2D96EA3900F7AE03 /* PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel.swift in Sources */,
 				EEC099382BF3C6A900FBCF6C /* MostActiveCouponsCardViewModel.swift in Sources */,
 				B943E7252AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift in Sources */,
 				45EF7984244F26BB00B22BA2 /* Array+IndexPath.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -182,9 +182,9 @@ extension MockCardReaderSettingsAlerts: BluetoothReaderConnnectionAlertsProvidin
         return MockCardPresentPaymentsModalViewModel()
     }
 
-    func locationRequired(dismiss: @escaping () -> Void) -> any AlertDetails {
+    func locationRequired(cancel: @escaping () -> Void) -> any AlertDetails {
         if let onLocationRequired {
-            onLocationRequired(dismiss)
+            onLocationRequired(cancel)
         }
         return MockCardPresentPaymentsModalViewModel()
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -18,7 +18,7 @@ final class MockCardReaderSettingsAlerts {
     private var didPresentFoundReader: Bool
 
     var onLocationRequestPreAlert: ((_ onLocationRequestPreAlert: @escaping () -> Void) -> Void)?
-    var onLocationRequired: ((_ dismiss: @escaping () -> Void, _ skip: @escaping () -> Void) -> Void)?
+    var onLocationRequired: ((_ dismiss: @escaping () -> Void) -> Void)?
 
     init(mode: MockCardReaderSettingsAlertsMode) {
         self.mode = mode
@@ -182,9 +182,9 @@ extension MockCardReaderSettingsAlerts: BluetoothReaderConnnectionAlertsProvidin
         return MockCardPresentPaymentsModalViewModel()
     }
 
-    func locationRequired(dismiss: @escaping () -> Void, skip: @escaping () -> Void) -> any AlertDetails {
+    func locationRequired(dismiss: @escaping () -> Void) -> any AlertDetails {
         if let onLocationRequired {
-            onLocationRequired(dismiss, skip)
+            onLocationRequired(dismiss)
         }
         return MockCardPresentPaymentsModalViewModel()
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -536,54 +536,6 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         assertEqual(.foundReader, source)
     }
 
-    func test_seachAndConnect_when_locationDenied_and_skipped_to_connect() {
-        // Given
-        let mockStoresManager = MockCardPresentPaymentsStoresManager(
-            connectedReaders: [],
-            discoveredReaders: [MockCardReader.bbposChipper2XBT()],
-            sessionManager: SessionManager.testingInstance,
-            storageManager: storageManager
-        )
-
-        let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
-        let mockAlerts = MockCardReaderSettingsAlerts(mode: .connectFoundReader)
-        let mockLocationService = MockLocationService(status: .denied)
-        mockAlerts.onLocationRequired = { _, skip in
-            skip()
-        }
-
-        let controller = CardReaderConnectionController(
-            forSiteID: sampleSiteID,
-            storageManager: storageManager,
-            stores: mockStoresManager,
-            knownReaderProvider: mockKnownReaderProvider,
-            alertsPresenter: MockCardPresentPaymentAlertsPresenter(),
-            alertsProvider: mockAlerts,
-            configuration: Mocks.configuration,
-            analyticsTracker: .init(configuration: Mocks.configuration,
-                                    siteID: sampleSiteID,
-                                    connectionType: .userInitiated,
-                                    stores: mockStoresManager,
-                                    analytics: analytics),
-            locationService: mockLocationService
-        )
-
-        // When
-        let connectionResult: CardReaderConnectionResult = waitFor { promise in
-            controller.searchAndConnect() { result in
-                if case .success(let connectionResult) = result {
-                    promise(connectionResult)
-                }
-            }
-        }
-
-        // Then
-        guard case .connected(let reader) = connectionResult else {
-            return XCTFail("Expected reader to be connected")
-        }
-        assertEqual(MockCardReader.bbposChipper2XBT(), reader)
-    }
-
     func test_seachAndConnect_when_locationNotDetermined_and_later_authorized() {
         // Given
         let mockStoresManager = MockCardPresentPaymentsStoresManager(
@@ -650,7 +602,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
             requestPermission()
         }
 
-        mockAlerts.onLocationRequired = { dismiss, _ in
+        mockAlerts.onLocationRequired = { dismiss in
             dismiss()
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15223 <!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Location permission is required to take card payments. Previously, the POS skipped the location pre-alert and the error for not having location permission when connecting the reader, which led to a failure when taking a payment.

This PR adds the views needed to show the location messages in POS.

Prior to this, M2 readers were unaffected, but WisePad3 readers could get stuck on an `Authorizing` step for a minute or two. That's no longer so likely, as it would require turning off location permissions after you've connected the reader.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Deny permission

1. Set the location permissions for Woo to `Ask next time` in iOS settings
2. Using a UK store, launch the app and navigate to POS
3. Tap `Connect your reader`
4. Observe that you're shown a pre-alert for the location permissions request
5. Don't allow the permissions
6. Observe that you're shown the location required error
7. Tap `x`
8. Observe that the reader does not connect.

### Grant permission

1. Set the location permissions for Woo to `Ask next time` in iOS settings
2. Using a UK store, launch the app and navigate to POS
3. Tap `Connect your reader`
4. Observe that you're shown a pre-alert for the location permissions request
5. Grant location permission
9. Add items to the cart and check out
10. Tap your card
11. Observe that payment completes successfully, and there's no payment loop

### Grant permission after a previous denial 

1. Set the location permissions for Woo to `Never` in iOS settings
2. Using a UK store, launch the app and navigate to POS
3. Tap `Connect your reader`
4. Observe that you're shown the location required error
5. Tap the `Go to settings` button
6. Observe that you're taken to the Woo screen in iOS settings
7. Grant location permission in settings
8. Go back to the app – observe that connection continues and completes
9. Add items to the cart and check out
10. Tap your card
11. Observe that payment completes successfully, and there's no payment loop

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested the above flows with an iPad Air running iOS 17.7.3, and a simulator and simulated reader. With the physical readers, I tested with an M2 and a Wisepad3

There was one very tricky bug around retrying payments after the first retry attempt – the payment cancellable was populated but invalid, when it should have been nil.

This happened because the `collectPaymentMethod` call on the first retry called its completion handler (which should have nilled the cancellable) before it returned the cancellable – so the nil happened, but then the function returned and we set the cancellable back up again. Checking some cancellation flows is worthwhile, particularly going back while the reader is preparing or as you tap a card.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/73c5162a-5b9f-4b16-b178-9671b7c12f91


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.