### PR TITLE
[Mobile Payments] Fix loading spinner color in dark mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [internal] POS: Always create a new order during the checkout [https://github.com/woocommerce/woocommerce-ios/pull/15427].
 - [internal] Improve data fetching in Order Details, to avoid I/O performance on the main thread. [https://github.com/woocommerce/woocommerce-ios/pull/14999]
 - [internal] POS: Show location pre-alert and error during reader connection [https://github.com/woocommerce/woocommerce-ios/pull/15456].
+- [internal] Payments: update reader preparation spinner color [https://github.com/woocommerce/woocommerce-ios/pull/15460]
 
 22.0
 -----

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IndefiniteCircularProgressViewStyle.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IndefiniteCircularProgressViewStyle.swift
@@ -4,8 +4,8 @@ public struct IndefiniteCircularProgressViewStyle: ProgressViewStyle {
     var size: CGFloat
     var lineWidth: CGFloat = Constants.lineWidth
     var lineCap: CGLineCap = .round
-    var circleColor: Color = Color(.primary).opacity(Constants.backgroundOpacity)
-    var fillColor: Color = Color(.primary)
+    var circleColor: Color = Color(.primaryButtonBackground).opacity(Constants.backgroundOpacity)
+    var fillColor: Color = Color(.primaryButtonBackground)
 
     private let arcStart: Double = Constants.initialArcStart
     private let animationDuration: Double = 1.6


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15364
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This updates the spinner to use the same colors as the primary button – it looks strange when this element goes to a more muted color in dark mode, similar to buttons.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and create an order
2. Collect payment
3. Connect your reader – observe that the steps which show a spinner don't look like they use old colours in dark mode any more.
4. Check that lightmode still looks correct as well.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on an iPad Air running 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/user-attachments/assets/4f711687-2b3e-4c59-8a31-3835c9c4660a

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.