### PR TITLE
Shipping Labels: Update tabs for shipments with purchased labels

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
@@ -60,7 +60,7 @@ public struct WooShippingLabelData: Decodable, Equatable {
     /// Labels purchased for the current order
     public let currentOrderLabels: [ShippingLabelPurchase]
 
-    init(currentOrderLabels: [ShippingLabelPurchase]) {
+    public init(currentOrderLabels: [ShippingLabelPurchase]) {
         self.currentOrderLabels = currentOrderLabels
     }
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
@@ -104,7 +104,9 @@ extension ShippingLabelPurchase: Decodable {
         let productIDs = try container.decodeIfPresent([Int64].self, forKey: .productIDs) ?? []
         let productNames = try container.decode([String].self, forKey: .productNames)
 
-        let shipmentID = try container.decodeIfPresent(String.self, forKey: .shipmentID)
+        let shipmentID = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                           forKey: .shipmentID,
+                                                           alternativeTypes: [.integer(transform: { String($0) })])
 
         self.init(siteID: siteID,
                   orderID: orderID,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -64,8 +64,11 @@ final class OrderDetailsDataSource: NSObject {
     /// Whether the button to create shipping labels should be visible.
     ///
     var shouldShowShippingLabelCreation: Bool {
-        return isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty &&
-            !isEligibleForPayment
+        if featureFlags.isFeatureFlagEnabled(.revampedShippingLabelCreation) {
+            // TODO-15375: update logic to show shipping label creation button
+            return isEligibleForShippingLabelCreation && !isEligibleForPayment
+        }
+        return isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty && !isEligibleForPayment
     }
 
     /// Whether the option to re-create shipping labels should be visible.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCardViewModel.swift
@@ -25,6 +25,7 @@ final class CollapsibleShipmentItemCardViewModel: ObservableObject, Identifiable
     }
 
     init(item: ShippingLabelPackageItem,
+         isSelectable: Bool = true,
          currency: String) {
         self.packageItem = item
 
@@ -34,7 +35,7 @@ final class CollapsibleShipmentItemCardViewModel: ObservableObject, Identifiable
                                                             currency: currency)
 
         self.mainItemRow = SelectableShipmentItemRowViewModel(itemID: "\(item.orderItemID)",
-                                                              isSelectable: true,
+                                                              isSelectable: isSelectable,
                                                               item: mainShippingItem,
                                                               showQuantity: true)
 
@@ -45,7 +46,7 @@ final class CollapsibleShipmentItemCardViewModel: ObservableObject, Identifiable
             for index in 0..<item.quantity.intValue {
                 let childShipmentId = "\(item.orderItemID)-sub-\(index)"
                 childItemRows.append(SelectableShipmentItemRowViewModel(itemID: childShipmentId,
-                                                                        isSelectable: true,
+                                                                        isSelectable: isSelectable,
                                                                         item: childShippingItem,
                                                                         showQuantity: false))
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -102,7 +102,9 @@ private extension WooShippingSplitShipmentsDetailView {
                        selectedTabIndicatorHeight: Layout.selectedTabIndicatorHeight,
                        tabPadding: Layout.tabPadding,
                        tabsNameFont: Font.subheadline.bold(),
-                       tabsIconSize: nil,
+                       tabsIconSize: Layout.purchasedIconWidth,
+                       tabsIconAlignment: .trailing,
+                       tabsIconForegroundColor: Color(.info),
                        tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
                        tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
             .overlay(alignment: .trailing) {
@@ -325,6 +327,7 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
         static let tabItemContentVerticalPadding: CGFloat = 9.0
         static let cornerRadius: CGFloat = 8
         static let gradientViewWidth: CGFloat = 32
+        static let purchasedIconWidth: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -26,20 +26,7 @@ struct WooShippingSplitShipmentsDetailView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: Layout.contentPadding) {
                         if viewModel.currentShipment.isPurchased {
-                            VStack {
-                                Text(Localization.PurchasedShipment.title)
-                                    .bold()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                Text(Localization.PurchasedShipment.subtitle)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-                            .multilineTextAlignment(.leading)
-                            .foregroundStyle(Layout.green)
-                            .padding(Layout.contentPadding)
-                            .background(
-                                Layout.greenBackground
-                                    .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
-                            )
+                            fulfilledShipmentView
                         }
 
                         AdaptiveStack(horizontalAlignment: .leading) {
@@ -150,6 +137,23 @@ private extension WooShippingSplitShipmentsDetailView {
             Image(systemName: "ellipsis")
                 .padding()
         }
+    }
+
+    var fulfilledShipmentView: some View {
+        VStack {
+            Text(Localization.PurchasedShipment.title)
+                .bold()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(Localization.PurchasedShipment.subtitle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .multilineTextAlignment(.leading)
+        .foregroundStyle(Layout.green)
+        .padding(Layout.contentPadding)
+        .background(
+            Layout.greenBackground
+                .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
+        )
     }
 
     var noticeStack: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -140,7 +140,7 @@ private extension WooShippingSplitShipmentsDetailView {
                 Button(String.localizedStringWithFormat(Localization.removeShipmentFormat,
                                                         viewModel.retrieveName(for: shipment).lowercased())) {
                     shipmentToRemove = shipment
-                }
+                }.disabled(shipment.isPurchased)
             }
             Divider()
             Button(Localization.mergeAll) {
@@ -227,36 +227,37 @@ private extension WooShippingSplitShipmentsDetailView {
 
             VStack {
                 ForEach(viewModel.shipmentsToMerge(for: shipment)) { otherShipment in
-                    HStack {
-                        Image(systemName: "arrow.turn.down.right")
-                            .foregroundStyle(otherShipment == shipmentToMergeInto ? Color.accentColor : Color.secondary)
-                            .subheadlineStyle()
-                            .bold()
-                        VStack(alignment: .leading) {
-                            Text(viewModel.retrieveName(for: otherShipment))
-                                .headlineStyle()
-                            AdaptiveStack(horizontalAlignment: .leading) {
-                                Text(otherShipment.quantity)
-                                Spacer()
-                                Text(otherShipment.itemsDetailLabel)
-                            }
-                            .font(.subheadline)
-                        }
-                    }
-                    .padding(Layout.contentPadding)
-                    .if(otherShipment == shipmentToMergeInto) { view in
-                        view.background(
-                            Color(.listSelectedBackground)
-                                .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
-                        )
-                    }
-                    .roundedBorder(cornerRadius: Layout.cornerRadius,
-                                   lineColor: otherShipment == shipmentToMergeInto ? .accentColor : Color(.separator),
-                                   lineWidth: otherShipment == shipmentToMergeInto ? 2 : 1)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
+                    Button {
                         shipmentToMergeInto = otherShipment
+                    } label: {
+                        HStack {
+                            Image(systemName: "arrow.turn.down.right")
+                                .foregroundStyle(otherShipment == shipmentToMergeInto ? Color.accentColor : Color.secondary)
+                                .font(.subheadline)
+                                .bold()
+                            VStack(alignment: .leading) {
+                                Text(viewModel.retrieveName(for: otherShipment))
+                                    .font(.headline)
+                                AdaptiveStack(horizontalAlignment: .leading) {
+                                    Text(otherShipment.quantity)
+                                    Spacer()
+                                    Text(otherShipment.itemsDetailLabel)
+                                }
+                                .font(.subheadline)
+                            }
+                        }
+                        .padding(Layout.contentPadding)
+                        .if(otherShipment == shipmentToMergeInto) { view in
+                            view.background(
+                                Color(.listSelectedBackground)
+                                    .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
+                            )
+                        }
+                        .roundedBorder(cornerRadius: Layout.cornerRadius,
+                                       lineColor: otherShipment == shipmentToMergeInto ? .accentColor : Color(.separator),
+                                       lineWidth: otherShipment == shipmentToMergeInto ? 2 : 1)
                     }
+                    .disabled(otherShipment.isPurchased)
                 }
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsDetailView.swift
@@ -25,6 +25,23 @@ struct WooShippingSplitShipmentsDetailView: View {
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: Layout.contentPadding) {
+                        if viewModel.currentShipment.isPurchased {
+                            VStack {
+                                Text(Localization.PurchasedShipment.title)
+                                    .bold()
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Text(Localization.PurchasedShipment.subtitle)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .multilineTextAlignment(.leading)
+                            .foregroundStyle(Layout.green)
+                            .padding(Layout.contentPadding)
+                            .background(
+                                Layout.greenBackground
+                                    .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
+                            )
+                        }
+
                         AdaptiveStack(horizontalAlignment: .leading) {
                             Text(viewModel.itemsCountLabel)
                                 .headlineStyle()
@@ -104,7 +121,7 @@ private extension WooShippingSplitShipmentsDetailView {
                        tabsNameFont: Font.subheadline.bold(),
                        tabsIconSize: Layout.purchasedIconWidth,
                        tabsIconAlignment: .trailing,
-                       tabsIconForegroundColor: Color(.info),
+                       tabsIconForegroundColor: Layout.green,
                        tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
                        tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
             .overlay(alignment: .trailing) {
@@ -328,6 +345,10 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
         static let cornerRadius: CGFloat = 8
         static let gradientViewWidth: CGFloat = 32
         static let purchasedIconWidth: CGFloat = 16
+
+        static let green = Color(UIColor(light: .withColorStudio(.green, shade: .shade60),
+                                         dark: .withColorStudio(.green, shade: .shade40)))
+        static let greenBackground = Color.withColorStudio(name: .green, shade: .shade0)
     }
 
     enum Localization {
@@ -405,6 +426,19 @@ fileprivate extension WooShippingSplitShipmentsDetailView {
                 comment: "Button to confirm removing a shipment in the shipping label creation flow. " +
                 "Placeholder is the name of the shipment. " +
                 "Reads as: 'Remove Shipment 1.'"
+            )
+        }
+
+        enum PurchasedShipment {
+            static let title = NSLocalizedString(
+                "wooShippingSplitShipmentsDetailView.purchasedShipment.title",
+                value: "You purchased a label for this shipment.",
+                comment: "Title label displayed on a shipment whose label is purchased in the shipping label creation flow."
+            )
+            static let subtitle = NSLocalizedString(
+                "wooShippingSplitShipmentsDetailView.purchasedShipment.subtitle",
+                value: "You can't move products into or out of it.",
+                comment: "Subtitle label displayed on a shipment whose label is purchased in the shipping label creation flow."
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -400,11 +400,11 @@ private extension WooShippingSplitShipmentsViewModel {
     }
 }
 
-// MARK: Create shipments
+// MARK: Shipments
 
 extension WooShippingSplitShipmentsViewModel {
 
-    static func createShipments(with config: WooShippingConfig,
+    private static func createShipments(with config: WooShippingConfig,
                                 packageItems: [ShippingLabelPackageItem],
                                 currency: String,
                                 currencySettings: CurrencySettings,
@@ -455,7 +455,7 @@ extension WooShippingSplitShipmentsViewModel {
         return shipments
     }
 
-    func createShipment(with contents: [CollapsibleShipmentItemCardViewModel]) -> Shipment {
+    private func createShipment(with contents: [CollapsibleShipmentItemCardViewModel]) -> Shipment {
         Shipment(contents: contents,
                  currency: order.currency,
                  currencySettings: currencySettings,
@@ -520,7 +520,7 @@ extension WooShippingSplitShipmentsViewModel {
 
     @discardableResult
     @MainActor
-    func updateShipment() async throws -> WooShippingShipments {
+    private func updateShipment() async throws -> WooShippingShipments {
         let shipments = editedShipmentsInfo
         return try await withCheckedThrowingContinuation { continuation in
             let action = WooShippingAction.updateShipment(siteID: order.siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -76,9 +76,10 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         "\(itemsWeightLabel) • \(itemsPriceLabel)"
     }
 
+    private let purchasedIcon = UIImage(systemName: "checkmark.circle.fill")?.withRenderingMode(.alwaysTemplate)
+
     var topTabItems: [TopTabItem<EmptyView>] {
         shipments.enumerated().map { (index, item) in
-            let purchasedIcon = UIImage(systemName: "checkmark.circle.fill")?.withRenderingMode(.alwaysTemplate)
             return TopTabItem(name: String.localizedStringWithFormat(Localization.shipmentFormat, index + 1),
                               icon: item.isPurchased ? purchasedIcon : nil,
                               content: { EmptyView() })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -111,14 +111,12 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         self.currencySettings = currencySettings
         self.shippingSettingsService = shippingSettingsService
 
-        let contents = items.map { item in
-            CollapsibleShipmentItemCardViewModel(item: item, currency: order.currency)
-        }
-        let shipment = Shipment(contents: contents,
-                                currency: order.currency,
-                                currencySettings: currencySettings,
-                                shippingSettingsService: shippingSettingsService)
-        self.shipments = [shipment]
+        self.shipments = Self.createShipments(with: config,
+                                              packageItems: items,
+                                              currency: order.currency,
+                                              currencySettings: currencySettings,
+                                              shippingSettingsService: shippingSettingsService)
+
         shipmentsSavedInRemote = editedShipmentsInfo
 
         configureSectionHeader()
@@ -402,8 +400,60 @@ private extension WooShippingSplitShipmentsViewModel {
     }
 }
 
-// MARK: Shipment
+// MARK: Create shipments
+
 extension WooShippingSplitShipmentsViewModel {
+
+    static func createShipments(with config: WooShippingConfig,
+                                packageItems: [ShippingLabelPackageItem],
+                                currency: String,
+                                currencySettings: CurrencySettings,
+                                shippingSettingsService: ShippingSettingsService) -> [Shipment] {
+        guard config.shipments.isEmpty == false else {
+            let contents = packageItems.map { item in
+                CollapsibleShipmentItemCardViewModel(item: item, currency: currency)
+            }
+            let shipment = Shipment(contents: contents,
+                                    currency: currency,
+                                    currencySettings: currencySettings,
+                                    shippingSettingsService: shippingSettingsService)
+            return [shipment]
+        }
+
+        let currentOrderLabels = config.shippingLabelData?.currentOrderLabels ?? []
+        var shipments = [Shipment]()
+
+        for key in config.shipments.keys.sorted() {
+            guard let shipmentItems = config.shipments[key] else {
+                continue
+            }
+
+            let isPurchased = (currentOrderLabels.filter { $0.shipmentID == key}).isNotEmpty
+
+            var shipmentContents = ShipmentContents()
+            for shipmentItem in shipmentItems {
+                guard let packageItem = packageItems.first(where: { $0.orderItemID == shipmentItem.id }),
+                      let subItems = shipmentItem.subItems else {
+                    continue
+                }
+
+                let quantity = subItems.count > 0 ? subItems.count : 1
+                let updatedItem = ShippingLabelPackageItem(copy: packageItem, quantity: Decimal(quantity))
+                let content = CollapsibleShipmentItemCardViewModel(item: updatedItem,
+                                                                   isSelectable: !isPurchased,
+                                                                   currency: currency)
+                shipmentContents.append(content)
+            }
+
+            let shipment = Shipment(contents: shipmentContents,
+                                    isPurchased: isPurchased,
+                                    currency: currency,
+                                    currencySettings: currencySettings,
+                                    shippingSettingsService: shippingSettingsService)
+            shipments.append(shipment)
+        }
+        return shipments
+    }
 
     func createShipment(with contents: [CollapsibleShipmentItemCardViewModel]) -> Shipment {
         Shipment(contents: contents,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -266,10 +266,10 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     }
 
     func mergeAllUnfulfilledShipments() {
+        let (unfulfilledShipments, fulfilledShipments) = shipments.partitioned(by: { $0.isPurchased })
         var mergedShipmentContents = ShipmentContents()
 
-        // TODO-15440: check for fulfilled shipments and remove them from the list.
-        shipments.forEach { shipment in
+        unfulfilledShipments.forEach { shipment in
             for item in shipment.contents {
                 let matchingItemIndex = mergedShipmentContents.firstIndex(where: {
                     $0.packageItem.productOrVariationID == item.packageItem.productOrVariationID
@@ -286,7 +286,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
             }
         }
 
-        shipments = [createShipment(with: mergedShipmentContents)]
+        shipments = [createShipment(with: mergedShipmentContents)] + fulfilledShipments
         selectedShipmentIndex = 0
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -78,8 +78,10 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
 
     var topTabItems: [TopTabItem<EmptyView>] {
         shipments.enumerated().map { (index, item) in
-            TopTabItem(name: String.localizedStringWithFormat(Localization.shipmentFormat, index + 1),
-                       content: { EmptyView() })
+            let purchasedIcon = UIImage(systemName: "checkmark.circle.fill")?.withRenderingMode(.alwaysTemplate)
+            return TopTabItem(name: String.localizedStringWithFormat(Localization.shipmentFormat, index + 1),
+                              icon: item.isPurchased ? purchasedIcon : nil,
+                              content: { EmptyView() })
         }
     }
 
@@ -414,6 +416,7 @@ extension WooShippingSplitShipmentsViewModel {
 
         let id = UUID().uuidString
         let contents: [CollapsibleShipmentItemCardViewModel]
+        let isPurchased: Bool
 
         let quantity: String
         let weight: String
@@ -426,10 +429,12 @@ extension WooShippingSplitShipmentsViewModel {
         }
 
         init(contents: [CollapsibleShipmentItemCardViewModel],
+             isPurchased: Bool = false,
              currency: String,
              currencySettings: CurrencySettings,
              shippingSettingsService: ShippingSettingsService) {
             self.contents = contents
+            self.isPurchased = isPurchased
 
             let items = contents.map(\.packageItem)
             let itemsCount = items.map(\.quantity).reduce(0, +)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -268,15 +268,19 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                     await self.loadStoreOptions()
                 }
             }
-
+            
             if originAddress.isEmpty {
                 group.addTask {
                     await self.loadOriginAddresses()
                 }
             }
-
-            group.addTask {
-                await self.loadShipmentsInfo()
+            
+            let totalOrderItems = order.items.map(\.quantity).reduce(0, +)
+            if totalOrderItems > 1 {
+                // Only fetch shipments info if there are more than one order items.
+                group.addTask {
+                    await self.loadShipmentsInfo()
+                }
             }
         }
 
@@ -443,7 +447,6 @@ private extension WooShippingCreateLabelsViewModel {
             stores.dispatch(action)
         }
 
-        // TODO: Create view model only if order has more than 1 items that can be split into multiple shipments. (Check web logic)
         if let config {
             splitShipmentsViewModel = WooShippingSplitShipmentsViewModel(order: order,
                                                                          config: config,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -268,13 +268,13 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                     await self.loadStoreOptions()
                 }
             }
-            
+
             if originAddress.isEmpty {
                 group.addTask {
                     await self.loadOriginAddresses()
                 }
             }
-            
+
             let totalOrderItems = order.items.map(\.quantity).reduce(0, +)
             if totalOrderItems > 1 {
                 // Only fetch shipments info if there are more than one order items.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -18,6 +18,11 @@ struct TopTabItem<Content: View> {
 }
 
 struct TopTabView<Content: View>: View {
+    enum TabsIconAlignment {
+        case leading
+        case trailing
+    }
+
     @Binding private var selectedTab: Int
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
@@ -50,6 +55,9 @@ struct TopTabView<Content: View>: View {
     // Specifies the height and width of the icon
     // - Applied with the conditional modifier
     let tabsIconSize: CGFloat?
+    let tabsIconAlignment: TabsIconAlignment
+    let tabsIconForegroundColor: Color?
+
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?
 
@@ -65,6 +73,8 @@ struct TopTabView<Content: View>: View {
          tabPadding: CGFloat = Layout.tabPadding,
          tabsNameFont: Font = .headline,
          tabsIconSize: CGFloat? = 20.0,
+         tabsIconAlignment: TabsIconAlignment = .leading,
+         tabsIconForegroundColor: Color? = nil,
          tabItemContentHorizontalPadding: CGFloat? = nil,
          tabItemContentVerticalPadding: CGFloat? = nil) {
         self.tabs = tabs
@@ -80,24 +90,26 @@ struct TopTabView<Content: View>: View {
         self.tabPadding = tabPadding
         self.tabsNameFont = tabsNameFont
         self.tabsIconSize = tabsIconSize
+        self.tabsIconAlignment = tabsIconAlignment
+        self.tabsIconForegroundColor = tabsIconForegroundColor
         self.tabItemContentHorizontalPadding = tabItemContentHorizontalPadding
         self.tabItemContentVerticalPadding = tabItemContentVerticalPadding
     }
 
     private func tabItemContentView(_ index: Int, selected: Bool) -> some View {
         HStack {
-            if let icon = tabs[index].icon {
-                Image(uiImage: icon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .if(tabsIconSize != nil) {
-                        $0.frame(width: tabsIconSize, height: tabsIconSize)
-                    }
+            if let icon = tabs[index].icon, tabsIconAlignment == .leading {
+                tabIconView(with: icon)
             }
+
             Text(tabs[index].name)
                 .font(tabsNameFont)
                 .foregroundColor(selected ? selectedStateColor : unselectedStateColor)
                 .id(index)
+
+            if let icon = tabs[index].icon, tabsIconAlignment == .trailing {
+                tabIconView(with: icon)
+            }
         }
         .contentShape(Rectangle())
         .onTapGesture {
@@ -108,6 +120,18 @@ struct TopTabView<Content: View>: View {
         }
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(selected ? [.isSelected, .isHeader] : [])
+    }
+
+    func tabIconView(with icon: UIImage) -> some View {
+        Image(uiImage: icon)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .if(tabsIconForegroundColor != nil) {
+                $0.foregroundStyle(tabsIconForegroundColor ?? .clear)
+            }
+            .if(tabsIconSize != nil) {
+                $0.frame(width: tabsIconSize, height: tabsIconSize)
+            }
     }
 
     var body: some View {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import WooCommerce
 import WooFoundation
 import Yosemite
+import struct Networking.WooShippingLabelData
+import struct Networking.ShippingLabelPurchase
 
 final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
 
@@ -79,7 +81,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         assertEqual("13 kg • ₹22.50", viewModel.itemsDetailLabel)
     }
 
-    func test_shipments_is_correct_initially() throws {
+    func test_shipments_is_correct_initially_if_config_is_empty() throws {
         // Given
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
                      sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
@@ -95,6 +97,36 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shipments.count, 1)
         let shipment = try XCTUnwrap(viewModel.shipments.first)
         XCTAssertEqual(shipment.contents.count, items.count)
+    }
+
+    func test_shipments_is_correct_initially_if_config_is_not_empty() throws {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+
+        // When
+        let shippingLabelData = WooShippingLabelData(currentOrderLabels: [ShippingLabelPurchase.fake().copy(shipmentID: "2")])
+        let config = WooShippingConfig(siteID: 123, shipments: [
+            "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+            "2": [WooShippingShipmentItem(id: 2, subItems: [])]
+        ], shippingLabelData: shippingLabelData)
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: config,
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        // Then
+        XCTAssertEqual(viewModel.shipments.count, 2)
+        XCTAssertEqual(viewModel.shipments[0].contents.count, 1)
+        XCTAssertEqual(viewModel.shipments[0].contents[0].packageItem.orderItemID, items[0].orderItemID)
+        XCTAssertEqual(viewModel.shipments[0].contents[0].packageItem.quantity, 2)
+        XCTAssertFalse(viewModel.shipments[0].isPurchased)
+
+        XCTAssertEqual(viewModel.shipments[1].contents.count, 1)
+        XCTAssertEqual(viewModel.shipments[1].contents[0].packageItem.orderItemID, items[1].orderItemID)
+        XCTAssertEqual(viewModel.shipments[1].contents[0].packageItem.quantity, 1)
+        XCTAssertTrue(viewModel.shipments[1].isPurchased)
     }
 
     // MARK: - `moveToNoticeViewModel`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -621,8 +621,8 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
     func test_mergeAllUnfulfilledShipments_updates_shipments_correctly() {
         // Given
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
-                        sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1),
-                        sampleItem(id: 3, weight: 4, value: 5, quantity: 3)]
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1),
+                     sampleItem(id: 3, weight: 4, value: 5, quantity: 3)]
         let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
                                                             config: WooShippingConfig.fake(),
                                                             items: items,
@@ -650,6 +650,44 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shipments[0].contents[1].packageItem.quantity, 1)
         XCTAssertEqual(viewModel.shipments[0].contents[2].packageItem.orderItemID, items[2].orderItemID)
         XCTAssertEqual(viewModel.shipments[0].contents[2].packageItem.quantity, 3)
+    }
+
+    func test_mergeAllUnfulfilledShipments_updates_shipments_correctly_when_there_exists_a_purchased_shipment() throws {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1),
+                     sampleItem(id: 3, weight: 4, value: 5, quantity: 3)]
+
+        let shippingLabelData = WooShippingLabelData(currentOrderLabels: [ShippingLabelPurchase.fake().copy(shipmentID: "2")])
+        let config = WooShippingConfig(siteID: 123, shipments: [
+            "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+            "2": [WooShippingShipmentItem(id: 2, subItems: [])],
+            "3": [WooShippingShipmentItem(id: 3, subItems: ["sub-1", "sub-2", "sub-3"])]
+        ], shippingLabelData: shippingLabelData)
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: config,
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        // Confidence check
+        XCTAssertEqual(viewModel.shipments.count, 3)
+
+        // When
+        viewModel.mergeAllUnfulfilledShipments()
+
+        // Then
+        XCTAssertEqual(viewModel.shipments.count, 2)
+        XCTAssertEqual(viewModel.shipments[0].contents.count, 2)
+        XCTAssertEqual(viewModel.shipments[0].contents[0].packageItem.orderItemID, items[0].orderItemID)
+        XCTAssertEqual(viewModel.shipments[0].contents[0].packageItem.quantity, 2)
+        XCTAssertEqual(viewModel.shipments[0].contents[1].packageItem.orderItemID, items[2].orderItemID)
+        XCTAssertEqual(viewModel.shipments[0].contents[1].packageItem.quantity, 3)
+
+
+        XCTAssertEqual(viewModel.shipments[1].contents.count, 1)
+        XCTAssertEqual(viewModel.shipments[1].contents[0].packageItem.orderItemID, items[1].orderItemID)
+        XCTAssertEqual(viewModel.shipments[1].contents[0].packageItem.quantity, 1)
     }
 
     // MARK: - `enableDoneButton`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -167,6 +167,82 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.originAddresses.addresses, [originAddress])
     }
 
+    func test_shipping_config_is_not_loaded_if_order_contains_one_item() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let error = NetworkError.notFound(response: nil)
+        let originAddress = WooShippingOriginAddress.fake().copy(id: "default", defaultAddress: true)
+
+        var loadedConfig = false
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.failure(error))
+            case .loadConfig(_, _, let completion):
+                loadedConfig = true
+                completion(.success(WooShippingConfig.fake()))
+            case .loadPackages, .verifyDestinationAddress:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+
+        // When
+        let order = Order.fake().copy(items: [OrderItem.fake().copy(quantity: Decimal(1))])
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores)
+
+        // Then
+        waitUntil {
+            viewModel.state != .loading
+        }
+        XCTAssertFalse(loadedConfig)
+        XCTAssertNil(viewModel.splitShipmentsViewModel)
+    }
+
+    func test_shipping_config_is_loaded_if_order_contains_more_than_one_item() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let error = NetworkError.notFound(response: nil)
+        let originAddress = WooShippingOriginAddress.fake().copy(id: "default", defaultAddress: true)
+
+        var loadedConfig = false
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.failure(error))
+            case .loadConfig(_, _, let completion):
+                loadedConfig = true
+                completion(.success(WooShippingConfig.fake()))
+            case .loadPackages, .verifyDestinationAddress:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+
+        // When
+        let order = Order.fake().copy(items: [OrderItem.fake().copy(quantity: Decimal(2))])
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores)
+
+        // Then
+        waitUntil {
+            viewModel.state != .loading
+        }
+        XCTAssertTrue(loadedConfig)
+        XCTAssertNotNil(viewModel.splitShipmentsViewModel)
+    }
+
     func test_origin_unverified_state_is_correct() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15440 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR implements a few changes to support showing existing shipments on the split shipments screen:
- Updated the order details screen to display the Create shipping label button even when a label is created. This is a temporary solution until #15375 is done. This change is also hidden under the feature flag to ensure that the behavior of the legacy flow stays the same.
- Updated the shipping label creation form to only load shipment configs and show the split shipments entry point if there are more than 1 item in the order.
- Updated the split shipments screen to display existing shipments in the loaded configs.
- Updated the shipment tabs when a shipment's label has already been purchased.
- Disabled removing purchased shipments.
- Updated the logic of merging all unfulfilled shipments to exclude purchased ones.

Note: the design found for the purchased shipment shows the checkbox disabled, but I think hiding the checkbox is simpler so I'm keeping that behavior.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing the Create shipping label button on the order details screen
1. Log in to a test store with Woo Shipping set up.
2. On the web, open a complete order with more than 1 physical product with different quantities - split shipments and purchase the label for one of the shipments.
3. Open the same order on the app and confirm that the Create shipping label button is available.
4. Switch to a different store with only the legacy WCShip plugin set up.
5. Open an order with a purchased shipping label and confirm that the Create shipping label button is unavailable.

### Testing the split shipments entry point
1. Log in to a test store with Woo Shipping set up.
2. On the app, open a complete order with more than 1 physical product with different quantities.
3. Select Create shipping label and confirm that the Split shipment entry point is displayed.
4. Navigate back to the order list and select an order with only 1 physical product with 1 item.
5. Select Create shipping label and confirm that the Split shipment entry point is not present.

### Testing existing shipments
1. Log in to a test store with Woo Shipping set up.
2. On the web, open a complete order with more than 1 physical product with different quantities - split shipments and purchase the label for one of the shipments.
3. Open the same order on the app and select Create shipping label > Split shipments.
4. Confirm that the correct shipments are displayed.
5. Confirm that the shipment with the purchased label is displayed with a check icon on the tab bar, and the items are not selectable.
6. Tap the ellipsis button on the tab bar and confirm that the purchased shipment is not enabled as an option to remove.
7. Select to remove any other shipments and confirm in the bottom sheet that the option to merge into the purchased shipment is disabled.
8. Tap the ellipsis button again and select Merge all unfulfilled. 
9. Confirm that only unfulfilled shipments are merged.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested and confirmed the above test cases in simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/7a5cb3bd-7a9a-4fe4-a11a-9fb52c0af108




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.