### PR TITLE
[Woo POS] Coupons: Update coupon service conformance

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -1,6 +1,5 @@
 import Observation
 import enum Yosemite.POSItem
-import enum Yosemite.CouponAction
 import protocol Yosemite.PointOfSaleItemServiceProtocol
 import protocol Yosemite.PointOfSaleCouponServiceProtocol
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -2,6 +2,7 @@ import Observation
 import enum Yosemite.POSItem
 import enum Yosemite.CouponAction
 import protocol Yosemite.PointOfSaleItemServiceProtocol
+import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
 @available(iOS 17.0, *)
 @Observable final class PointOfSaleCouponsController: PointOfSaleItemsControllerProtocol {
@@ -10,10 +11,10 @@ import protocol Yosemite.PointOfSaleItemServiceProtocol
                                                                                     itemStates: [:]))
     private let paginationTracker: AsyncPaginationTracker
     private var childPaginationTrackers: [POSItem: AsyncPaginationTracker] = [:]
-    private let itemProvider: PointOfSaleItemServiceProtocol
+    private let couponProvider: PointOfSaleCouponServiceProtocol
 
-    init(itemProvider: PointOfSaleItemServiceProtocol) {
-        self.itemProvider = itemProvider
+    init(itemProvider: PointOfSaleCouponServiceProtocol) {
+        self.couponProvider = itemProvider
         self.paginationTracker = .init()
     }
 
@@ -44,7 +45,7 @@ private extension PointOfSaleCouponsController {
     @MainActor
     func loadFirstPage() async {
         do {
-            let coupons = try await itemProvider.providePointOfSaleItems(pageNumber: 1).items
+            let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1).items
             itemsViewState = ItemsViewState(containerState: .content,
                                             itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
                                                               itemStates: [:]))

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -105,7 +105,7 @@ final class HubMenuViewModel: ObservableObject {
                                       storage: storage)
     }()
 
-    private(set) lazy var posCouponProvider: PointOfSaleItemServiceProtocol = {
+    private(set) lazy var posCouponProvider: PointOfSaleCouponServiceProtocol = {
         let storage = ServiceLocator.storageManager
         let currencySettings = ServiceLocator.currencySettings
         let stores = ServiceLocator.stores

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -3,25 +3,22 @@ import Testing
 import Foundation
 
 import protocol Yosemite.PointOfSaleItemServiceProtocol
+import protocol Yosemite.PointOfSaleCouponServiceProtocol
 import enum Yosemite.POSItem
 import struct Yosemite.POSCoupon
 import struct Yosemite.PagedItems
 import struct Yosemite.POSVariableParentProduct
 
-final class MockPointOfSaleCouponService: PointOfSaleItemServiceProtocol {
+final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     var shouldReturnZeroItems = false
 
-    func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
+    func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
         if shouldReturnZeroItems {
             return .init(items: [], hasMorePages: false)
         } else {
             return .init(items: Self.makeInitialCoupons(),
                          hasMorePages: false)
         }
-    }
-
-    func providePointOfSaleVariationItems(for parentProduct: POSVariableParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem> {
-        return .init(items: [], hasMorePages: false)
     }
 
     static func makeInitialCoupons() -> [POSItem] {

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -6,7 +6,11 @@ import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 import Storage
 
-public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
+public protocol PointOfSaleCouponServiceProtocol {
+    func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem>
+}
+
+public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     private var siteID: Int64
     private let currencyFormatter: CurrencyFormatter
     private let couponsRemote: CouponsRemote
@@ -40,7 +44,7 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
     // TODO:
     // gh-15326 - Return PagedItems<POSItem> instead.
     @MainActor
-    public func providePointOfSaleCoupons() async -> [POSItem] {
+    private func providePointOfSaleCoupons() async -> [POSItem] {
         guard let storage = storage else {
             return []
         }
@@ -69,13 +73,8 @@ public final class PointOfSaleCouponService: PointOfSaleItemServiceProtocol {
         }
     }
 
-    // TODO: Remove this conformance
-    public func providePointOfSaleVariationItems(for parentProduct: POSVariableParentProduct, pageNumber: Int) async throws -> PagedItems<POSItem> {
-        return .init(items: [], hasMorePages: false)
-    }
-
     @MainActor
-    public func providePointOfSaleItems(pageNumber: Int) async throws -> PagedItems<POSItem> {
+    public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
         let coupons = await providePointOfSaleCoupons()
 
         if !coupons.isEmpty {

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -1,5 +1,4 @@
 import protocol Networking.Network
-import protocol Networking.ProductVariationsRemoteProtocol
 import class Networking.CouponsRemote
 import class Networking.AlamofireNetwork
 import class WooFoundation.CurrencyFormatter
@@ -41,10 +40,28 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                   storage: storage)
     }
 
-    // TODO:
-    // gh-15326 - Return PagedItems<POSItem> instead.
     @MainActor
-    private func providePointOfSaleCoupons() async -> [POSItem] {
+    public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+        let coupons = await providePointOfSaleCoupons()
+
+        if !coupons.isEmpty {
+            // Fire-and-forget sync
+            Task.detached {
+                await self.syncCouponsFromRemote(pageNumber: pageNumber)
+            }
+            return .init(items: coupons, hasMorePages: false)
+        } else {
+            // Wait for the sync to complete
+            await syncCouponsFromRemote(pageNumber: pageNumber)
+            let refreshedCoupons = await providePointOfSaleCoupons()
+            return .init(items: refreshedCoupons, hasMorePages: false)
+        }
+    }
+}
+
+private extension PointOfSaleCouponService {
+    @MainActor
+    func providePointOfSaleCoupons() async -> [POSItem] {
         guard let storage = storage else {
             return []
         }
@@ -67,31 +84,13 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
         }
     }
 
-    private func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
+    func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
         coupons.compactMap { coupon in
                 .coupon(POSCoupon(id: UUID(), code: coupon.code))
         }
     }
 
-    @MainActor
-    public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
-        let coupons = await providePointOfSaleCoupons()
-
-        if !coupons.isEmpty {
-            // Fire-and-forget sync
-            Task.detached {
-                await self.syncCouponsFromRemote(pageNumber: pageNumber)
-            }
-            return .init(items: coupons, hasMorePages: false)
-        } else {
-            // Wait for the sync to complete
-            await syncCouponsFromRemote(pageNumber: pageNumber)
-            let refreshedCoupons = await providePointOfSaleCoupons()
-            return .init(items: refreshedCoupons, hasMorePages: false)
-        }
-    }
-
-    private func syncCouponsFromRemote(pageNumber: Int) async {
+    func syncCouponsFromRemote(pageNumber: Int) async {
         guard let stores = stores else {
             return
         }


### PR DESCRIPTION
## Description
This PR removes the `PointOfSaleItemServiceProtocol` conformance from the coupon service, and adds a new `PointOfSaleCouponServiceProtocol` instead, so it's more specialized to what we need.

## Testing information
There are no functional changes to how POS coupons currently work in trunk.

- Set `.enableCouponsInPointOfSale` to `true`
- Load POS, tap on coupons. Coupons will load normally
- Add a new coupon via the web. Pull-to-refresh the view a couple of times, you should see the new coupon synced at the top of the list.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
