### PR TITLE
[Order form] Fix blurry image for scan product, and QR & TTP payment methods; update selected icon color in product selector

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] Order Creation: Resolved an issue where the exit confirmation was not displayed when there were unsaved changes in a split view [https://github.com/woocommerce/woocommerce-ios/pull/15394].
 - [*] Order Creation: Fixed an issue where order recalculation would stop working after canceling a confirmation with unsaved changes [https://github.com/woocommerce/woocommerce-ios/pull/15392].
+- [*] Order Creation/Editing: Fixed blurry icons for product scanning, QR code & Tap To Pay payment methods. Polished checkmark icon color in selected product row. [https://github.com/woocommerce/woocommerce-ios/pull/15465]
 - [internal] POS: Always create a new order during the checkout [https://github.com/woocommerce/woocommerce-ios/pull/15427].
 - [internal] Improve data fetching in Order Details, to avoid I/O performance on the main thread. [https://github.com/woocommerce/woocommerce-ios/pull/14999]
 - [internal] POS: Show location pre-alert and error during reader connection [https://github.com/woocommerce/woocommerce-ios/pull/15456].

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -281,10 +281,6 @@ extension UIImage {
         UIImage(systemName: "wave.3.right.circle")?.withRenderingMode(.alwaysTemplate) ?? .creditCardImage
     }
 
-    static var bankIcon: UIImage {
-        UIImage(systemName: "building.columns")?.withRenderingMode(.alwaysTemplate) ?? .emptyBoxImage
-    }
-
     static var scanToPayIcon: UIImage {
         UIImage(systemName: "qrcode.viewfinder")?.withRenderingMode(.alwaysTemplate) ?? .creditCardImage
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -812,7 +812,7 @@ private extension ProductsSection {
                 ProgressView()
             } else {
                 HStack() {
-                    Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                    Image(systemName: "barcode.viewfinder")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(height: Layout.scanImageSize * scale)
@@ -838,7 +838,7 @@ private extension ProductsSection {
             if showAddProductViaSKUScannerLoading {
                 ProgressView()
             } else {
-                Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                Image(systemName: "barcode.viewfinder")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(height: Layout.scanImageSize * scale)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
@@ -28,7 +28,7 @@ struct GiftCardInputView: View {
                             Button {
                                 showsScanner = true
                             } label: {
-                                Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                                Image(systemName: "barcode.viewfinder")
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
                                     .frame(maxHeight: Constants.scanImageSize * scale)

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -43,7 +43,7 @@ struct PaymentMethodsView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     VStack(alignment: .leading, spacing: Layout.noSpacing) {
                         if viewModel.showTapToPayRow {
-                            MethodRow(icon: .tapToPayOnIPhoneIcon,
+                            MethodRow(icon: Image(systemName: "wave.3.right.circle"),
                                       title: Localization.tapToPay,
                                       accessibilityID: Accessibility.tapToPayMethod) {
                                 viewModel.collectPayment(using: .tapToPay, on: rootViewController, onSuccess: dismiss, onFailure: dismiss)
@@ -77,7 +77,11 @@ struct PaymentMethodsView: View {
                         if viewModel.showScanToPayRow {
                             Divider()
 
-                            MethodRow(icon: .scanToPayIcon, title: Localization.scanToPay, accessibilityID: Accessibility.scanToPayMethod) {
+                            MethodRow(
+                                icon: Image(systemName: "qrcode.viewfinder"),
+                                title: Localization.scanToPay,
+                                accessibilityID: Accessibility.scanToPayMethod
+                            ) {
                                 showingScanToPayView = true
                                 viewModel.trackCollectByScanToPay()
                             }
@@ -150,7 +154,7 @@ struct PaymentMethodsView: View {
 private struct MethodRow: View {
     /// Icon of the row
     ///
-    private let icon: UIImage
+    private let icon: Image
 
     /// Title of the row
     ///
@@ -173,6 +177,13 @@ private struct MethodRow: View {
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
 
     init(icon: UIImage, title: String, accessibilityID: String = "", action: @escaping () -> ()) {
+        self.icon = Image(uiImage: icon)
+        self.title = title
+        self.accessibilityID = accessibilityID
+        self.action = action
+    }
+
+    init(icon: Image, title: String, accessibilityID: String = "", action: @escaping () -> ()) {
         self.icon = icon
         self.title = title
         self.accessibilityID = accessibilityID
@@ -182,7 +193,7 @@ private struct MethodRow: View {
     var body: some View {
         Button(action: action) {
             HStack {
-                Image(uiImage: icon)
+                icon
                     .resizable()
                     .flipsForRightToLeftLayoutDirection(true)
                     .frame(width: PaymentMethodsView.Layout.iconWidthHeight(scale: scale),

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -87,7 +87,7 @@ struct ProductRow: View {
         Image(uiImage: viewModel.selectedState.image)
             .resizable()
             .frame(width: Layout.checkImageSize * scale, height: Layout.checkImageSize * scale)
-            .foregroundColor(isEnabled ? Color(.brand) : .gray)
+            .foregroundColor(isEnabled ? Color(.accent) : .gray)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15355 
Parts of #15363 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request includes changes to fix some blurry icons from converting `UIImage(systemName:)` to SwiftUI Image with scaled size. When a SwiftUI image is resizable, I think it's best to avoid using a `UIImage` as the explained in this [SO answer](https://stackoverflow.com/a/66526244). It also makes a quick update on the product selector row's checkmark icon to be more readable in dark mode.

### Standardizing Icons:

* [`WooCommerce/Classes/Extensions/UIImage+Woo.swift`](diffhunk://#diff-4194c2a99e1f0a5559f6429aac68d72051379e072f89585fb4038fd979c16e68L284-L287): Removed the unused `bankIcon` static variable.
* [`WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift`](diffhunk://#diff-2e1179be83959416087ddd5227efbd0be1f15ba739eadfd62943a0c548d8a54dL815-R815): Replaced `.scanImage` with the system icon `barcode.viewfinder` in two locations. [[1]](diffhunk://#diff-2e1179be83959416087ddd5227efbd0be1f15ba739eadfd62943a0c548d8a54dL815-R815) [[2]](diffhunk://#diff-2e1179be83959416087ddd5227efbd0be1f15ba739eadfd62943a0c548d8a54dL841-R841)
* [`WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift`](diffhunk://#diff-1b782a94edc3446cf016721caaaa81917efa8c0eea1e9c3966059fb3da29b9beL31-R31): Replaced `.scanImage` with the system icon `barcode.viewfinder`.

### Refactoring MethodRow Component:

* [`WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift`](diffhunk://#diff-80eacec4b691bde1f01beb6d9d0cd0b2eb9892ddac50f2987e9cf7c86dd022ccL46-R46): Replaced custom icons with system icons in `MethodRow` for QR code & TTP rows, and refactored `MethodRow` to support both `UIImage` and `Image`. [[1]](diffhunk://#diff-80eacec4b691bde1f01beb6d9d0cd0b2eb9892ddac50f2987e9cf7c86dd022ccL46-R46) [[2]](diffhunk://#diff-80eacec4b691bde1f01beb6d9d0cd0b2eb9892ddac50f2987e9cf7c86dd022ccL80-R84) [[3]](diffhunk://#diff-80eacec4b691bde1f01beb6d9d0cd0b2eb9892ddac50f2987e9cf7c86dd022ccL153-R157) [[4]](diffhunk://#diff-80eacec4b691bde1f01beb6d9d0cd0b2eb9892ddac50f2987e9cf7c86dd022ccR180-R186) [[5]](diffhunk://#diff-80eacec4b691bde1f01beb6d9d0cd0b2eb9892ddac50f2987e9cf7c86dd022ccL185-R196)

### Miscellaneous:

* [`WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift`](diffhunk://#diff-f1f515b54eeea03f87f4617ede3b35e781d9d064f560c26d070960bf7022ddc0L90-R90): Changed the color of the `Image` foreground from `.brand` to `.accent`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

For easier testing in the payment methods view, feel free to return true for TTP in `PaymentMethodsView` L45.

- Go to the Orders tab
- Tap + to create an order --> the scan CTA in the products section should not be blurry in all font sizes
- Open product selector if needed (like on iPhone)
- Select a product --> notice the checkmark icon in the selected product row should have enough contrast in both light and dark modes
- Recalculate --> the scan CTA in the products section title should not be blurry in all font sizes
- Create order
- Collect payment --> the icon in the QR code & TTP rows should not be blurry in all font sizes

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [x] @jaclync tested with gift card input in a store with Gift Cards extension (check screenshot).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | before | after
-- | -- | --
scan product CTA - no products | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 14 51 29](https://github.com/user-attachments/assets/09dd88dd-4726-4e35-ac12-8bcc428baed9) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 14 50 38](https://github.com/user-attachments/assets/29957010-8942-4810-9006-b5c803c5bb41)
scan product CTA - with products | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 14 51 38](https://github.com/user-attachments/assets/eafc7385-f5ac-4078-9222-b27608c0829b) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 14 50 29](https://github.com/user-attachments/assets/699776bd-874d-4940-b52a-1d756fe55d29)
scan CTA in gift card input | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 12 48](https://github.com/user-attachments/assets/a18c6765-c2e2-4772-bd7f-b737b0c946de) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 14 09](https://github.com/user-attachments/assets/7d5eeea4-2b43-40ab-abc6-4b50128f5829)
payment methods | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 37 00](https://github.com/user-attachments/assets/61da84d4-4245-459f-840b-1f447d72f28f) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 54 21](https://github.com/user-attachments/assets/dd5bb4ee-0802-4cb7-a58b-973a16d4f878)
product selector - dark | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 52 36](https://github.com/user-attachments/assets/994692b1-a9fc-47c6-a91e-62ab7df14b71) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 42 00](https://github.com/user-attachments/assets/79a37c07-1eae-4c39-b85f-7400dd73f9ad)
product selector - light | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 52 38](https://github.com/user-attachments/assets/0fc8eacd-4b6e-42c7-9e74-1da5edc0497f) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-01 at 15 42 02](https://github.com/user-attachments/assets/de7d7319-d6f3-416b-a345-c5266ce3986a)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.15