### PR TITLE
[Woo POS] Coupons: Show error when coupons are disabled in core

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -1,5 +1,6 @@
 import Observation
 import enum Yosemite.POSItem
+import enum Yosemite.PointOfSaleCouponServiceError
 import protocol Yosemite.PointOfSaleItemServiceProtocol
 import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
@@ -20,7 +21,8 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
     @MainActor
     func loadItems(base: ItemListBaseItem) async {
         // TODO:
-        // Handle unhappy path
+        // Handle unhappy path:
+        // Depending on the error type (failed to load vs coupons disabled) we want to show a different CTA choice
         await loadFirstPage()
     }
 
@@ -49,7 +51,16 @@ private extension PointOfSaleCouponsController {
                                             itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
                                                               itemStates: [:]))
         } catch {
-            debugPrint(error)
+            if let couponError = error as? PointOfSaleCouponServiceError {
+                switch couponError {
+                case .couponsLoadingError:
+                    itemsViewState = ItemsViewState(containerState: .error(.errorOnLoadingCoupons()),
+                                                    itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
+                case .couponsDisabled:
+                    itemsViewState = ItemsViewState(containerState: .error(.errorCouponsDisabled()),
+                                                    itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
+                }
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -34,7 +34,7 @@ struct PointOfSaleErrorState: Equatable {
     }
 
     static func errorCouponsDisabled() -> Self {
-        PointOfSaleErrorState(title: "Error loading coupons", subtitle: "Please enable coupons", buttonText: "Enable")
+        PointOfSaleErrorState(title: "Error loading coupons", subtitle: "Please enable coupons in WooCommerce Settings, and tap Retry", buttonText: "Retry")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -29,6 +29,14 @@ struct PointOfSaleErrorState: Equatable {
                               buttonText: Constants.failedToLoadVariationsNextPageButtonTitle)
     }
 
+    static func errorOnLoadingCoupons() -> Self {
+        PointOfSaleErrorState(title: "Error loading coupons", subtitle: "Error loading coupons", buttonText: "Retry")
+    }
+
+    static func errorCouponsDisabled() -> Self {
+        PointOfSaleErrorState(title: "Error loading coupons", subtitle: "Please enable coupons", buttonText: "Enable")
+    }
+
     enum Constants {
         static let failedToLoadProductsTitle = NSLocalizedString(
             "pos.itemList.failedToLoadProductsTitle",

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -42,6 +42,18 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+
+        loadStoreCouponSettings { result in
+            switch result {
+            case let .success(isEnabled):
+                debugPrint("Coupons enabled? \(isEnabled)")
+                break
+            case let .failure(error):
+                debugPrint("Coupons settings error: \(error)")
+                break
+            }
+        }
+
         let coupons = await providePointOfSaleCoupons()
 
         if !coupons.isEmpty {
@@ -56,6 +68,13 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
             let refreshedCoupons = await providePointOfSaleCoupons()
             return .init(items: refreshedCoupons, hasMorePages: false)
         }
+    }
+
+    private func loadStoreCouponSettings(onCompletion: @escaping ((Result<Bool, Error>) -> Void)) {
+        let action = SettingAction.retrieveCouponSetting(siteID: siteID) { result in
+            onCompletion(result)
+        }
+        stores?.dispatch(action)
     }
 }
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -42,18 +42,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
-
-        loadStoreCouponSettings { result in
-            switch result {
-            case let .success(isEnabled):
-                debugPrint("Coupons enabled? \(isEnabled)")
-                break
-            case let .failure(error):
-                debugPrint("Coupons settings error: \(error)")
-                break
-            }
-        }
-
+        let couponsEnabled = await checkStoreCouponSettings()
         let coupons = await providePointOfSaleCoupons()
 
         if !coupons.isEmpty {
@@ -68,13 +57,6 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
             let refreshedCoupons = await providePointOfSaleCoupons()
             return .init(items: refreshedCoupons, hasMorePages: false)
         }
-    }
-
-    private func loadStoreCouponSettings(onCompletion: @escaping ((Result<Bool, Error>) -> Void)) {
-        let action = SettingAction.retrieveCouponSetting(siteID: siteID) { result in
-            onCompletion(result)
-        }
-        stores?.dispatch(action)
     }
 }
 
@@ -125,6 +107,24 @@ private extension PointOfSaleCouponService {
             )
             Task { @MainActor in
                 stores.dispatch(action)
+            }
+        }
+    }
+
+    private func checkStoreCouponSettings() async -> Bool {
+        await withCheckedContinuation { continuation in
+            let action = SettingAction.retrieveCouponSetting(siteID: siteID) { result in
+                switch result {
+                case let .success(isEnabled):
+                    debugPrint("Coupons enabled? \(isEnabled)")
+                    continuation.resume(returning: isEnabled)
+                case let .failure(error):
+                    debugPrint("Coupons settings error: \(error)")
+                    continuation.resume(returning: false)
+                }
+            }
+            Task { @MainActor in
+                stores?.dispatch(action)
             }
         }
     }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -5,6 +5,11 @@ import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 import Storage
 
+public enum PointOfSaleCouponServiceError: Error {
+    case couponsLoadingError
+    case couponsDisabled
+}
+
 public protocol PointOfSaleCouponServiceProtocol {
     func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem>
 }
@@ -43,6 +48,10 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
         let couponsEnabled = await checkStoreCouponSettings()
+        if !couponsEnabled {
+            throw PointOfSaleCouponServiceError.couponsDisabled
+        }
+
         let coupons = await providePointOfSaleCoupons()
 
         if !coupons.isEmpty {
@@ -120,6 +129,24 @@ private extension PointOfSaleCouponService {
                     continuation.resume(returning: isEnabled)
                 case let .failure(error):
                     debugPrint("Coupons settings error: \(error)")
+                    continuation.resume(returning: false)
+                }
+            }
+            Task { @MainActor in
+                stores?.dispatch(action)
+            }
+        }
+    }
+
+    private func enableStoreCouponSettings() async -> Bool {
+        await withCheckedContinuation { continuation in
+            let action = SettingAction.enableCouponSetting(siteID: siteID) { result in
+                switch result {
+                case .success:
+                    debugPrint("Coupons enabled")
+                    continuation.resume(returning: true)
+                case let .failure(error):
+                    debugPrint("Error when attempting to enable Coupons: \(error)")
                     continuation.resume(returning: false)
                 }
             }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -137,22 +137,4 @@ private extension PointOfSaleCouponService {
             }
         }
     }
-
-    private func enableStoreCouponSettings() async -> Bool {
-        await withCheckedContinuation { continuation in
-            let action = SettingAction.enableCouponSetting(siteID: siteID) { result in
-                switch result {
-                case .success:
-                    debugPrint("Coupons enabled")
-                    continuation.resume(returning: true)
-                case let .failure(error):
-                    debugPrint("Error when attempting to enable Coupons: \(error)")
-                    continuation.resume(returning: false)
-                }
-            }
-            Task { @MainActor in
-                stores?.dispatch(action)
-            }
-        }
-    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Partially closes: #15348
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->


## Description:
This PR takes a first go to handling coupons being enabled or disabled in core. When coupons are disabled, we show an error screen prompting the user to enable them. Once done, we can refresh and coupons will load.

https://github.com/user-attachments/assets/d147239b-1326-478e-bc62-baa93d36eb14

## Next steps:

I think we have two options to move forward:
1. Current approach: The error message just tell the merchant "Please enable coupons in WooCommerce Settings, and retry", then wait until they do so in the web and retry. 
2. A continuation is the CTA showing "Retry" and which would call `enableStoreCouponSettings` at some point, which enables this setting and refreshes the view automatically. This would need some [refactor around how we retry errors](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift#L27-L32) in the dashboard view, or perhaps add a secondary action that we can use for coupons only.

In both cases we'd still need a way for the user to switch between products and coupons, this should not be an issue with the latest designs, as both are in the navigation bar, so there's no need for dismissal/close button.


## Testing information
- Load POS, go to coupons, see how they load
- In WooCommerce Settings > General > Disable "Enable the use of coupon codes" and save changes
- Reload the view in POS, observe how the error is displayed
- Re-enable coupons, reload the view in POS, observe how coupons are loaded.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
