### PR TITLE
[Woo POS] Coupons: Show error view when store has no coupons

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -43,16 +43,18 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 private extension PointOfSaleCouponsController {
     @MainActor
     func loadFirstPage() async {
-        // WIP
-        let containerState = ItemsContainerState.content
-        let stackState = ItemsStackState(root: .inlineError([], error: .errorCouponsNotFound()), itemStates: [:])
-        itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
-        return
         do {
             let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1).items
-            itemsViewState = ItemsViewState(containerState: .content,
-                                            itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
-                                                              itemStates: [:]))
+            if coupons.isEmpty {
+                let containerState = ItemsContainerState.content
+                let stackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
+                itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
+                
+            } else {
+                itemsViewState = ItemsViewState(containerState: .content,
+                                                itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
+                                                                  itemStates: [:]))
+            }
         } catch {
             debugPrint(error)
         }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -49,7 +49,6 @@ private extension PointOfSaleCouponsController {
                 let containerState = ItemsContainerState.content
                 let stackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
                 itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
-                
             } else {
                 itemsViewState = ItemsViewState(containerState: .content,
                                                 itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -43,6 +43,11 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 private extension PointOfSaleCouponsController {
     @MainActor
     func loadFirstPage() async {
+        // WIP
+        let containerState = ItemsContainerState.content
+        let stackState = ItemsStackState(root: .inlineError([], error: .errorCouponsNotFound()), itemStates: [:])
+        itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
+        return
         do {
             let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1).items
             itemsViewState = ItemsViewState(containerState: .content,

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -30,12 +30,27 @@ struct PointOfSaleErrorState: Equatable {
     }
 
     static func errorCouponsNotFound() -> Self {
-        PointOfSaleErrorState(title: "No coupons found",
-                              subtitle: "Boost your business by sending customers special offers and discounts",
-                              buttonText: "Create coupon")
+        PointOfSaleErrorState(title: Constants.noCouponsFoundTitle,
+                              subtitle: Constants.noCouponsFoundSubtitle
+                              buttonText: Constants.noCouponsFoundButtonTitle)
     }
 
     enum Constants {
+        static let noCouponsFoundTitle = NSLocalizedString(
+            "pos.itemList.noCouponsFoundTitle",
+            value: "No coupons found",
+            comment: "Text appearing on the coupon list screen when there's no coupons found."
+        )
+        static let noCouponsFoundSubtitle = NSLocalizedString(
+            "pos.itemList.noCouponsFoundSubtitle",
+            value: "Boost your business by sending customers special offers and discounts",
+            comment: "Text appearing on the coupons list screen as subtitle when there's no coupons found."
+        )
+        static let noCouponsFoundButtonTitle = NSLocalizedString(
+            "pos.itemList.noCouponsFoundButtonTitleButtonTitle",
+            value: "Create coupon",
+            comment: "Text for the button appearing on the coupons list screen when there's no coupons found."
+        )
         static let failedToLoadProductsTitle = NSLocalizedString(
             "pos.itemList.failedToLoadProductsTitle",
             value: "Error loading products",

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -28,6 +28,12 @@ struct PointOfSaleErrorState: Equatable {
                               subtitle: Constants.failedToLoadVariationsNextPageSubtitle,
                               buttonText: Constants.failedToLoadVariationsNextPageButtonTitle)
     }
+    
+    static func errorCouponsNotFound() -> Self {
+        PointOfSaleErrorState(title: "No coupons found",
+                              subtitle: "Boost your business by sending customers special offers and discounts",
+                              buttonText: "Create coupon")
+    }
 
     enum Constants {
         static let failedToLoadProductsTitle = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -28,7 +28,7 @@ struct PointOfSaleErrorState: Equatable {
                               subtitle: Constants.failedToLoadVariationsNextPageSubtitle,
                               buttonText: Constants.failedToLoadVariationsNextPageButtonTitle)
     }
-    
+
     static func errorCouponsNotFound() -> Self {
         PointOfSaleErrorState(title: "No coupons found",
                               subtitle: "Boost your business by sending customers special offers and discounts",

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -31,7 +31,7 @@ struct PointOfSaleErrorState: Equatable {
 
     static func errorCouponsNotFound() -> Self {
         PointOfSaleErrorState(title: Constants.noCouponsFoundTitle,
-                              subtitle: Constants.noCouponsFoundSubtitle
+                              subtitle: Constants.noCouponsFoundSubtitle,
                               buttonText: Constants.noCouponsFoundButtonTitle)
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -60,10 +60,14 @@ struct ItemListView: View {
                     .loaded(let items, _),
                     .inlineError(let items, _):
                 listView(items)
-            case .error:
-                // Currently unused, but this will show errors that are displayed inline with previously
-                // loaded items, e.g. when loading a new page or refreshing.
-                EmptyView()
+            case .error(let errorState):
+                if errorState == .errorCouponsNotFound() {
+                    PointOfSaleItemListErrorView(error: .errorCouponsNotFound(), onRetry: {
+                        // TODO
+                    })
+                } else {
+                    EmptyView()
+                }
             }
         }
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -31,13 +31,13 @@ final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
 struct PointOfSaleCouponsControllerTests {
     @available(iOS 17.0, *)
-    @Test func loadItems_when_empty_coupons_then_results_in_empty_loaded_state() async throws {
+    @Test func loadItems_when_empty_coupons_then_results_in_errorCouponsNotFound_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
         couponProvider.shouldReturnZeroItems = true
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .loaded([], hasMoreItems: false), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
@@ -65,13 +65,13 @@ struct PointOfSaleCouponsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func refreshItems_when_empty_coupons_then_results_in_empty_loaded_state() async throws {
+    @Test func refreshItems_when_empty_coupons_then_results_in_errorCouponsNotFound_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
         couponProvider.shouldReturnZeroItems = true
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .loaded([], hasMoreItems: false), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
@@ -99,13 +99,13 @@ struct PointOfSaleCouponsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func loadNextItems_when_empty_coupons_then_results_in_empty_loaded_state() async throws {
+    @Test func loadNextItems_when_empty_coupons_then_results_in_errorCouponsNotFound_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
         couponProvider.shouldReturnZeroItems = true
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .loaded([], hasMoreItems: false), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15345 

## Description
This PR handles showing an error when there's no coupons in store, caveats:
- I've reused the existing error UI, I didn't want to update the designs just in case these change.
- The action handler is not implemented yet

https://github.com/user-attachments/assets/f1742718-398c-48c5-b506-26d12cdaa8b8

We have an `.empty` state for the dashboard view, but currently this is pretty tied to showing as full-screen error for products, so for the moment I've treated this case as an error, so we could handle it with the cart showing up as well and being able to switch between products/errors tabs. I'll drop a comment in the design P2 to see if we want to keep this discrepancy (products showing empty full-screen vs coupons showing empty left-side-only), in which case the dashboard might need some further refactoring.

## Testing information
For easier testing, add the following line to the `PointOfSaleCouponService`:
```diff
    @MainActor
    public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+ return .init(items: [], hasMorePages: false)
```
- Load POS
- Tap on Coupons
- Observe the error screen is shown

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
