### PR TITLE
[Payments] Allow any number of retries for a retryable payment error

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -549,8 +549,7 @@ private extension CollectOrderPaymentUseCase {
                                         self.handlePaymentCancellation(from: .other)
                                     }
                                 case .failure(let error):
-                                    let retryError = CollectOrderPaymentUseCaseError.alreadyRetried(error)
-                                    self.checkThenHandlePaymentFailureAndRetryPayment(retryError,
+                                    self.checkThenHandlePaymentFailureAndRetryPayment(error,
                                                                                       alertProvider: paymentAlerts,
                                                                                       paymentGatewayAccount: paymentGatewayAccount,
                                                                                       channel: channel,
@@ -772,9 +771,7 @@ private extension CollectOrderPaymentUseCase {
         let isErrorEligibleForSendingFailureReceiptAfterPayment: Bool = {
             switch error {
             case CardReaderServiceError.paymentCaptureWithPaymentMethod(.paymentDeclinedByPaymentProcessorAPI, _),
-                CardReaderServiceError.paymentCapture(.paymentDeclinedByPaymentProcessorAPI),
-                CollectOrderPaymentUseCaseError.alreadyRetried(CardReaderServiceError.paymentCaptureWithPaymentMethod(.paymentDeclinedByPaymentProcessorAPI, _)),
-                CollectOrderPaymentUseCaseError.alreadyRetried(CardReaderServiceError.paymentCapture(.paymentDeclinedByPaymentProcessorAPI)):
+                CardReaderServiceError.paymentCapture(.paymentDeclinedByPaymentProcessorAPI):
                 return true
             default:
                 return false
@@ -914,7 +911,6 @@ enum CollectOrderPaymentUseCaseError: LocalizedError {
     case orderTotalChanged
     case couldNotRefreshOrder(Error)
     case orderAlreadyPaid
-    case alreadyRetried(Error)
 
     var errorDescription: String? {
         switch self {
@@ -930,10 +926,6 @@ enum CollectOrderPaymentUseCaseError: LocalizedError {
             return String.localizedStringWithFormat(Localization.couldNotRefreshOrderLocalizedDescription, error.localizedDescription)
         case .orderAlreadyPaid:
             return Localization.orderAlreadyPaidLocalizedDescription
-        case .alreadyRetried(let error as LocalizedError):
-            return error.errorDescription
-        case .alreadyRetried(let error):
-            return String.localizedStringWithFormat(Localization.couldNotRetryPaymentLocalizedDescription, error.localizedDescription)
         }
     }
 
@@ -962,10 +954,6 @@ enum CollectOrderPaymentUseCaseError: LocalizedError {
 
         static let paymentCancelledLocalizedDescription = NSLocalizedString(
             "The payment was cancelled.", comment: "Message shown if a payment cancellation is shown as an error.")
-
-        static let couldNotRetryPaymentLocalizedDescription = NSLocalizedString(
-            "Unable to process payment. We could not complete this payment while retrying. Underlying error: %1$@",
-            comment: "Error message when retrying an In-Person Payment and an unknown error is received.")
     }
 }
 
@@ -1025,7 +1013,7 @@ extension CardReaderServiceError: CardPaymentErrorProtocol {
 extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
     var retryApproach: CardPaymentRetryApproach {
         switch self {
-        case .flowCanceledByUser, .orderAlreadyPaid, .alreadyRetried, .orderTotalChanged:
+        case .flowCanceledByUser, .orderAlreadyPaid, .orderTotalChanged:
             return .dontRetry
         case .paymentGatewayNotFound:
             return .restart
@@ -1035,12 +1023,7 @@ extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
     }
 
     var requiresFallbackPaymentMethod: Bool {
-        switch self {
-        case .alreadyRetried(let error as CardReaderServiceError):
-            return error.requiresFallbackPaymentMethod
-        default:
-            return false
-        }
+        false
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13326 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request focuses on simplifying the error handling in the `CollectOrderPaymentUseCase` class by removing the `alreadyRetried` error case. The primary changes involve updating the error handling logic and cleaning up related code. From the discussion in https://github.com/woocommerce/woocommerce-ios/issues/13326, I agree that allowing the merchant to retry for any number of times makes sense especially if it can be from a recoverable issue like connectivity.

Key changes include:

### Error Handling Simplification:
* Removed the `alreadyRetried` error case from the `CollectOrderPaymentUseCaseError` enum and updated all relevant error handling logic to reflect this change. [[1]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38L917) [[2]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38L933-L936) [[3]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38L965-L968)
* Updated the `checkThenHandlePaymentFailureAndRetryPayment` method to handle errors directly without wrapping them in the `alreadyRetried` error case.
* Simplified the logic for determining if an error is eligible for sending a failure receipt after payment by removing checks for the `alreadyRetried` error case.
* Adjusted the `retryApproach` and `requiresFallbackPaymentMethod` properties in the `CardPaymentErrorProtocol` extension to remove references to the `alreadyRetried` error case. [[1]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38L1028-R1016) [[2]](diffhunk://#diff-0c3adf508810c6f3b2f211cb853971249def207885516de3c148ae660c8c1c38L1038-R1026)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

One easy way for me to reproduce a retryable error is to pay with an expired card (even though it feels non-retryable, retrying the same expired card will never work; it is the existing behavior).

### POS

- Launch POS in a store eligible for POS
- Add item(s) to cart
- Tap to connect to a reader
- When ready for payment, pay in a way that results in a retryable error (expired card, etc.)
- Tap to try again --> after failure again, the CTA should still be visible to try again. before this PR, the CTA to retry disappears after the first retry
- Tap to go back to checkout (❓  maybe this "Go back to checkout" CTA can be reworded to indicate that the customer can try another payment method?)
- Pay in a way that should succeed (valid test card, etc.) --> payment should succeed

### IPP

- Go to ther orders tab
- Create an order with some item(s) that totals to non-zero price
- Tap to collect payment
- Tap Card Reader payment method
- Connect to a reader if needed
- When ready for payment, pay in a way that results in a retryable error (expired card, etc.)
- Tap to try again --> after failure again, the CTA should still be visible to try again. before this PR, the CTA to retry disappears after the first retry
- Tap to go back to order (❓  maybe we can add a third CTA to try a different payment method without dismissing the payment collection flow?)
- Repeat collect payment steps above, and pay in a way that should succeed (valid test card, etc.) --> payment should succeed

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

POS:

https://github.com/user-attachments/assets/21f2a4cd-b8fd-45f6-b710-07498746716e

IPP:

https://github.com/user-attachments/assets/f4e90bcb-8e81-4184-a507-695cb83f8cde

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.