### PR TITLE
[Shipping Labels] Destination address status

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -580,13 +580,13 @@ private extension WooShippingCreateLabelsView {
         }
 
         enum AddressVerification {
-            static func label(for status: WooShippingCreateLabelsViewModel.DestinationAddressStatus) -> String {
+            static func label(for status: WooShippingAddressStatus) -> String {
                 switch status {
                 case .verified:
                     return verified
                 case .unverified:
                     return unverified
-                case .missing:
+                case .missingInformation:
                     return missing
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -457,13 +457,13 @@ private extension WooShippingCreateLabelsViewModel {
             switch result {
             case .success(let address):
                 destinationAddress = address.normalizedAddress.toWooShippingAddress()
-                destinationAddressStatus = address.isVerified ? .verified : .unverified
+                destinationAddressStatus = calculateDestinationAddressStatus(isVerified: address.isVerified)
             case .failure(let error):
                 DDLogError("⛔️ Error loading destination addresses for Woo Shipping labels: \(error)")
 
                 if let orderShippingAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress) {
                     destinationAddress = orderShippingAddress
-                    destinationAddressStatus = destinationAddressLines == nil ? .missing : .unverified
+                    destinationAddressStatus = calculateDestinationAddressStatus(isVerified: false)
                 } else {
                     destinationAddressStatus = .missingInformation
                 }
@@ -649,6 +649,16 @@ private extension WooShippingCreateLabelsViewModel {
                                      isLetter: WooShippingPackageType(rawValue: packageData.packageType) == .envelope,
                                      hazmatCategory: hazmatCategory?.rawValue,
                                      customsForm: customsForm)
+    }
+
+    func calculateDestinationAddressStatus(isVerified: Bool) -> WooShippingAddressStatus {
+        let viewModel = WooShippingEditAddressViewModel(address: destinationAddress,
+                                                        orderID: order.orderID,
+                                                        email: destinationEmail,
+                                                        isVerified: isVerified,
+                                                        originCountryCode: selectedOriginAddress?.country,
+                                                        originStateCode: selectedOriginAddress?.state)
+        return viewModel.status
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -107,15 +107,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")
     }
 
-    /// Possible statuses for a Woo Shipping destination address.
-    enum DestinationAddressStatus {
-        case verified
-        case unverified
-        case missing
-    }
-
     /// The current destination address status.
-    @Published private(set) var destinationAddressStatus: DestinationAddressStatus?
+    @Published private(set) var destinationAddressStatus: WooShippingAddressStatus?
 
     /// This property can be set to display a notice with the provided label about the destination address status.
     @Published var destinationAddressStatusNoticeLabel: String?
@@ -472,7 +465,7 @@ private extension WooShippingCreateLabelsViewModel {
                     destinationAddress = orderShippingAddress
                     destinationAddressStatus = destinationAddressLines == nil ? .missing : .unverified
                 } else {
-                    destinationAddressStatus = .missing
+                    destinationAddressStatus = .missingInformation
                 }
             }
         }
@@ -529,7 +522,7 @@ private extension WooShippingCreateLabelsViewModel {
                     return Localization.DestinationAddressStatus.verified
                 case .unverified:
                     return Localization.DestinationAddressStatus.unverified
-                case .missing:
+                case .missingInformation:
                     return Localization.DestinationAddressStatus.missing
                 }
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -123,19 +123,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let originAddress = WooShippingOriginAddress(id: "default_address",
-                                               company: "HEADQUARTERS",
-                                               address1: "15 ALGONKIN ST",
-                                               address2: "STE 100",
-                                               city: "TICONDEROGA",
-                                               state: "NY",
-                                               postcode: "12883-1487",
-                                               country: "US",
-                                               phone: "223-456-7890",
-                                               firstName: "JANE",
-                                               lastName: "DOE",
-                                               email: "TEST@EXAMPLE.COM",
-                                               defaultAddress: true,
-                                               isVerified: false)
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case .loadOriginAddresses(_, let completion):
@@ -345,19 +345,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_customsFormRequired_when_origin_and_destination_in_US_then_returns_false() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",
-                                               company: "HEADQUARTERS",
-                                               address1: "15 ALGONKIN ST",
-                                               address2: "STE 100",
-                                               city: "TICONDEROGA",
-                                               state: "NY",
-                                               postcode: "12883-1487",
-                                               country: "US",
-                                               phone: "223-456-7890",
-                                               firstName: "JANE",
-                                               lastName: "DOE",
-                                               email: "TEST@EXAMPLE.COM",
-                                               defaultAddress: true,
-                                               isVerified: false)
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
 
         let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
         let order = Order.fake().copy(shippingAddress: address)
@@ -372,19 +372,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_customsFormRequired_when_origin_address_is_US_military_then_returns_true() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",
-                                               company: "HEADQUARTERS",
-                                               address1: "15 ALGONKIN ST",
-                                               address2: "STE 100",
-                                               city: "TICONDEROGA",
-                                               state: "AA",
-                                               postcode: "12883-1487",
-                                               country: "US",
-                                               phone: "223-456-7890",
-                                               firstName: "JANE",
-                                               lastName: "DOE",
-                                               email: "TEST@EXAMPLE.COM",
-                                               defaultAddress: true,
-                                               isVerified: false)
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "AA",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
 
         let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
         let order = Order.fake().copy(shippingAddress: address)
@@ -399,19 +399,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_customsFormRequired_when_destination_address_is_US_military_then_returns_true() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",
-                                               company: "HEADQUARTERS",
-                                               address1: "15 ALGONKIN ST",
-                                               address2: "STE 100",
-                                               city: "TICONDEROGA",
-                                               state: "NY",
-                                               postcode: "12883-1487",
-                                               country: "US",
-                                               phone: "223-456-7890",
-                                               firstName: "JANE",
-                                               lastName: "DOE",
-                                               email: "TEST@EXAMPLE.COM",
-                                               defaultAddress: true,
-                                               isVerified: false)
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
 
         let address = Address.fake().copy(address1: "1 Main Street", city: "Military City", state: "AA", postcode: "12345", country: "US")
         let order = Order.fake().copy(shippingAddress: address)
@@ -426,19 +426,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_customsFormRequired_when_destination_address_is_not_in_US_then_returns_true() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",
-                                               company: "HEADQUARTERS",
-                                               address1: "15 ALGONKIN ST",
-                                               address2: "STE 100",
-                                               city: "TICONDEROGA",
-                                               state: "NY",
-                                               postcode: "12883-1487",
-                                               country: "US",
-                                               phone: "223-456-7890",
-                                               firstName: "JANE",
-                                               lastName: "DOE",
-                                               email: "TEST@EXAMPLE.COM",
-                                               defaultAddress: true,
-                                               isVerified: false)
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
 
         let address = Address.fake().copy(address1: "1 Main Street", city: "London", state: "LD", postcode: "12345", country: "GB")
         let order = Order.fake().copy(shippingAddress: address)
@@ -453,19 +453,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_itnMissingNoticeLabel_when_customs_form_is_not_required() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",
-                                               company: "HEADQUARTERS",
-                                               address1: "15 ALGONKIN ST",
-                                               address2: "STE 100",
-                                               city: "TICONDEROGA",
-                                               state: "NY",
-                                               postcode: "12883-1487",
-                                               country: "US",
-                                               phone: "223-456-7890",
-                                               firstName: "JANE",
-                                               lastName: "DOE",
-                                               email: "TEST@EXAMPLE.COM",
-                                               defaultAddress: true,
-                                               isVerified: false)
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
 
         let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
         let order = Order.fake().copy(shippingAddress: address)
@@ -480,19 +480,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     func test_itnMissingNoticeLabel_when_customs_form_is_required() {
         // Given
         let originAddress = WooShippingOriginAddress(id: "default_address",
-                                               company: "HEADQUARTERS",
-                                               address1: "15 ALGONKIN ST",
-                                               address2: "STE 100",
-                                               city: "TICONDEROGA",
-                                               state: "NY",
-                                               postcode: "12883-1487",
-                                               country: "US",
-                                               phone: "223-456-7890",
-                                               firstName: "JANE",
-                                               lastName: "DOE",
-                                               email: "TEST@EXAMPLE.COM",
-                                               defaultAddress: true,
-                                               isVerified: false)
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
 
         let address = Address.fake().copy(address1: "1 Main Street", city: "London", state: "LD", postcode: "12345", country: "GB")
         let order = Order.fake().copy(shippingAddress: address)
@@ -944,13 +944,28 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_destinationAddressStatus_unverified_and_noticeLabel_set_for_unverified_address() {
         // Given
-        let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
+        let address = Address.fake().copy(firstName: "JANE",
+                                          lastName: "DOE",
+                                          address1: "1 Main Street",
+                                          city: "San Francisco",
+                                          state: "CA",
+                                          postcode: "12345",
+                                          country: "US",
+                                          email: "jane@example.com")
         let order = Order.fake().copy(shippingAddress: address)
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case .verifyDestinationAddress(_, _, let completion):
-                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
+                let address = WooShippingNormalizedAddress.fake().copy(firstName: "JANE",
+                                                                       lastName: "DOE",
+                                                                       phone: "223-456-7890",
+                                                                       country: "US",
+                                                                       state: "CA",
+                                                                       address1: "1 Main Street",
+                                                                       city: "San Francisco",
+                                                                       postcode: "12345")
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: address,
                                                                                isTrivialNormalization: false,
                                                                                isVerified: false)))
             case .loadAccountSettings(_, let completion):
@@ -972,13 +987,28 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_destinationAddressStatus_verified_and_noticeLabel_set_for_verified_address() {
         // Given
-        let address = Address.fake().copy(address1: "1 Main Street", city: "San Francisco", state: "CA", postcode: "12345", country: "US")
+        let address = Address.fake().copy(firstName: "JANE",
+                                          lastName: "DOE",
+                                          address1: "1 Main Street",
+                                          city: "San Francisco",
+                                          state: "CA",
+                                          postcode: "12345",
+                                          country: "US",
+                                          email: "jane@example.com")
         let order = Order.fake().copy(shippingAddress: address)
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case .verifyDestinationAddress(_, _, let completion):
-                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
+                let address = WooShippingNormalizedAddress.fake().copy(firstName: "JANE",
+                                                                       lastName: "DOE",
+                                                                       phone: "223-456-7890",
+                                                                       country: "US",
+                                                                       state: "CA",
+                                                                       address1: "1 Main Street",
+                                                                       city: "San Francisco",
+                                                                       postcode: "12345")
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: address,
                                                                                isTrivialNormalization: nil,
                                                                                isVerified: true)))
             case .loadAccountSettings(_, let completion):
@@ -1021,7 +1051,46 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores)
 
         // Then
-        XCTAssertEqual(viewModel.destinationAddressStatus, .missing)
+        XCTAssertEqual(viewModel.destinationAddressStatus, .missingInformation)
+        XCTAssertNotNil(viewModel.destinationAddressStatusNoticeLabel)
+    }
+
+    func test_destinationAddressStatus_missing_and_noticeLabel_set_for_address_with_missing_information() {
+        // Given
+        let addressMissingName = Address.fake().copy(address1: "1 Main Street",
+                                                     city: "San Francisco",
+                                                     state: "CA",
+                                                     postcode: "12345",
+                                                     country: "US",
+                                                     email: "jane@addressMissingName.com")
+        let order = Order.fake().copy(shippingAddress: addressMissingName)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .verifyDestinationAddress(_, _, let completion):
+                let addressMissingName = WooShippingNormalizedAddress.fake().copy(phone: "223-456-7890",
+                                                                                  country: "US",
+                                                                                  state: "CA",
+                                                                                  address1: "1 Main Street",
+                                                                                  city: "San Francisco",
+                                                                                  postcode: "12345")
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: addressMissingName,
+                                                                               isTrivialNormalization: nil,
+                                                                               isVerified: true)))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadPackages, .loadOriginAddresses, .loadConfig:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores)
+
+        // Then
+        XCTAssertEqual(viewModel.destinationAddressStatus, .missingInformation)
         XCTAssertNotNil(viewModel.destinationAddressStatusNoticeLabel)
     }
 
@@ -1083,33 +1152,33 @@ private extension WooShippingCreateLabelsViewModelTests {
                                                                deliveryDays: 2,
                                                                deliveryDateGuaranteed: false),
                                 signatureRate: signatureRequirement == .signatureRequired ?
-                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                             insurance: "100",
-                                                             retailRate: 42.76,
-                                                             rate: 42.76,
-                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
-                                                             serviceID: "",
-                                                             carrierID: "usps",
-                                                             shipmentID: "",
-                                                             hasTracking: true,
-                                                             isSelected: false,
-                                                             isPickupFree: true,
-                                                             deliveryDays: 2,
-                                                             deliveryDateGuaranteed: false) : nil,
+                                ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                         insurance: "100",
+                                                         retailRate: 42.76,
+                                                         rate: 42.76,
+                                                         rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
+                                                         serviceID: "",
+                                                         carrierID: "usps",
+                                                         shipmentID: "",
+                                                         hasTracking: true,
+                                                         isSelected: false,
+                                                         isPickupFree: true,
+                                                         deliveryDays: 2,
+                                                         deliveryDateGuaranteed: false) : nil,
                                 adultSignatureRate: signatureRequirement == .adultSignatureRequired ?
-                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                             insurance: "100",
-                                                             retailRate: 46.96,
-                                                             rate: 46.96,
-                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
-                                                             serviceID: "",
-                                                             carrierID: "usps",
-                                                             shipmentID: "",
-                                                             hasTracking: true,
-                                                             isSelected: false,
-                                                             isPickupFree: true,
-                                                             deliveryDays: 2,
-                                                             deliveryDateGuaranteed: false) : nil)
+                                ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                                         insurance: "100",
+                                                         retailRate: 46.96,
+                                                         rate: 46.96,
+                                                         rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
+                                                         serviceID: "",
+                                                         carrierID: "usps",
+                                                         shipmentID: "",
+                                                         hasTracking: true,
+                                                         isSelected: false,
+                                                         isPickupFree: true,
+                                                         deliveryDays: 2,
+                                                         deliveryDateGuaranteed: false) : nil)
     }
 
     func samplePackageData() -> WooShippingPackageDataRepresentable {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15435 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To show the correct status of the destination address, this PR starts using the `WooShippingEditAddressViewModel` to check if there are missing fields in the destination address. 

Changes
- Pass destination address to `WooShippingEditAddressViewModel` to check for missing information.
- Reuse `WooShippingAddressStatus` enum and remove local `DestinationAddressStatus` enum. 
- Unit tests.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with Woo Shipping set up.
2. Create an order 1 physical product and a full shipping address.
3. Open the order from the mobile app.
4. Navigate to the create shipping labels flow and verify the destination address.
5. Dismiss the shipping labels flow. 
6. From the order details screen, remove the name/phone from the shipping address.
7. Open the create shipping labels flow and validate that the destination address status is shown as missing information.



## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Validated that the destination address status is marked as missing if missing address fields. 
- Validated that unverified and verified address statuses are displayed as before. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

If a verified destination address is missing required information such as name, phone or email.

| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/4421a56d-9025-404c-8d51-44eb95a5d864) | ![After](https://github.com/user-attachments/assets/d7137d59-a7ea-4b83-b950-22042b95c233) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.