### PR TITLE
[Woo POS] Restore checkStoreCouponSettings to PointOfSaleCouponService

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.54.0
+swiftlint_version: 0.55.1
 
 excluded:
   - DerivedData

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		012848DC2D9ED55B00A9C69B /* SettingStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */; };
+		012848DE2D9EDAC100A9C69B /* MockCouponStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */; };
 		0139C2B02D91D1C600C78FDE /* POSCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0139C2AF2D91D1C400C78FDE /* POSCart.swift */; };
 		016A776B2D9D30C90004FCD6 /* PointOfSaleCouponServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */; };
 		016A89D82D9D6DB50004FCD6 /* CouponStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */; };
@@ -558,6 +559,7 @@
 
 /* Begin PBXFileReference section */
 		012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStoreMethods.swift; sourceTree = "<group>"; };
+		012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponStoreMethods.swift; sourceTree = "<group>"; };
 		0139C2AF2D91D1C400C78FDE /* POSCart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCart.swift; sourceTree = "<group>"; };
 		016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCouponServiceTests.swift; sourceTree = "<group>"; };
 		016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreMethods.swift; sourceTree = "<group>"; };
@@ -2001,6 +2003,7 @@
 		B5C9DE1D2087FF20006B910A /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */,
 				20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */,
 				6801E41B2D1007D000F9DF46 /* MockPOSReceiptsRemote.swift */,
 				207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */,
@@ -2871,6 +2874,7 @@
 				748525AC218A45360036DF75 /* NotificationStoreTests.swift in Sources */,
 				26E5A09225A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift in Sources */,
 				020C908124C7D71D001E2BEB /* MockProductVariationsRemote.swift in Sources */,
+				012848DE2D9EDAC100A9C69B /* MockCouponStoreMethods.swift in Sources */,
 				020C907D24C729D6001E2BEB /* MockProductVariation.swift in Sources */,
 				7499936820EFC0ED00CF01CD /* OrderNoteStoreTests.swift in Sources */,
 				578CE7972475FD8200492EBF /* MockProductReview.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		012848DC2D9ED55B00A9C69B /* SettingStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */; };
 		012848DE2D9EDAC100A9C69B /* MockCouponStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */; };
+		012848E22D9EDF2D00A9C69B /* MockSettingStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848E12D9EDF2D00A9C69B /* MockSettingStoreMethods.swift */; };
 		0139C2B02D91D1C600C78FDE /* POSCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0139C2AF2D91D1C400C78FDE /* POSCart.swift */; };
 		016A776B2D9D30C90004FCD6 /* PointOfSaleCouponServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */; };
 		016A89D82D9D6DB50004FCD6 /* CouponStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */; };
@@ -560,6 +561,7 @@
 /* Begin PBXFileReference section */
 		012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStoreMethods.swift; sourceTree = "<group>"; };
 		012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponStoreMethods.swift; sourceTree = "<group>"; };
+		012848E12D9EDF2D00A9C69B /* MockSettingStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingStoreMethods.swift; sourceTree = "<group>"; };
 		0139C2AF2D91D1C400C78FDE /* POSCart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCart.swift; sourceTree = "<group>"; };
 		016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCouponServiceTests.swift; sourceTree = "<group>"; };
 		016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreMethods.swift; sourceTree = "<group>"; };
@@ -2003,6 +2005,7 @@
 		B5C9DE1D2087FF20006B910A /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				012848E12D9EDF2D00A9C69B /* MockSettingStoreMethods.swift */,
 				012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */,
 				20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */,
 				6801E41B2D1007D000F9DF46 /* MockPOSReceiptsRemote.swift */,
@@ -2856,6 +2859,7 @@
 				DE87F40C2D2F839700869522 /* AppSettingsStoreTests+ProductFilterHistory.swift in Sources */,
 				20D210C12B177EEF0099E517 /* WooPaymentsPayoutServiceTests.swift in Sources */,
 				D87F615E2265B1BC0031A13B /* AppSettingsStoreTests.swift in Sources */,
+				012848E22D9EDF2D00A9C69B /* MockSettingStoreMethods.swift in Sources */,
 				207D2D1B2CFA06BD00F79204 /* POSCartItemTests.swift in Sources */,
 				02E7FFD52562226B00C53030 /* ShippingLabelStoreTests.swift in Sources */,
 				031FD8A026FC970400B315C7 /* RosettaTestingHelper.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		012848DC2D9ED55B00A9C69B /* SettingStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */; };
 		0139C2B02D91D1C600C78FDE /* POSCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0139C2AF2D91D1C400C78FDE /* POSCart.swift */; };
 		016A776B2D9D30C90004FCD6 /* PointOfSaleCouponServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */; };
 		016A89D82D9D6DB50004FCD6 /* CouponStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */; };
@@ -556,6 +557,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStoreMethods.swift; sourceTree = "<group>"; };
 		0139C2AF2D91D1C400C78FDE /* POSCart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCart.swift; sourceTree = "<group>"; };
 		016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCouponServiceTests.swift; sourceTree = "<group>"; };
 		016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreMethods.swift; sourceTree = "<group>"; };
@@ -1118,6 +1120,7 @@
 		016A89D42D9D6D980004FCD6 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */,
 				016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */,
 			);
 			path = Helpers;
@@ -2629,6 +2632,7 @@
 				B93E03282A960CAD009CA9C1 /* TaxBasedOnSetting.swift in Sources */,
 				CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */,
 				74D42DBC221C983F00B4977D /* ShipmentTracking+ReadOnlyConvertible.swift in Sources */,
+				012848DC2D9ED55B00A9C69B /* SettingStoreMethods.swift in Sources */,
 				247CE87A258332B400F9D9D1 /* MockNotificationActionHandler.swift in Sources */,
 				CCCF3A8129C07DD9001D3507 /* ProductBundleItem+ReadOnlyConvertible.swift in Sources */,
 				B9AECD3E2850F41100E78584 /* OrderCardPresentPaymentEligibilityAction.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		0139C2B02D91D1C600C78FDE /* POSCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0139C2AF2D91D1C400C78FDE /* POSCart.swift */; };
 		016A776B2D9D30C90004FCD6 /* PointOfSaleCouponServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */; };
-		016A89D82D9D6DB50004FCD6 /* CouponService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A89D72D9D6DAE0004FCD6 /* CouponService.swift */; };
+		016A89D82D9D6DB50004FCD6 /* CouponStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */; };
 		016EFCAE2C4155650016BDAA /* OrderItem+BasePrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EFCAD2C4155650016BDAA /* OrderItem+BasePrice.swift */; };
 		016EFCB02C41559D0016BDAA /* OrderItem+BasePriceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EFCAF2C41559D0016BDAA /* OrderItem+BasePriceTests.swift */; };
 		01AAD8122D92DE110081D60B /* CouponsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AAD8112D92DE0F0081D60B /* CouponsError.swift */; };
@@ -558,7 +558,7 @@
 /* Begin PBXFileReference section */
 		0139C2AF2D91D1C400C78FDE /* POSCart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCart.swift; sourceTree = "<group>"; };
 		016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCouponServiceTests.swift; sourceTree = "<group>"; };
-		016A89D72D9D6DAE0004FCD6 /* CouponService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponService.swift; sourceTree = "<group>"; };
+		016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreMethods.swift; sourceTree = "<group>"; };
 		016EFCAD2C4155650016BDAA /* OrderItem+BasePrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItem+BasePrice.swift"; sourceTree = "<group>"; };
 		016EFCAF2C41559D0016BDAA /* OrderItem+BasePriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItem+BasePriceTests.swift"; sourceTree = "<group>"; };
 		01AAD8112D92DE0F0081D60B /* CouponsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponsError.swift; sourceTree = "<group>"; };
@@ -1118,7 +1118,7 @@
 		016A89D42D9D6D980004FCD6 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				016A89D72D9D6DAE0004FCD6 /* CouponService.swift */,
+				016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2408,7 +2408,7 @@
 				CE4FD4522350FB5400A16B31 /* OrderItemTaxRefund+ReadOnlyConvertible.swift in Sources */,
 				31A89EE6278CC38F002A588E /* StripeAccount+PaymentGatewayAccount.swift in Sources */,
 				02FF055223D983F30058E6E7 /* MediaExportService.swift in Sources */,
-				016A89D82D9D6DB50004FCD6 /* CouponService.swift in Sources */,
+				016A89D82D9D6DB50004FCD6 /* CouponStoreMethods.swift in Sources */,
 				45010695239A6CDE00E24722 /* TaxAction.swift in Sources */,
 				B9DFE4C02AA2136100174004 /* TaxRate+ReadOnlyConvertible.swift in Sources */,
 				03FBDA222631521100ACE257 /* CouponAction.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -19,15 +19,18 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     private let currencyFormatter: CurrencyFormatter
     private let storage: StorageManagerType?
     private let couponStoreMethods: CouponStoreMethodsProtocol
+    private let settingsStoreMethods: SettingStoreMethodsProtocol
 
     init(siteID: Int64,
          currencySettings: CurrencySettings,
          couponStoreMethods: CouponStoreMethodsProtocol,
+         settingStoreMethods: SettingStoreMethodsProtocol,
          storage: StorageManagerType) {
         self.siteID = siteID
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.storage = storage
         self.couponStoreMethods = couponStoreMethods
+        self.settingsStoreMethods = settingStoreMethods
     }
 
     public convenience init(siteID: Int64,
@@ -39,6 +42,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
                   couponStoreMethods: CouponStoreMethods(storageManager: storage, remote: remote),
+                  settingStoreMethods: SettingStoreMethods(storageManager: storage, network: network),
                   storage: storage)
     }
 
@@ -111,7 +115,17 @@ private extension PointOfSaleCouponService {
     }
 
     private func checkStoreCouponSettings() async -> Bool {
-        // TODO: WOOMOB-250
-        return true
+        await withCheckedContinuation { continuation in
+            settingsStoreMethods.retrieveCouponSetting(siteID: siteID) { result in
+                switch result {
+                case let .success(isEnabled):
+                    debugPrint("Coupons enabled? \(isEnabled)")
+                    continuation.resume(returning: isEnabled)
+                case let .failure(error):
+                    debugPrint("Coupons settings error: \(error)")
+                    continuation.resume(returning: false)
+                }
+            }
+        }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -18,16 +18,16 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     private var siteID: Int64
     private let currencyFormatter: CurrencyFormatter
     private let storage: StorageManagerType?
-    private let couponService: CouponServiceProtocol
+    private let couponStoreMethods: CouponStoreMethodsProtocol
 
     init(siteID: Int64,
          currencySettings: CurrencySettings,
-         couponService: CouponServiceProtocol,
+         couponStoreMethods: CouponStoreMethodsProtocol,
          storage: StorageManagerType) {
         self.siteID = siteID
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.storage = storage
-        self.couponService = couponService
+        self.couponStoreMethods = couponStoreMethods
     }
 
     public convenience init(siteID: Int64,
@@ -38,7 +38,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
         let remote = CouponsRemote(network: network)
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
-                  couponService: CouponService(storageManager: storage, remote: remote),
+                  couponStoreMethods: CouponStoreMethods(storageManager: storage, remote: remote),
                   storage: storage)
     }
 
@@ -99,7 +99,7 @@ private extension PointOfSaleCouponService {
 
     func syncCouponsFromRemote(pageNumber: Int) async {
         await withCheckedContinuation { continuation in
-            couponService.synchronizeCoupons(
+            couponStoreMethods.synchronizeCoupons(
                 siteID: siteID,
                 pageNumber: pageNumber,
                 pageSize: 25,
@@ -111,20 +111,6 @@ private extension PointOfSaleCouponService {
     }
 
     private func checkStoreCouponSettings() async -> Bool {
-        await withCheckedContinuation { continuation in
-            let action = SettingAction.retrieveCouponSetting(siteID: siteID) { result in
-                switch result {
-                case let .success(isEnabled):
-                    debugPrint("Coupons enabled? \(isEnabled)")
-                    continuation.resume(returning: isEnabled)
-                case let .failure(error):
-                    debugPrint("Coupons settings error: \(error)")
-                    continuation.resume(returning: false)
-                }
-            }
-            Task { @MainActor in
-                stores?.dispatch(action)
-            }
-        }
+        return true
     }
 }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -5,14 +5,12 @@ import Storage
 // MARK: - CouponStore
 //
 public final class CouponStore: Store {
-    private let remote: CouponsRemoteProtocol
     private let methods: CouponStoreMethods
 
     init(dispatcher: Dispatcher,
          storageManager: StorageManagerType,
          network: Network,
          remote: CouponsRemoteProtocol) {
-        self.remote = remote
         self.methods = CouponStoreMethods(storageManager: storageManager, remote: remote)
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -6,14 +6,14 @@ import Storage
 //
 public final class CouponStore: Store {
     private let remote: CouponsRemoteProtocol
-    private let service: CouponService
+    private let methods: CouponStoreMethods
 
     init(dispatcher: Dispatcher,
          storageManager: StorageManagerType,
          network: Network,
          remote: CouponsRemoteProtocol) {
         self.remote = remote
-        self.service = CouponService(storageManager: storageManager, remote: remote)
+        self.methods = CouponStoreMethods(storageManager: storageManager, remote: remote)
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -52,7 +52,7 @@ public final class CouponStore: Store {
 
         switch action {
         case .synchronizeCoupons(let siteID, let pageNumber, let pageSize, let onCompletion):
-            service.synchronizeCoupons(siteID: siteID,
+            methods.synchronizeCoupons(siteID: siteID,
                                        pageNumber: pageNumber,
                                        pageSize: pageSize,
                                        onCompletion: onCompletion)
@@ -110,7 +110,7 @@ private extension CouponStore {
                                "while expecting couponID \(couponID) and site \(siteID)")
                     return
                 }
-                self.service.deleteStoredCoupon(siteID: siteID, couponID: couponID) {
+                self.methods.deleteStoredCoupon(siteID: siteID, couponID: couponID) {
                     onCompletion(.success(()))
                 }
             }
@@ -133,7 +133,7 @@ private extension CouponStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let updatedCoupon):
-                self.service.upsertStoredCouponsInBackground(readOnlyCoupons: [updatedCoupon], siteID: updatedCoupon.siteID) {
+                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: [updatedCoupon], siteID: updatedCoupon.siteID) {
                     onCompletion(.success(updatedCoupon))
                 }
             }
@@ -156,7 +156,7 @@ private extension CouponStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let createdCoupon):
-                self.service.upsertStoredCouponsInBackground(readOnlyCoupons: [createdCoupon], siteID: createdCoupon.siteID) {
+                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: [createdCoupon], siteID: createdCoupon.siteID) {
                     onCompletion(.success(createdCoupon))
                 }
             }
@@ -222,7 +222,7 @@ private extension CouponStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let coupons):
-                self.service.upsertSearchResultsInBackground(siteID: siteID,
+                self.methods.upsertSearchResultsInBackground(siteID: siteID,
                                                      keyword: keyword,
                                                      readOnlyCoupons: coupons) {
                     onCompletion(.success(()))
@@ -249,7 +249,7 @@ private extension CouponStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let coupon):
-                self.service.upsertStoredCouponsInBackground(readOnlyCoupons: [coupon], siteID: siteID) {
+                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: [coupon], siteID: siteID) {
                     onCompletion(.success(coupon))
                 }
             }
@@ -270,7 +270,7 @@ private extension CouponStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let coupons):
-                self.service.upsertStoredCouponsInBackground(readOnlyCoupons: coupons, siteID: siteID) {
+                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: coupons, siteID: siteID) {
                     onCompletion(.success(coupons))
                 }
             }

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -57,238 +57,31 @@ public final class CouponStore: Store {
                                        pageSize: pageSize,
                                        onCompletion: onCompletion)
         case .deleteCoupon(let siteID, let couponID, let onCompletion):
-            deleteCoupon(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
+            methods.deleteCoupon(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
         case .updateCoupon(let coupon, let siteTimezone, let onCompletion):
-            updateCoupon(coupon, siteTimezone: siteTimezone, onCompletion: onCompletion)
+            methods.updateCoupon(coupon, siteTimezone: siteTimezone, onCompletion: onCompletion)
         case .createCoupon(let coupon, let siteTimezone, let onCompletion):
-            createCoupon(coupon, siteTimezone: siteTimezone, onCompletion: onCompletion)
+            methods.createCoupon(coupon, siteTimezone: siteTimezone, onCompletion: onCompletion)
         case .loadCouponReport(let siteID, let couponID, let startDate, let onCompletion):
-            loadCouponReport(siteID: siteID, couponID: couponID, startDate: startDate, onCompletion: onCompletion)
+            methods.loadCouponReport(siteID: siteID, couponID: couponID, startDate: startDate, onCompletion: onCompletion)
         case .loadMostActiveCoupons(let siteID, let numberOfCouponsToLoad, let timeRange, let siteTimezone, let onCompletion):
-            loadMostActiveCoupons(siteID: siteID,
-                                  numberOfCouponsToLoad: numberOfCouponsToLoad,
-                                  timeRange: timeRange,
-                                  siteTimezone: siteTimezone,
-                                  onCompletion: onCompletion)
+            methods.loadMostActiveCoupons(siteID: siteID,
+                                          numberOfCouponsToLoad: numberOfCouponsToLoad,
+                                          timeRange: timeRange,
+                                          siteTimezone: siteTimezone,
+                                          onCompletion: onCompletion)
         case .searchCoupons(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
-            searchCoupons(siteID: siteID,
-                          keyword: keyword,
-                          pageNumber: pageNumber,
-                          pageSize: pageSize,
-                          onCompletion: onCompletion)
+            methods.searchCoupons(siteID: siteID,
+                                  keyword: keyword,
+                                  pageNumber: pageNumber,
+                                  pageSize: pageSize,
+                                  onCompletion: onCompletion)
         case .retrieveCoupon(let siteID, let couponID, let onCompletion):
-            retrieveCoupon(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
+            methods.retrieveCoupon(siteID: siteID, couponID: couponID, onCompletion: onCompletion)
         case .validateCouponCode(let code, let siteID, let onCompletion):
-            validateCouponCode(code: code, siteID: siteID, onCompletion: onCompletion)
+            methods.validateCouponCode(code: code, siteID: siteID, onCompletion: onCompletion)
         case .loadCoupons(let siteID, let couponIDs, let onCompletion):
-            loadCoupons(siteID: siteID, couponIDs: couponIDs, onCompletion: onCompletion)
+            methods.loadCoupons(siteID: siteID, couponIDs: couponIDs, onCompletion: onCompletion)
         }
     }
-}
-
-// MARK: - Services
-//
-private extension CouponStore {
-    /// Deletes a coupon from a Site with what is persisted in the storage layer.
-    /// After the API request succeeds, the stored coupon should be removed from the local storage.
-    /// - Parameters:
-    ///   - siteID: The site that the deleted coupon belongs to.
-    ///   - couponID: The ID of the coupon to be deleted.
-    ///   - onCompletion: Closure to call after deletion is complete. Called on the main thread.
-    ///
-    func deleteCoupon(siteID: Int64, couponID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        remote.deleteCoupon(for: siteID, couponID: couponID) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .success(let coupon):
-                // This is unlikely to happen, but worth checking
-                guard coupon.siteID == siteID, coupon.couponID == couponID else {
-                    onCompletion(.failure(CouponError.unexpectedCouponDeleted))
-                    DDLogError("⛔️ Unexpected coupon: Deleted couponID \(coupon.couponID) for site \(coupon.siteID) " +
-                               "while expecting couponID \(couponID) and site \(siteID)")
-                    return
-                }
-                self.methods.deleteStoredCoupon(siteID: siteID, couponID: couponID) {
-                    onCompletion(.success(()))
-                }
-            }
-        }
-    }
-
-    /// Updates a coupon given its details.
-    /// After the API request succeeds, the stored coupon should be updated accordingly.
-    /// - Parameters:
-    ///   - coupon: The coupon to be updated
-    ///   - siteTimezone: the timezone configured on the site (also know as local time of the site).
-    ///   - onCompletion: Closure to call after update is complete. Called on the main thread.
-    ///
-    func updateCoupon(_ coupon: Coupon,
-                      siteTimezone: TimeZone? = nil,
-                      onCompletion: @escaping (Result<Coupon, Error>) -> Void) {
-        remote.updateCoupon(coupon, siteTimezone: siteTimezone) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .success(let updatedCoupon):
-                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: [updatedCoupon], siteID: updatedCoupon.siteID) {
-                    onCompletion(.success(updatedCoupon))
-                }
-            }
-        }
-    }
-
-    /// Creates a coupon given its details.
-    /// After the API request succeeds, a new stored coupon should be inserted into the local storage.
-    /// - Parameters:
-    ///   - coupon: The coupon to be created
-    ///   - siteTimezone: the timezone configured on the site (also know as local time of the site).
-    ///   - onCompletion: Closure to call after creation is complete. Called on the main thread.
-    ///
-    func createCoupon(_ coupon: Coupon,
-                      siteTimezone: TimeZone? = nil,
-                      onCompletion: @escaping (Result<Coupon, Error>) -> Void) {
-        remote.createCoupon(coupon, siteTimezone: siteTimezone) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .success(let createdCoupon):
-                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: [createdCoupon], siteID: createdCoupon.siteID) {
-                    onCompletion(.success(createdCoupon))
-                }
-            }
-        }
-    }
-
-    /// Loads analytics report for a coupon with the specified coupon ID and site ID.
-    ///
-    /// - Parameters:
-    ///     - siteID: ID of the site that the coupon belongs to.
-    ///     - couponID: ID of the coupon to load the analytics report for.
-    ///     - startDate: the start of the date range to load the analytics report for.
-    ///     - onCompletion: invoked when the creation finishes.
-    ///
-    func loadCouponReport(siteID: Int64, couponID: Int64, startDate: Date, onCompletion: @escaping (Result<CouponReport, Error>) -> Void) {
-        remote.loadCouponReport(for: siteID, couponID: couponID, from: startDate, completion: onCompletion)
-    }
-
-    /// Loads top 3 most active coupons report within the specified time range and site ID.
-    ///
-    /// - `siteID`: site ID.
-    /// - `numberOfCouponsToLoad`: Number of coupons to load.
-    /// - `timeRange`: Time range to fetch report for.
-    /// - `siteTimezone`: site's timezone
-    /// - `onCompletion`: invoked when the reports are fetched.
-    ///
-    func loadMostActiveCoupons(siteID: Int64,
-                               numberOfCouponsToLoad: Int,
-                               timeRange: StatsTimeRangeV4,
-                               siteTimezone: TimeZone,
-                               onCompletion: @escaping (Result<[CouponReport], Error>) -> Void) {
-        let to = timeRange.latestDate(currentDate: Date(), siteTimezone: siteTimezone)
-        let from = timeRange.earliestDate(latestDate: to, siteTimezone: siteTimezone)
-        remote.loadMostActiveCoupons(for: siteID,
-                                     numberOfCouponsToLoad: numberOfCouponsToLoad,
-                                     from: from,
-                                     to: to,
-                                     completion: onCompletion)
-    }
-
-    /// Search coupons from a Site that match a specified keyword.
-    /// Search results are persisted in the local storage to ensure
-    /// good performance for future search of the same keyword.
-    ///
-    /// - Parameters:
-    ///   - siteId: The site to search coupons for.
-    ///   - keyword: The string to match the results with.
-    ///   - pageNumber: Page number of coupons to fetch from the API
-    ///   - pageSize: Number of coupons per page to fetch from the API
-    ///   - onCompletion: Closure to call after the search is complete. Called on the main thread.
-    ///
-    func searchCoupons(siteID: Int64,
-                       keyword: String,
-                       pageNumber: Int,
-                       pageSize: Int,
-                       onCompletion: @escaping (_ result: Result<Void, Error>) -> Void) {
-        remote.searchCoupons(for: siteID,
-                             keyword: keyword,
-                             pageNumber: pageNumber,
-                             pageSize: pageSize) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .success(let coupons):
-                self.methods.upsertSearchResultsInBackground(siteID: siteID,
-                                                     keyword: keyword,
-                                                     readOnlyCoupons: coupons) {
-                    onCompletion(.success(()))
-                }
-            }
-        }
-    }
-
-    /// Retrieve a coupon from a Site given.
-    /// The fetched coupon is persisted to the local storage.
-    ///
-    /// - Parameters:
-    ///   - siteID: The site to retrieve the coupon for.
-    ///   - couponID: ID of the coupon to be retrieved.
-    ///   - onCompletion: Closure to call upon completion. Called on the main thread.
-    ///
-    func retrieveCoupon(siteID: Int64,
-                        couponID: Int64,
-                        onCompletion: @escaping (_ result: Result<Coupon, Error>) -> Void) {
-        remote.retrieveCoupon(for: siteID,
-                              couponID: couponID) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .success(let coupon):
-                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: [coupon], siteID: siteID) {
-                    onCompletion(.success(coupon))
-                }
-            }
-        }
-    }
-    /// Loads the coupons for a site given all the coupon IDs
-    ///
-    /// - `siteID`: the site for which coupons should be fetched.
-    /// - `couponIDs`: IDs of the coupons to be retrieved.
-    /// - `onCompletion`: invoked upon completion.
-    ///
-    func loadCoupons(siteID: Int64,
-                     couponIDs: [Int64],
-                     onCompletion: @escaping (_ result: Result<[Coupon], Error>) -> Void) {
-        remote.loadCoupons(for: siteID, by: couponIDs) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .success(let coupons):
-                self.methods.upsertStoredCouponsInBackground(readOnlyCoupons: coupons, siteID: siteID) {
-                    onCompletion(.success(coupons))
-                }
-            }
-        }
-    }
-
-    func validateCouponCode(code: String, siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
-        remote.searchCoupons(for: siteID, keyword: code, pageNumber: Remote.Default.firstPageNumber, pageSize: 25) { result in
-            switch result {
-            case let .success(coupons):
-                onCompletion(.success(coupons.contains(where: { $0.code == code })))
-            case let .failure(error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
-}
-
-public enum CouponError: Error {
-    case unexpectedCouponDeleted
 }

--- a/Yosemite/Yosemite/Stores/Helpers/CouponStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/CouponStoreMethods.swift
@@ -5,12 +5,51 @@ import Storage
 /// CouponStoreMethods is intentionally internal not to be exposed outside the module
 ///
 internal protocol CouponStoreMethodsProtocol {
-    func synchronizeCoupons(
-        siteID: Int64,
-        pageNumber: Int,
-        pageSize: Int,
-        onCompletion: @escaping (_ result: Result<Bool, Error>) -> Void
-    )
+    func synchronizeCoupons(siteID: Int64,
+                            pageNumber: Int,
+                            pageSize: Int,
+                            onCompletion: @escaping (_ result: Result<Bool, Error>) -> Void)
+
+    func deleteCoupon(siteID: Int64,
+                      couponID: Int64,
+                      onCompletion: @escaping (Result<Void, Error>) -> Void)
+
+    func updateCoupon(_ coupon: Coupon,
+                      siteTimezone: TimeZone?,
+                      onCompletion: @escaping (Result<Coupon, Error>) -> Void)
+
+    func createCoupon(_ coupon: Coupon,
+                      siteTimezone: TimeZone?,
+                      onCompletion: @escaping (Result<Coupon, Error>) -> Void)
+
+    func loadCouponReport(siteID: Int64,
+                          couponID: Int64,
+                          startDate: Date,
+                          onCompletion: @escaping (Result<CouponReport, Error>) -> Void)
+
+    func loadMostActiveCoupons(siteID: Int64,
+                               numberOfCouponsToLoad: Int,
+                               timeRange: StatsTimeRangeV4,
+                               siteTimezone: TimeZone,
+                               onCompletion: @escaping (Result<[CouponReport], Error>) -> Void)
+
+    func searchCoupons(siteID: Int64,
+                       keyword: String,
+                       pageNumber: Int,
+                       pageSize: Int,
+                       onCompletion: @escaping (_ result: Result<Void, Error>) -> Void)
+
+    func retrieveCoupon(siteID: Int64,
+                        couponID: Int64,
+                        onCompletion: @escaping (_ result: Result<Coupon, Error>) -> Void)
+
+    func loadCoupons(siteID: Int64,
+                     couponIDs: [Int64],
+                     onCompletion: @escaping (_ result: Result<[Coupon], Error>) -> Void)
+
+    func validateCouponCode(code: String,
+                           siteID: Int64,
+                           onCompletion: @escaping (Result<Bool, Error>) -> Void)
 }
 
 internal class CouponStoreMethods: CouponStoreMethodsProtocol {
@@ -60,8 +99,210 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
         }
     }
 
-    // MARK: - Storage Coupon
+    /// Deletes a coupon from a Site with what is persisted in the storage layer.
+    /// After the API request succeeds, the stored coupon should be removed from the local storage.
+    /// - Parameters:
+    ///   - siteID: The site that the deleted coupon belongs to.
+    ///   - couponID: The ID of the coupon to be deleted.
+    ///   - onCompletion: Closure to call after deletion is complete. Called on the main thread.
+    ///
+    func deleteCoupon(siteID: Int64, couponID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        remote.deleteCoupon(for: siteID, couponID: couponID) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let coupon):
+                // This is unlikely to happen, but worth checking
+                guard coupon.siteID == siteID, coupon.couponID == couponID else {
+                    onCompletion(.failure(CouponError.unexpectedCouponDeleted))
+                    DDLogError("⛔️ Unexpected coupon: Deleted couponID \(coupon.couponID) for site \(coupon.siteID) " +
+                               "while expecting couponID \(couponID) and site \(siteID)")
+                    return
+                }
+                self.deleteStoredCoupon(siteID: siteID, couponID: couponID) {
+                    onCompletion(.success(()))
+                }
+            }
+        }
+    }
 
+    /// Updates a coupon given its details.
+    /// After the API request succeeds, the stored coupon should be updated accordingly.
+    /// - Parameters:
+    ///   - coupon: The coupon to be updated
+    ///   - siteTimezone: the timezone configured on the site (also know as local time of the site).
+    ///   - onCompletion: Closure to call after update is complete. Called on the main thread.
+    ///
+    func updateCoupon(_ coupon: Coupon,
+                      siteTimezone: TimeZone? = nil,
+                      onCompletion: @escaping (Result<Coupon, Error>) -> Void) {
+        remote.updateCoupon(coupon, siteTimezone: siteTimezone) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let updatedCoupon):
+                self.upsertStoredCouponsInBackground(readOnlyCoupons: [updatedCoupon], siteID: updatedCoupon.siteID) {
+                    onCompletion(.success(updatedCoupon))
+                }
+            }
+        }
+    }
+
+    /// Creates a coupon given its details.
+    /// After the API request succeeds, a new stored coupon should be inserted into the local storage.
+    /// - Parameters:
+    ///   - coupon: The coupon to be created
+    ///   - siteTimezone: the timezone configured on the site (also know as local time of the site).
+    ///   - onCompletion: Closure to call after creation is complete. Called on the main thread.
+    ///
+    func createCoupon(_ coupon: Coupon,
+                      siteTimezone: TimeZone? = nil,
+                      onCompletion: @escaping (Result<Coupon, Error>) -> Void) {
+        remote.createCoupon(coupon, siteTimezone: siteTimezone) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let createdCoupon):
+                self.upsertStoredCouponsInBackground(readOnlyCoupons: [createdCoupon], siteID: createdCoupon.siteID) {
+                    onCompletion(.success(createdCoupon))
+                }
+            }
+        }
+    }
+
+    /// Loads analytics report for a coupon with the specified coupon ID and site ID.
+    ///
+    /// - Parameters:
+    ///     - siteID: ID of the site that the coupon belongs to.
+    ///     - couponID: ID of the coupon to load the analytics report for.
+    ///     - startDate: the start of the date range to load the analytics report for.
+    ///     - onCompletion: invoked when the creation finishes.
+    ///
+    func loadCouponReport(siteID: Int64, couponID: Int64, startDate: Date, onCompletion: @escaping (Result<CouponReport, Error>) -> Void) {
+        remote.loadCouponReport(for: siteID, couponID: couponID, from: startDate, completion: onCompletion)
+    }
+
+    /// Loads top 3 most active coupons report within the specified time range and site ID.
+    ///
+    /// - `siteID`: site ID.
+    /// - `numberOfCouponsToLoad`: Number of coupons to load.
+    /// - `timeRange`: Time range to fetch report for.
+    /// - `siteTimezone`: site's timezone
+    /// - `onCompletion`: invoked when the reports are fetched.
+    ///
+    func loadMostActiveCoupons(siteID: Int64,
+                               numberOfCouponsToLoad: Int,
+                               timeRange: StatsTimeRangeV4,
+                               siteTimezone: TimeZone,
+                               onCompletion: @escaping (Result<[CouponReport], Error>) -> Void) {
+        let to = timeRange.latestDate(currentDate: Date(), siteTimezone: siteTimezone)
+        let from = timeRange.earliestDate(latestDate: to, siteTimezone: siteTimezone)
+        remote.loadMostActiveCoupons(for: siteID,
+                                     numberOfCouponsToLoad: numberOfCouponsToLoad,
+                                     from: from,
+                                     to: to,
+                                     completion: onCompletion)
+    }
+
+    /// Search coupons from a Site that match a specified keyword.
+    /// Search results are persisted in the local storage to ensure
+    /// good performance for future search of the same keyword.
+    ///
+    /// - Parameters:
+    ///   - siteId: The site to search coupons for.
+    ///   - keyword: The string to match the results with.
+    ///   - pageNumber: Page number of coupons to fetch from the API
+    ///   - pageSize: Number of coupons per page to fetch from the API
+    ///   - onCompletion: Closure to call after the search is complete. Called on the main thread.
+    ///
+    func searchCoupons(siteID: Int64,
+                       keyword: String,
+                       pageNumber: Int,
+                       pageSize: Int,
+                       onCompletion: @escaping (_ result: Result<Void, Error>) -> Void) {
+        remote.searchCoupons(for: siteID,
+                             keyword: keyword,
+                             pageNumber: pageNumber,
+                             pageSize: pageSize) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let coupons):
+                self.upsertSearchResultsInBackground(siteID: siteID,
+                                                     keyword: keyword,
+                                                     readOnlyCoupons: coupons) {
+                    onCompletion(.success(()))
+                }
+            }
+        }
+    }
+
+    /// Retrieve a coupon from a Site given.
+    /// The fetched coupon is persisted to the local storage.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site to retrieve the coupon for.
+    ///   - couponID: ID of the coupon to be retrieved.
+    ///   - onCompletion: Closure to call upon completion. Called on the main thread.
+    ///
+    func retrieveCoupon(siteID: Int64,
+                        couponID: Int64,
+                        onCompletion: @escaping (_ result: Result<Coupon, Error>) -> Void) {
+        remote.retrieveCoupon(for: siteID,
+                              couponID: couponID) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let coupon):
+                self.upsertStoredCouponsInBackground(readOnlyCoupons: [coupon], siteID: siteID) {
+                    onCompletion(.success(coupon))
+                }
+            }
+        }
+    }
+    /// Loads the coupons for a site given all the coupon IDs
+    ///
+    /// - `siteID`: the site for which coupons should be fetched.
+    /// - `couponIDs`: IDs of the coupons to be retrieved.
+    /// - `onCompletion`: invoked upon completion.
+    ///
+    func loadCoupons(siteID: Int64,
+                     couponIDs: [Int64],
+                     onCompletion: @escaping (_ result: Result<[Coupon], Error>) -> Void) {
+        remote.loadCoupons(for: siteID, by: couponIDs) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let coupons):
+                self.upsertStoredCouponsInBackground(readOnlyCoupons: coupons, siteID: siteID) {
+                    onCompletion(.success(coupons))
+                }
+            }
+        }
+    }
+
+    func validateCouponCode(code: String, siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        remote.searchCoupons(for: siteID, keyword: code, pageNumber: Remote.Default.firstPageNumber, pageSize: 25) { result in
+            switch result {
+            case let .success(coupons):
+                onCompletion(.success(coupons.contains(where: { $0.code == code })))
+            case let .failure(error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+}
+
+// MARK: - Persistence
+
+private extension CouponStoreMethods {
     /// Updates or Inserts specified Coupon Entities in a background thread
     /// `onCompletion` will be called on the main thread.
     ///
@@ -91,7 +332,7 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
     /// Deletes the Storage.Coupon with the specified `siteID` and `couponID` in a background thread.
     /// Triggers `onCompletion` on the main thread when done.
     ///
-    private func upsertStoredCoupons(readOnlyCoupons: [Networking.Coupon],
+    func upsertStoredCoupons(readOnlyCoupons: [Networking.Coupon],
                              in storage: StorageType,
                              siteID: Int64) {
         let storedCoupons = storage.loadCoupons(siteID: siteID, with: readOnlyCoupons.map { $0.couponID })
@@ -119,7 +360,7 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
 
     /// Upserts the Coupons, and associates them to the Search Results Entity (in the specified Storage)
     ///
-    private func upsertStoredResults(siteID: Int64, keyword: String, readOnlyCoupons: [Networking.Coupon], in storage: StorageType) {
+    func upsertStoredResults(siteID: Int64, keyword: String, readOnlyCoupons: [Networking.Coupon], in storage: StorageType) {
         let searchResult = storage.loadCouponSearchResult(keyword: keyword) ?? storage.insertNewObject(ofType: Storage.CouponSearchResult.self)
         searchResult.keyword = keyword
 
@@ -132,4 +373,8 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
             storedCoupon.addToSearchResults(searchResult)
         }
     }
+}
+
+public enum CouponError: Error {
+    case unexpectedCouponDeleted
 }

--- a/Yosemite/Yosemite/Stores/Helpers/CouponStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/CouponStoreMethods.swift
@@ -1,10 +1,10 @@
 import Networking
 import Storage
 
-/// CouponService extracts functionality of CouponStore that needs be reused within Yosemite
-/// Service is intentionally internal not to be exposed outside the module
+/// CouponStoreMethods extracts functionality of CouponStore that needs be reused within Yosemite
+/// CouponStoreMethods is intentionally internal not to be exposed outside the module
 ///
-internal protocol CouponServiceProtocol {
+internal protocol CouponStoreMethodsProtocol {
     func synchronizeCoupons(
         siteID: Int64,
         pageNumber: Int,
@@ -13,7 +13,7 @@ internal protocol CouponServiceProtocol {
     )
 }
 
-internal class CouponService: CouponServiceProtocol {
+internal class CouponStoreMethods: CouponStoreMethodsProtocol {
     private let remote: CouponsRemoteProtocol
     private let storageManager: StorageManagerType
 

--- a/Yosemite/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -1,0 +1,244 @@
+import Foundation
+import Networking
+import Storage
+
+/// SettingStoreMethods extracts functionality of SettingStore that needs be reused within Yosemite
+/// SettingStoreMethods is intentionally internal not to be exposed outside the module
+///
+internal protocol SettingStoreMethodsProtocol {
+    func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void)
+    func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void)
+    func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void)
+    func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void)
+    func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void)
+    func retrieveAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void)
+    func enableAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void)
+    func retrieveTaxBasedOnSetting(siteID: Int64, onCompletion: @escaping (Result<TaxBasedOnSetting, Error>) -> Void)
+}
+
+internal class SettingStoreMethods: SettingStoreMethodsProtocol {
+    private let siteSettingsRemote: SiteSettingsRemote
+    private let siteAPIRemote: SiteAPIRemote
+    private let storageManager: StorageManagerType
+    private let network: Network
+
+    init(storageManager: StorageManagerType, network: Network) {
+        self.siteSettingsRemote = SiteSettingsRemote(network: network)
+        self.siteAPIRemote = SiteAPIRemote(network: network)
+        self.network = network
+        self.storageManager = storageManager
+    }
+
+    /// Synchronizes the general site settings associated with the provided Site ID (if any!).
+    ///
+    func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
+        siteSettingsRemote.loadGeneralSettings(for: siteID) { [weak self] (settings, error) in
+            guard let settings = settings else {
+                onCompletion(error)
+                return
+            }
+
+            self?.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: settings) {
+                onCompletion(nil)
+            }
+        }
+    }
+
+    /// Synchronizes the product site settings associated with the provided Site ID (if any!).
+    ///
+    func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
+        siteSettingsRemote.loadProductSettings(for: siteID) { [weak self] (settings, error) in
+            guard let settings = settings else {
+                onCompletion(error)
+                return
+            }
+
+            self?.upsertStoredProductSettingsInBackground(siteID: siteID, readOnlySiteSettings: settings) {
+                onCompletion(nil)
+            }
+        }
+    }
+
+    /// Retrieves the site API information associated with the provided Site ID (if any!).
+    /// This call does NOT persist returned data into the Storage layer.
+    ///
+    func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void) {
+        siteAPIRemote.loadAPIInformation(for: siteID, completion: onCompletion)
+    }
+
+    /// Retrieves the setting for whether coupons are enabled for the specified store
+    ///
+    func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    let isEnabled = setting.value == SettingValue.yes
+                    onCompletion(.success(isEnabled))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Enables coupons for the specified store
+    ///
+    func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        siteSettingsRemote.updateSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons, value: SettingValue.yes) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    onCompletion(.success(Void()))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Retrieves the setting for whether WC Analytics are enabled for the specified store
+    ///
+    func retrieveAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .advanced, settingID: SettingKeys.analytics) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    let isEnabled = setting.value == SettingValue.yes
+                    onCompletion(.success(isEnabled))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Enables WC Analytics for the specified store
+    ///
+    func enableAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        siteSettingsRemote.updateSetting(for: siteID,
+                                            settingGroup: .advanced,
+                                            settingID: SettingKeys.analytics,
+                                            value: SettingValue.yes) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    onCompletion(.success(Void()))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Retrieves the used address to calculate the tax
+    ///
+    func retrieveTaxBasedOnSetting(siteID: Int64, onCompletion: @escaping (Result<TaxBasedOnSetting, Error>) -> Void) {
+        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .custom("tax"), settingID: SettingKeys.taxBasedOn) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let setting):
+                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                    guard let taxBasedOnSetting = TaxBasedOnSetting(backendValue: setting.value) else {
+                        onCompletion(.failure(SettingError.parseError))
+                        return
+                    }
+
+                    onCompletion(.success(taxBasedOnSetting))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+}
+
+// MARK: - Persistence
+
+private extension SettingStoreMethods {
+
+    /// Updates (OR Inserts) the specified **general** ReadOnly `SiteSetting` Entities **in a background thread**. `onCompletion` will be called
+    /// on the main thread!
+    ///
+    func upsertStoredGeneralSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ [weak self] storage in
+            self?.upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.general)
+        }, completion: onCompletion, on: .main)
+    }
+
+    /// Updates (OR Inserts) the specified **product** ReadOnly `SiteSetting` entities **in a background thread**. `onCompletion` will be called
+    /// on the main thread!
+    ///
+    func upsertStoredProductSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ [weak self] storage in
+            self?.upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.product)
+        }, completion: onCompletion, on: .main)
+    }
+
+    /// Updates (OR Inserts) the specified **advanced** ReadOnly `SiteSetting` entities **in a background thread**. `onCompletion` will be called
+    /// on the main thread!
+    ///
+    func upsertStoredAdvancedSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ [weak self] storage in
+            self?.upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.advanced)
+        }, completion: onCompletion, on: .main)
+    }
+
+    func upsertSettings(_ readOnlySiteSettings: [SiteSetting], in storage: StorageType, siteID: Int64, settingGroup: SiteSettingGroup) {
+        let storageSiteSettings = storage.loadSiteSettings(siteID: siteID, settingGroupKey: settingGroup.rawValue)
+        // Upsert the settings from the read-only site settings
+        for readOnlyItem in readOnlySiteSettings {
+            if let existingStorageItem = storageSiteSettings?.first(where: { $0.settingID == readOnlyItem.settingID }) {
+                existingStorageItem.update(with: readOnlyItem)
+            } else {
+                let newStorageItem = storage.insertNewObject(ofType: Storage.SiteSetting.self)
+                newStorageItem.update(with: readOnlyItem)
+            }
+        }
+
+        // Now, remove any objects that exist in storageSiteSettings but not in readOnlySiteSettings
+        if let storageSiteSettings {
+            storageSiteSettings.forEach({ storageItem in
+                if readOnlySiteSettings.first(where: { $0.settingID == storageItem.settingID } ) == nil {
+                    storage.deleteObject(storageItem)
+                }
+            })
+        }
+    }
+}
+
+// MARK: - Unit Testing Helpers
+//
+extension SettingStoreMethods {
+
+    /// Unit Testing Helper: Updates or Inserts the specified **general** ReadOnly SiteSetting entities in the provided Storage instance.
+    ///
+    func upsertStoredGeneralSiteSettings(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
+        upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.general)
+    }
+
+    /// Unit Testing Helper: Updates or Inserts the specified **product** ReadOnly SiteSetting entities in the provided Storage instance.
+    ///
+    func upsertStoredProductSiteSettings(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
+        upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.product)
+    }
+}
+
+// MARK: Definitions
+extension SettingStoreMethods {
+    /// Settings keys.
+    ///
+    private enum SettingKeys {
+        static let coupons = "woocommerce_enable_coupons"
+        static let analytics = "woocommerce_analytics_enabled"
+        static let taxBasedOn = "woocommerce_tax_based_on"
+    }
+
+    private enum SettingValue {
+        static let yes = "yes"
+    }
+}

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -8,10 +8,12 @@ import Storage
 public class SettingStore: Store {
     private let siteSettingsRemote: SiteSettingsRemote
     private let siteAPIRemote: SiteAPIRemote
+    private let methods: SettingStoreMethods
 
     public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         self.siteSettingsRemote = SiteSettingsRemote(network: network)
         self.siteAPIRemote = SiteAPIRemote(network: network)
+        self.methods = SettingStoreMethods(storageManager: storageManager, network: network)
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -31,243 +33,36 @@ public class SettingStore: Store {
 
         switch action {
         case .synchronizeGeneralSiteSettings(let siteID, let onCompletion):
-            synchronizeGeneralSiteSettings(siteID: siteID, onCompletion: onCompletion)
+            methods.synchronizeGeneralSiteSettings(siteID: siteID, onCompletion: onCompletion)
         case .synchronizeProductSiteSettings(let siteID, let onCompletion):
-            synchronizeProductSiteSettings(siteID: siteID, onCompletion: onCompletion)
+            methods.synchronizeProductSiteSettings(siteID: siteID, onCompletion: onCompletion)
         case .retrieveSiteAPI(let siteID, let onCompletion):
-            retrieveSiteAPI(siteID: siteID, onCompletion: onCompletion)
+            methods.retrieveSiteAPI(siteID: siteID, onCompletion: onCompletion)
         case let .retrieveCouponSetting(siteID, onCompletion):
-            retrieveCouponSetting(siteID: siteID, onCompletion: onCompletion)
+            methods.retrieveCouponSetting(siteID: siteID, onCompletion: onCompletion)
         case let .enableCouponSetting(siteID, onCompletion):
-            enableCouponSetting(siteID: siteID, onCompletion: onCompletion)
+            methods.enableCouponSetting(siteID: siteID, onCompletion: onCompletion)
         case let .retrieveAnalyticsSetting(siteID, onCompletion):
-            retrieveAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
+            methods.retrieveAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
         case let .enableAnalyticsSetting(siteID, onCompletion):
-            enableAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
+            methods.enableAnalyticsSetting(siteID: siteID, onCompletion: onCompletion)
         case let .retrieveTaxBasedOnSetting(siteID: siteID, onCompletion: onCompletion):
-            retrieveTaxBasedOnSetting(siteID: siteID, onCompletion: onCompletion)
+            methods.retrieveTaxBasedOnSetting(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
-
-
-// MARK: - Services!
-//
-private extension SettingStore {
-
-    /// Synchronizes the general site settings associated with the provided Site ID (if any!).
-    ///
-    func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        siteSettingsRemote.loadGeneralSettings(for: siteID) { [weak self] (settings, error) in
-            guard let settings = settings else {
-                onCompletion(error)
-                return
-            }
-
-            self?.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: settings) {
-                onCompletion(nil)
-            }
-        }
-    }
-
-    /// Synchronizes the product site settings associated with the provided Site ID (if any!).
-    ///
-    func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        siteSettingsRemote.loadProductSettings(for: siteID) { [weak self] (settings, error) in
-            guard let settings = settings else {
-                onCompletion(error)
-                return
-            }
-
-            self?.upsertStoredProductSettingsInBackground(siteID: siteID, readOnlySiteSettings: settings) {
-                onCompletion(nil)
-            }
-        }
-    }
-
-    /// Retrieves the site API information associated with the provided Site ID (if any!).
-    /// This call does NOT persist returned data into the Storage layer.
-    ///
-    func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void) {
-        siteAPIRemote.loadAPIInformation(for: siteID, completion: onCompletion)
-    }
-
-    /// Retrieves the setting for whether coupons are enabled for the specified store
-    ///
-    func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
-        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let setting):
-                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
-                    let isEnabled = setting.value == SettingValue.yes
-                    onCompletion(.success(isEnabled))
-                }
-            case .failure(let error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
-
-    /// Enables coupons for the specified store
-    ///
-    func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        siteSettingsRemote.updateSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons, value: SettingValue.yes) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let setting):
-                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
-                    onCompletion(.success(Void()))
-                }
-            case .failure(let error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
-
-    /// Retrieves the setting for whether WC Analytics are enabled for the specified store
-    ///
-    func retrieveAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
-        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .advanced, settingID: SettingKeys.analytics) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let setting):
-                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
-                    let isEnabled = setting.value == SettingValue.yes
-                    onCompletion(.success(isEnabled))
-                }
-            case .failure(let error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
-
-    /// Enables WC Analytics for the specified store
-    ///
-    func enableAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        siteSettingsRemote.updateSetting(for: siteID,
-                                            settingGroup: .advanced,
-                                            settingID: SettingKeys.analytics,
-                                            value: SettingValue.yes) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let setting):
-                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
-                    onCompletion(.success(Void()))
-                }
-            case .failure(let error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
-
-    /// Retrieves the used address to calculate the tax
-    ///
-    func retrieveTaxBasedOnSetting(siteID: Int64, onCompletion: @escaping (Result<TaxBasedOnSetting, Error>) -> Void) {
-        siteSettingsRemote.loadSetting(for: siteID, settingGroup: .custom("tax"), settingID: SettingKeys.taxBasedOn) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let setting):
-                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
-                    guard let taxBasedOnSetting = TaxBasedOnSetting(backendValue: setting.value) else {
-                        onCompletion(.failure(SettingError.parseError))
-                        return
-                    }
-
-                    onCompletion(.success(taxBasedOnSetting))
-                }
-            case .failure(let error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
-}
-
-
-// MARK: - Persistence
-//
-private extension SettingStore {
-
-    /// Updates (OR Inserts) the specified **general** ReadOnly `SiteSetting` Entities **in a background thread**. `onCompletion` will be called
-    /// on the main thread!
-    ///
-    func upsertStoredGeneralSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
-        storageManager.performAndSave({ [weak self] storage in
-            self?.upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.general)
-        }, completion: onCompletion, on: .main)
-    }
-
-    /// Updates (OR Inserts) the specified **product** ReadOnly `SiteSetting` entities **in a background thread**. `onCompletion` will be called
-    /// on the main thread!
-    ///
-    func upsertStoredProductSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
-        storageManager.performAndSave({ [weak self] storage in
-            self?.upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.product)
-        }, completion: onCompletion, on: .main)
-    }
-
-    /// Updates (OR Inserts) the specified **advanced** ReadOnly `SiteSetting` entities **in a background thread**. `onCompletion` will be called
-    /// on the main thread!
-    ///
-    func upsertStoredAdvancedSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
-        storageManager.performAndSave({ [weak self] storage in
-            self?.upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.advanced)
-        }, completion: onCompletion, on: .main)
-    }
-
-    func upsertSettings(_ readOnlySiteSettings: [SiteSetting], in storage: StorageType, siteID: Int64, settingGroup: SiteSettingGroup) {
-        let storageSiteSettings = storage.loadSiteSettings(siteID: siteID, settingGroupKey: settingGroup.rawValue)
-        // Upsert the settings from the read-only site settings
-        for readOnlyItem in readOnlySiteSettings {
-            if let existingStorageItem = storageSiteSettings?.first(where: { $0.settingID == readOnlyItem.settingID }) {
-                existingStorageItem.update(with: readOnlyItem)
-            } else {
-                let newStorageItem = storage.insertNewObject(ofType: Storage.SiteSetting.self)
-                newStorageItem.update(with: readOnlyItem)
-            }
-        }
-
-        // Now, remove any objects that exist in storageSiteSettings but not in readOnlySiteSettings
-        if let storageSiteSettings {
-            storageSiteSettings.forEach({ storageItem in
-                if readOnlySiteSettings.first(where: { $0.settingID == storageItem.settingID } ) == nil {
-                    storage.deleteObject(storageItem)
-                }
-            })
-        }
-    }
-}
-
 
 // MARK: - Unit Testing Helpers
 //
 extension SettingStore {
-
-    /// Unit Testing Helper: Updates or Inserts the specified **general** ReadOnly SiteSetting entities in the provided Storage instance.
-    ///
     func upsertStoredGeneralSiteSettings(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
-        upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.general)
+        methods.upsertStoredGeneralSiteSettings(siteID: siteID, readOnlySiteSettings: readOnlySiteSettings, in: storage)
     }
 
     /// Unit Testing Helper: Updates or Inserts the specified **product** ReadOnly SiteSetting entities in the provided Storage instance.
     ///
     func upsertStoredProductSiteSettings(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
-        upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.product)
-    }
-}
-
-// MARK: Definitions
-extension SettingStore {
-    /// Settings keys.
-    ///
-    private enum SettingKeys {
-        static let coupons = "woocommerce_enable_coupons"
-        static let analytics = "woocommerce_analytics_enabled"
-        static let taxBasedOn = "woocommerce_tax_based_on"
-    }
-
-    private enum SettingValue {
-        static let yes = "yes"
+        methods.upsertStoredProductSiteSettings(siteID: siteID, readOnlySiteSettings: readOnlySiteSettings, in: storage)
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/MockCouponStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockCouponStoreMethods.swift
@@ -1,0 +1,89 @@
+@testable import Yosemite
+
+final class MockCouponStoreMethods: CouponStoreMethodsProtocol {
+    var synchronizeCalled = false
+    var deleteCalled = false
+    var updateCalled = false
+    var createCalled = false
+    var loadReportCalled = false
+    var loadMostActiveCalled = false
+    var searchCalled = false
+    var retrieveCalled = false
+    var loadCouponsCalled = false
+    var validateCalled = false
+
+    var onSynchronizeCalled: () -> Void = {}
+
+    func synchronizeCoupons(siteID: Int64,
+                            pageNumber: Int,
+                            pageSize: Int,
+                            onCompletion: @escaping (Result<Bool, any Error>) -> Void) {
+        synchronizeCalled = true
+        onCompletion(.success(true))
+        onSynchronizeCalled()
+    }
+
+    func deleteCoupon(siteID: Int64,
+                      couponID: Int64,
+                      onCompletion: @escaping (Result<Void, any Error>) -> Void) {
+        deleteCalled = true
+        onCompletion(.success(()))
+    }
+
+    func updateCoupon(_ coupon: Yosemite.Coupon,
+                      siteTimezone: TimeZone?,
+                      onCompletion: @escaping (Result<Yosemite.Coupon, any Error>) -> Void) {
+        updateCalled = true
+        onCompletion(.success(coupon))
+    }
+
+    func createCoupon(_ coupon: Yosemite.Coupon,
+                      siteTimezone: TimeZone?,
+                      onCompletion: @escaping (Result<Yosemite.Coupon, any Error>) -> Void) {
+        createCalled = true
+        onCompletion(.success(coupon))
+    }
+
+    func loadCouponReport(siteID: Int64,
+                          couponID: Int64,
+                          startDate: Date,
+                          onCompletion: @escaping (Result<Yosemite.CouponReport, any Error>) -> Void) {
+        loadReportCalled = true
+    }
+
+    func loadMostActiveCoupons(siteID: Int64,
+                               numberOfCouponsToLoad: Int,
+                               timeRange: Yosemite.StatsTimeRangeV4,
+                               siteTimezone: TimeZone,
+                               onCompletion: @escaping (Result<[Yosemite.CouponReport], any Error>) -> Void) {
+        loadMostActiveCalled = true
+    }
+
+    func searchCoupons(siteID: Int64,
+                       keyword: String,
+                       pageNumber: Int,
+                       pageSize: Int,
+                       onCompletion: @escaping (Result<Void, any Error>) -> Void) {
+        searchCalled = true
+        onCompletion(.success(()))
+    }
+
+    func retrieveCoupon(siteID: Int64,
+                        couponID: Int64,
+                        onCompletion: @escaping (Result<Yosemite.Coupon, any Error>) -> Void) {
+        retrieveCalled = true
+    }
+
+    func loadCoupons(siteID: Int64,
+                     couponIDs: [Int64],
+                     onCompletion: @escaping (Result<[Yosemite.Coupon], any Error>) -> Void) {
+        loadCouponsCalled = true
+    }
+
+    func validateCouponCode(code: String,
+                           siteID: Int64,
+                           onCompletion: @escaping (Result<Bool, any Error>) -> Void) {
+        validateCalled = true
+        onCompletion(.success(false))
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/MockSettingStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockSettingStoreMethods.swift
@@ -1,5 +1,58 @@
 @testable import Yosemite
 
 final class MockSettingStoreMethods: SettingStoreMethodsProtocol {
+    var generalSiteSettingsSyncCalled = false
+    var productSiteSettingsSyncCalled = false
+    var retrieveSiteAPICalled = false
+    var retrieveCouponSettingCalled = false
+    var enableCouponSettingCalled = false
+    var retrieveAnalyticsSettingCalled = false
+    var enableAnalyticsSettingCalled = false
+    var retrieveTaxBasedOnSettingCalled = false
 
+    func synchronizeGeneralSiteSettings(siteID: Int64,
+                                      onCompletion: @escaping (Error?) -> Void) {
+        generalSiteSettingsSyncCalled = true
+        onCompletion(nil)
+    }
+
+    func synchronizeProductSiteSettings(siteID: Int64,
+                                      onCompletion: @escaping (Error?) -> Void) {
+        productSiteSettingsSyncCalled = true
+        onCompletion(nil)
+    }
+
+    func retrieveSiteAPI(siteID: Int64,
+                        onCompletion: @escaping (Result<Yosemite.SiteAPI, Error>) -> Void) {
+        retrieveSiteAPICalled = true
+    }
+
+    func retrieveCouponSetting(siteID: Int64,
+                             onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        retrieveCouponSettingCalled = true
+        onCompletion(.success(true))
+    }
+
+    func enableCouponSetting(siteID: Int64,
+                           onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        enableCouponSettingCalled = true
+        onCompletion(.success(()))
+    }
+
+    func retrieveAnalyticsSetting(siteID: Int64,
+                                onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        retrieveAnalyticsSettingCalled = true
+        onCompletion(.success(true))
+    }
+
+    func enableAnalyticsSetting(siteID: Int64,
+                              onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        enableAnalyticsSettingCalled = true
+        onCompletion(.success(()))
+    }
+
+    func retrieveTaxBasedOnSetting(siteID: Int64,
+                                 onCompletion: @escaping (Result<Yosemite.TaxBasedOnSetting, Error>) -> Void) {
+        retrieveTaxBasedOnSettingCalled = true
+    }
 }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -67,13 +67,3 @@ struct PointOfSaleCouponServiceTests {
 
     }
 }
-
-private class MockCouponStoreMethods: CouponStoreMethodsProtocol {
-    var synchronizeCalled = false
-    var onSynchronizeCalled: () -> Void = {}
-    func synchronizeCoupons(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Result<Bool, any Error>) -> Void) {
-        synchronizeCalled = true
-        onCompletion(.success(true))
-        onSynchronizeCalled()
-    }
-}

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -4,15 +4,15 @@ import class WooFoundation.CurrencySettings
 
 struct PointOfSaleCouponServiceTests {
     private let sut: PointOfSaleCouponService
-    private let couponService: MockCouponService
+    private let couponStoreMethods: MockCouponStoreMethods
     private let storage: MockStorageManager
 
     init() {
-        self.couponService = MockCouponService()
+        self.couponStoreMethods = MockCouponStoreMethods()
         self.storage = MockStorageManager()
         self.sut = .init(siteID: 123,
                          currencySettings: CurrencySettings(),
-                         couponService: couponService,
+                         couponStoreMethods: couponStoreMethods,
                          storage: storage
         )
     }
@@ -46,7 +46,7 @@ struct PointOfSaleCouponServiceTests {
     @Test func providePointOfSaleCoupons_when_no_coupons_then_synchronize_called() async throws {
         try await _ = sut.providePointOfSaleCoupons(pageNumber: 0)
 
-        #expect(couponService.synchronizeCalled == true)
+        #expect(couponStoreMethods.synchronizeCalled == true)
     }
 
     @available(iOS 17.0, *)
@@ -56,7 +56,7 @@ struct PointOfSaleCouponServiceTests {
         storage.insertSampleCoupon(readOnlyCoupon: coupon)
 
         try await confirmation(expectedCount: 1) { confirmation in
-            couponService.onSynchronizeCalled = {
+            couponStoreMethods.onSynchronizeCalled = {
                 // Then
                 confirmation()
             }
@@ -68,7 +68,7 @@ struct PointOfSaleCouponServiceTests {
     }
 }
 
-private class MockCouponService: CouponServiceProtocol {
+private class MockCouponStoreMethods: CouponStoreMethodsProtocol {
     var synchronizeCalled = false
     var onSynchronizeCalled: () -> Void = {}
     func synchronizeCoupons(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Result<Bool, any Error>) -> Void) {

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -5,14 +5,17 @@ import class WooFoundation.CurrencySettings
 struct PointOfSaleCouponServiceTests {
     private let sut: PointOfSaleCouponService
     private let couponStoreMethods: MockCouponStoreMethods
+    private let settingStoreMethods: MockSettingStoreMethods
     private let storage: MockStorageManager
 
     init() {
         self.couponStoreMethods = MockCouponStoreMethods()
+        self.settingStoreMethods = MockSettingStoreMethods()
         self.storage = MockStorageManager()
         self.sut = .init(siteID: 123,
                          currencySettings: CurrencySettings(),
                          couponStoreMethods: couponStoreMethods,
+                         settingStoreMethods: settingStoreMethods,
                          storage: storage
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

`checkStoreCouponSettings` depended on the `store` but the store was removed by another PR. This caused a conflict between these two PRs:
- https://github.com/woocommerce/woocommerce-ios/pull/15476
- https://github.com/woocommerce/woocommerce-ios/pull/15468

The conflict was quickly fixed by https://github.com/woocommerce/woocommerce-ios/pull/15480 PR.

### Solution

Use the same pattern developed in https://github.com/woocommerce/woocommerce-ios/pull/15476 to allow testing Yosemite store methods internally. I made slight updates to the naming of the solution as well.

- Renamed `CouponService` to `CouponStoreMethods` to clearly communicate what the internal class does
- Added remaining `CouponStoreMethodsMocks`
- Created `SettingStoreMethods` moving them from `SettingStore`
- Using `SettingStoreMethods` in `PointOfSaleCouponsService` to check settings.

I didn't add additional tests to `PointOfSaleCouponsService`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- `SettingStore` and `CouponStore` tests should succeed
- https://github.com/woocommerce/woocommerce-ios/pull/15468 test cases should succeed

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

`SettingStore` is widely used so I did a smoke test around the app and settings. The functionality looks to be unaffected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.to:
- [ ] 