### PR TITLE
[Woo POS] Fix empty state display

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -31,6 +31,7 @@ struct PointOfSaleItemListEmptyView: View {
                 .padding([.leading, .trailing])
             Spacer()
         }
+        .multilineTextAlignment(.center)
         .padding(.bottom, floatingControlAreaSize.height)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -10,31 +10,28 @@ struct PointOfSaleItemListEmptyView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
-                Spacer()
-                Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: Constants.iconSize, height: Constants.iconSize)
-                    .foregroundColor(.posOnSurfaceVariantHighest)
-                    .renderedIf(!dynamicTypeSize.isAccessibilitySize)
-                Text(title)
-                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                    .font(. posHeadingBold)
-                Text(subtitle)
-                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                    .font(.posBodyLargeRegular())
-                    .padding([.leading, .trailing])
-                Text(hint)
-                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                    .font(.posBodyLargeRegular())
-                    .padding([.leading, .trailing])
-                Spacer()
-                    .renderedIf(!dynamicTypeSize.isAccessibilitySize)
-            }
-            .padding(.bottom, floatingControlAreaSize.height)
+        VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
+            Spacer()
+            Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Constants.iconSize, height: Constants.iconSize)
+                .foregroundColor(.posOnSurfaceVariantHighest)
+                .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+            Text(title)
+                .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                .font(.posHeadingBold)
+            Text(subtitle)
+                .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                .font(.posBodyLargeRegular())
+                .padding([.leading, .trailing])
+            Text(hint)
+                .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                .font(.posBodyLargeRegular())
+                .padding([.leading, .trailing])
+            Spacer()
         }
+        .padding(.bottom, floatingControlAreaSize.height)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -77,7 +77,9 @@ private extension ChildItemList {
     var emptyView: some View {
         VStack {
             headerView
-            PointOfSaleItemListEmptyView(base: node)
+            ScrollView {
+                PointOfSaleItemListEmptyView(base: node)
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR improves the display of the empty state for the item list, ensuring it's shown vertically centred.

There had been some changes previously to support larger text in smaller spaces, particularly for the variations empty state. That involved adding a scrollview, but it's never needed on the full-size empty state.

The previous changes made the empty state show at the top of the view, not vertically centred.

This isn't perfect, but keeps most of the fixes while making the normal display work better too.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set up Charles or Proxyman to proxy with breakpoints on the `products` and `product/id/variations` endpoints (optional)
2. Launch the app and open POS
3. Delete the content of the `data` array when you hit the breakpoint, or ensure you're using a store with no products.
4. Change your dynamic type size to check it displays sensibly.

Try again with variations.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested on an iPad Air running iOS 17.7.3

The videos below show it working; note that I only spotted the wrapped text alignment after recording the first video, you can see that it's centred now in the second.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ba754c81-ad13-49b7-8054-47de010df9c4


https://github.com/user-attachments/assets/ca1575bf-7afc-4432-9af9-3a0f2b881543




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.