### PR TITLE
[Woo POS][Products search] Add feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -99,6 +99,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .allowMerchantAIAPIKey:
             return false
+        case .searchProductsInPOS:
+            return false
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -212,4 +212,8 @@ public enum FeatureFlag: Int {
     /// Allows merchants to use their own API keys for AI-powered features
     ///
     case allowMerchantAIAPIKey
+
+    /// Allows searching products in POS
+    ///
+    case searchProductsInPOS
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -9,6 +9,9 @@ struct ItemListView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
 
     @State private var showSimpleProductsModal: Bool = false
+
+    @State private var searchTerm: String = ""
+
     private var itemListState: ItemListState {
         itemsStack.root
     }
@@ -119,16 +122,25 @@ private extension ItemListView {
     var headerView: some View {
         VStack {
             POSPageHeaderView(title: Localization.title, trailingContent: {
-                Button(action: {
-                    ServiceLocator.analytics.track(.pointOfSaleSimpleProductsExplanationDialogShown)
-                    showSimpleProductsModal = true
-                }, label: {
-                    Text(Image(systemName: "info.circle"))
-                        .font(.posButtonSymbolLarge)
-                        .foregroundStyle(Color.posOnSurface)
-                        .padding(Constants.infoIconInset)
-                })
-                .renderedIf(!shouldShowHeaderBanner)
+                HStack {
+                    if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS),
+                       selectedItemType == .products {
+                        TextField(text: $searchTerm) {
+                            Text("Search")
+                        }
+                    }
+
+                    Button(action: {
+                        ServiceLocator.analytics.track(.pointOfSaleSimpleProductsExplanationDialogShown)
+                        showSimpleProductsModal = true
+                    }, label: {
+                        Text(Image(systemName: "info.circle"))
+                            .font(.posButtonSymbolLarge)
+                            .foregroundStyle(Color.posOnSurface)
+                            .padding(Constants.infoIconInset)
+                    })
+                    .renderedIf(!shouldShowHeaderBanner)
+                }
             })
             if !dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-145
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a feature flag `searchProductsInPOS` to act as the gate for the product search feature.

Additionally, this adds a search field in the header which is shown when on the products screen, with the feature flag on. This is (obviously) not final UI.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Feature flag off
1. Launch the app
2. Open POS
3. Observe that the search field is not shown.

### Feature flag on
1. Set `searchProductsInPOS` to `true` in `DefaultFeatureFlagService`
2. Build and run the app
3. Open POS
4. Observe that the search field is shown.

Repeat with the coupons flag enabled; observe that search only shows when products are selected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.