### PR TITLE
[Jetpack Setup] Use magic link for login when detecting suspicious emails

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 22.2
 -----
-
+- [*] [Internal] Improved login flow during Jetpack Setup for accounts using emails marked as suspicious [https://github.com/woocommerce/woocommerce-ios/pull/15491]
 
 22.1
 -----

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
@@ -148,7 +148,8 @@ struct WPComEmailLoginView_Previews: PreviewProvider {
                                              requiresConnectionOnly: true,
                                              allowAccountCreation: false,
                                              onPasswordUIRequest: { _ in },
-                                             onMagicLinkUIRequest: { _, _ in },
+                                             onMagicLinkRequest: { _ in },
+                                             onMagicLinkSent: { _, _ in },
                                              onError: { _ in }))
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
@@ -73,9 +73,9 @@ struct WPComEmailLoginView: View {
 
                 // Email field
                 AuthenticationFormFieldView(viewModel: .init(
-                    header: Localization.emailLabel,
-                    placeholder: Localization.enterEmail,
-                    keyboardType: .emailAddress,
+                    header: viewModel.usernameOnly ? Localization.usernameLabel : Localization.emailLabel,
+                    placeholder: viewModel.usernameOnly ? Localization.enterUsername : Localization.enterEmail,
+                    keyboardType: viewModel.usernameOnly ? .default : .emailAddress,
                     text: $viewModel.emailOrUsername,
                     isSecure: false,
                     errorMessage: nil,
@@ -84,7 +84,8 @@ struct WPComEmailLoginView: View {
                 ))
                 .focused($isEmailFieldFocused)
 
-                if viewModel.allowAccountCreation {
+                if viewModel.allowAccountCreation,
+                   !viewModel.usernameOnly {
                     // Account creation hint
                     Text(Localization.accountCreationHint)
                         .footnoteStyle()
@@ -129,9 +130,19 @@ private extension WPComEmailLoginView {
             "Email Address or Username",
             comment: "Label for the email field on the WPCom email login screen of the Jetpack setup flow."
         )
+        static let usernameLabel = NSLocalizedString(
+            "wpComEmailLoginView.usernameLabel",
+            value: "Username",
+            comment: "Label for the username field on the WPCom email login screen of the Jetpack setup flow."
+        )
         static let enterEmail = NSLocalizedString(
             "Enter email or username",
             comment: "Placeholder text for the email field on the WPCom email login screen of the Jetpack setup flow."
+        )
+        static let enterUsername = NSLocalizedString(
+            "wpComEmailLoginView.enterUsername",
+            value: "Enter username",
+            comment: "Placeholder text for the username field on the WPCom email login screen of the Jetpack setup flow."
         )
         static let accountCreationHint = NSLocalizedString(
             "wpComEmailLoginView.accountCreationHint",

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
@@ -76,7 +76,7 @@ struct WPComEmailLoginView: View {
                     header: Localization.emailLabel,
                     placeholder: Localization.enterEmail,
                     keyboardType: .emailAddress,
-                    text: $viewModel.emailAddress,
+                    text: $viewModel.emailOrUsername,
                     isSecure: false,
                     errorMessage: nil,
                     isFocused: isEmailFieldFocused,
@@ -101,12 +101,12 @@ struct WPComEmailLoginView: View {
                     ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, tap: .submit))
                     Task { @MainActor in
                         isPrimaryButtonLoading = true
-                        await viewModel.checkWordPressComAccount(email: viewModel.emailAddress)
+                        await viewModel.checkWordPressComAccount(emailOrUsername: viewModel.emailOrUsername)
                         isPrimaryButtonLoading = false
                     }
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPrimaryButtonLoading))
-                .disabled(viewModel.emailAddress.isEmpty)
+                .disabled(viewModel.emailOrUsername.isEmpty)
 
                 // Terms label
                 AttributedText(viewModel.termsAttributedString)

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
@@ -21,7 +21,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
     let titleString: String
     let subtitleString: String
 
-    @Published var emailAddress: String = ""
+    @Published var emailOrUsername: String = ""
 
     let termsAttributedString: NSAttributedString
 
@@ -76,17 +76,17 @@ final class WPComEmailLoginViewModel: ObservableObject {
     }
 
     @MainActor
-    func checkWordPressComAccount(email: String) async {
+    func checkWordPressComAccount(emailOrUsername: String) async {
         do {
             let passwordless = try await withCheckedThrowingContinuation { continuation in
-                accountService.isPasswordlessAccount(username: email, success: { passwordless in
+                accountService.isPasswordlessAccount(username: emailOrUsername, success: { passwordless in
                     continuation.resume(returning: passwordless)
                 }, failure: { error in
                     DDLogError("⛔️ Error checking for passwordless account: \(error)")
                     continuation.resume(throwing: error)
                 })
             }
-            await startAuthentication(email: email, isPasswordlessAccount: passwordless)
+            await startAuthentication(emailOrUsername: emailOrUsername, isPasswordlessAccount: passwordless)
         } catch {
             let apiErrorCode: String? = {
                 if let apiError = error as? WordPressAPIError<WordPressComRestApiEndpointError>,
@@ -98,12 +98,12 @@ final class WPComEmailLoginViewModel: ObservableObject {
 
             if allowAccountCreation,
                apiErrorCode == Constants.unknownUserErrorCode {
-                await handleUnkownUserError(emailOrUsername: email, error: error)
+                await handleUnkownUserError(emailOrUsername: emailOrUsername, error: error)
                 return
             }
 
             if apiErrorCode == Constants.emailNotAllowed {
-                onMagicLinkRequest(email)
+                onMagicLinkRequest(emailOrUsername)
                 return
             }
 
@@ -113,11 +113,11 @@ final class WPComEmailLoginViewModel: ObservableObject {
     }
 
     @MainActor
-    private func startAuthentication(email: String, isPasswordlessAccount: Bool) async {
+    private func startAuthentication(emailOrUsername: String, isPasswordlessAccount: Bool) async {
         if isPasswordlessAccount {
-            await requestAuthenticationLink(email: email)
+            await requestAuthenticationLink(email: emailOrUsername)
         } else {
-            onPasswordUIRequest(email)
+            onPasswordUIRequest(emailOrUsername)
         }
     }
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
@@ -22,6 +22,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
     let subtitleString: String
 
     @Published var emailOrUsername: String = ""
+    @Published var usernameOnly: Bool = false
 
     let termsAttributedString: NSAttributedString
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
@@ -144,6 +144,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
 }
 
 private extension WPComEmailLoginViewModel {
+    @MainActor
     func handleUnkownUserError(emailOrUsername: String, error: Error) async {
         guard emailOrUsername.isValidEmail() else {
             analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
@@ -29,7 +29,8 @@ final class WPComEmailLoginViewModel: ObservableObject {
     private let accountService: WordPressComAccountServiceProtocol
     private let analytics: Analytics
     private let onPasswordUIRequest: (String) -> Void
-    private let onMagicLinkUIRequest: (_ email: String, _ isSignup: Bool) -> Void
+    private let onMagicLinkRequest: (String) -> Void
+    private let onMagicLinkSent: (_ email: String, _ isSignup: Bool) -> Void
     private let onError: (String) -> Void
 
     private var emailFieldSubscription: AnyCancellable?
@@ -41,13 +42,15 @@ final class WPComEmailLoginViewModel: ObservableObject {
          accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
          analytics: Analytics = ServiceLocator.analytics,
          onPasswordUIRequest: @escaping (String) -> Void,
-         onMagicLinkUIRequest: @escaping (String, Bool) -> Void,
+         onMagicLinkRequest: @escaping (String) -> Void,
+         onMagicLinkSent: @escaping (String, Bool) -> Void,
          onError: @escaping (String) -> Void) {
         self.allowAccountCreation = allowAccountCreation
         self.analytics = analytics
         self.accountService = accountService
         self.onPasswordUIRequest = onPasswordUIRequest
-        self.onMagicLinkUIRequest = onMagicLinkUIRequest
+        self.onMagicLinkRequest = onMagicLinkRequest
+        self.onMagicLinkSent = onMagicLinkSent
         self.onError = onError
 
         self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
@@ -85,22 +88,27 @@ final class WPComEmailLoginViewModel: ObservableObject {
             }
             await startAuthentication(email: email, isPasswordlessAccount: passwordless)
         } catch {
-            guard allowAccountCreation,
-                  let apiError = error as? WordPressAPIError<WordPressComRestApiEndpointError>,
-                  case .endpointError(let endpointError) = apiError,
-                  endpointError.apiErrorCode == Constants.unknownUserErrorCode else {
-                analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
-                onError(error.localizedDescription)
+            let apiErrorCode: String? = {
+                if let apiError = error as? WordPressAPIError<WordPressComRestApiEndpointError>,
+                   case .endpointError(let endpointError) = apiError {
+                    return endpointError.apiErrorCode
+                }
+                return nil
+            }()
+
+            if allowAccountCreation,
+               apiErrorCode == Constants.unknownUserErrorCode {
+                await handleUnkownUserError(emailOrUsername: email, error: error)
                 return
             }
 
-            guard email.isValidEmail() else {
-                analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
-                onError(Localization.unknownUsername)
+            if apiErrorCode == Constants.emailNotAllowed {
+                onMagicLinkRequest(email)
                 return
             }
 
-            await requestAuthenticationLink(email: email, forAccountCreation: true)
+            analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
+            onError(error.localizedDescription)
         }
     }
 
@@ -126,11 +134,23 @@ final class WPComEmailLoginViewModel: ObservableObject {
                     continuation.resume(throwing: error)
                 })
             }
-            onMagicLinkUIRequest(email, forAccountCreation)
+            onMagicLinkSent(email, forAccountCreation)
         } catch {
             onError(error.localizedDescription)
             analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, isSignup: forAccountCreation, failure: error))
         }
+    }
+}
+
+private extension WPComEmailLoginViewModel {
+    func handleUnkownUserError(emailOrUsername: String, error: Error) async {
+        guard emailOrUsername.isValidEmail() else {
+            analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
+            onError(Localization.unknownUsername)
+            return
+        }
+
+        await requestAuthenticationLink(email: emailOrUsername, forAccountCreation: true)
     }
 }
 
@@ -141,6 +161,7 @@ extension WPComEmailLoginViewModel {
         static let jetpackShareDetailsURL = "https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync&site="
         static let wpcomErrorCodeKey = "WordPressComRestApiErrorCodeKey"
         static let unknownUserErrorCode = "unknown_user"
+        static let emailNotAllowed = "email_login_not_allowed"
     }
 
     enum Localization {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginGravatarView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginGravatarView.swift
@@ -32,12 +32,9 @@ private extension WPComLoginGravatarView {
     }
 }
 
-struct WPComLoginGravatarView_Previews: PreviewProvider {
-    static var previews: some View {
-        WPComLoginGravatarView(
-            email: "example@example.com",
-            gravatarURL: URL(string: "https://www.gravatar.com/avatar/example")
-        )
-        .previewLayout(.sizeThatFits)
-    }
+#Preview {
+    WPComLoginGravatarView(
+        email: "example@example.com",
+        gravatarURL: URL(string: "https://www.gravatar.com/avatar/example")
+    )
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginGravatarView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginGravatarView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import Kingfisher
+
+struct WPComLoginGravatarView: View {
+    let email: String
+    let gravatarURL: URL?
+
+    var body: some View {
+        HStack(spacing: Constants.spacing) {
+            KFImage(gravatarURL)
+                .resizable()
+                .clipShape(Circle())
+                .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+
+            Text(email)
+
+            Spacer()
+        }
+        .padding(Constants.avatarPadding)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(.gray, lineWidth: 1)
+        )
+    }
+}
+
+private extension WPComLoginGravatarView {
+    enum Constants {
+        static let spacing: CGFloat = 16
+        static let avatarSize: CGFloat = 32
+        static let avatarPadding: EdgeInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
+    }
+}

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginGravatarView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginGravatarView.swift
@@ -31,3 +31,13 @@ private extension WPComLoginGravatarView {
         static let avatarPadding: EdgeInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
     }
 }
+
+struct WPComLoginGravatarView_Previews: PreviewProvider {
+    static var previews: some View {
+        WPComLoginGravatarView(
+            email: "example@example.com",
+            gravatarURL: URL(string: "https://www.gravatar.com/avatar/example")
+        )
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -58,7 +58,7 @@ struct WPComMagicLinkRequestView: View {
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
 
                 Button(Localization.fallbackButton) {
-                    // TODO: handle fallback action
+                    viewModel.useUsernamePassword()
                 }
                 .buttonStyle(SecondaryButtonStyle())
             }
@@ -101,6 +101,7 @@ private extension WPComMagicLinkRequestView {
     WPComMagicLinkRequestView(title: "Connect Jetpack",
                               viewModel: WPComMagicLinkRequestViewModel(email: "test@example.com",
                                                                         onMagicLinkSent: { _ in },
+                                                                        onUseUsernamePassword: {},
                                                                         onError: { _ in })
     )
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -21,7 +21,7 @@ final class WPComMagicLinkRequestHostingController: UIHostingController<WPComMag
 }
 
 struct WPComMagicLinkRequestView: View {
-    @ObservedObject private var viewModel: WPComMagicLinkRequestViewModel
+    @StateObject private var viewModel: WPComMagicLinkRequestViewModel
 
     /// Title to display at the top of the view.
     private let title: String
@@ -29,7 +29,7 @@ struct WPComMagicLinkRequestView: View {
     init(title: String,
          viewModel: WPComMagicLinkRequestViewModel) {
         self.title = title
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -86,7 +86,7 @@ private extension WPComMagicLinkRequestView {
         static let sendLinkButton = NSLocalizedString(
             "wpcomMagicLinkRequestView.primaryAction",
             value: "Send link by email",
-            comment: "Button title for the action of logging in with a password."
+            comment: "Button title for the action of sending a magic link email to log in to WordPress.com."
         )
         // For now this is hardcoded for the username/password fallback, if we need to support email/password in the future,
         // we can add a  way to configure the fallback action.

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -53,7 +53,9 @@ struct WPComMagicLinkRequestView: View {
         }.safeAreaInset(edge: .bottom) {
             VStack {
                 Button(Localization.sendLinkButton) {
-                    viewModel.sendMagicLink()
+                    Task {
+                        await viewModel.sendMagicLink()
+                    }
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -13,6 +13,11 @@ class WPComMagicLinkRequestHostingController: UIHostingController<WPComMagicLink
                                              viewModel: viewModel)
         super.init(rootView: view)
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTransparentNavigationBar()
+    }
 }
 
 struct WPComMagicLinkRequestView: View {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -94,5 +94,8 @@ private extension WPComMagicLinkRequestView {
 
 #Preview {
     WPComMagicLinkRequestView(title: "Connect Jetpack",
-                              viewModel: WPComMagicLinkRequestViewModel(email: "test@example.com"))
+                              viewModel: WPComMagicLinkRequestViewModel(email: "test@example.com",
+                                                                        onMagicLinkSent: { _ in },
+                                                                        onError: { _ in })
+    )
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Kingfisher
 
-class WPComMagicLinkRequestHostingController: UIHostingController<WPComMagicLinkRequestView> {
+final class WPComMagicLinkRequestHostingController: UIHostingController<WPComMagicLinkRequestView> {
     @available(*, unavailable)
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import Kingfisher
+
+class WPComMagicLinkRequestHostingController: UIHostingController<WPComMagicLinkRequestView> {
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(title: String,
+         viewModel: WPComMagicLinkRequestViewModel) {
+        let view = WPComMagicLinkRequestView(title: title,
+                                             viewModel: viewModel)
+        super.init(rootView: view)
+    }
+}
+
+struct WPComMagicLinkRequestView: View {
+    @ObservedObject private var viewModel: WPComMagicLinkRequestViewModel
+
+    /// Title to display at the top of the view.
+    private let title: String
+
+    init(title: String,
+         viewModel: WPComMagicLinkRequestViewModel) {
+        self.title = title
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
+                JetpackInstallHeaderView()
+
+                // Title
+                Text(title)
+                    .largeTitleStyle()
+
+                // Avatar and email
+                WPComLoginGravatarView(email: viewModel.email, gravatarURL: viewModel.avatarURL)
+
+                Text(Localization.label)
+                    .bodyStyle()
+
+                Spacer()
+            }
+            .padding(Constants.contentPadding)
+        }.safeAreaInset(edge: .bottom) {
+            VStack {
+                Button(Localization.sendLinkButton) {
+                    viewModel.sendMagicLink()
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
+
+                Button(Localization.fallbackButton) {
+                    // TODO: handle fallback action
+                }
+                .buttonStyle(SecondaryButtonStyle())
+            }
+            .padding(Constants.contentPadding)
+            .background(Color(uiColor: .systemBackground))
+        }
+    }
+}
+
+private extension WPComMagicLinkRequestView {
+    enum Constants {
+        static let blockVerticalPadding: CGFloat = 32
+        static let contentVerticalSpacing: CGFloat = 8
+        static let contentPadding: CGFloat = 16
+    }
+
+    enum Localization {
+        static let label = NSLocalizedString(
+            "wpcomMagicLinkRequestView.label",
+            value: "We'll email you a link that'll log you in instantly, no password needed.",
+            comment: "A message that informs the user that a magic link will be sent to their email address."
+        )
+        static let sendLinkButton = NSLocalizedString(
+            "wpcomMagicLinkRequestView.primaryAction",
+            value: "Send link by email",
+            comment: "Button title for the action of logging in with a password."
+        )
+        // For now this is hardcoded for the username/password fallback, if we need to support email/password in the future,
+        // we can add a  way to configure the fallback action.
+        static let fallbackButton = NSLocalizedString(
+            "wpcomMagicLinkRequestView.useUsernamePassword",
+            value: "Use username and password",
+            comment: "Button title for the action of signing in using WordPress.com username and password."
+        )
+    }
+}
+
+
+#Preview {
+    WPComMagicLinkRequestView(title: "Connect Jetpack",
+                              viewModel: WPComMagicLinkRequestViewModel(email: "test@example.com"))
+}

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
@@ -1,4 +1,6 @@
 import Foundation
+import WooFoundation
+import WordPressAuthenticator
 import WordPressUI
 
 class WPComMagicLinkRequestViewModel: ObservableObject {
@@ -7,13 +9,53 @@ class WPComMagicLinkRequestViewModel: ObservableObject {
     private(set) var avatarURL: URL?
     @Published private(set) var isLoading = false
 
-    init(email: String) {
-        self.email = email
+    private let onMagicLinkSent: (String) -> Void
+    private let onError: (String) -> Void
 
+    private let accountService: WordPressComAccountServiceProtocol
+    private let analytics: Analytics
+
+    init(email: String,
+         onMagicLinkSent: @escaping (String) -> Void,
+         onError: @escaping (String) -> Void,
+         accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.email = email
         self.avatarURL = Gravatar.gravatarUrl(for: email, defaultImage: .mp)
+
+        self.onMagicLinkSent = onMagicLinkSent
+        self.onError = onError
+
+        self.accountService = accountService
+        self.analytics = analytics
     }
 
     func sendMagicLink() {
-        // TODO
+        Task { @MainActor in
+            isLoading = true
+            await handleSendingMagicLink()
+            isLoading = false
+        }
+    }
+}
+
+private extension WPComMagicLinkRequestViewModel {
+    func handleSendingMagicLink() async {
+        do {
+            try await withCheckedThrowingContinuation { continuation in
+                accountService.requestAuthenticationLink(for: email,
+                                                         jetpackLogin: false,
+                                                         createAccountIfNotFound: false,
+                                                         success: {
+                    continuation.resume()
+                }, failure: { error in
+                    continuation.resume(throwing: error)
+                })
+            }
+            onMagicLinkSent(email)
+        } catch {
+            onError(error.localizedDescription)
+            analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, failure: error))
+        }
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
@@ -18,7 +18,7 @@ final class WPComMagicLinkRequestViewModel: ObservableObject {
 
     init(email: String,
          onMagicLinkSent: @escaping (String) -> Void,
-            onUseUsernamePassword: @escaping () -> Void,
+         onUseUsernamePassword: @escaping () -> Void,
          onError: @escaping (String) -> Void,
          accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
          analytics: Analytics = ServiceLocator.analytics) {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
@@ -3,7 +3,7 @@ import WooFoundation
 import WordPressAuthenticator
 import WordPressUI
 
-class WPComMagicLinkRequestViewModel: ObservableObject {
+final class WPComMagicLinkRequestViewModel: ObservableObject {
     let email: String
 
     @Published private(set) var isLoading = false

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
@@ -1,0 +1,19 @@
+import Foundation
+import WordPressUI
+
+class WPComMagicLinkRequestViewModel: ObservableObject {
+    let email: String
+
+    private(set) var avatarURL: URL?
+    @Published private(set) var isLoading = false
+
+    init(email: String) {
+        self.email = email
+
+        self.avatarURL = Gravatar.gravatarUrl(for: email, defaultImage: .mp)
+    }
+
+    func sendMagicLink() {
+        // TODO
+    }
+}

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
@@ -10,6 +10,7 @@ class WPComMagicLinkRequestViewModel: ObservableObject {
     @Published private(set) var isLoading = false
 
     private let onMagicLinkSent: (String) -> Void
+    private let onUseUsernamePassword: () -> Void
     private let onError: (String) -> Void
 
     private let accountService: WordPressComAccountServiceProtocol
@@ -17,6 +18,7 @@ class WPComMagicLinkRequestViewModel: ObservableObject {
 
     init(email: String,
          onMagicLinkSent: @escaping (String) -> Void,
+            onUseUsernamePassword: @escaping () -> Void,
          onError: @escaping (String) -> Void,
          accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
          analytics: Analytics = ServiceLocator.analytics) {
@@ -24,6 +26,7 @@ class WPComMagicLinkRequestViewModel: ObservableObject {
         self.avatarURL = Gravatar.gravatarUrl(for: email, defaultImage: .mp)
 
         self.onMagicLinkSent = onMagicLinkSent
+        self.onUseUsernamePassword = onUseUsernamePassword
         self.onError = onError
 
         self.accountService = accountService
@@ -36,6 +39,10 @@ class WPComMagicLinkRequestViewModel: ObservableObject {
             await handleSendingMagicLink()
             isLoading = false
         }
+    }
+
+    func useUsernamePassword() {
+        onUseUsernamePassword()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
@@ -6,8 +6,8 @@ import WordPressUI
 class WPComMagicLinkRequestViewModel: ObservableObject {
     let email: String
 
-    private(set) var avatarURL: URL?
     @Published private(set) var isLoading = false
+    let avatarURL: URL?
 
     private let onMagicLinkSent: (String) -> Void
     private let onUseUsernamePassword: () -> Void

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComMagicLinkRequestViewModel.swift
@@ -33,12 +33,11 @@ class WPComMagicLinkRequestViewModel: ObservableObject {
         self.analytics = analytics
     }
 
-    func sendMagicLink() {
-        Task { @MainActor in
-            isLoading = true
-            await handleSendingMagicLink()
-            isLoading = false
-        }
+    @MainActor
+    func sendMagicLink() async {
+        isLoading = true
+        await handleSendingMagicLink()
+        isLoading = false
     }
 
     func useUsernamePassword() {
@@ -47,6 +46,7 @@ class WPComMagicLinkRequestViewModel: ObservableObject {
 }
 
 private extension WPComMagicLinkRequestViewModel {
+    @MainActor
     func handleSendingMagicLink() async {
         do {
             try await withCheckedThrowingContinuation { continuation in

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComPasswordLoginView.swift
@@ -66,21 +66,7 @@ struct WPComPasswordLoginView: View {
                     .largeTitleStyle()
 
                 // Avatar and email
-                HStack(spacing: Constants.contentPadding) {
-                    viewModel.avatarURL.map { url in
-                        KFImage(url)
-                            .resizable()
-                            .clipShape(Circle())
-                            .frame(width: Constants.avatarSize, height: Constants.avatarSize)
-                    }
-                    Text(viewModel.email)
-                    Spacer()
-                }
-                .padding(Constants.avatarPadding)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .strokeBorder(.gray, lineWidth: 1)
-                )
+                WPComLoginGravatarView(email: viewModel.email, gravatarURL: viewModel.avatarURL)
 
                 // Password field
                 AuthenticationFormFieldView(viewModel: .init(
@@ -141,8 +127,6 @@ private extension WPComPasswordLoginView {
         static let blockVerticalPadding: CGFloat = 32
         static let contentVerticalSpacing: CGFloat = 8
         static let contentPadding: CGFloat = 16
-        static let avatarSize: CGFloat = 32
-        static let avatarPadding: EdgeInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -367,7 +367,9 @@ private extension JetpackSetupCoordinator {
     }
 
     func showMagicLinkRequestUI(email: String) {
-        // TODO: Implement the magic link request UI
+        let magicLinkRequestController = WPComMagicLinkRequestHostingController(title: loginViewTitle,
+                                                                                viewModel: .init(email: email))
+        pushOrInitLoginViewController(magicLinkRequestController)
     }
 
     func showMagicLinkSentUI(email: String, isSignup: Bool) {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -92,11 +92,11 @@ final class JetpackSetupCoordinator {
         return true
     }
 
-    func startAuthentication(with email: String?) {
-        if let email {
+    func startAuthentication(with emailOrUsername: String?) {
+        if let emailOrUsername {
             Task { @MainActor in
                 analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress))
-                await emailLoginViewModel.checkWordPressComAccount(email: email)
+                await emailLoginViewModel.checkWordPressComAccount(emailOrUsername: emailOrUsername)
             }
         } else {
             showWPComEmailLogin()

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -368,7 +368,13 @@ private extension JetpackSetupCoordinator {
 
     func showMagicLinkRequestUI(email: String) {
         let magicLinkRequestController = WPComMagicLinkRequestHostingController(title: loginViewTitle,
-                                                                                viewModel: .init(email: email))
+                                                                                viewModel: .init(email: email,
+                                                                                                 onMagicLinkSent: { [weak self] email in
+            self?.showMagicLinkSentUI(email: email, isSignup: false)
+        },
+                                                                                                 onError: { [weak self] message in
+            self?.showAlert(message: message)
+        }))
         pushOrInitLoginViewController(magicLinkRequestController)
     }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -362,8 +362,22 @@ private extension JetpackSetupCoordinator {
 
     func showWPComEmailLogin() {
         analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress))
+        emailLoginViewModel.usernameOnly = false
         let emailLoginController = WPComEmailLoginHostingController(viewModel: emailLoginViewModel)
         pushOrInitLoginViewController(emailLoginController)
+    }
+
+    func showWPComUsernameLogin() {
+        emailLoginViewModel.usernameOnly = true
+        emailLoginViewModel.emailOrUsername = ""
+
+        let emailViewController = loginNavigationController?.viewControllers.first(where: { $0 is WPComEmailLoginHostingController })
+        if let emailViewController {
+            loginNavigationController?.popToViewController(emailViewController, animated: true)
+        } else {
+            loginNavigationController?.dismiss(animated: true, completion: nil)
+            pushOrInitLoginViewController(WPComEmailLoginHostingController(viewModel: emailLoginViewModel))
+        }
     }
 
     func showMagicLinkRequestUI(email: String) {
@@ -372,6 +386,7 @@ private extension JetpackSetupCoordinator {
                                                                                                  onMagicLinkSent: { [weak self] email in
             self?.showMagicLinkSentUI(email: email, isSignup: false)
         },
+                                                                                                 onUseUsernamePassword: showWPComUsernameLogin,
                                                                                                  onError: { [weak self] message in
             self?.showAlert(message: message)
         }))

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -30,7 +30,8 @@ final class JetpackSetupCoordinator {
               allowAccountCreation: true,
               accountService: accountService,
               onPasswordUIRequest: showPasswordUI(email:),
-              onMagicLinkUIRequest: showMagicLinkUI,
+              onMagicLinkRequest: showMagicLinkRequestUI,
+              onMagicLinkSent: showMagicLinkSentUI,
               onError: { [weak self] message in
             self?.showAlert(message: message)
         })
@@ -365,7 +366,11 @@ private extension JetpackSetupCoordinator {
         pushOrInitLoginViewController(emailLoginController)
     }
 
-    func showMagicLinkUI(email: String, isSignup: Bool) {
+    func showMagicLinkRequestUI(email: String) {
+        // TODO: Implement the magic link request UI
+    }
+
+    func showMagicLinkSentUI(email: String, isSignup: Bool) {
         analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, isSignup: isSignup))
         let viewController = WPComMagicLinkHostingController(email: email,
                                                              title: loginViewTitle,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1814,6 +1814,9 @@
 		93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA787121CD2A1A00B663E5 /* CurrencySettingsTests.swift */; };
 		953728F82B23635300FDF1D1 /* UIAlertController+helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953728F72B23635300FDF1D1 /* UIAlertController+helpers.swift */; };
 		95968A512CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95968A502CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift */; };
+		95B6C60C2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C60B2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift */; };
+		95B6C60E2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C60D2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift */; };
+		95B6C6102D9DADAA00E1A661 /* WPComLoginGravatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C60F2D9DAD9600E1A661 /* WPComLoginGravatarView.swift */; };
 		A650BE862578E76600C655E0 /* MockStorageManager+Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE842578E76600C655E0 /* MockStorageManager+Sample.swift */; };
 		A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE852578E76600C655E0 /* MockStorageManager.swift */; };
 		A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
@@ -5009,6 +5012,9 @@
 		93FA787121CD2A1A00B663E5 /* CurrencySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencySettingsTests.swift; sourceTree = "<group>"; };
 		953728F72B23635300FDF1D1 /* UIAlertController+helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertController+helpers.swift"; sourceTree = "<group>"; };
 		95968A502CD109D6001F0DA1 /* CustomFieldsListTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListTopBanner.swift; sourceTree = "<group>"; };
+		95B6C60B2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkRequestView.swift; sourceTree = "<group>"; };
+		95B6C60D2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkRequestViewModel.swift; sourceTree = "<group>"; };
+		95B6C60F2D9DAD9600E1A661 /* WPComLoginGravatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComLoginGravatarView.swift; sourceTree = "<group>"; };
 		9D2992FEF3D1246B8CCC2EBB /* Pods-WooCommerceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A650BE842578E76600C655E0 /* MockStorageManager+Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MockStorageManager+Sample.swift"; path = "../../../Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift"; sourceTree = "<group>"; };
 		A650BE852578E76600C655E0 /* MockStorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockStorageManager.swift; path = ../../../Yosemite/YosemiteTests/Mocks/MockStorageManager.swift; sourceTree = "<group>"; };
@@ -13357,6 +13363,7 @@
 		DE63115D2AF1E16500587641 /* WPComLogin */ = {
 			isa = PBXGroup;
 			children = (
+				95B6C60F2D9DAD9600E1A661 /* WPComLoginGravatarView.swift */,
 				DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */,
 				DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */,
 				DE4D239B29B06642003A4B5D /* WPComMagicLinkView.swift */,
@@ -13366,6 +13373,8 @@
 				DE4D23A929B1B0CA003A4B5D /* WPCom2FALoginView.swift */,
 				DE4D23AD29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift */,
 				DE63115A2AF1E13200587641 /* WPComLoginCoordinator.swift */,
+				95B6C60B2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift */,
+				95B6C60D2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -16681,6 +16690,7 @@
 				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,
 				01AAD8142D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift in Sources */,
 				01F42C162CE34AB8003D0A5A /* CardPresentModalTapToPaySuccessEmailSent.swift in Sources */,
+				95B6C6102D9DADAA00E1A661 /* WPComLoginGravatarView.swift in Sources */,
 				028FF8E32AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift in Sources */,
 				DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */,
 				26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */,
@@ -16969,6 +16979,7 @@
 				2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */,
 				B6C838DE28793B3A003AB786 /* CustomFieldViewModel.swift in Sources */,
 				DE65C1F72C48E7DC003EF8D1 /* SupportButton.swift in Sources */,
+				95B6C60E2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift in Sources */,
 				20D210BE2B14C9B90099E517 /* WooPaymentsPayoutStatusDisplayDetails.swift in Sources */,
 				026225212C21F01F00700977 /* PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift in Sources */,
 				E1E125AA26EB42530068A9B0 /* CardPresentModalUpdateProgress.swift in Sources */,
@@ -17271,6 +17282,7 @@
 				262C922126F1370000011F92 /* StorePickerError.swift in Sources */,
 				4515C89825D6C00E0099C8E3 /* ShippingLabelAddressFormViewModel.swift in Sources */,
 				20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */,
+				95B6C60C2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
 				0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */,
 				011DF3442C53A5CF000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1817,6 +1817,7 @@
 		95B6C60C2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C60B2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift */; };
 		95B6C60E2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C60D2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift */; };
 		95B6C6102D9DADAA00E1A661 /* WPComLoginGravatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C60F2D9DAD9600E1A661 /* WPComLoginGravatarView.swift */; };
+		95B6C6142DA18E3A00E1A661 /* WPComMagicLinkRequestViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C6132DA18E3A00E1A661 /* WPComMagicLinkRequestViewModelTests.swift */; };
 		A650BE862578E76600C655E0 /* MockStorageManager+Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE842578E76600C655E0 /* MockStorageManager+Sample.swift */; };
 		A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE852578E76600C655E0 /* MockStorageManager.swift */; };
 		A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
@@ -5015,6 +5016,7 @@
 		95B6C60B2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkRequestView.swift; sourceTree = "<group>"; };
 		95B6C60D2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkRequestViewModel.swift; sourceTree = "<group>"; };
 		95B6C60F2D9DAD9600E1A661 /* WPComLoginGravatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComLoginGravatarView.swift; sourceTree = "<group>"; };
+		95B6C6132DA18E3A00E1A661 /* WPComMagicLinkRequestViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkRequestViewModelTests.swift; sourceTree = "<group>"; };
 		9D2992FEF3D1246B8CCC2EBB /* Pods-WooCommerceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A650BE842578E76600C655E0 /* MockStorageManager+Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MockStorageManager+Sample.swift"; path = "../../../Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift"; sourceTree = "<group>"; };
 		A650BE852578E76600C655E0 /* MockStorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockStorageManager.swift; path = ../../../Yosemite/YosemiteTests/Mocks/MockStorageManager.swift; sourceTree = "<group>"; };
@@ -13745,6 +13747,7 @@
 				DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */,
 				DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */,
 				DE4D23AF29B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift */,
+				95B6C6132DA18E3A00E1A661 /* WPComMagicLinkRequestViewModelTests.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -17958,6 +17961,7 @@
 				011D39712D0A324200DB1445 /* LocationServiceTests.swift in Sources */,
 				028E1F722833E954001F8829 /* DashboardViewModelTests.swift in Sources */,
 				02BC5AA424D27F8900C43326 /* ProductVariationFormViewModel+ObservablesTests.swift in Sources */,
+				95B6C6142DA18E3A00E1A661 /* WPComMagicLinkRequestViewModelTests.swift in Sources */,
 				CCCC5B1326CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift in Sources */,
 				D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */,
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
@@ -108,7 +108,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
         XCTAssertFalse(mockAccountService.triggeredRequestAuthenticationLink)
 
         // When
-        await viewModel.checkWordPressComAccount(email: "mail@example.com")
+        await viewModel.checkWordPressComAccount(emailOrUsername: "mail@example.com")
 
         // Then
         XCTAssertTrue(mockAccountService.triggeredIsPasswordlessAccount)
@@ -128,7 +128,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in triggeredOnError = true })
         // When
-        await viewModel.checkWordPressComAccount(email: "mail@example.com")
+        await viewModel.checkWordPressComAccount(emailOrUsername: "mail@example.com")
 
         // Then
         XCTAssertTrue(triggeredOnError)
@@ -147,7 +147,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  onMagicLinkUIRequest: { _, _ in },
                                                  onError: { _ in })
         // When
-        await viewModel.checkWordPressComAccount(email: "mail@example.com")
+        await viewModel.checkWordPressComAccount(emailOrUsername: "mail@example.com")
 
         // Then
         XCTAssertTrue(triggeredPasswordUIRequest)
@@ -209,7 +209,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  onError: { _ in })
 
         // When
-        await viewModel.checkWordPressComAccount(email: "mail@example.com")
+        await viewModel.checkWordPressComAccount(emailOrUsername: "mail@example.com")
 
         // Then
         XCTAssertTrue(triggeredOnMagicLinkUIRequest)
@@ -234,7 +234,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  onError: { _ in triggeredOnError = true })
 
         // When
-        await viewModel.checkWordPressComAccount(email: "mail@example.com")
+        await viewModel.checkWordPressComAccount(emailOrUsername: "mail@example.com")
 
         // Then
         XCTAssertTrue(triggeredOnError)
@@ -259,7 +259,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  onError: { errorMessage = $0 })
 
         // When
-        await viewModel.checkWordPressComAccount(email: "unknown_username")
+        await viewModel.checkWordPressComAccount(emailOrUsername: "unknown_username")
 
         // Then
         XCTAssertEqual(errorMessage, WPComEmailLoginViewModel.Localization.unknownUsername)

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
@@ -11,7 +11,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: false,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -28,7 +29,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: true,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -45,7 +47,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: false,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -62,7 +65,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: true,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -79,7 +83,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  requiresConnectionOnly: true,
                                                  allowAccountCreation: false,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in })
 
         // When
@@ -101,7 +106,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in })
         // Confidence checks
         XCTAssertFalse(mockAccountService.triggeredIsPasswordlessAccount)
@@ -125,7 +131,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in triggeredOnError = true })
         // When
         await viewModel.checkWordPressComAccount(emailOrUsername: "mail@example.com")
@@ -144,7 +151,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in triggeredPasswordUIRequest = true },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in })
         // When
         await viewModel.checkWordPressComAccount(emailOrUsername: "mail@example.com")
@@ -162,7 +170,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in triggeredOnMagicLinkUIRequest = true },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in triggeredOnMagicLinkUIRequest = true},
                                                  onError: { _ in })
         // When
         await viewModel.requestAuthenticationLink(email: "mail@example.com")
@@ -181,7 +190,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in triggeredOnError = true })
         // When
         await viewModel.requestAuthenticationLink(email: "mail@example.com")
@@ -205,7 +215,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: true,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, isSignup in triggeredOnMagicLinkUIRequest = isSignup },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, isSignup in triggeredOnMagicLinkUIRequest = isSignup },
                                                  onError: { _ in })
 
         // When
@@ -230,7 +241,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: false,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { _ in triggeredOnError = true })
 
         // When
@@ -255,7 +267,8 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
                                                  allowAccountCreation: true,
                                                  accountService: mockAccountService,
                                                  onPasswordUIRequest: { _ in },
-                                                 onMagicLinkUIRequest: { _, _ in },
+                                                 onMagicLinkRequest: { _ in },
+                                                 onMagicLinkSent: { _, _ in },
                                                  onError: { errorMessage = $0 })
 
         // When
@@ -263,5 +276,31 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(errorMessage, WPComEmailLoginViewModel.Localization.unknownUsername)
+    }
+
+    func test_given_emailLoginNotAllowed_when_signingIn_then_trigger_onMagicLinkRequest() async {
+        // Given
+        let mockAccountService = MockWordPressComAccountService()
+        mockAccountService.passwordlessAccountCheckError = WordPressAPIError.endpointError(
+            WordPressComRestApiEndpointError(
+                code: WordPressComRestApiErrorCode.unknown,
+                apiErrorCode: "email_login_not_allowed"
+            )
+        )
+        var triggeredOnMagicLinkRequest = false
+        let viewModel = WPComEmailLoginViewModel(siteURL: "https://example.com",
+                                                 requiresConnectionOnly: true,
+                                                 allowAccountCreation: true,
+                                                 accountService: mockAccountService,
+                                                 onPasswordUIRequest: { _ in },
+                                                 onMagicLinkRequest: { _ in triggeredOnMagicLinkRequest = true },
+                                                 onMagicLinkSent: { _, _ in },
+                                                 onError: { _ in })
+
+        // When
+        await viewModel.checkWordPressComAccount(emailOrUsername: "email@example.com")
+
+        // Then
+        XCTAssertTrue(triggeredOnMagicLinkRequest)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComMagicLinkRequestViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComMagicLinkRequestViewModelTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import WordPressAuthenticator
+@testable import WooCommerce
+
+final class WPComMagicLinkRequestViewModelTests: XCTestCase {
+    func test_givenSuccessMagicLink_when_magicLinkRequested_then_onMagicLinkSent_called() async {
+        // Given
+        let mockAccountService = MockWordPressComAccountService()
+        mockAccountService.authenticationLinkRequestError = nil
+
+        var isMagicLinkSent = false
+        let viewModel = WPComMagicLinkRequestViewModel(email: "email@example.com",
+                                                       onMagicLinkSent: {_ in isMagicLinkSent = true },
+                                                       onUseUsernamePassword: { },
+                                                       onError: { _ in },
+                                                       accountService: mockAccountService
+        )
+
+        // When
+        await viewModel.sendMagicLink()
+
+        // Then
+        XCTAssertTrue(isMagicLinkSent)
+    }
+
+    func test_givenFailedMagicLink_when_magicLinkRequested_then_onError_called() async {
+        // Given
+        let mockAccountService = MockWordPressComAccountService()
+        mockAccountService.authenticationLinkRequestError = NSError(domain: "Test", code: 401)
+
+        var isErrorShown = false
+        let viewModel = WPComMagicLinkRequestViewModel(email: "email@example.com",
+                                                       onMagicLinkSent: {_ in },
+                                                       onUseUsernamePassword: { },
+                                                       onError: { _ in isErrorShown = true },
+                                                       accountService: mockAccountService
+        )
+
+        // When
+        await viewModel.sendMagicLink()
+
+        // Then
+        XCTAssertTrue(isErrorShown)
+    }
+
+    @MainActor func test_when_useUsernamePassword_called_then_handleCallback() {
+        var isUsernamePasswordUsed = false
+        let viewModel = WPComMagicLinkRequestViewModel(email: "email@example.com",
+                                                       onMagicLinkSent: {_ in },
+                                                       onUseUsernamePassword: { isUsernamePasswordUsed = true },
+                                                       onError: { _ in }
+        )
+
+        // When
+        viewModel.useUsernamePassword()
+
+        // Then
+        XCTAssertTrue(isUsernamePasswordUsed)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #15443
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
This PR improves the login of users with flagged emails during Jetpack Setup by using magic link by default, this is achieved by:

- Adding a new screen that allows requesting a magic link manually.
- The screen allows the user to switch to username/password login.
- The `WPComEmailLoginView` is updated to support a `usernameOnly` mode and reused when the user wants to use their username.

## Steps to reproduce
For all tests, please sign in using Application Passwords.

TC1: Confirming navigation to magic link request screen
1. Start Jetpack Setup from the dashboard or the app settings.
2. Enter the email address shared here 37602-pb
3. Make sure not to send the magic link.

For all the following TCs, apply the following [~~patch~~](https://github.com/user-attachments/files/19617690/patch.patch) (edit: correct [patch](https://github.com/user-attachments/files/19632878/patch.patch))

TC2: Magic Link login flow
1. Start Jetpack Setup from the dashboard or the app settings.
2. Enter any email address
3. Tap on Send email in the next screen.

TC3: Fallback to username/password
1. Start Jetpack Setup from the dashboard or the app settings.
2. Enter any email address
3. Tap on Use username and password instead.
4. Sign in using WordPress.com credentials..

## Testing information
TC1: Confirm that the app shows the Magic Link request screen.

TC2: Confirm that the email was sent.

TC3: Confirm that signing using WordPress.com credentials work

## Screenshots

https://github.com/user-attachments/assets/a931e962-151c-4928-a30e-ba1a918d1280


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.