### PR TITLE
[Woo POS] Coupons: Coupon Row (Designer UI)

### DIFF
--- a/WooCommerce/Classes/Model/Coupon+Woo.swift
+++ b/WooCommerce/Classes/Model/Coupon+Woo.swift
@@ -94,37 +94,14 @@ extension Coupon {
 
     /// Summary line for the coupon
     ///
-    func summary(currencySettings: CurrencySettings = ServiceLocator.currencySettings) -> String {
-        let amount = formattedAmount(currencySettings: currencySettings)
-        let applyRules = localizeApplyRules(productsCount: productIds.count,
-                                            excludedProductsCount: excludedProductIds.count,
-                                            categoriesCount: productCategories.count,
-                                            excludedCategoriesCount: excludedProductCategories.count)
-        return amount.isEmpty ? applyRules : String.localizedStringWithFormat(Localization.summaryFormat, amount, applyRules)
+    func summary() -> String {
+        return summary(currencySettings: ServiceLocator.currencySettings)
     }
 
     /// Formatted amount for the coupon
     ///
-    func formattedAmount(currencySettings: CurrencySettings) -> String {
-        var amountString: String = ""
-        switch discountType {
-        case .percent:
-            let percentFormatter = NumberFormatter()
-            percentFormatter.numberStyle = .percent
-            percentFormatter.maximumFractionDigits = 2
-            percentFormatter.multiplier = 1
-            percentFormatter.decimalSeparator = currencySettings.decimalSeparator
-            if let amountDouble = Double(amount) {
-                let amountNumber = NSNumber(value: amountDouble)
-                amountString = percentFormatter.string(from: amountNumber) ?? ""
-            }
-        case .fixedCart, .fixedProduct:
-            let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-            amountString = currencyFormatter.formatAmount(amount) ?? ""
-        case .other:
-            break // skip formatting for unsupported types
-        }
-        return amountString
+    func formattedAmount() -> String {
+        return formattedAmount(currencySettings: ServiceLocator.currencySettings)
     }
 
     /// The message to be shared about the coupon
@@ -139,42 +116,6 @@ extension Coupon {
             return String.localizedStringWithFormat(Localization.shareMessageSomeProducts, couponAmount, code)
         }
         return String.localizedStringWithFormat(Localization.shareMessageAllProducts, couponAmount, code)
-    }
-
-    /// Localize content for the "Apply to" field. This takes into consideration different cases of apply rules:
-    ///    - When only specific products or categories are defined: Display "x Products" or "x Categories"
-    ///    - When specific products/categories and exceptions are defined: Display "x Products excl. y Categories" etc.
-    ///    - When both specific products and categories are defined: Display "x Products and y Categories"
-    ///    - When only exceptions are defined: Display "All excl. x Products" or "All excl. y Categories"
-    ///
-    private func localizeApplyRules(productsCount: Int, excludedProductsCount: Int, categoriesCount: Int, excludedCategoriesCount: Int) -> String {
-        let productText = String.pluralize(productsCount, singular: Localization.singleProduct, plural: Localization.multipleProducts)
-        let productExceptionText = String.pluralize(excludedProductsCount, singular: Localization.singleProduct, plural: Localization.multipleProducts)
-        let categoryText = String.pluralize(categoriesCount, singular: Localization.singleCategory, plural: Localization.multipleCategories)
-        let categoryExceptionText = String.pluralize(excludedCategoriesCount, singular: Localization.singleCategory, plural: Localization.multipleCategories)
-
-        switch (productsCount, excludedProductsCount, categoriesCount, excludedCategoriesCount) {
-        case let (products, _, categories, _) where products > 0 && categories > 0:
-            return String.localizedStringWithFormat(Localization.combinedRules, productText, categoryText)
-        case let (products, excludedProducts, _, _) where products > 0 && excludedProducts > 0:
-            return String.localizedStringWithFormat(Localization.ruleWithException, productText, productExceptionText)
-        case let (products, _, _, excludedCategories) where products > 0 && excludedCategories > 0:
-            return String.localizedStringWithFormat(Localization.ruleWithException, productText, categoryExceptionText)
-        case let (products, _, _, _) where products > 0:
-            return productText
-        case let (_, excludedProducts, categories, _) where excludedProducts > 0 && categories > 0:
-            return String.localizedStringWithFormat(Localization.ruleWithException, categoryText, productExceptionText)
-        case let (_, _, categories, excludedCategories) where categories > 0 && excludedCategories > 0:
-            return String.localizedStringWithFormat(Localization.ruleWithException, categoryText, categoryExceptionText)
-        case let (_, _, categories, _) where categories > 0:
-            return categoryText
-        case let (_, excludedProducts, _, _) where excludedProducts > 0:
-            return String.localizedStringWithFormat(Localization.allWithException, productExceptionText)
-        case let (_, _, _, excludedCategories) where excludedCategories > 0:
-            return String.localizedStringWithFormat(Localization.allWithException, categoryExceptionText)
-        default:
-            return Localization.allProducts
-        }
     }
 }
 
@@ -220,46 +161,6 @@ extension Coupon {
     }
 
     private enum Localization {
-        static let allProducts = NSLocalizedString(
-            "All Products",
-            comment: "Text indicating that there's no limit to the number of products that a coupon can be applied for. " +
-            "Displayed on coupon list items and details screen"
-        )
-        static let singleProduct = NSLocalizedString(
-            "%1$d Product",
-            comment: "The number of products allowed for a coupon in singular form. Reads like: 1 Product"
-        )
-        static let multipleProducts = NSLocalizedString(
-            "%1$d Products",
-            comment: "The number of products allowed for a coupon in plural form. " +
-            "Reads like: 10 Products"
-        )
-        static let singleCategory = NSLocalizedString(
-            "%1$d Category",
-            comment: "The number of category allowed for a coupon in singular form. Reads like: 1 Category"
-        )
-        static let multipleCategories = NSLocalizedString(
-            "%1$d Categories",
-            comment: "The number of category allowed for a coupon in plural form. " +
-            "Reads like: 10 Categories"
-        )
-        static let summaryFormat = NSLocalizedString(
-            "%1$@ off · %2$@",
-            comment: "Summary line for a coupon, with the discounted amount and number of products and categories that the coupon is limited to. " +
-            "Reads like: '10% off · all products' or '$15 off · 2 Product 1 Category'"
-        )
-        static let allWithException = NSLocalizedString(
-            "All Products · Excl. %1$@",
-            comment: "Exception rule for a coupon. Reads like: All Products · Excl. 2 Products"
-        )
-        static let ruleWithException = NSLocalizedString(
-            "%1$@ · Excl. %2$@",
-            comment: "Exception rule for a coupon. Reads like: 3 Products · Excl. 1 Category"
-        )
-        static let combinedRules = NSLocalizedString(
-            "%1$@, %2$@",
-            comment: "Combined rule for a coupon. Reads like: 2 Products, 1 Category"
-        )
         static let shareMessageAllProducts = NSLocalizedString(
                 "Apply %1$@ off to all products with the promo code “%2$@”.",
                 comment: "Message to share the coupon code if it is applicable to all products. " +

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -191,7 +191,7 @@ private extension PointOfSaleOrderController {
         return order.coupons.compactMap { coupon in
             PointOfSaleCouponTotal(
                 code: coupon.code,
-                total: formattedPrice(coupon.discount, currency: order.currency) ?? ""
+                total: formattedPrice("-\(coupon.discount)", currency: order.currency) ?? ""
             )
         }
     }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -274,7 +274,7 @@ extension PointOfSaleOrderController {
 private extension POSCart {
     init(cart: Cart) {
         let items = cart.items.map { POSCartItem(item: $0.item, quantity: Decimal($0.quantity)) }
-        let coupons = cart.coupons.map { POSCoupon(id: $0.id, code: $0.code) }
+        let coupons = cart.coupons.map { POSCoupon(id: $0.id, code: $0.code, summary: $0.summary) }
         self.init(items: items, coupons: coupons)
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -191,7 +191,7 @@ private extension PointOfSaleOrderController {
         return order.coupons.compactMap { coupon in
             PointOfSaleCouponTotal(
                 code: coupon.code,
-                total: formattedPrice("-\(coupon.discount)", currency: order.currency) ?? ""
+                total: formattedPrice(coupon.discount, currency: order.currency, isNegative: true) ?? ""
             )
         }
     }

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -20,7 +20,7 @@ struct CartCouponItem {
     let code: String
     let summary: String
 
-    init(id: UUID, code: String, summary: String = "") {
+    init(id: UUID, code: String, summary: String) {
         self.id = id
         self.code = code
         self.summary = summary

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -18,6 +18,13 @@ struct CartItem {
 struct CartCouponItem {
     let id: UUID
     let code: String
+    let summary: String
+
+    init(id: UUID, code: String, summary: String = "") {
+        self.id = id
+        self.code = code
+        self.summary = summary
+    }
 }
 
 // MARK: - Helper Methods
@@ -34,7 +41,7 @@ extension Cart {
         case .variableParentProduct:
             return
         case .coupon(let coupon):
-            let couponItem = CartCouponItem(id: UUID(), code: coupon.code)
+            let couponItem = CartCouponItem(id: UUID(), code: coupon.code, summary: coupon.summary)
             coupons.insert(couponItem, at: coupons.startIndex)
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/CartRowRemoveButton.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartRowRemoveButton.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct CartRowRemoveButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: {
+            action()
+        }, label: {
+            Text(Image(systemName: "xmark.circle"))
+                .font(.posButtonSymbolMedium)
+        })
+        .accessibilityLabel(Localization.removeFromCartAccessibilityLabel)
+        .foregroundColor(Color.posOnSurfaceVariantLowest)
+    }
+
+    private enum Localization {
+        static let removeFromCartAccessibilityLabel = NSLocalizedString(
+            "pointOfSale.item.removeFromCart.button.accessibilityLabel",
+            value: "Remove",
+            comment: "The accessibility label for the `x` button next to each item in the Point of Sale cart." +
+            "The button removes the item. The translation should be short, to make it quick to navigate by voice.")
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -332,8 +332,6 @@ private extension CartView {
                 .id(couponItem.id)
                 .transition(.opacity)
             }
-
-            Spacer(minLength: 48)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -326,6 +326,7 @@ private extension CartView {
                               couponRowState: viewHelper.couponRowState(orderStage: posModel.orderStage,
                                                                         orderState: posModel.orderState,
                                                                         couponItem: couponItem),
+                              showImage: $shouldShowItemImages,
                               onItemRemoveTapped: posModel.orderStage == .building ? {
                     posModel.remove(cartCouponItem: couponItem)
                 } : nil)

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -53,18 +53,14 @@ struct CouponRowView: View {
                 switch couponRowState {
                 case .valid(let couponTotal):
                     Text("-\(couponTotal.total)")
-                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.summaryFont)
-                case .idle, .none:
-                    EmptyView()
+                        .foregroundColor(.posSuccess)
+                        .font(.posBodySmallRegular())
                 case .invalid:
                     Text(Localization.invalidCoupon)
                         .foregroundColor(.posError)
                         .font(.posBodySmallRegular())
-                case .validating:
-                    Text("Validating...")
-                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.summaryFont)
+                case .idle, .validating, .none:
+                    EmptyView()
                 }
             }
             .animation(.default, value: couponRowState)

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -22,7 +22,7 @@ struct CouponRowView: View {
             Rectangle()
                 .foregroundColor(.posSurfaceDim)
                 .overlay {
-                    Text(Image(systemName: "tag.square.fill"))
+                    Text(Image(systemName: "tag"))
                         .font(.posButtonSymbolLarge)
                         .foregroundColor(.posOnSurfaceVariantLowest)
                 }

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -58,9 +58,9 @@ struct CouponRowView: View {
                 case .idle, .none:
                     EmptyView()
                 case .invalid:
-                    Text("Invalid coupon")
-                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.summaryFont)
+                    Text(Localization.invalidCoupon)
+                        .foregroundColor(.posError)
+                        .font(.posBodySmallRegular())
                 case .validating:
                     Text("Validating...")
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
@@ -96,6 +96,15 @@ private extension CouponRowView {
         static let titleFont: POSFontStyle = .posBodySmallBold
         static let titleSummarySpacing: CGFloat = POSSpacing.xSmall
         static let summaryFont: POSFontStyle = .posBodySmallRegular()
+    }
+}
+
+private extension CouponRowView {
+    private enum Localization {
+        static let invalidCoupon = NSLocalizedString(
+            "pointOfSale.couponRow.invalidCoupon",
+            value: "Coupon not applied",
+            comment: "A message shown on the coupon if's not valid after attempting to apply it")
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -52,7 +52,7 @@ struct CouponRowView: View {
 
                 switch couponRowState {
                 case .valid(let couponTotal):
-                    Text("-\(couponTotal.total)")
+                    Text(couponTotal.total)
                         .foregroundColor(.posSuccess)
                         .font(.posBodySmallRegular())
                 case .invalid:

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -6,15 +6,25 @@ struct CouponRowView: View {
     private let onItemRemoveTapped: (() -> Void)?
 
     @ScaledMetric private var scale: CGFloat = 1.0
+    @Binding private var showImage: Bool
 
-    init(couponItem: CartCouponItem, couponRowState: CouponRowState? = nil, onItemRemoveTapped: (() -> Void)? = nil) {
+    init(couponItem: CartCouponItem,
+         couponRowState: CouponRowState? = nil,
+         showImage: Binding<Bool> = .constant(true),
+         onItemRemoveTapped: (() -> Void)? = nil
+    ) {
         self.couponItem = couponItem
         self.couponRowState = couponRowState
+        self._showImage = showImage
         self.onItemRemoveTapped = onItemRemoveTapped
     }
 
     private var dynamicSpacing: CGFloat {
         Constants.titleSummarySpacing * (1 / scale)
+    }
+
+    private var dimension: CGFloat {
+        min(Constants.couponCardSize * scale, Constants.maximumCouponCardSize)
     }
 
     var body: some View {
@@ -26,7 +36,10 @@ struct CouponRowView: View {
                         .font(.posButtonSymbolMedium)
                         .foregroundColor(.posOnSurfaceVariantLowest)
                 }
-                .frame(width: Constants.couponCardSize, height: Constants.couponCardSize)
+                .frame(width: dimension)
+                .frame(minHeight: dimension)
+                .accessibilityHidden(true)
+                .renderedIf(showImage)
 
             VStack(alignment: .leading, spacing: dynamicSpacing) {
                 Text(couponItem.code)
@@ -56,15 +69,13 @@ struct CouponRowView: View {
             }
             .animation(.default, value: couponRowState)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, showImage ? 0 : Constants.cardContentHorizontalPadding)
+            .accessibilityElement(children: .combine)
 
             if let onItemRemoveTapped {
-                Button(action: {
+                CartRowRemoveButton {
                     onItemRemoveTapped()
-                }, label: {
-                    Text(Image(systemName: "xmark.circle"))
-                        .font(.posButtonSymbolMedium)
-                })
-                .foregroundColor(Color.posOnSurfaceVariantLowest)
+                }
             }
         }
         .padding(.trailing, Constants.cardContentHorizontalPadding)
@@ -78,6 +89,7 @@ struct CouponRowView: View {
 private extension CouponRowView {
     enum Constants {
         static let couponCardSize: CGFloat = 96
+        static let maximumCouponCardSize: CGFloat = Self.couponCardSize * 1.5
         static let horizontalPadding: CGFloat = POSPadding.medium
         static let horizontalElementSpacing: CGFloat = POSSpacing.medium
         static let cardContentHorizontalPadding: CGFloat = POSPadding.medium

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -14,7 +14,7 @@ struct CouponRowView: View {
     }
 
     private var dynamicSpacing: CGFloat {
-        Constants.itemTitleAndPriceSpacing * (1 / scale)
+        Constants.titleSummarySpacing * (1 / scale)
     }
 
     var body: some View {
@@ -23,7 +23,7 @@ struct CouponRowView: View {
                 .foregroundColor(.posSurfaceDim)
                 .overlay {
                     Text(Image(systemName: "tag"))
-                        .font(.posButtonSymbolLarge)
+                        .font(.posButtonSymbolMedium)
                         .foregroundColor(.posOnSurfaceVariantLowest)
                 }
                 .frame(width: Constants.couponCardSize, height: Constants.couponCardSize)
@@ -31,23 +31,27 @@ struct CouponRowView: View {
             VStack(alignment: .leading, spacing: dynamicSpacing) {
                 Text(couponItem.code)
                     .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
-                    .font(Constants.itemTitleFont)
+                    .font(Constants.titleFont)
+
+                Text(couponItem.summary)
+                    .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                    .font(Constants.summaryFont)
 
                 switch couponRowState {
                 case .valid(let couponTotal):
                     Text("-\(couponTotal.total)")
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.itemPriceFont)
+                        .font(Constants.summaryFont)
                 case .idle, .none:
                     EmptyView()
                 case .invalid:
                     Text("Invalid coupon")
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.itemPriceFont)
+                        .font(Constants.summaryFont)
                 case .validating:
                     Text("Validating...")
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.itemPriceFont)
+                        .font(Constants.summaryFont)
                 }
             }
             .animation(.default, value: couponRowState)
@@ -77,9 +81,9 @@ private extension CouponRowView {
         static let horizontalPadding: CGFloat = POSPadding.medium
         static let horizontalElementSpacing: CGFloat = POSSpacing.medium
         static let cardContentHorizontalPadding: CGFloat = POSPadding.medium
-        static let itemTitleFont: POSFontStyle = .posBodySmallBold
-        static let itemTitleAndPriceSpacing: CGFloat = POSSpacing.xSmall
-        static let itemPriceFont: POSFontStyle = .posBodySmallRegular()
+        static let titleFont: POSFontStyle = .posBodySmallBold
+        static let titleSummarySpacing: CGFloat = POSSpacing.xSmall
+        static let summaryFont: POSFontStyle = .posBodySmallRegular()
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -86,6 +86,6 @@ private extension CouponRowView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview(traits: .sizeThatFitsLayout) {
-    CouponRowView(couponItem: CartCouponItem(id: UUID(), code: "10-Discount"), couponRowState: .idle) {}
+    CouponRowView(couponItem: CartCouponItem(id: UUID(), code: "10-Discount", summary: "$10 Off · All products"), couponRowState: .idle) {}
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
+++ b/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
@@ -24,7 +24,7 @@ private struct POSCouponCreationSheetModifier: ViewModifier {
             .sheet(item: $selectedType) { (posDiscountType: POSCouponDiscountType) in
                 var addedCouponItem: POSItem?
                 let viewModel = AddEditCouponViewModel(discountType: posDiscountType.discountType, onSuccess: { coupon in
-                    addedCouponItem = .coupon(.init(id: UUID(), code: coupon.code))
+                    addedCouponItem = .coupon(.init(id: UUID(), code: coupon.code, summary: coupon.summary()))
                 })
                 var view = AddEditCoupon(viewModel)
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -154,7 +154,8 @@ private struct ItemListRow: View {
                 posModel.addToCart(item)
             }, label: {
                 CouponRowView(couponItem: .init(id: coupon.id,
-                                               code: coupon.code))
+                                                code: coupon.code,
+                                                summary: coupon.summary))
             })
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -39,14 +39,9 @@ struct ItemRowView: View {
             .accessibilityElement(children: .combine)
 
             if let onItemRemoveTapped {
-                Button(action: {
+                CartRowRemoveButton {
                     onItemRemoveTapped()
-                }, label: {
-                    Text(Image(systemName: "xmark.circle"))
-                        .font(.posButtonSymbolMedium)
-                })
-                .accessibilityLabel(Localization.removeFromCartAccessibilityLabel)
-                .foregroundColor(Color.posOnSurfaceVariantLowest)
+                }
             }
         }
         .padding(.trailing, Constants.cardContentHorizontalPadding)
@@ -80,14 +75,6 @@ private extension ItemRowView {
         static let itemTitleFont: POSFontStyle = .posBodySmallBold
         static let itemSubtitleFont: POSFontStyle = .posBodySmallRegular()
         static let itemPriceFont: POSFontStyle = .posBodySmallRegular()
-    }
-
-    enum Localization {
-        static let removeFromCartAccessibilityLabel = NSLocalizedString(
-            "pointOfSale.item.removeFromCart.button.accessibilityLabel",
-            value: "Remove",
-            comment: "The accessibility label for the `x` button next to each item in the Point of Sale cart." +
-            "The button removes the item. The translation should be short, to make it quick to navigate by voice.")
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		01BD77482C58D19C00147191 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD77472C58D19C00147191 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift */; };
 		01BD774A2C58D29700147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD77492C58D29700147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageView.swift */; };
 		01BD774C2C58D2BE00147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD774B2C58D2BE00147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift */; };
+		01C9C59F2DA3D98400CD81D8 /* CartRowRemoveButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C9C59E2DA3D97E00CD81D8 /* CartRowRemoveButton.swift */; };
 		01D082402C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */; };
 		01F067ED2D0C5D59001C5805 /* MockLocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F067EC2D0C5D56001C5805 /* MockLocationService.swift */; };
 		01F42C162CE34AB8003D0A5A /* CardPresentModalTapToPaySuccessEmailSent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F42C152CE34AB3003D0A5A /* CardPresentModalTapToPaySuccessEmailSent.swift */; };
@@ -3310,6 +3311,7 @@
 		01BD77472C58D19C00147191 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift; sourceTree = "<group>"; };
 		01BD77492C58D29700147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisconnectedMessageView.swift; sourceTree = "<group>"; };
 		01BD774B2C58D2BE00147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift; sourceTree = "<group>"; };
+		01C9C59E2DA3D97E00CD81D8 /* CartRowRemoveButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartRowRemoveButton.swift; sourceTree = "<group>"; };
 		01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSBackgroundAppearanceKey.swift; sourceTree = "<group>"; };
 		01F067EC2D0C5D56001C5805 /* MockLocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocationService.swift; sourceTree = "<group>"; };
 		01F42C152CE34AB3003D0A5A /* CardPresentModalTapToPaySuccessEmailSent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapToPaySuccessEmailSent.swift; sourceTree = "<group>"; };
@@ -7274,6 +7276,7 @@
 				026826A32BF59DF60036F959 /* CartView.swift */,
 				026826A22BF59DF60036F959 /* ItemRowView.swift */,
 				0139BB512D91B45500C78FDE /* CouponRowView.swift */,
+				01C9C59E2DA3D97E00CD81D8 /* CartRowRemoveButton.swift */,
 				68D8FBD02BFEF9C700477C42 /* TotalsView.swift */,
 				68AF3C3A2D01481A006F1ED2 /* POSReceiptEligibilityBanner.swift */,
 				DA1D68C12C36F0980097859A /* PointOfSaleAssets.swift */,
@@ -16036,6 +16039,7 @@
 				205E79512C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift in Sources */,
 				03F5CB012A0BA3D40026877A /* ModalOverlay.swift in Sources */,
 				02C37B7D2967B72A00F0CF9E /* FreeStagingDomainView.swift in Sources */,
+				01C9C59F2DA3D98400CD81D8 /* CartRowRemoveButton.swift in Sources */,
 				457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */,
 				D8815B0D263861A400EDAD62 /* CardPresentModalSuccess.swift in Sources */,
 				CCE73D2529EDAB5C0064E797 /* SubscriptionPeriod+UI.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -377,12 +377,12 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync to set up the order
-        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items and coupons
-        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode, summary: "")]), retryHandler: {})
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == false)
@@ -401,12 +401,12 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync
-        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: initialCouponCode)]), retryHandler: {})
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: initialCouponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items but different coupon
-        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: "DIFFERENT20")]), retryHandler: {})
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: "DIFFERENT20", summary: "")]), retryHandler: {})
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == true)
@@ -425,7 +425,7 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync with coupon
-        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode)]), retryHandler: {})
+        await sut.syncOrder(for: .init(items: [cartItem], coupons: [.init(id: UUID(), code: couponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
@@ -462,7 +462,7 @@ struct PointOfSaleOrderControllerTests {
 
             // When
             await sut.syncOrder(for: .init(items: [makeItem()],
-                                         coupons: [.init(id: UUID(), code: "INVALID")]),
+                                         coupons: [.init(id: UUID(), code: "INVALID", summary: "")]),
                               retryHandler: {})
         }
 
@@ -509,7 +509,7 @@ struct PointOfSaleOrderControllerTests {
 
             // When
             await sut.syncOrder(for: .init(items: [makeItem()],
-                                         coupons: [.init(id: UUID(), code: "INVALID")]),
+                                         coupons: [.init(id: UUID(), code: "INVALID", summary: "")]),
                               retryHandler: {})
         }
 

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
@@ -88,7 +88,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_building_stage_returns_idle() async throws {
         // Given
-        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10", summary: "")
         let orderState = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
             cartTotal: "$10.00",
             orderTotal: "$12.00",
@@ -103,7 +103,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_syncing_returns_validating() async throws {
         // Given
-        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -114,7 +114,7 @@ struct CartViewHelperTests {
     @Test func couponRowState_finalizing_and_loaded_with_matching_coupon_returns_valid() async throws {
         // Given
         let couponCode = "TEST10"
-        let coupon = CartCouponItem(id: UUID(), code: couponCode)
+        let coupon = CartCouponItem(id: UUID(), code: couponCode, summary: "")
         let couponTotal = PointOfSaleCouponTotal(code: couponCode, total: "10.00")
         let orderTotals = PointOfSaleOrderTotals(
             cartTotal: "$10.00",
@@ -131,7 +131,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_loaded_with_no_matching_coupon_returns_idle() async throws {
         // Given
-        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10", summary: "")
         let orderTotals = PointOfSaleOrderTotals(
             cartTotal: "$10.00",
             orderTotal: "$12.00",
@@ -147,7 +147,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_invalid_coupon_error_returns_invalid() async throws {
         // Given
-        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -157,7 +157,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_other_error_returns_idle() async throws {
         // Given
-        let coupon = CartCouponItem(id: UUID(), code: "TEST10")
+        let coupon = CartCouponItem(id: UUID(), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/TotalsViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/TotalsViewHelperTests.swift
@@ -116,7 +116,7 @@ struct TotalsViewHelperTests {
     @Test
     func test_shouldShowTotalDiscountField_returns_true_when_cart_has_coupons_order_syncing() {
         var cart = Cart()
-        cart.add(.coupon(.init(id: .init(), code: "TEST10")))
+        cart.add(.coupon(.init(id: .init(), code: "TEST10", summary: "")))
 
         #expect(TotalsViewHelper().shouldShowTotalDiscountField(cart: cart, orderTotals: nil))
     }
@@ -124,7 +124,7 @@ struct TotalsViewHelperTests {
     @Test
     func test_shouldShowTotalDiscountField_returns_true_when_cart_has_coupons_and_orderTotals_with_discount() {
         var cart = Cart()
-        cart.add(.coupon(.init(id: .init(), code: "TEST10")))
+        cart.add(.coupon(.init(id: .init(), code: "TEST10", summary: "")))
         let orderTotals = PointOfSaleOrderTotals(cartTotal: "10",
                                                  orderTotal: "8",
                                                  taxTotal: "0",
@@ -137,7 +137,7 @@ struct TotalsViewHelperTests {
     @Test
     func test_shouldShowTotalDiscountField_returns_false_when_cart_has_coupons_and_orderTotals_without_discount() {
         var cart = Cart()
-        cart.add(.coupon(.init(id: .init(), code: "TEST10")))
+        cart.add(.coupon(.init(id: .init(), code: "TEST10", summary: "")))
         let orderTotals = PointOfSaleOrderTotals(cartTotal: "10",
                                                  orderTotal: "10",
                                                  taxTotal: "0",

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		016EFCAE2C4155650016BDAA /* OrderItem+BasePrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EFCAD2C4155650016BDAA /* OrderItem+BasePrice.swift */; };
 		016EFCB02C41559D0016BDAA /* OrderItem+BasePriceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EFCAF2C41559D0016BDAA /* OrderItem+BasePriceTests.swift */; };
 		01AAD8122D92DE110081D60B /* CouponsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AAD8112D92DE0F0081D60B /* CouponsError.swift */; };
+		01C9C59D2DA3B09200CD81D8 /* Coupon+Summary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C9C59C2DA3B08800CD81D8 /* Coupon+Summary.swift */; };
 		0202B690238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B68F238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift */; };
 		0202B6972387AFBF00F3EBE0 /* MockInMemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6962387AFBF00F3EBE0 /* MockInMemoryStorage.swift */; };
 		0202B6992387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */; };
@@ -571,6 +572,7 @@
 		016EFCAD2C4155650016BDAA /* OrderItem+BasePrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItem+BasePrice.swift"; sourceTree = "<group>"; };
 		016EFCAF2C41559D0016BDAA /* OrderItem+BasePriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItem+BasePriceTests.swift"; sourceTree = "<group>"; };
 		01AAD8112D92DE0F0081D60B /* CouponsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponsError.swift; sourceTree = "<group>"; };
+		01C9C59C2DA3B08800CD81D8 /* Coupon+Summary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+Summary.swift"; sourceTree = "<group>"; };
 		0202B68F238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFeatureSwitchPListWrapper.swift; sourceTree = "<group>"; };
 		0202B6962387AFBF00F3EBE0 /* MockInMemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInMemoryStorage.swift; sourceTree = "<group>"; };
 		0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettingsStoreTests+ProductsFeatureSwitch.swift"; sourceTree = "<group>"; };
@@ -1134,6 +1136,14 @@
 				016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		01C9C59B2DA3B08200CD81D8 /* Coupons */ = {
+			isa = PBXGroup;
+			children = (
+				01C9C59C2DA3B08800CD81D8 /* Coupon+Summary.swift */,
+			);
+			path = Coupons;
 			sourceTree = "<group>";
 		};
 		0202B68E238790B900F3EBE0 /* PListStorage */ = {
@@ -1708,6 +1718,7 @@
 		B53D89E720E6C7DC00F90866 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				01C9C59B2DA3B08200CD81D8 /* Coupons */,
 				0331A7032A38B9D7001D2C2C /* WooPlans */,
 				02F6AAA827055655002425D0 /* Copiable */,
 				247CE7AF2582DBD000F9D9D1 /* Mocks */,
@@ -2640,6 +2651,7 @@
 				02EF1668292DB68C00D90AD6 /* PaymentAction.swift in Sources */,
 				CE0FBB232D0C65C8008B7789 /* WooShippingSavedPredefinedPackage+ReadOnlyConvertible.swift in Sources */,
 				B5C9DE162087FF0E006B910A /* Store.swift in Sources */,
+				01C9C59D2DA3B09200CD81D8 /* Coupon+Summary.swift in Sources */,
 				02FF056123D98FD40058E6E7 /* ImageSourceWriter.swift in Sources */,
 				0212AC5E242C67FA00C51F6C /* ProductsSortOrder.swift in Sources */,
 				026CF626237D8EFB009563D4 /* ProductVariationStore.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Coupons/Coupon+Summary.swift
+++ b/Yosemite/Yosemite/Model/Coupons/Coupon+Summary.swift
@@ -1,0 +1,133 @@
+import Foundation
+import UIKit
+import WooFoundation
+
+public extension Coupon {
+    /// Summary line for the coupon
+    ///
+    func summary(currencySettings: CurrencySettings) -> String {
+        let amount = formattedAmount(currencySettings: currencySettings)
+        let applyRules = localizeApplyRules(productsCount: productIds.count,
+                                            excludedProductsCount: excludedProductIds.count,
+                                            categoriesCount: productCategories.count,
+                                            excludedCategoriesCount: excludedProductCategories.count)
+        return amount.isEmpty ? applyRules : String.localizedStringWithFormat(Localization.summaryFormat, amount, applyRules)
+    }
+
+    /// Formatted amount for the coupon
+    ///
+    func formattedAmount(currencySettings: CurrencySettings) -> String {
+        var amountString: String = ""
+        switch discountType {
+        case .percent:
+            let percentFormatter = NumberFormatter()
+            percentFormatter.numberStyle = .percent
+            percentFormatter.maximumFractionDigits = 2
+            percentFormatter.multiplier = 1
+            percentFormatter.decimalSeparator = currencySettings.decimalSeparator
+            if let amountDouble = Double(amount) {
+                let amountNumber = NSNumber(value: amountDouble)
+                amountString = percentFormatter.string(from: amountNumber) ?? ""
+            }
+        case .fixedCart, .fixedProduct:
+            let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+            amountString = currencyFormatter.formatAmount(amount) ?? ""
+        case .other:
+            break // skip formatting for unsupported types
+        }
+        return amountString
+    }
+
+    /// Localize content for the "Apply to" field. This takes into consideration different cases of apply rules:
+    ///    - When only specific products or categories are defined: Display "x Products" or "x Categories"
+    ///    - When specific products/categories and exceptions are defined: Display "x Products excl. y Categories" etc.
+    ///    - When both specific products and categories are defined: Display "x Products and y Categories"
+    ///    - When only exceptions are defined: Display "All excl. x Products" or "All excl. y Categories"
+    ///
+    private func localizeApplyRules(productsCount: Int, excludedProductsCount: Int, categoriesCount: Int, excludedCategoriesCount: Int) -> String {
+        let productText = productsCount == 1 ?
+            String.localizedStringWithFormat(Localization.singleProduct, productsCount) :
+            String.localizedStringWithFormat(Localization.multipleProducts, productsCount)
+
+        let productExceptionText = excludedProductsCount == 1 ?
+            String.localizedStringWithFormat(Localization.singleProduct, excludedProductsCount) :
+            String.localizedStringWithFormat(Localization.multipleProducts, excludedProductsCount)
+
+        let categoryText = categoriesCount == 1 ?
+            String.localizedStringWithFormat(Localization.singleCategory, categoriesCount) :
+            String.localizedStringWithFormat(Localization.multipleCategories, categoriesCount)
+
+        let categoryExceptionText = excludedCategoriesCount == 1 ?
+            String.localizedStringWithFormat(Localization.singleCategory, excludedCategoriesCount) :
+            String.localizedStringWithFormat(Localization.multipleCategories, excludedCategoriesCount)
+
+        switch (productsCount, excludedProductsCount, categoriesCount, excludedCategoriesCount) {
+        case let (products, _, categories, _) where products > 0 && categories > 0:
+            return String.localizedStringWithFormat(Localization.combinedRules, productText, categoryText)
+        case let (products, excludedProducts, _, _) where products > 0 && excludedProducts > 0:
+            return String.localizedStringWithFormat(Localization.ruleWithException, productText, productExceptionText)
+        case let (products, _, _, excludedCategories) where products > 0 && excludedCategories > 0:
+            return String.localizedStringWithFormat(Localization.ruleWithException, productText, categoryExceptionText)
+        case let (products, _, _, _) where products > 0:
+            return productText
+        case let (_, excludedProducts, categories, _) where excludedProducts > 0 && categories > 0:
+            return String.localizedStringWithFormat(Localization.ruleWithException, categoryText, productExceptionText)
+        case let (_, _, categories, excludedCategories) where categories > 0 && excludedCategories > 0:
+            return String.localizedStringWithFormat(Localization.ruleWithException, categoryText, categoryExceptionText)
+        case let (_, _, categories, _) where categories > 0:
+            return categoryText
+        case let (_, excludedProducts, _, _) where excludedProducts > 0:
+            return String.localizedStringWithFormat(Localization.allWithException, productExceptionText)
+        case let (_, _, _, excludedCategories) where excludedCategories > 0:
+            return String.localizedStringWithFormat(Localization.allWithException, categoryExceptionText)
+        default:
+            return Localization.allProducts
+        }
+    }
+}
+
+// MARK: - Subtypes
+extension Coupon {
+    private enum Localization {
+        static let allProducts = NSLocalizedString(
+            "All Products",
+            comment: "Text indicating that there's no limit to the number of products that a coupon can be applied for. " +
+            "Displayed on coupon list items and details screen"
+        )
+        static let singleProduct = NSLocalizedString(
+            "%1$d Product",
+            comment: "The number of products allowed for a coupon in singular form. Reads like: 1 Product"
+        )
+        static let multipleProducts = NSLocalizedString(
+            "%1$d Products",
+            comment: "The number of products allowed for a coupon in plural form. " +
+            "Reads like: 10 Products"
+        )
+        static let singleCategory = NSLocalizedString(
+            "%1$d Category",
+            comment: "The number of category allowed for a coupon in singular form. Reads like: 1 Category"
+        )
+        static let multipleCategories = NSLocalizedString(
+            "%1$d Categories",
+            comment: "The number of category allowed for a coupon in plural form. " +
+            "Reads like: 10 Categories"
+        )
+        static let summaryFormat = NSLocalizedString(
+            "%1$@ off · %2$@",
+            comment: "Summary line for a coupon, with the discounted amount and number of products and categories that the coupon is limited to. " +
+            "Reads like: '10% off · all products' or '$15 off · 2 Product 1 Category'"
+        )
+        static let allWithException = NSLocalizedString(
+            "All Products · Excl. %1$@",
+            comment: "Exception rule for a coupon. Reads like: All Products · Excl. 2 Products"
+        )
+        static let ruleWithException = NSLocalizedString(
+            "%1$@ · Excl. %2$@",
+            comment: "Exception rule for a coupon. Reads like: 3 Products · Excl. 1 Category"
+        )
+        static let combinedRules = NSLocalizedString(
+            "%1$@, %2$@",
+            comment: "Combined rule for a coupon. Reads like: 2 Products, 1 Category"
+        )
+    }
+}

--- a/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
@@ -1,9 +1,11 @@
 public struct POSCoupon: Equatable, Hashable {
     public let id: UUID
     public let code: String
+    public let summary: String
 
-    public init(id: UUID, code: String) {
+    public init(id: UUID, code: String, summary: String = "") {
         self.id = id
         self.code = code
+        self.summary = summary
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -16,6 +16,7 @@ public protocol PointOfSaleCouponServiceProtocol {
 
 public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     private var siteID: Int64
+    private let currencySettings: CurrencySettings
     private let currencyFormatter: CurrencyFormatter
     private let storage: StorageManagerType?
     private let couponStoreMethods: CouponStoreMethodsProtocol
@@ -27,6 +28,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
          settingStoreMethods: SettingStoreMethodsProtocol,
          storage: StorageManagerType) {
         self.siteID = siteID
+        self.currencySettings = currencySettings
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.storage = storage
         self.couponStoreMethods = couponStoreMethods
@@ -97,7 +99,11 @@ private extension PointOfSaleCouponService {
 
     func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
         coupons.compactMap { coupon in
-                .coupon(POSCoupon(id: UUID(), code: coupon.code))
+                .coupon(POSCoupon(
+                    id: UUID(),
+                    code: coupon.code,
+                    summary: coupon.summary(currencySettings: currencySettings)
+                ))
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Make Coupon Row in the Cart to fulfill design requirements:
- Updated coupon icon view
- Added coupon summary label by moving the summary building to `Yosemite` so it could be more easily reused between IPP and POS
- Adjusted the row to behave in a similar way to item row based on growing dynamic type size
- Added accessibility labels for voice over
- Configured invalid and valid states

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites: Enable `enableCouponsInPointOfSale` local feature flag


Repeat these steps:
1. Load POS
2. Add coupon and product to cart
3. Check out

With different configurations:
- Valid coupon
- Invalid coupon
- Large dynamic type size
- Light / Dark Mode
- Voice Over

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 11 inch M2 (18.2)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


| Large Dynamic Type Size | Normal |
| --- | --- |
| ![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-07 at 13:22:16](https://github.com/user-attachments/assets/71c2daf2-935e-4d64-8282-b72ad721789a) | ![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-07 at 13:21:05](https://github.com/user-attachments/assets/80b54dd9-97bc-43c5-86f0-710b4e9e2b1f) |

| Dark Mode | Error State |
| --- | --- |
| ![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-07 at 13:20:59](https://github.com/user-attachments/assets/8b9f9fb5-2c9e-4a7a-96e1-c680cb2490af) | ![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-07 at 13:20:41](https://github.com/user-attachments/assets/1e6f3add-cdd2-4ead-902f-3fd32aa5721f) |

| Success State |
| --- |
| ![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-07 at 13:20:26](https://github.com/user-attachments/assets/8d515d2f-98bd-44a2-85c0-7d6704477a01) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.