### PR TITLE
[Woo POS] Coupons: Checkout - Error Handling (Designer UI)

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -4,23 +4,10 @@ import SwiftUI
 struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
     let message: String
     let retryHandler: () -> Void
+    @State private var attributedMessage: AttributedString = ""
 
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
-
-    private var attributedMessage: AttributedString {
-        if let data = message.data(using: .utf8),
-           let nsAttributedString = try? NSAttributedString(
-               data: data,
-               options: [.documentType: NSAttributedString.DocumentType.html],
-               documentAttributes: nil) {
-            var attributedString = AttributedString(nsAttributedString)
-            attributedString.font = POSFontStyle.posBodyLargeRegular().font()
-            attributedString.foregroundColor = UIColor(Color.posOnSurface)
-            return attributedString
-        }
-        return AttributedString(message)
-    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -62,6 +49,11 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
                 Spacer()
             }
         }
+        .onAppear {
+            // Setting attributed string once in onAppear to prevent a SwiftUI crash
+            // Building attributed HTML string within SwiftUI body causes never-ending redraw cycles
+            attributedMessage = message.attributedHTMLString
+        }
     }
 }
 
@@ -101,5 +93,21 @@ private extension PointOfSaleOrderSyncCouponsErrorMessageView {
 #Preview {
     if #available(iOS 17.0, *) {
         PointOfSaleOrderSyncCouponsErrorMessageView(message: "An error happened!") {}
+    }
+}
+
+private extension String {
+    var attributedHTMLString: AttributedString {
+        if let data = self.data(using: .utf8),
+           let nsAttributedString = try? NSAttributedString(
+               data: data,
+               options: [.documentType: NSAttributedString.DocumentType.html],
+               documentAttributes: nil) {
+            var attributedString = AttributedString(nsAttributedString)
+            attributedString.font = POSFontStyle.posBodyLargeRegular().font()
+            attributedString.foregroundColor = UIColor(Color.posOnSurface)
+            return attributedString
+        }
+        return AttributedString(self)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -23,41 +23,44 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
     }
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: POSSpacing.none) {
+        GeometryReader { geometry in
+            HStack(alignment: .center) {
                 Spacer()
-                POSErrorExclamationMark(size: .large)
-                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
-                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                    Text(Localization.title)
-                        .foregroundStyle(Color.posOnSurface)
-                        .font(.posHeadingBold)
+                VStack(alignment: .center, spacing: POSSpacing.none) {
+                    Spacer()
+                    POSErrorXMark()
+                    Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
+                    VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                        Text(Localization.title)
+                            .foregroundStyle(Color.posOnSurface)
+                            .font(.posHeadingBold)
 
-                    Text(attributedMessage)
-                        .padding([.leading, .trailing])
+                        Text(attributedMessage)
+                            .padding([.leading, .trailing])
+                    }
+                    Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
+
+                    VStack(spacing: POSSpacing.medium) {
+                        Button(Localization.retryActionTitle, action: {
+                            posModel.removeAllCouponsFromCart()
+                            retryHandler()
+                        })
+                        .buttonStyle(POSFilledButtonStyle(size: .normal))
+
+                        Button(Localization.editOrderTitle, action: {
+                            posModel.addMoreToCart()
+                        })
+                        .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                    }
+                    .frame(width: geometry.size.width / 2)
+                    .padding([.leading, .trailing], Constants.buttonSidePadding)
+                    .padding([.bottom], Constants.buttonBottomPadding)
+
+                    Spacer()
                 }
-                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
-
-                VStack(spacing: POSSpacing.medium) {
-                    Button(Localization.retryActionTitle, action: {
-                        posModel.removeAllCouponsFromCart()
-                        retryHandler()
-                    })
-                    .buttonStyle(POSFilledButtonStyle(size: .normal))
-
-                    Button(Localization.editOrderTitle, action: {
-                        posModel.addMoreToCart()
-                    })
-                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-                }
-                .padding([.leading, .trailing], Constants.buttonSidePadding)
-                .padding([.bottom], Constants.buttonBottomPadding)
-
+                .multilineTextAlignment(.center)
                 Spacer()
             }
-            .multilineTextAlignment(.center)
-            Spacer()
         }
     }
 }
@@ -76,7 +79,7 @@ private extension PointOfSaleOrderSyncCouponsErrorMessageView {
 private extension PointOfSaleOrderSyncCouponsErrorMessageView {
     enum Localization {
         static let title = NSLocalizedString(
-            "pointOfSale.orderSync.couponsError.title",
+            "pointOfSale.orderSync.couponsError.errorTitle",
             value: "Couldn't apply coupon",
             comment: "Title of the error when failing to validate coupons and calculate order totals"
         )

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -30,7 +30,7 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
                 POSErrorExclamationMark(size: .large)
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
                 VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                    Text("Invalid coupons")
+                    Text(Localization.title)
                         .foregroundStyle(Color.posOnSurface)
                         .font(.posHeadingBold)
 
@@ -38,11 +38,19 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
                         .padding([.leading, .trailing])
                 }
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
-                Button("Continue without coupons", action: {
-                    posModel.removeAllCouponsFromCart()
-                    retryHandler()
-                })
-                .buttonStyle(POSFilledButtonStyle(size: .normal))
+
+                VStack(spacing: POSSpacing.medium) {
+                    Button(Localization.retryActionTitle, action: {
+                        posModel.removeAllCouponsFromCart()
+                        retryHandler()
+                    })
+                    .buttonStyle(POSFilledButtonStyle(size: .normal))
+
+                    Button(Localization.editOrderTitle, action: {
+                        posModel.addMoreToCart()
+                    })
+                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                }
                 .padding([.leading, .trailing], Constants.buttonSidePadding)
                 .padding([.bottom], Constants.buttonBottomPadding)
 
@@ -64,23 +72,28 @@ private extension PointOfSaleOrderSyncCouponsErrorMessageView {
     }
 }
 
-// MARK: - TODO https://github.com/woocommerce/woocommerce-ios/issues/15424
-//
-//private extension PointOfSaleOrderSyncErrorMessageView {
-//    enum Localization {
-//        static let title = NSLocalizedString(
-//            "pointOfSale.orderSync.couponsError.title",
-//            value: "Invalid coupons",
-//            comment: "Title of the error when failing to validate coupons and calculate order totals"
-//        )
-//
-//        static let actionTitle = NSLocalizedString(
-//            "pointOfSale.orderSync.couponsError.proceed",
-//            value: "Continue without coupons",
-//            comment: "Button title to remove coupons and retry synchronizing order and calculating order totals"
-//        )
-//    }
-//}
+@available(iOS 17.0, *)
+private extension PointOfSaleOrderSyncCouponsErrorMessageView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.orderSync.couponsError.title",
+            value: "Couldn't apply coupon",
+            comment: "Title of the error when failing to validate coupons and calculate order totals"
+        )
+
+        static let retryActionTitle = NSLocalizedString(
+            "pointOfSale.orderSync.couponsError.removeCoupons",
+            value: "Remove coupons",
+            comment: "Button title to remove coupons and retry synchronizing order and calculating order totals"
+        )
+
+        static let editOrderTitle =  NSLocalizedString(
+            "pointOfSale.orderSync.couponsError.editOrder",
+            value: "Edit order",
+            comment: "Button to come back to order editing when coupon validation fails."
+        )
+    }
+}
 
 #Preview {
     if #available(iOS 17.0, *) {

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -28,7 +28,7 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
                     Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
 
                     VStack(spacing: POSSpacing.medium) {
-                        Button(Localization.retryActionTitle, action: {
+                        Button(retryActionTitle, action: {
                             posModel.removeAllCouponsFromCart()
                             retryHandler()
                         })
@@ -55,6 +55,14 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
             attributedMessage = message.attributedHTMLString
         }
     }
+
+    private var retryActionTitle: String {
+        if posModel.cart.coupons.count == 1 {
+            Localization.retryActionTitleSingular
+        } else {
+            Localization.retryActionTitlePlural
+        }
+    }
 }
 
 @available(iOS 17.0, *)
@@ -76,10 +84,16 @@ private extension PointOfSaleOrderSyncCouponsErrorMessageView {
             comment: "Title of the error when failing to validate coupons and calculate order totals"
         )
 
-        static let retryActionTitle = NSLocalizedString(
+        static let retryActionTitlePlural = NSLocalizedString(
             "pointOfSale.orderSync.couponsError.removeCoupons",
             value: "Remove coupons",
             comment: "Button title to remove coupons and retry synchronizing order and calculating order totals"
+        )
+
+        static let retryActionTitleSingular = NSLocalizedString(
+            "pointOfSale.orderSync.couponsError.removeCoupon",
+            value: "Remove coupon",
+            comment: "Button title to remove a single coupon and retry synchronizing order and calculating order totals"
         )
 
         static let editOrderTitle =  NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Error State and Multiple Coupons.
- Show ‘Remove Coupons’ CTA
- Show ‘Coupon Not Applied’ on all the coupons.

Since the state of backend changes are unclear right now (https://github.com/woocommerce/woocommerce/pull/56488), I'm  not implementing a solution to handle coupon removal one by one. We can do it if we confirm backend changes.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites: Enable `enableCouponsInPointOfSale` local feature flag

### Invalid coupon

1. Open POS
2. Add a single invalid coupon
3. Add product
4. Check out
5. Confirm the error view appears according to designs FnDpCHVQ3Zpefad04ptbd4-fi-144_17356
6. Confirm 'Edit Order' comes back to the order
7. Confirm 'Remove Coupons' removes the coupon and proceeds with order creation

### Invalid coupons

Add multiple invalid coupons, it should behave the same way as with single invalid coupon

### NSAttributedString crash

I noticed an occasional crash when the `NSAttributedString` with HTML is built within the SwiftUI body. It's been  reported a few times on Stackoverflow (https://stackoverflow.com/questions/59561564/sometime-app-crashing-nsattributedstring-converting-html-to-attributed-string). It was reproduced 100% when turning the device to portrait and landscape when error appears.

1. Open POS
2. Add a single invalid coupon
3. Add product
4. Check out
5. Confirm the error view appears
6. Switch from landscape to portrait a few times
7. Confirm there's no crash

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 11 Inch M2 iOS 18.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/42eae1a1-1053-4e84-b425-03971e1aab50

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.