### PR TITLE
[Woo POS] Coupons: Checkout - Discount Total (Designer UI)

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -175,16 +175,16 @@ private extension PointOfSaleOrderController {
             orderTotal: formattedPrice(order.total, currency: order.currency) ?? "",
             taxTotal: formattedPrice(order.totalTax, currency: order.currency) ?? "",
             orderTotalDecimal: totalsCalculator.orderTotal.decimalValue,
-            discountTotal: formattedDiscount(totalsCalculator.discountTotal.multiplying(by: -1),
+            discountTotal: formattedDiscount(totalsCalculator.discountTotal,
                                              currency: order.currency),
             couponsTotals: couponsTotals(order))
     }
 
-    func formattedPrice(_ price: String?, currency: String?) -> String? {
+    func formattedPrice(_ price: String?, currency: String?, isNegative: Bool = false) -> String? {
         guard let price, let currency else {
             return nil
         }
-        return currencyFormatter.formatAmount(price, with: currency)
+        return currencyFormatter.formatAmount(price, with: currency, isNegative: isNegative)
     }
 
     func couponsTotals(_ order: Order) -> [PointOfSaleCouponTotal] {
@@ -198,7 +198,7 @@ private extension PointOfSaleOrderController {
 
     func formattedDiscount(_ discount: NSDecimalNumber, currency: String) -> String? {
         guard !discount.isZero(),
-              let formattedDiscount = formattedPrice(discount.stringValue, currency: currency) else {
+              let formattedDiscount = formattedPrice(discount.stringValue, currency: currency, isNegative: true) else {
             return nil
         }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -175,7 +175,7 @@ private extension PointOfSaleOrderController {
             orderTotal: formattedPrice(order.total, currency: order.currency) ?? "",
             taxTotal: formattedPrice(order.totalTax, currency: order.currency) ?? "",
             orderTotalDecimal: totalsCalculator.orderTotal.decimalValue,
-            discountTotal: formattedDiscount(totalsCalculator.discountTotal,
+            discountTotal: formattedDiscount(totalsCalculator.discountTotal.multiplying(by: -1),
                                              currency: order.currency),
             couponsTotals: couponsTotals(order))
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
     private let viewModel = PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel()
     private let connectCardReader: () -> Void
+    @ScaledMetric private var scale: CGFloat = 1.0
 
     @State private var width: CGFloat = 0
 
@@ -15,9 +16,9 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
             Image(decorative: PointOfSaleAssets.readerDisconnected.imageName)
 
             Spacer()
-                .frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
+                .frame(height: dynamicSpacing(PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing))
 
-            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+            VStack(alignment: .center, spacing: dynamicSpacing(PointOfSaleCardPresentPaymentLayout.textSpacing)) {
                 Text(viewModel.title)
                     .font(.posHeadingBold)
                     .foregroundStyle(Color.posOnSurface)
@@ -30,7 +31,7 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
             .padding(.horizontal, PointOfSaleCardPresentPaymentLayout.horizontalPadding)
 
             Spacer()
-                .frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
+                .frame(height: dynamicSpacing(PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing))
 
             Button {
                 connectCardReader()
@@ -44,6 +45,14 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
             width = containerWidth
         })
         .multilineTextAlignment(.center)
+    }
+
+    private func dynamicSpacing(_ spacing: CGFloat) -> CGFloat {
+        guard scale > 1 else {
+            return spacing
+        }
+
+        return spacing * (1 / scale)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -38,7 +38,7 @@ struct TotalsView: View {
                                 .transition(.opacity)
                                 .accessibilityShowsLargeContentViewer()
                                 .background(backgroundColor.ignoresSafeArea(.all))
-                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility1)
                                 .minimumScaleFactor(isShowingTotalsFields ? 0.5 : 1)
                                 .geometryGroup()
                         }
@@ -49,7 +49,7 @@ struct TotalsView: View {
                                 .animation(.default, value: posModel.orderState.isSyncing)
                                 .opacity(viewHelper.shouldShowTotalsFields(for: posModel.paymentState) ? 1 : 0)
                                 .layoutPriority(1)
-                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility1)
                         }
                     }
                     .animation(.default, value: posModel.cardPresentPaymentInlineMessage)
@@ -66,7 +66,7 @@ struct TotalsView: View {
                             .font(POSFontStyle.posBodyLargeBold)
                     })
                     .layoutPriority(1)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
                     .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                     .padding(.horizontal, Constants.buttonHorizontalPadding)
                     .safeAreaPadding(.bottom, Constants.cashButtonBottomPadding)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -132,7 +132,7 @@ private extension TotalsView {
             Spacer().frame(height: Constants.subtotalsVerticalSpacing)
 
             if viewHelper.shouldShowTotalDiscountField(cart: posModel.cart, orderTotals: orderTotals) {
-                subtotalFieldView(title: Localization.discount,
+                subtotalFieldView(title: Localization.discountTotal,
                                   formattedPrice: orderTotals?.discountTotal,
                                   shimmeringActive: totalsLoading,
                                   matchedGeometryId: Constants.matchedGeometryDiscountId)
@@ -441,10 +441,10 @@ private extension TotalsView {
             "pos.totalsView.taxes",
             value: "Taxes",
             comment: "Title for taxes amount field")
-        static let discount = NSLocalizedString(
-            "pos.totalsView.discountTotal",
-            value: "Discount",
-            comment: "Title for discount amount field")
+        static let discountTotal = NSLocalizedString(
+            "pos.totalsView.discountTotal2",
+            value: "Discount total",
+            comment: "Title for discount total amount field")
         static let cashPaymentButtonTitle = NSLocalizedString(
             "pos.totalsView.cash.button.title",
             value: "Cash payment",

--- a/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
@@ -166,13 +166,20 @@ public class CurrencyFormatter {
     ///     - amount: a raw string representation of the amount, from the API, with no formatting applied. e.g. "19.87"
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///     - locale: the locale that is used to format the currency amount string.
+    ///     - isNegative: optional enforce number presentation as negative. e.g "-$19.23"
     ///
-    public func formatAmount(_ amount: String, with currency: String? = nil, locale: Locale = .current) -> String? {
+    public func formatAmount(_ amount: String,
+                             with currency: String? = nil,
+                             locale: Locale = .current,
+                             isNegative: Bool? = nil) -> String? {
         guard let decimalAmount = convertToDecimal(amount, locale: locale) else {
             return nil
         }
 
-        return formatAmount(decimalAmount, with: currency ?? currencySettings.currencyCode.rawValue, locale: locale)
+        return formatAmount(decimalAmount,
+                            with: currency ?? currencySettings.currencyCode.rawValue,
+                            locale: locale,
+                            isNegative: isNegative)
     }
 
     /// Formats the provided `amount` param into a human readable value and applies the currency option
@@ -278,8 +285,13 @@ public class CurrencyFormatter {
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///     - locale: the locale that is used to format the currency amount string.
     ///     - numberOfDecimals: optional number of decimal points to show for the amount. If nil, the currency settings value is used.
+    ///     - isNegative: optional enforce number presentation as negative. e.g "-$19.23"
     ///
-    public func formatAmount(_ amount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current, numberOfDecimals: Int? = nil) -> String? {
+    public func formatAmount(_ amount: NSDecimalNumber,
+                             with currency: String? = nil,
+                             locale: Locale = .current,
+                             numberOfDecimals: Int? = nil,
+                             isNegative: Bool? = nil) -> String? {
         let currency = currency ?? currencySettings.currencyCode.rawValue
         // Get the currency code
         let code = CurrencyCode(rawValue: currency.uppercased()) ?? currencySettings.currencyCode
@@ -306,7 +318,7 @@ public class CurrencyFormatter {
         let formattedAmount = formatCurrency(using: localizedAmount,
                                              currencyPosition: position,
                                              currencySymbol: symbol,
-                                             isNegative: amount.isNegative(),
+                                             isNegative: isNegative ?? amount.isNegative(),
                                              locale: locale)
 
         return formattedAmount
@@ -318,7 +330,17 @@ public class CurrencyFormatter {
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///     - locale: the locale that is used to format the currency amount string.
     ///     - numberOfDecimals: optional number of decimal points to show for the amount. If nil, the currency settings value is used.
-    public func formatAmount(_ amount: Decimal, with currency: String? = nil, locale: Locale = .current, numberOfDecimals: Int? = nil) -> String? {
-        formatAmount(amount as NSDecimalNumber, with: currency, locale: locale, numberOfDecimals: numberOfDecimals)
+    ///     - isNegative: optional enforce number presentation as negative. e.g "-$19.23"
+    ///
+    public func formatAmount(_ amount: Decimal,
+                             with currency: String? = nil,
+                             locale: Locale = .current,
+                             numberOfDecimals: Int? = nil,
+                             isNegative: Bool? = nil) -> String? {
+        formatAmount(amount as NSDecimalNumber,
+                     with: currency,
+                     locale: locale,
+                     numberOfDecimals: numberOfDecimals,
+                     isNegative: isNegative)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is a small PR. Most of the logic was already implemented in https://github.com/woocommerce/woocommerce-ios/pull/15455

Show the discount total in the checkout screen according to the designs:

- Display "Discount total" label
- Display discount with a negative sign
- Ensure all the lines fit with larger dynamic type sizes


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites: Enable `enableCouponsInPointOfSale` local feature flag

### Valid Coupon
1. Open POS
2. Add a valid coupon and a product
3. Check out
4. Confirm "Discount total" line appears according to designs FnDpCHVQ3Zpefad04ptbd4-fi-152_44400

### Large dynamic type size
1. Open POS
2. Increase dynamic type size
3. Add a valid coupon and a product
4. Check out
5. Confirm "Discount total" line fits into the screen

### No coupon
1. Open POS
2. Add a product
3. Check out
4. Confirm no "Discount total" line

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 11 Inch M2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-08 at 12 30 57](https://github.com/user-attachments/assets/688830fe-e0ef-446e-b177-9e06dc158fb4)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.