### PR TITLE
[Woo POS] Coupons: Centralize view state source of truth

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -24,7 +24,7 @@ protocol PointOfSaleAggregateModelProtocol {
     func cancelCardPaymentsOnboarding()
     func trackCardPaymentsOnboardingShown()
 
-    var itemsViewState: ItemsViewState { get }
+    var currentViewState: ItemsViewState { get }
 
     func loadItems(base: ItemListBaseItem) async
     func loadNextItems(base: ItemListBaseItem) async
@@ -55,10 +55,6 @@ protocol PointOfSaleAggregateModelProtocol {
     var cardPresentPaymentOnboardingViewModel: CardPresentPaymentsOnboardingViewModel?
     private var onOnboardingCancellation: (() -> Void)?
 
-    var itemsViewState: ItemsViewState { itemsController.itemsViewState }
-    var couponsViewState: ItemsViewState { couponsController.itemsViewState }
-    var currentViewState: ItemsViewState
-
     private(set) var cart: Cart = .init()
 
     var orderState: PointOfSaleOrderState { orderController.orderState.externalState }
@@ -66,6 +62,11 @@ protocol PointOfSaleAggregateModelProtocol {
 
     private let itemsController: PointOfSaleItemsControllerProtocol
     private let couponsController: PointOfSaleCouponsControllerProtocol
+    private var currentController: PointOfSaleItemsControllerProtocol {
+        selectedItemType == .products ? itemsController : couponsController
+    }
+    var currentViewState: ItemsViewState { currentController.itemsViewState }
+    var selectedItemType: ItemType = .products
 
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderController: PointOfSaleOrderControllerProtocol
@@ -91,9 +92,6 @@ protocol PointOfSaleAggregateModelProtocol {
         self.analytics = analytics
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
         self.paymentState = paymentState
-        // Initial, set to items (products)
-        self.currentViewState = itemsController.itemsViewState
-
         publishCardReaderConnectionStatus()
         publishPaymentMessages()
         setupReaderReconnectionObservation()
@@ -103,33 +101,19 @@ protocol PointOfSaleAggregateModelProtocol {
 // MARK: - ItemList
 @available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
-    func updateCurrentViewState(base: ItemListBaseItem) {
-        let viewState = base.itemType == .products ? itemsViewState : couponsViewState
-        currentViewState = viewState
-    }
-
     @MainActor
     func loadItems(base: ItemListBaseItem) async {
-        let controller = base.itemType == .products ? itemsController : couponsController
-
-        await controller.loadItems(base: base)
-        updateCurrentViewState(base: base)
+        await currentController.loadItems(base: base)
     }
 
     @MainActor
     func refreshItems(base: ItemListBaseItem) async {
-        let controller = base.itemType == .products ? itemsController : couponsController
-
-        await controller.refreshItems(base: base)
-        updateCurrentViewState(base: base)
+        await currentController.refreshItems(base: base)
     }
 
     @MainActor
     func loadNextItems(base: ItemListBaseItem) async {
-        let controller = base.itemType == .products ? itemsController : couponsController
-
-        await controller.loadNextItems(base: base)
-        updateCurrentViewState(base: base)
+        await currentController.loadNextItems(base: base)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -14,12 +14,7 @@ struct ItemListView: View {
     }
 
     private var itemsStack: ItemsStackState {
-        switch selectedItemType {
-        case .products:
-            return posModel.itemsViewState.itemsStack
-        case .coupons:
-            return posModel.couponsViewState.itemsStack
-        }
+        posModel.currentViewState.itemsStack
     }
 
     @AppStorage(BannerState.isSimpleProductsOnlyBannerDismissedKey)
@@ -28,8 +23,6 @@ struct ItemListView: View {
     private var shouldShowCoupons: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
     }
-
-    @State private var selectedItemType: ItemType = .products
 
     @State private var showCouponCreationModal: Bool = false
 
@@ -72,7 +65,7 @@ struct ItemListView: View {
                 })
                 .font(.posButtonSymbolLarge)
                 .foregroundStyle(Color.posOnSurface)
-                .renderedIf(selectedItemType == .coupons)
+                .renderedIf(posModel.selectedItemType == .coupons)
             }
             .padding(POSPadding.medium)
             .renderedIf(shouldShowCoupons)
@@ -165,14 +158,14 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        ItemList(state: itemListState, itemsStack: itemsStack, node: .root(selectedItemType)) {
+        ItemList(state: itemListState, itemsStack: itemsStack, node: .root(posModel.selectedItemType)) {
             if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView
             }
         }
         .refreshable {
             ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
-            await posModel.refreshItems(base: .root(selectedItemType))
+            await posModel.refreshItems(base: .root(posModel.selectedItemType))
         }
     }
 
@@ -181,7 +174,7 @@ private extension ItemListView {
         // Note that navigation is handled by the ItemList in iOS 17, so any changes to this should be reflected in ItemListRow.
         switch parentItem {
         case let .variableParentProduct(parentProduct):
-            let itemsStack = selectedItemType == .products ? posModel.itemsViewState.itemsStack : posModel.couponsViewState.itemsStack
+            let itemsStack = posModel.currentViewState.itemsStack
             ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsStack: itemsStack)
         default:
             EmptyView()
@@ -196,7 +189,7 @@ private extension ItemListView {
     }
 
     func displayItemType(_ itemType: ItemType) {
-        selectedItemType = itemType
+        posModel.selectedItemType = itemType
         Task { @MainActor in
             await posModel.loadItems(base: .root(itemType))
         }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -27,7 +27,7 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
 
     var orderState: WooCommerce.PointOfSaleOrderState
 
-    var itemsViewState: ItemsViewState
+    var currentViewState: ItemsViewState
 
     var blockReturnToItemSelection: Bool = false
 
@@ -38,7 +38,7 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
          orderState: PointOfSaleOrderState = .idle,
          paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.cardReaderConnectionStatus = cardReaderConnectionStatus
-        self.itemsViewState = itemsViewState
+        self.currentViewState = itemsViewState
         self.orderStage = orderStage
         self.orderState = orderState
         self.paymentState = paymentState


### PR DESCRIPTION

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Follow-up from https://github.com/woocommerce/woocommerce-ios/pull/15478#discussion_r2031048441

The PR introduced `currentViewState` which is set when Product | Coupons section is tapped. However, at the same time, `ItemListView` tracks `selectedItemType`.

This PR simplifies the approach. Using `selectedItemType` as a source of truth. All other variables are computed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

No functionality has changed. Only general smoke testing is required. For Coupons, I recommend re-testing a case from [[Woo POS] Coupons: Enable site coupons when tap on CTA](https://github.com/woocommerce/woocommerce-ios/pull/15478) which introduced  `currentViewState`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested both with feature flag enabled and disabled. Checked different product states, pagination, variations, variations pagination, empty states.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.