### PR TITLE
[Woo POS] Coupons: Preparation work for pagination

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -37,7 +37,15 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
     func loadNextItems(base: ItemListBaseItem) async {
         // TODO:
         // Pagination WOOMOB-129
-        await fetchCoupons(pageNumber: 1)
+        do {
+            try await paginationTracker.resync { [weak self] pageNumber in
+                guard let self else { return true }
+                await fetchCoupons(pageNumber: pageNumber)
+                return true
+            }
+        } catch {
+            debugPrint(error)
+        }
     }
 
     @MainActor
@@ -59,11 +67,12 @@ private extension PointOfSaleCouponsController {
     @MainActor
     func fetchCoupons(pageNumber: Int = Constants.firstPage) async {
         do {
-            let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber).items
-            if pagedCoupons.isEmpty {
+            let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber)
+            let hasMoreItems = pagedCoupons.hasMorePages
+            if pagedCoupons.items.isEmpty {
                 setCouponsEmptyViewState()
             } else {
-                setCouponsLoadedViewState(pagedCoupons)
+                setCouponsLoadedViewState(pagedCoupons.items, hasMoreItems: hasMoreItems)
             }
         } catch {
             if let couponError = error as? PointOfSaleCouponServiceError {
@@ -83,9 +92,9 @@ private extension PointOfSaleCouponsController {
         itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
     }
 
-    func setCouponsLoadedViewState(_ coupons: [POSItem]) {
+    func setCouponsLoadedViewState(_ coupons: [POSItem], hasMoreItems: Bool) {
         itemsViewState = ItemsViewState(containerState: .content,
-                                        itemsStack: .init(root: .loaded(coupons, hasMoreItems: true),
+                                        itemsStack: .init(root: .loaded(coupons, hasMoreItems: hasMoreItems),
                                                           itemStates: [:]))
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -37,7 +37,7 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
     func loadNextItems(base: ItemListBaseItem) async {
         // TODO:
         // Pagination WOOMOB-129
-        await fetchCoupons()
+        await fetchCoupons(pageNumber: 1)
     }
 
     @MainActor
@@ -85,7 +85,7 @@ private extension PointOfSaleCouponsController {
 
     func setCouponsLoadedViewState(_ coupons: [POSItem]) {
         itemsViewState = ItemsViewState(containerState: .content,
-                                        itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
+                                        itemsStack: .init(root: .loaded(coupons, hasMoreItems: true),
                                                           itemStates: [:]))
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -23,21 +23,21 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
         // TODO:
         // Handle unhappy path:
         // Depending on the error type (failed to load vs coupons disabled) we want to show a different CTA choice
-        await loadFirstPage()
+        await fetchCoupons()
     }
 
     @MainActor
     func refreshItems(base: ItemListBaseItem) async {
         // TODO:
         // Handle unhappy path
-        await loadFirstPage()
+        await fetchCoupons()
     }
 
     @MainActor
     func loadNextItems(base: ItemListBaseItem) async {
         // TODO:
-        // Pagination https://github.com/woocommerce/woocommerce-ios/issues/15343
-        await loadFirstPage()
+        // Pagination WOOMOB-129
+        await fetchCoupons()
     }
 
     @MainActor
@@ -57,9 +57,9 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 @available(iOS 17.0, *)
 private extension PointOfSaleCouponsController {
     @MainActor
-    func loadFirstPage() async {
+    func fetchCoupons(pageNumber: Int = Constants.firstPage) async {
         do {
-            let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1).items
+            let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber).items
             if coupons.isEmpty {
                 let containerState = ItemsContainerState.content
                 let stackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
@@ -81,5 +81,12 @@ private extension PointOfSaleCouponsController {
                 }
             }
         }
+    }
+}
+
+@available(iOS 17.0, *)
+private extension PointOfSaleCouponsController {
+    enum Constants {
+        static let firstPage: Int = 1
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -59,27 +59,44 @@ private extension PointOfSaleCouponsController {
     @MainActor
     func fetchCoupons(pageNumber: Int = Constants.firstPage) async {
         do {
-            let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber).items
-            if coupons.isEmpty {
-                let containerState = ItemsContainerState.content
-                let stackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
-                itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
+            let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber).items
+            if pagedCoupons.isEmpty {
+                setCouponsEmptyViewState()
             } else {
-                itemsViewState = ItemsViewState(containerState: .content,
-                                                itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
-                                                                  itemStates: [:]))
+                setCouponsLoadedViewState(pagedCoupons)
             }
         } catch {
             if let couponError = error as? PointOfSaleCouponServiceError {
-                switch couponError {
-                case .couponsLoadingError:
-                    itemsViewState = ItemsViewState(containerState: .error(.errorOnLoadingCoupons()),
-                                                    itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
-                case .couponsDisabled:
-                    itemsViewState = ItemsViewState(containerState: .error(.errorCouponsDisabled()),
-                                                    itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
-                }
+                setCouponsErrorViewState(couponError)
             }
+        }
+    }
+}
+
+// MARK: - View state helpers
+//
+@available(iOS 17.0, *)
+private extension PointOfSaleCouponsController {
+    func setCouponsEmptyViewState() {
+        let containerState = ItemsContainerState.content
+        let stackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
+        itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
+    }
+
+    func setCouponsLoadedViewState(_ coupons: [POSItem]) {
+        itemsViewState = ItemsViewState(containerState: .content,
+                                        itemsStack: .init(root: .loaded(coupons, hasMoreItems: false),
+                                                          itemStates: [:]))
+    }
+
+    func setCouponsErrorViewState(_ couponError: PointOfSaleCouponServiceError) {
+        switch couponError {
+        case .couponsLoadingError:
+            itemsViewState = ItemsViewState(containerState: .error(.errorOnLoadingCoupons()),
+                                            itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
+        case .couponsDisabled:
+            itemsViewState = ItemsViewState(containerState: .error(.errorCouponsDisabled()),
+                                            itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
         }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -56,17 +56,17 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
         let coupons = await providePointOfSaleCoupons()
 
-        if !coupons.isEmpty {
+        if !coupons.items.isEmpty {
             // Fire-and-forget sync
             Task.detached {
                 await self.syncCouponsFromRemote(pageNumber: pageNumber)
             }
-            return .init(items: coupons, hasMorePages: false)
+            return .init(items: coupons.items, hasMorePages: true)
         } else {
             // Wait for the sync to complete
             await syncCouponsFromRemote(pageNumber: pageNumber)
             let refreshedCoupons = await providePointOfSaleCoupons()
-            return .init(items: refreshedCoupons, hasMorePages: false)
+            return .init(items: refreshedCoupons.items, hasMorePages: true)
         }
     }
 
@@ -87,9 +87,9 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
 private extension PointOfSaleCouponService {
     @MainActor
-    func providePointOfSaleCoupons() async -> [POSItem] {
+    func providePointOfSaleCoupons() async -> PagedItems<POSItem> {
         guard let storage = storage else {
-            return []
+            return .init(items: [], hasMorePages: false)
         }
 
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
@@ -103,10 +103,11 @@ private extension PointOfSaleCouponService {
         do {
             try resultsController.performFetch()
             let storageCoupons = resultsController.fetchedObjects
-            return mapCouponsToPOSItems(coupons: storageCoupons)
+            let posItems = mapCouponsToPOSItems(coupons: storageCoupons)
+            return .init(items: posItems, hasMorePages: true)
         } catch {
             debugPrint("Failed to load coupons from storage:", error)
-            return []
+            return .init(items: [], hasMorePages: false)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Preparation work for WOOMOB-129

## Description
This PR starts the work on coupons pagination by updating the service to account for the existence of paged items, as well as the different coupons controller functions, to take into account that pagination might exist.

No real functional changes have been made and we're still fetching only the 1st page from remote, the only difference is that we perform calls to `loadNextItems()` now when we scroll, which we didn't before.

## Changes
- Updated `loadFirstPage()` to be `fetchCoupons(pageNumber: n)`, we reuse this function for all item protocol calls, the only thing that changes is the page passed through.
- Updated the coupon service signatures to return `PagedItems<POSItem>` instead of a simple array, as we'll need to know if has more items in order to update the state
- Updated `setCouponsLoadedViewState` to accept a `hasMoreItems` property, this is used to set the view state and check if we need to trigger a `loadNextItems()` from `ItemList`. At the moment, we trigger it every time we scroll.

## Testing information
- Enable `.enableCouponsInPointOfSale`
- Add a break point in `await fetchCoupons(pageNumber: pageNumber)` in `PointOfSaleCouponsController` line 43
- Load POS and go to coupons
- You should see no difference in expected initial loading behavior
- Scroll down, observe how the breakpoint is triggered once the `ItemList` triggers infinite scroll.

As mentioned the work here is just preparatory, there's no proper pagination implemented yet, and we'll continue triggering a page 1 load when the infinite scrolling trigger is called.

---

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
