### PR TITLE
Do not remove all site settings when updating a single setting

### DIFF
--- a/Yosemite/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -73,7 +73,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
             guard let self = self else { return }
             switch result {
             case .success(let setting):
-                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
                     let isEnabled = setting.value == SettingValue.yes
                     onCompletion(.success(isEnabled))
                 }
@@ -90,7 +90,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
             guard let self = self else { return }
             switch result {
             case .success(let setting):
-                self.upsertStoredGeneralSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
                     onCompletion(.success(Void()))
                 }
             case .failure(let error):
@@ -106,7 +106,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
             guard let self = self else { return }
             switch result {
             case .success(let setting):
-                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
                     let isEnabled = setting.value == SettingValue.yes
                     onCompletion(.success(isEnabled))
                 }
@@ -126,7 +126,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
             guard let self = self else { return }
             switch result {
             case .success(let setting):
-                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
                     onCompletion(.success(Void()))
                 }
             case .failure(let error):
@@ -142,7 +142,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
             guard let self = self else { return }
             switch result {
             case .success(let setting):
-                self.upsertStoredAdvancedSettingsInBackground(siteID: siteID, readOnlySiteSettings: [setting]) {
+                self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
                     guard let taxBasedOnSetting = TaxBasedOnSetting(backendValue: setting.value) else {
                         onCompletion(.failure(SettingError.parseError))
                         return
@@ -207,6 +207,28 @@ private extension SettingStoreMethods {
                     storage.deleteObject(storageItem)
                 }
             })
+        }
+    }
+
+    /// Updates (OR Inserts) a single ReadOnly `SiteSetting` entity **in a background thread**. `onCompletion` will be called
+    /// on the main thread!
+    ///
+    /// Doesn't remove other settings
+    ///
+    func upsertSingleStoredSettingInBackground(siteID: Int64, readOnlySiteSetting: Networking.SiteSetting, onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ [weak self] storage in
+            self?.upsertSingleSetting(readOnlySiteSetting, in: storage, siteID: siteID)
+        }, completion: onCompletion, on: .main)
+    }
+
+    func upsertSingleSetting(_ readOnlySiteSetting: SiteSetting, in storage: StorageType, siteID: Int64) {
+        let storageSiteSettings = storage.loadSiteSettings(siteID: siteID, settingGroupKey: readOnlySiteSetting.settingGroupKey)
+
+        if let existingStorageItem = storageSiteSettings?.first(where: { $0.settingID == readOnlySiteSetting.settingID }) {
+            existingStorageItem.update(with: readOnlySiteSetting)
+        } else {
+            let newStorageItem = storage.insertNewObject(ofType: Storage.SiteSetting.self)
+            newStorageItem.update(with: readOnlySiteSetting)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -789,6 +789,39 @@ final class SettingStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
     }
+
+    func test_retrieveCouponSetting_does_not_remove_other_settings_in_same_group() {
+        // Given
+        let oldSetting = SiteSetting.fake().copy(siteID: sampleSiteID, settingID: "woocommerce_enable_coupons", value: "no", settingGroupKey: "general")
+        let otherSetting = SiteSetting.fake().copy(siteID: sampleSiteID, settingID: "woocommerce_currency", value: "USD", settingGroupKey: "general")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: oldSetting)
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: otherSetting)
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/general/woocommerce_enable_coupons", filename: "setting-coupon")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = SettingAction.retrieveCouponSetting(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+
+        // Verify coupon setting was updated
+        let updatedCouponSetting = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: "woocommerce_enable_coupons")?.toReadOnly()
+        XCTAssertEqual(updatedCouponSetting?.value, "yes")
+
+        // Verify other setting still exists and wasn't modified
+        let otherSettingAfterUpdate = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: "woocommerce_currency")?.toReadOnly()
+        XCTAssertEqual(otherSettingAfterUpdate?.value, "USD")
+
+        // Verify total count of settings in the group remains the same
+        let allSettings = viewStorage.loadSiteSettings(siteID: sampleSiteID, settingGroupKey: "general")
+        XCTAssertEqual(allSettings?.count, 2)
+    }
 }
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

`SettingStore` `upserSettings` removes all the settings that are not included in the update:

```
    func upsertSettings(_ readOnlySiteSettings: [SiteSetting], in storage: StorageType, siteID: Int64, settingGroup: SiteSettingGroup) {
       <...>
        // Now, remove any objects that exist in storageSiteSettings but not in readOnlySiteSettings
        if let storageSiteSettings {
            storageSiteSettings.forEach({ storageItem in
                if readOnlySiteSettings.first(where: { $0.settingID == storageItem.settingID } ) == nil {
                    storage.deleteObject(storageItem)
                }
            })
        }
    }
```

This logic was created when `SettingStore` only retrieved all the settings for the specific section. However, this logic doesn't fit when we only fetch a single setting through `retrieveCouponSetting` and similar methods.

It results in some bugs. For example, if we try to make payment after calling `retrieveCouponSetting`, the payment intent creation would fail since site settings wouldn't contain country code anymore.

## Solution

When single setting is retrieved, only update that single setting without removing the rest of the settings.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The issue before was easily reproduced by following these steps. Enable `enableCouponsInPointOfSale` feature flag.

1. Open POS
2. Open Coupons section (it calls `retrieveCouponSetting`)
3. Select a product
4. Connect a reader
5. Proceed to payment
6. Confirm that payment can be succesfully created

### Regression

We can also confirm that `retrieveCouponSetting` and `enableCouponSetting` continues to work.

1. Disable coupons in (WooCommerce -> Settings)
2. Open POS
3. Open Coupons section (it calls `retrieveCouponSetting`)
4. Confirm disabled state is shown
5. Tap Enable
6. Confirm it's enabled

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested IPP and POS. Confirmed unit tests are succeeding.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.