### PR TITLE
[Woo POS] Coupons: Integrate empty | error | disabled | loading states within the view

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -50,8 +50,7 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
     @MainActor
     func enableCoupons() async {
-        // TODO: WOOMOB-255
-        // Handle loading state while coupons are being enabled
+        itemsViewState.itemsStack.root = .loading([])
         do {
             try await couponProvider.enableCoupons()
         } catch {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -103,9 +103,9 @@ private extension PointOfSaleCouponsController {
 
         switch couponError {
         case .couponsLoadingError:
-            stackState = ItemsStackState(root: .error(.errorOnLoadingCoupons()), itemStates: [:])
+            stackState = ItemsStackState(root: .error(.errorOnLoadingCoupons), itemStates: [:])
         case .couponsDisabled:
-            stackState = ItemsStackState(root: .error(.errorCouponsDisabled()), itemStates: [:])
+            stackState = ItemsStackState(root: .error(.errorCouponsDisabled), itemStates: [:])
         }
 
         itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -87,7 +87,7 @@ private extension PointOfSaleCouponsController {
 private extension PointOfSaleCouponsController {
     func setCouponsEmptyViewState() {
         let containerState = ItemsContainerState.content
-        let stackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
+        let stackState = ItemsStackState(root: .empty, itemStates: [:])
         itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -99,14 +99,17 @@ private extension PointOfSaleCouponsController {
     }
 
     func setCouponsErrorViewState(_ couponError: PointOfSaleCouponServiceError) {
+        let containerState = ItemsContainerState.content
+        let stackState: ItemsStackState
+
         switch couponError {
         case .couponsLoadingError:
-            itemsViewState = ItemsViewState(containerState: .error(.errorOnLoadingCoupons()),
-                                            itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
+            stackState = ItemsStackState(root: .error(.errorOnLoadingCoupons()), itemStates: [:])
         case .couponsDisabled:
-            itemsViewState = ItemsViewState(containerState: .error(.errorCouponsDisabled()),
-                                            itemsStack: .init(root: .loaded([], hasMoreItems: false), itemStates: [:]))
+            stackState = ItemsStackState(root: .error(.errorCouponsDisabled()), itemStates: [:])
         }
+
+        itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
     }
 }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -6,7 +6,7 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
 @available(iOS 17.0, *)
 @Observable final class PointOfSaleCouponsController: PointOfSaleCouponsControllerProtocol {
-    var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
+    var itemsViewState: ItemsViewState = ItemsViewState(containerState: .content,
                                                         itemsStack: ItemsStackState(root: .loading([]),
                                                                                     itemStates: [:]))
     private let paginationTracker: AsyncPaginationTracker

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -236,9 +236,8 @@ private extension PointOfSaleItemsController {
             }
             allItems.append(contentsOf: uniqueNewItems)
             if allItems.isEmpty {
-                itemsViewState.containerState = .empty
-                itemsViewState.itemsStack = ItemsStackState(root: .loaded([], hasMoreItems: false),
-                                                            itemStates: [:])
+                itemsViewState.containerState = .content
+                itemsViewState.itemsStack = ItemsStackState(root: .empty, itemStates: [:])
             } else {
                 let itemStates = itemsViewState.itemsStack.itemStates
                     .filter { allItems.contains($0.key) }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -92,7 +92,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
                 return try await fetchItems(pageNumber: pageNumber, appendToExistingItems: false)
             }
         } catch {
-            itemsViewState.containerState = .error(PointOfSaleErrorState.errorOnLoadingProducts())
+            itemsViewState.containerState = .error(PointOfSaleErrorState.errorOnLoadingProducts)
             itemsViewState.itemsStack = ItemsStackState(root: .loaded([], hasMoreItems: false),
                                                        itemStates: [:])
         }
@@ -126,7 +126,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
         } catch {
             itemsViewState.containerState = .content
             itemsViewState.itemsStack = ItemsStackState(root: .inlineError(currentItems,
-                                                                           error: .errorOnLoadingProductsNextPage()),
+                                                                           error: .errorOnLoadingProductsNextPage),
                                                         itemStates: currentItemStates)
         }
     }
@@ -140,7 +140,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
                 return try await fetchChildItems(for: parent, pageNumber: Store.Default.firstPageNumber, appendToExistingItems: false)
             }
         } catch {
-            updateState(for: parent, to: .error(.errorOnLoadingVariations()))
+            updateState(for: parent, to: .error(.errorOnLoadingVariations))
         }
     }
 
@@ -161,7 +161,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
             }
         } catch {
             updateState(for: parent, to: .inlineError(currentItems,
-                                                      error: PointOfSaleErrorState.errorOnLoadingVariationsNextPage()))
+                                                      error: PointOfSaleErrorState.errorOnLoadingVariationsNextPage))
         }
     }
 

--- a/WooCommerce/Classes/POS/Models/ItemListState.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListState.swift
@@ -5,6 +5,7 @@ enum ItemListState {
     case loaded(_ items: [POSItem], hasMoreItems: Bool)
     case inlineError(_ items: [POSItem], error: PointOfSaleErrorState)
     case error(PointOfSaleErrorState)
+    case empty
 
     var isLoading: Bool {
         switch self {
@@ -23,7 +24,7 @@ extension ItemListState {
                 .loaded(let items, _),
                 .inlineError(let items, _):
             return items
-        case .error:
+        case .error, .empty:
             return []
         }
     }

--- a/WooCommerce/Classes/POS/Models/ItemsContainerState.swift
+++ b/WooCommerce/Classes/POS/Models/ItemsContainerState.swift
@@ -2,7 +2,6 @@ import Foundation
 
 enum ItemsContainerState {
     case loading
-    case empty
     case error(PointOfSaleErrorState)
     case content
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -48,14 +48,6 @@ struct PointOfSaleErrorState: Equatable {
             buttonText: Constants.failedToLoadVariationsNextPageButtonTitle)
     }
 
-    static func errorCouponsNotFound() -> Self {
-        PointOfSaleErrorState(
-            errorType: .couponsNotFound,
-            title: Constants.noCouponsFoundTitle,
-            subtitle: Constants.noCouponsFoundSubtitle,
-            buttonText: Constants.noCouponsFoundButtonTitle)
-    }
-
     static func errorOnLoadingCoupons() -> Self {
         PointOfSaleErrorState(
             errorType: .couponsLoadError,
@@ -102,21 +94,6 @@ struct PointOfSaleErrorState: Equatable {
             "pos.itemList.loadingCouponsDisabledAction",
             value: "Enable",
             comment: "Text of the button appearing on the coupon list screen when coupons are disabled."
-        )
-        static let noCouponsFoundTitle = NSLocalizedString(
-            "pos.itemList.noCouponsFoundTitle",
-            value: "No coupons found",
-            comment: "Text appearing on the coupon list screen when there's no coupons found."
-        )
-        static let noCouponsFoundSubtitle = NSLocalizedString(
-            "pos.itemList.noCouponsFoundSubtitle",
-            value: "Boost your business by sending customers special offers and discounts",
-            comment: "Text appearing on the coupons list screen as subtitle when there's no coupons found."
-        )
-        static let noCouponsFoundButtonTitle = NSLocalizedString(
-            "pos.itemList.noCouponsFoundButtonTitleButtonTitle",
-            value: "Create coupon",
-            comment: "Text for the button appearing on the coupons list screen when there's no coupons found."
         )
         static let failedToLoadProductsTitle = NSLocalizedString(
             "pos.itemList.failedToLoadProductsTitle",

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -16,7 +16,7 @@ struct PointOfSaleErrorState: Equatable {
     let subtitle: String
     let buttonText: String
 
-    static func errorOnLoadingProducts() -> Self {
+    static var errorOnLoadingProducts: Self {
         PointOfSaleErrorState(
             errorType: .productsLoadError,
             title: Constants.failedToLoadProductsTitle,
@@ -24,7 +24,7 @@ struct PointOfSaleErrorState: Equatable {
             buttonText: Constants.failedToLoadProductsButtonTitle)
     }
 
-    static func errorOnLoadingVariations() -> Self {
+    static var errorOnLoadingVariations: Self {
         PointOfSaleErrorState(
             errorType: .variationsLoadError,
             title: Constants.failedToLoadVariationsTitle,
@@ -32,7 +32,7 @@ struct PointOfSaleErrorState: Equatable {
             buttonText: Constants.failedToLoadVariationsButtonTitle)
     }
 
-    static func errorOnLoadingProductsNextPage() -> Self {
+    static var errorOnLoadingProductsNextPage: Self {
         PointOfSaleErrorState(
             errorType: .productsNextPageError,
             title: Constants.failedToLoadProductsNextPageTitle,
@@ -40,7 +40,7 @@ struct PointOfSaleErrorState: Equatable {
             buttonText: Constants.failedToLoadProductsNextPageButtonTitle)
     }
 
-    static func errorOnLoadingVariationsNextPage() -> Self {
+    static var errorOnLoadingVariationsNextPage: Self {
         PointOfSaleErrorState(
             errorType: .variationsNextPageError,
             title: Constants.failedToLoadVariationsNextPageTitle,
@@ -48,7 +48,7 @@ struct PointOfSaleErrorState: Equatable {
             buttonText: Constants.failedToLoadVariationsNextPageButtonTitle)
     }
 
-    static func errorOnLoadingCoupons() -> Self {
+    static var errorOnLoadingCoupons: Self {
         PointOfSaleErrorState(
             errorType: .couponsLoadError,
             title: Constants.loadingCouponsErrorTitle,
@@ -56,7 +56,7 @@ struct PointOfSaleErrorState: Equatable {
             buttonText: Constants.loadingCouponsErrorRetry)
     }
 
-    static func errorCouponsDisabled() -> Self {
+    static var errorCouponsDisabled: Self {
         PointOfSaleErrorState(
             errorType: .couponsDisabled,
             title: Constants.loadingCouponsDisabledTitle,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -9,6 +9,10 @@ struct PointOfSaleItemListEmptyView: View {
 
     @State private var viewWidth: CGFloat = 0
 
+    private var shouldShowErrorIcon: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
+    }
+
     init(base: ItemListBaseItem, onAction: (() -> Void)? = nil) {
         self.baseItem = base
         self.onAction = onAction
@@ -18,7 +22,16 @@ struct PointOfSaleItemListEmptyView: View {
         VStack {
             Spacer()
             VStack(alignment: .center, spacing: POSSpacing.none) {
-                POSErrorExclamationMark(size: .large)
+                if shouldShowErrorIcon {
+                    POSErrorExclamationMark(size: .large)
+                } else {
+                    Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: Constants.iconSize, height: Constants.iconSize)
+                        .foregroundColor(.posOnSurfaceVariantHighest)
+                        .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+                }
 
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
 
@@ -26,7 +39,6 @@ struct PointOfSaleItemListEmptyView: View {
                     .accessibilityAddTraits(.isHeader)
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posHeadingBold)
-                    .multilineTextAlignment(.center)
 
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textSpacing)
 
@@ -34,7 +46,6 @@ struct PointOfSaleItemListEmptyView: View {
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posBodyLargeRegular())
                     .padding([.leading, .trailing])
-                    .multilineTextAlignment(.center)
 
                 if let hint {
                     Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textSpacing)
@@ -59,7 +70,7 @@ struct PointOfSaleItemListEmptyView: View {
             }
             Spacer()
         }
-        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+        .multilineTextAlignment(.center)
         .padding(.bottom, floatingControlAreaSize.height)
         .measureWidth { width in
             viewWidth = width
@@ -120,7 +131,6 @@ private extension PointOfSaleItemListEmptyView {
     }
 
     enum Constants {
-        static let iconSystemName: String = "plus.magnifyingglass"
         static let iconSize: CGFloat = 100
     }
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -7,6 +7,8 @@ struct PointOfSaleItemListEmptyView: View {
 
     private let onAction: (() -> Void)?
 
+    @State private var viewWidth: CGFloat = 0
+
     init(base: ItemListBaseItem, onAction: (() -> Void)? = nil) {
         self.baseItem = base
         self.onAction = onAction
@@ -51,11 +53,16 @@ struct PointOfSaleItemListEmptyView: View {
                         Text(buttonTitle)
                     })
                     .buttonStyle(POSFilledButtonStyle(size: .normal))
-                    .frame(maxWidth: PointOfSaleItemListErrorLayout.buttonWidth)
+                    .frame(width: viewWidth / 2)
                     .padding([.leading, .trailing])
                 }
             }
             Spacer()
+        }
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+        .padding(.bottom, floatingControlAreaSize.height)
+        .measureWidth { width in
+            viewWidth = width
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -19,7 +19,7 @@ struct PointOfSaleItemListEmptyView: View {
     }
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
             VStack(alignment: .center, spacing: POSSpacing.none) {
                 if shouldShowErrorIcon {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -5,42 +5,68 @@ struct PointOfSaleItemListEmptyView: View {
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     private let baseItem: ItemListBaseItem
 
-    init(base: ItemListBaseItem) {
+    private let onAction: (() -> Void)?
+
+    init(base: ItemListBaseItem, onAction: (() -> Void)? = nil) {
         self.baseItem = base
+        self.onAction = onAction
     }
 
     var body: some View {
-        VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
+        VStack {
             Spacer()
-            Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: Constants.iconSize, height: Constants.iconSize)
-                .foregroundColor(.posOnSurfaceVariantHighest)
-                .renderedIf(!dynamicTypeSize.isAccessibilitySize)
-            Text(title)
-                .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                .font(.posHeadingBold)
-            Text(subtitle)
-                .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                .font(.posBodyLargeRegular())
-                .padding([.leading, .trailing])
-            Text(hint)
-                .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                .font(.posBodyLargeRegular())
-                .padding([.leading, .trailing])
+            VStack(alignment: .center, spacing: POSSpacing.none) {
+                POSErrorExclamationMark(size: .large)
+
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
+
+                Text(title)
+                    .accessibilityAddTraits(.isHeader)
+                    .foregroundStyle(Color.posOnSurface)
+                    .font(.posHeadingBold)
+                    .multilineTextAlignment(.center)
+
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textSpacing)
+
+                Text(subtitle)
+                    .foregroundStyle(Color.posOnSurface)
+                    .font(.posBodyLargeRegular())
+                    .padding([.leading, .trailing])
+                    .multilineTextAlignment(.center)
+
+                if let hint {
+                    Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textSpacing)
+                    Text(hint)
+                        .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                        .font(.posBodyLargeRegular())
+                        .padding([.leading, .trailing])
+                }
+
+                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
+
+                if let onAction, let buttonTitle {
+                    Button(action: {
+                        onAction()
+                    }, label: {
+                        Text(buttonTitle)
+                    })
+                    .buttonStyle(POSFilledButtonStyle(size: .normal))
+                    .frame(maxWidth: PointOfSaleItemListErrorLayout.buttonWidth)
+                    .padding([.leading, .trailing])
+                }
+            }
             Spacer()
         }
-        .multilineTextAlignment(.center)
-        .padding(.bottom, floatingControlAreaSize.height)
     }
 }
 
 private extension PointOfSaleItemListEmptyView {
     var title: String {
         switch baseItem {
-        case .root:
+        case .root(.products):
             return Localization.emptyProductsTitle
+        case .root(.coupons):
+            return Localization.emptyCouponsTitle
         case .parent(.variableParentProduct, _):
             return Localization.emptyVariableParentProductTitle
         default:
@@ -51,8 +77,10 @@ private extension PointOfSaleItemListEmptyView {
 
     var subtitle: String {
         switch baseItem {
-        case .root:
+        case .root(.products):
             return Localization.emptyProductsSubtitle
+        case .root(.coupons):
+            return Localization.emptyCouponsSubtitle
         case .parent(.variableParentProduct, _):
             return Localization.emptyVariableParentProductSubtitle
         default:
@@ -61,15 +89,26 @@ private extension PointOfSaleItemListEmptyView {
         }
     }
 
-    var hint: String {
+    var hint: String? {
         switch baseItem {
-        case .root:
+        case .root(.products):
             return Localization.emptyProductsHint
+        case .root(.coupons):
+            return nil
         case .parent(.variableParentProduct, _):
             return Localization.emptyVariableParentProductHint
         default:
             assertionFailure("No hint defined for \(baseItem)")
             return Localization.emptyProductsTitle
+        }
+    }
+
+    var buttonTitle: String? {
+        switch baseItem {
+        case .root(.coupons):
+            return Localization.emptyCouponsButtonTitle
+        default:
+            return nil
         }
     }
 
@@ -108,6 +147,22 @@ private extension PointOfSaleItemListEmptyView {
             "pos.pointOfSaleItemListEmptyView.emptyVariableParentProductHint",
             value: "To add one, exit POS and edit this product in the Products tab.",
             comment: "Text hinting the merchant to create a product."
+        )
+
+        static let emptyCouponsTitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyCouponsTitle",
+            value: "No coupons found.",
+            comment: "Text appearing on the coupon list screen when there's no coupons found."
+        )
+        static let emptyCouponsSubtitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyCouponsSubtitle",
+            value: "Boost your business by sending customers special offers and discounts.",
+            comment: "Text appearing on the coupons list screen as subtitle when there's no coupons found."
+        )
+        static let emptyCouponsButtonTitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.noCouponsFoundButtonTitleButtonTitle",
+            value: "Create coupon",
+            comment: "Text for the button appearing on the coupons list screen when there's no coupons found."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorLayout.swift
@@ -2,6 +2,5 @@ import Foundation
 
 enum PointOfSaleItemListErrorLayout {
     static let headerSpacing: CGFloat = POSSpacing.medium
-    static let buttonWidth: CGFloat = 600
     static let verticalPadding: CGFloat = POSPadding.medium
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -2,8 +2,11 @@ import SwiftUI
 
 /// A view that displays an error message with a retry CTA when the list of POS items fails to load.
 struct PointOfSaleItemListErrorView: View {
+    @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     private let error: PointOfSaleErrorState
     private let onAction: (() -> Void)?
+
+    @State private var viewWidth: CGFloat = 0
 
     init(error: PointOfSaleErrorState, onAction: (() -> Void)? = nil) {
         self.error = error
@@ -38,10 +41,15 @@ struct PointOfSaleItemListErrorView: View {
                     Text(error.buttonText)
                 })
                 .buttonStyle(POSFilledButtonStyle(size: .normal))
-                .frame(maxWidth: PointOfSaleItemListErrorLayout.buttonWidth)
+                .frame(width: viewWidth / 2)
                 .padding([.leading, .trailing])
             }
             Spacer()
+        }
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+        .padding(.bottom, floatingControlAreaSize.height)
+        .measureWidth { width in
+            viewWidth = width
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -14,7 +14,7 @@ struct PointOfSaleItemListErrorView: View {
     }
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
             VStack(alignment: .center, spacing: POSSpacing.none) {
                 POSErrorExclamationMark(size: .large)
@@ -46,7 +46,6 @@ struct PointOfSaleItemListErrorView: View {
             }
             Spacer()
         }
-        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
         .padding(.bottom, floatingControlAreaSize.height)
         .measureWidth { width in
             viewWidth = width

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -55,5 +55,5 @@ struct PointOfSaleItemListErrorView: View {
 }
 
 #Preview {
-    PointOfSaleItemListErrorView(error: .errorOnLoadingProducts(), onAction: nil)
+    PointOfSaleItemListErrorView(error: .errorOnLoadingProducts, onAction: nil)
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
@@ -18,5 +18,5 @@ struct PointOfSaleItemListFullscreenErrorView: View {
 }
 
 #Preview {
-    PointOfSaleItemListFullscreenErrorView(error: .errorOnLoadingProducts(), onAction: nil)
+    PointOfSaleItemListFullscreenErrorView(error: .errorOnLoadingProducts, onAction: nil)
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -177,7 +177,7 @@ private extension ChildItemList {
     let itemsStack = ItemsStackState(
         root: .loading([]),
         itemStates: [
-            parentItem: .error(.errorOnLoadingVariations())
+            parentItem: .error(.errorOnLoadingVariations)
         ])
     let posModel = PointOfSaleAggregateModel(
         itemsController: itemsController,

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -79,9 +79,7 @@ private extension ChildItemList {
     var emptyView: some View {
         VStack {
             headerView
-            ScrollView {
-                PointOfSaleItemListEmptyView(base: node)
-            }
+            PointOfSaleItemListEmptyView(base: node)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -34,6 +34,8 @@ struct ChildItemList: View {
                 listView
             case let .error(error):
                 errorView(error: error)
+            case .empty:
+                emptyView
             }
         }
         .background(Color.posSurface)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -89,7 +89,7 @@ struct ItemList<HeaderView: View>: View {
                     await posModel.loadNextItems(base: node)
                 }
             })
-        case .loaded, .error:
+        case .loaded, .error, .empty:
             EmptyView()
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemListErrorCardView.swift
@@ -48,7 +48,7 @@ private typealias Constants = PointOfSaleItemListCardConstants
 
 #Preview {
     ItemListErrorCardView(
-        errorState: .errorOnLoadingVariationsNextPage(),
+        errorState: .errorOnLoadingVariationsNextPage,
         buttonAction: {}
     )
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -76,12 +76,20 @@ struct ItemListView: View {
                     .inlineError(let items, _):
                 listView(items)
             case .error(let errorState):
-                if errorState == .errorCouponsNotFound() {
+                switch errorState {
+                case .errorCouponsNotFound():
                     PointOfSaleItemListErrorView(error: .errorCouponsNotFound(), onAction: {
                         showCouponCreationModal = true
                     })
-                } else {
-                    EmptyView()
+                default:
+                    PointOfSaleItemListErrorView(error: errorState, onAction: {
+                        Task {
+                            if errorState.errorType == .couponsDisabled {
+                                await posModel.enableCoupons()
+                            }
+                            await posModel.loadItems(base: .root(.products))
+                        }
+                    })
                 }
             }
         }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -44,32 +44,6 @@ struct ItemListView: View {
         VStack(spacing: 0) {
             headerView
 
-            HStack {
-                Button(action: {
-                    displayItemType(.products)
-                }, label: {
-                    Text("Products")
-                })
-                Button(action: {
-                    displayItemType(.coupons)
-                }, label: {
-                    Text("Coupons")
-                })
-
-                Spacer()
-
-                Button(action: {
-                    showCouponCreationModal = true
-                }, label: {
-                    Text(Image(systemName: "plus.circle.fill"))
-                })
-                .font(.posButtonSymbolLarge)
-                .foregroundStyle(Color.posOnSurface)
-                .renderedIf(posModel.selectedItemType == .coupons)
-            }
-            .padding(POSPadding.medium)
-            .renderedIf(shouldShowCoupons)
-
             switch itemListState {
             case .loading(let items),
                     .loaded(let items, _),
@@ -118,6 +92,7 @@ private extension ItemListView {
     var headerView: some View {
         VStack {
             POSPageHeaderView(title: Localization.title, trailingContent: {
+                temporaryProductsCouponsSwitcher
                 Button(action: {
                     ServiceLocator.analytics.track(.pointOfSaleSimpleProductsExplanationDialogShown)
                     showSimpleProductsModal = true
@@ -135,6 +110,33 @@ private extension ItemListView {
                     .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             }
         }
+    }
+
+    var temporaryProductsCouponsSwitcher: some View {
+        HStack {
+            Button(action: {
+                displayItemType(.products)
+            }, label: {
+                Text("Products")
+            })
+            Button(action: {
+                displayItemType(.coupons)
+            }, label: {
+                Text("Coupons")
+            })
+
+            Spacer()
+
+            Button(action: {
+                showCouponCreationModal = true
+            }, label: {
+                Text(Image(systemName: "plus.circle.fill"))
+            })
+            .font(.posButtonSymbolLarge)
+            .foregroundStyle(Color.posOnSurface)
+            .renderedIf(posModel.selectedItemType == .coupons)
+        }
+        .renderedIf(shouldShowCoupons)
     }
 
     var bannerCardView: some View {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -77,10 +77,6 @@ struct ItemListView: View {
                 listView(items)
             case .error(let errorState):
                 switch errorState {
-                case .errorCouponsNotFound():
-                    PointOfSaleItemListErrorView(error: .errorCouponsNotFound(), onAction: {
-                        showCouponCreationModal = true
-                    })
                 default:
                     PointOfSaleItemListErrorView(error: errorState, onAction: {
                         Task {
@@ -91,6 +87,8 @@ struct ItemListView: View {
                         }
                     })
                 }
+            case .empty:
+                emptyView
             }
         }
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
@@ -188,6 +186,18 @@ private extension ItemListView {
             EmptyView()
         }
     }
+
+    @ViewBuilder
+    var emptyView: some View {
+        switch posModel.selectedItemType {
+        case .products:
+            PointOfSaleItemListEmptyView(base: .root(posModel.selectedItemType))
+        case .coupons:
+            PointOfSaleItemListEmptyView(base: .root(posModel.selectedItemType)) {
+                showCouponCreationModal = true
+            }
+        }
+    }
 }
 
 @available(iOS 17.0, *)
@@ -211,7 +221,7 @@ private extension ItemListState {
                 .loaded,
                 .inlineError:
             return true
-        case .error:
+        case .error, .empty:
             return false
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -50,17 +50,7 @@ struct ItemListView: View {
                     .inlineError(let items, _):
                 listView(items)
             case .error(let errorState):
-                switch errorState {
-                default:
-                    PointOfSaleItemListErrorView(error: errorState, onAction: {
-                        Task {
-                            if errorState.errorType == .couponsDisabled {
-                                await posModel.enableCoupons()
-                            }
-                            await posModel.loadItems(base: .root(.products))
-                        }
-                    })
-                }
+                errorView(errorState)
             case .empty:
                 emptyView
             }
@@ -198,6 +188,24 @@ private extension ItemListView {
             PointOfSaleItemListEmptyView(base: .root(posModel.selectedItemType)) {
                 showCouponCreationModal = true
             }
+        }
+    }
+
+    @ViewBuilder
+    func errorView(_ errorState: PointOfSaleErrorState) -> some View {
+        switch errorState {
+        case .errorCouponsDisabled:
+            PointOfSaleItemListErrorView(error: errorState, onAction: {
+                Task {
+                    await posModel.enableCoupons()
+                }
+            })
+        default:
+            PointOfSaleItemListErrorView(error: errorState, onAction: {
+                Task {
+                    await posModel.loadItems(base: .root(.products))
+                }
+            })
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -78,7 +78,7 @@ struct ItemListView: View {
             case .error(let errorState):
                 if errorState == .errorCouponsNotFound() {
                     PointOfSaleItemListErrorView(error: .errorCouponsNotFound(), onAction: {
-                        // TODO
+                        showCouponCreationModal = true
                     })
                 } else {
                     EmptyView()

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -27,9 +27,6 @@ struct PointOfSaleDashboardView: View {
                 case .error(let error):
                     PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
                         Task {
-                            if error.errorType == .couponsDisabled {
-                                await posModel.enableCoupons()
-                            }
                             await posModel.loadItems(base: .root(.products))
                         }
                     })

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -20,10 +20,6 @@ struct PointOfSaleDashboardView: View {
                     PointOfSaleLoadingView()
                         .transition(.opacity)
                         .ignoresSafeArea()
-                case .empty:
-                    PointOfSaleItemListFullscreenView {
-                        PointOfSaleItemListEmptyView(base: .root(.products))
-                    }
                 case .error(let error):
                     PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
                         Task {

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -8,11 +8,16 @@ import enum Yosemite.POSItem
 import struct Yosemite.POSCoupon
 import struct Yosemite.PagedItems
 import struct Yosemite.POSVariableParentProduct
+import enum Yosemite.PointOfSaleCouponServiceError
 
 final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     var shouldReturnZeroItems = false
+    var errorToThrow: PointOfSaleCouponServiceError?
 
     func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+        if let error = errorToThrow {
+            throw error
+        }
         if shouldReturnZeroItems {
             return .init(items: [], hasMorePages: false)
         } else {
@@ -29,7 +34,9 @@ final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     }
 
     func enableCoupons() async throws {
-        // no-op
+        if let error = errorToThrow {
+            throw error
+        }
     }
 }
 
@@ -131,6 +138,23 @@ struct PointOfSaleCouponsControllerTests {
 
         // When
         await sut.loadNextItems(base: .root(.coupons))
+
+        // Then
+        #expect(sut.itemsViewState == expectedViewState)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func loadItems_when_retrieving_settings_fails_then_results_in_error_state() async throws {
+        // Given
+        let couponProvider = MockPointOfSaleCouponService()
+        couponProvider.errorToThrow = .couponsLoadingError
+        let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
+
+        let expectedItemStackState = ItemsStackState(root: .error(.errorOnLoadingCoupons), itemStates: [:])
+        let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
+
+        // When
+        await sut.loadItems(base: .root(.coupons))
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -35,13 +35,13 @@ final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
 struct PointOfSaleCouponsControllerTests {
     @available(iOS 17.0, *)
-    @Test func loadItems_when_empty_coupons_then_results_in_errorCouponsNotFound_state() async throws {
+    @Test func loadItems_when_empty_coupons_then_results_in_empty_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
         couponProvider.shouldReturnZeroItems = true
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .empty, itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
@@ -69,13 +69,13 @@ struct PointOfSaleCouponsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func refreshItems_when_empty_coupons_then_results_in_errorCouponsNotFound_state() async throws {
+    @Test func refreshItems_when_empty_coupons_then_results_in_empty_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
         couponProvider.shouldReturnZeroItems = true
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .empty, itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
@@ -103,13 +103,13 @@ struct PointOfSaleCouponsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func loadNextItems_when_empty_coupons_then_results_in_errorCouponsNotFound_state() async throws {
+    @Test func loadNextItems_when_empty_coupons_then_results_in_empty_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
         couponProvider.shouldReturnZeroItems = true
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .error(.errorCouponsNotFound()), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .empty, itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -288,7 +288,7 @@ final class PointOfSaleItemsControllerTests {
             return
         }
         #expect(items.count == 2)
-        #expect(errorState == PointOfSaleErrorState.errorOnLoadingVariationsNextPage())
+        #expect(errorState == PointOfSaleErrorState.errorOnLoadingVariationsNextPage)
     }
 
     @available(iOS 17.0, *)
@@ -361,7 +361,7 @@ final class PointOfSaleItemsControllerTests {
             return
         }
         #expect(items.count == 2)
-        #expect(errorState == PointOfSaleErrorState.errorOnLoadingProductsNextPage())
+        #expect(errorState == PointOfSaleErrorState.errorOnLoadingProductsNextPage)
     }
 
     @available(iOS 17.0, *)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -116,7 +116,7 @@ final class PointOfSaleItemsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func loadNextItems_when_initial_items_empty_then_container_state_is_empty() async throws {
+    @Test func loadNextItems_when_initial_items_empty_then_container_state_is_content_and_root_state_is_empty() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
         let sut = PointOfSaleItemsController(
@@ -132,7 +132,8 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadNextItems(base: .root(.products))
 
         // Then
-        #expect(sut.itemsViewState.containerState == .empty)
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .empty)
     }
 
     @available(iOS 17.0, *)
@@ -292,7 +293,7 @@ final class PointOfSaleItemsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func loadItems_when_no_items_then_state_is_loaded_empty() async throws {
+    @Test func loadItems_when_no_items_then_container_state_is_content_and_root_state_is_empty() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
         let sut = PointOfSaleItemsController(
@@ -308,7 +309,8 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadItems(base: .root(.products))
 
         // Then
-        #expect(sut.itemsViewState.containerState == .empty)
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .empty)
     }
 
     @available(iOS 17.0, *)

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponsController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponsController.swift
@@ -4,9 +4,8 @@
 final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtocol {
     func enableCoupons() async { }
 
-    var itemsViewState: ItemsViewState = .init(containerState: .empty,
-                                               itemsStack: .init(root: .loaded([], hasMoreItems: false),
-                                                                 itemStates: [:]))
+    var itemsViewState: ItemsViewState = .init(containerState: .content,
+                                               itemsStack: .init(root: .empty, itemStates: [:]))
 
     func loadItems(base: ItemListBaseItem) async { }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
@@ -5,9 +5,8 @@ import enum Yosemite.POSItem
 
 @available(iOS 17.0, *)
 final class MockPointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
-    var itemsViewState: ItemsViewState = .init(containerState: .empty,
-                                               itemsStack: .init(root: .loaded([], hasMoreItems: false),
-                                                                 itemStates: [:]))
+    var itemsViewState: ItemsViewState = .init(containerState: .content,
+                                               itemsStack: .init(root: .empty, itemStates: [:]))
 
     func loadItems(base: ItemListBaseItem) async { }
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -51,7 +51,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
-        let couponsEnabled = await checkStoreCouponSettings()
+        let couponsEnabled = try await checkStoreCouponSettings()
         if !couponsEnabled {
             throw PointOfSaleCouponServiceError.couponsDisabled
         }
@@ -136,14 +136,14 @@ private extension PointOfSaleCouponService {
         }
     }
 
-    private func checkStoreCouponSettings() async -> Bool {
-        await withCheckedContinuation { continuation in
+    private func checkStoreCouponSettings() async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             settingsStoreMethods.retrieveCouponSetting(siteID: siteID) { result in
                 switch result {
                 case let .success(isEnabled):
                     continuation.resume(returning: isEnabled)
                 case .failure:
-                    continuation.resume(returning: false)
+                    continuation.resume(throwing: PointOfSaleCouponServiceError.couponsLoadingError)
                 }
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There are a few changes in this PR to integrate error, disabled, empty, and loading states within the coupons view:

1. Moved coupon disabled and error states from the container state to list state ([Commit](https://github.com/woocommerce/woocommerce-ios/commit/e1388768e6a28304ab4c1f43dac70e0b8c29f9a5))
2. Moved default coupons loading state from container to list ([Commit](https://github.com/woocommerce/woocommerce-ios/commit/9c9d329ba694fa700474dd0f96b3fdd0fcb14815)]
3. Moved empty state from cointainer to item list. Both product and coupon empty states will now appear in the list rather than full screen. ([1](https://github.com/woocommerce/woocommerce-ios/commit/9003b3f9bf54e861375ffd65b65b969459526b9f), [2](https://github.com/woocommerce/woocommerce-ios/commit/f98efc84d91869196361dcb0240c6e3b3ce10daa), [3](https://github.com/woocommerce/woocommerce-ios/commit/649e102356975ab6ef77021b14ff8dc8c464dd77), [4](https://github.com/woocommerce/woocommerce-ios/commit/3e57edfa2248bd565ca318e395dbd2b11e9b74f9), [5](https://github.com/woocommerce/woocommerce-ios/commit/48569a5365e4f1f0c588f64ba011ba896e201d92), [6](https://github.com/woocommerce/woocommerce-ios/commit/e3de87f00fa328ede776936114afeb5d19aa808f)
4. Updated tests ([Commit](https://github.com/woocommerce/woocommerce-ios/commit/5b651ca386e40bd4dcd2f97ebaae114512c75b9a))
5. Moved dummy Products / Coupons switching view to a header to more easily evaluate UI of empty and error states ([Commit](https://github.com/woocommerce/woocommerce-ios/commit/7cb54c731f07ecc6efa9d3d250ba97e7a8835af8))

A few unrelated changes:
- [Launch coupon creation from an empty view](https://github.com/woocommerce/woocommerce-ios/commit/12e00227eadc70efcb24693cb104131f367a9c8d)
- [Display a coupons loading error if there's no network when loading coupons](https://github.com/woocommerce/woocommerce-ios/commit/651efa7b99f1a4a766ff747ca38e02aa05cb64db)

### Out of Scope

We will still need to adjust the copy for generic error states. There are still tasks to update designs and copy for Empty and Error views. We also have a task to properly update Item Rows for coupons and its loading state.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable `enableCouponsInPointOfSale` feature flag

There are a few different flows to test:
- Empty products state. (e.g return empty state from `PointOfSaleItemService`)
- Empty coupons state. (e.g return empty state from `PointOfSaleCouponService`)
- Disabled coupons state (disable WooCommerce -> Settings coupons)
- Loading state (switch to coupons view)
- Generic coupons error state (disable network when switching to coupons)

All of these states should appear within the coupons list. Error and loading state for products still appear full screen.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I will still want to run a few regression tests before merging:

- [x] Do regression testing for products and product variations when feature flag is disabled

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Generic Error

https://github.com/user-attachments/assets/625e44ca-6172-4ae7-a537-fb856daba521

### Empty Products and Coupons + Loading


https://github.com/user-attachments/assets/6db8a67f-cfb2-4fb9-9973-d14c43d578b1

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
This pull request includes several changes to improve the handling of view states and error states in the Point of Sale (POS) system. The most significant changes involve the introduction of new view states, refactoring error state handling, and updating UI components to reflect these changes.

