### PR TITLE
[Woo POS] Coupons: Separate first page fetch from subsequent paginated fetch. Initial pagination and infinite scrolling.

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -140,10 +140,3 @@ private extension PointOfSaleCouponsController {
         itemsViewState = ItemsViewState(containerState: containerState, itemsStack: stackState)
     }
 }
-
-@available(iOS 17.0, *)
-private extension PointOfSaleCouponsController {
-    enum Constants {
-        static let firstPage: Int = 1
-    }
-}

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -23,14 +23,14 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
         // TODO:
         // Handle unhappy path:
         // Depending on the error type (failed to load vs coupons disabled) we want to show a different CTA choice
-        await fetchCoupons()
+        await fetchFirstPage()
     }
 
     @MainActor
     func refreshItems(base: ItemListBaseItem) async {
         // TODO:
         // Handle unhappy path
-        await fetchCoupons()
+        await fetchFirstPage()
     }
 
     @MainActor
@@ -40,10 +40,10 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
         do {
             try await paginationTracker.resync { [weak self] pageNumber in
                 guard let self else { return true }
-                await fetchCoupons(pageNumber: pageNumber)
-                return true
+                return try await fetchCoupons(pageNumber: pageNumber, appendToExistingCoupons: false)
             }
         } catch {
+            // TODO: Error handling
             debugPrint(error)
         }
     }
@@ -64,20 +64,52 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
 @available(iOS 17.0, *)
 private extension PointOfSaleCouponsController {
+    func fetchFirstPage() async {
+        do {
+            // 1. Load first page from local storage
+            let localCoupons = try await couponProvider.provideLocalPointOfSaleCoupons()
+            if !localCoupons.isEmpty {
+                setCouponsLoadedViewState(localCoupons, hasMoreItems: true)
+            } else {
+                // 2. If there are no local results, fetch from remote, upsert, then fetch from storage again
+                let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1)
+                if !coupons.items.isEmpty {
+                    setCouponsLoadedViewState(coupons.items, hasMoreItems: true)
+                } else {
+                    setCouponsEmptyViewState()
+                }
+            }
+        } catch {
+            if let couponError = error as? PointOfSaleCouponServiceError {
+                setCouponsErrorViewState(couponError)
+            }
+        }
+    }
+
     @MainActor
-    func fetchCoupons(pageNumber: Int = Constants.firstPage) async {
+    func fetchCoupons(pageNumber: Int, appendToExistingCoupons: Bool = true) async throws -> Bool {
         do {
             let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber)
+
+            let newCoupons = pagedCoupons.items
+            var allCoupons = appendToExistingCoupons ? itemsViewState.itemsStack.root.items : []
+            let uniqueNewCoupons = newCoupons.filter { newCoupon in
+                !allCoupons.contains(newCoupon)
+            }
+            allCoupons.append(contentsOf: uniqueNewCoupons)
+
             let hasMoreItems = pagedCoupons.hasMorePages
             if pagedCoupons.items.isEmpty {
                 setCouponsEmptyViewState()
             } else {
                 setCouponsLoadedViewState(pagedCoupons.items, hasMoreItems: hasMoreItems)
             }
+            return pagedCoupons.hasMorePages
         } catch {
             if let couponError = error as? PointOfSaleCouponServiceError {
                 setCouponsErrorViewState(couponError)
             }
+            return true
         }
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -92,7 +92,7 @@ private extension PointOfSaleCouponsController {
         do {
             let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber)
 
-            var allCoupons = pagedCoupons.items
+            let allCoupons = pagedCoupons.items
             let hasMoreItems = pagedCoupons.hasMorePages
 
             if allCoupons.isEmpty {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -35,10 +35,12 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
     @MainActor
     func loadNextItems(base: ItemListBaseItem) async {
-        // TODO:
-        // Pagination WOOMOB-129
+        guard paginationTracker.hasNextPage else {
+            return
+        }
+
         do {
-            try await paginationTracker.resync { [weak self] pageNumber in
+            _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
                 guard let self else { return true }
                 return try await fetchCoupons(pageNumber: pageNumber, appendToExistingCoupons: false)
             }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -23,14 +23,14 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
         // TODO:
         // Handle unhappy path:
         // Depending on the error type (failed to load vs coupons disabled) we want to show a different CTA choice
-        await fetchFirstPage()
+        await loadFirstPage()
     }
 
     @MainActor
     func refreshItems(base: ItemListBaseItem) async {
         // TODO:
         // Handle unhappy path
-        await fetchFirstPage()
+        await loadFirstPage()
     }
 
     @MainActor
@@ -64,14 +64,15 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
 @available(iOS 17.0, *)
 private extension PointOfSaleCouponsController {
-    func fetchFirstPage() async {
+    func loadFirstPage() async {
         do {
-            // 1. Load first page from local storage
-            let localCoupons = try await couponProvider.provideLocalPointOfSaleCoupons()
-            if !localCoupons.isEmpty {
-                setCouponsLoadedViewState(localCoupons, hasMoreItems: true)
+            // 1. Attempt to load the first page from local storage, and present them
+            let storedCoupons = try await couponProvider.provideLocalPointOfSaleCoupons()
+
+            if !storedCoupons.isEmpty {
+                setCouponsLoadedViewState(storedCoupons, hasMoreItems: true)
             } else {
-                // 2. If there are no local results, fetch from remote, upsert, then fetch from storage again
+                // 2. If there are no local results, retry again after syncing the first page from remote first
                 let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1)
                 if !coupons.items.isEmpty {
                     setCouponsLoadedViewState(coupons.items, hasMoreItems: true)

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -42,7 +42,7 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
         do {
             _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
                 guard let self else { return true }
-                return try await fetchCoupons(pageNumber: pageNumber, appendToExistingCoupons: false)
+                return try await fetchCoupons(pageNumber: pageNumber)
             }
         } catch {
             // TODO: Error handling
@@ -89,22 +89,17 @@ private extension PointOfSaleCouponsController {
     }
 
     @MainActor
-    func fetchCoupons(pageNumber: Int, appendToExistingCoupons: Bool = true) async throws -> Bool {
+    func fetchCoupons(pageNumber: Int) async throws -> Bool {
         do {
             let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber)
 
-            let newCoupons = pagedCoupons.items
-            var allCoupons = appendToExistingCoupons ? itemsViewState.itemsStack.root.items : []
-            let uniqueNewCoupons = newCoupons.filter { newCoupon in
-                !allCoupons.contains(newCoupon)
-            }
-            allCoupons.append(contentsOf: uniqueNewCoupons)
-
+            var allCoupons = pagedCoupons.items
             let hasMoreItems = pagedCoupons.hasMorePages
-            if pagedCoupons.items.isEmpty {
+
+            if allCoupons.isEmpty {
                 setCouponsEmptyViewState()
             } else {
-                setCouponsLoadedViewState(pagedCoupons.items, hasMoreItems: hasMoreItems)
+                setCouponsLoadedViewState(allCoupons, hasMoreItems: hasMoreItems)
             }
             return pagedCoupons.hasMorePages
         } catch {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -70,16 +70,10 @@ private extension PointOfSaleCouponsController {
     func loadFirstPage() async {
         do {
             let storedCoupons = try await couponProvider.provideLocalPointOfSaleCoupons()
-
             if !storedCoupons.isEmpty {
                 setCouponsLoadedViewState(storedCoupons, hasMoreItems: true)
             }
-            let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1)
-            if !coupons.items.isEmpty {
-                setCouponsLoadedViewState(coupons.items, hasMoreItems: true)
-            } else {
-                setCouponsEmptyViewState()
-            }
+            _ = try await fetchCoupons(pageNumber: 1)
         } catch {
             if let couponError = error as? PointOfSaleCouponServiceError {
                 setCouponsErrorViewState(couponError)

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -66,21 +66,20 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 
 @available(iOS 17.0, *)
 private extension PointOfSaleCouponsController {
+    /// Loads the first page by attempting to load the first page from local storage
+    /// then syncs from the remote regardless the result
     func loadFirstPage() async {
         do {
-            // 1. Attempt to load the first page from local storage, and present them
             let storedCoupons = try await couponProvider.provideLocalPointOfSaleCoupons()
 
             if !storedCoupons.isEmpty {
                 setCouponsLoadedViewState(storedCoupons, hasMoreItems: true)
+            }
+            let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1)
+            if !coupons.items.isEmpty {
+                setCouponsLoadedViewState(coupons.items, hasMoreItems: true)
             } else {
-                // 2. If there are no local results, retry again after syncing the first page from remote first
-                let coupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: 1)
-                if !coupons.items.isEmpty {
-                    setCouponsLoadedViewState(coupons.items, hasMoreItems: true)
-                } else {
-                    setCouponsEmptyViewState()
-                }
+                setCouponsEmptyViewState()
             }
         } catch {
             if let couponError = error as? PointOfSaleCouponServiceError {

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -12,6 +12,10 @@ import struct Yosemite.POSVariableParentProduct
 final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     var shouldReturnZeroItems = false
 
+    func provideLocalPointOfSaleCoupons() async throws -> [Yosemite.POSItem] {
+        []
+    }
+
     func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
         if shouldReturnZeroItems {
             return .init(items: [], hasMorePages: false)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -62,7 +62,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedCoupons = MockPointOfSaleCouponService.makeInitialCoupons()
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: false), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: true), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
@@ -96,7 +96,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedCoupons = MockPointOfSaleCouponService.makeInitialCoupons()
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: false), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: true), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -69,7 +69,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedCoupons = MockPointOfSaleCouponService.makeInitialCoupons()
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: true), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: false), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
@@ -103,7 +103,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedCoupons = MockPointOfSaleCouponService.makeInitialCoupons()
         let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
 
-        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: true), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .loaded(expectedCoupons, hasMoreItems: false), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -11,6 +11,7 @@ public enum PointOfSaleCouponServiceError: Error {
 }
 
 public protocol PointOfSaleCouponServiceProtocol {
+    func provideLocalPointOfSaleCoupons() async throws -> [POSItem]
     func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem>
     func enableCoupons() async throws
 }
@@ -49,27 +50,24 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                   storage: storage)
     }
 
-    @MainActor
-    public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+    // Provides all available locally-stored coupons
+    public func provideLocalPointOfSaleCoupons() async throws -> [POSItem] {
         let couponsEnabled = await checkStoreCouponSettings()
         if !couponsEnabled {
             throw PointOfSaleCouponServiceError.couponsDisabled
         }
 
-        let coupons = await providePointOfSaleCoupons()
+        let localCoupons = await fetchLocalCoupons()
+        return localCoupons.items
+    }
 
-        if !coupons.items.isEmpty {
-            // Fire-and-forget sync
-            Task.detached {
-                await self.syncCouponsFromRemote(pageNumber: pageNumber)
-            }
-            return .init(items: coupons.items, hasMorePages: true)
-        } else {
-            // Wait for the sync to complete
-            await syncCouponsFromRemote(pageNumber: pageNumber)
-            let refreshedCoupons = await providePointOfSaleCoupons()
-            return .init(items: refreshedCoupons.items, hasMorePages: true)
-        }
+    @MainActor
+    public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+        // Sync local storage with remote coupons
+        await syncCouponsFromRemote(pageNumber: pageNumber)
+        // Then provide fresh coupons from local storage
+        let freshCoupons = try await provideLocalPointOfSaleCoupons()
+        return .init(items: freshCoupons, hasMorePages: true)
     }
 
     @MainActor
@@ -89,7 +87,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
 private extension PointOfSaleCouponService {
     @MainActor
-    func providePointOfSaleCoupons() async -> PagedItems<POSItem> {
+    func fetchLocalCoupons() async -> PagedItems<POSItem> {
         guard let storage = storage else {
             return .init(items: [], hasMorePages: false)
         }
@@ -128,7 +126,7 @@ private extension PointOfSaleCouponService {
             couponStoreMethods.synchronizeCoupons(
                 siteID: siteID,
                 pageNumber: pageNumber,
-                pageSize: 25,
+                pageSize: Constants.defaultPageSize,
                 onCompletion: { _ in
                     continuation.resume()
                 }
@@ -147,5 +145,11 @@ private extension PointOfSaleCouponService {
                 }
             }
         }
+    }
+}
+
+private extension PointOfSaleCouponService {
+    enum Constants {
+        public static let defaultPageSize: Int = 25
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -66,8 +66,8 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
         // Sync local storage with remote coupons
         await syncCouponsFromRemote(pageNumber: pageNumber)
         // Then provide fresh coupons from local storage
-        let freshCoupons = try await provideLocalPointOfSaleCoupons()
-        return .init(items: freshCoupons, hasMorePages: true)
+        let coupons = try await provideLocalPointOfSaleCoupons()
+        return .init(items: coupons, hasMorePages: true)
     }
 
     @MainActor

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -63,9 +63,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
-        // Sync local storage with remote coupons
         await syncCouponsFromRemote(pageNumber: pageNumber)
-        // Then provide fresh coupons from local storage
         let coupons = try await provideLocalPointOfSaleCoupons()
         return .init(items: coupons, hasMorePages: true)
     }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -50,7 +50,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                   storage: storage)
     }
 
-    // Provides all available locally-stored coupons
+    // Provides an array of coupons that are stored locally, it does not accept any sort of pagination
     public func provideLocalPointOfSaleCoupons() async throws -> [POSItem] {
         let couponsEnabled = await checkStoreCouponSettings()
         if !couponsEnabled {

--- a/Yosemite/YosemiteTests/Mocks/MockSettingStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockSettingStoreMethods.swift
@@ -10,6 +10,8 @@ final class MockSettingStoreMethods: SettingStoreMethodsProtocol {
     var enableAnalyticsSettingCalled = false
     var retrieveTaxBasedOnSettingCalled = false
 
+    var couponsEnabled: Bool = true
+
     func synchronizeGeneralSiteSettings(siteID: Int64,
                                       onCompletion: @escaping (Error?) -> Void) {
         generalSiteSettingsSyncCalled = true
@@ -29,8 +31,13 @@ final class MockSettingStoreMethods: SettingStoreMethodsProtocol {
 
     func retrieveCouponSetting(siteID: Int64,
                              onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+
         retrieveCouponSettingCalled = true
-        onCompletion(.success(true))
+        if couponsEnabled {
+            onCompletion(.success(true))
+        } else {
+            onCompletion(.success(false))
+        }
     }
 
     func enableCouponSetting(siteID: Int64,

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -7,17 +7,43 @@ struct PointOfSaleCouponServiceTests {
     private let couponStoreMethods: MockCouponStoreMethods
     private let settingStoreMethods: MockSettingStoreMethods
     private let storage: MockStorageManager
+    
+    private let sampleSiteID: Int64 = 123
 
     init() {
         self.couponStoreMethods = MockCouponStoreMethods()
         self.settingStoreMethods = MockSettingStoreMethods()
         self.storage = MockStorageManager()
-        self.sut = .init(siteID: 123,
+        self.sut = .init(siteID: sampleSiteID,
                          currencySettings: CurrencySettings(),
                          couponStoreMethods: couponStoreMethods,
                          settingStoreMethods: settingStoreMethods,
                          storage: storage
         )
+    }
+    
+    @Test func provideLocalPointOfSaleCoupons_when_zero_coupons_in_local_storage_then_provides_zero_coupons() async throws {
+        // Given, When
+        let coupons = try await sut.provideLocalPointOfSaleCoupons()
+        
+        // Then
+        #expect(coupons.isEmpty)
+    }
+    
+    @Test func provideLocalPointOfSaleCoupons_when_some_coupons_in_local_storage_then_provides_some_coupons() async throws {
+        // Given
+        let coupon1 = Coupon.fake().copy(siteID: sampleSiteID, code: "coupon_123")
+        let coupon2 = Coupon.fake().copy(siteID: sampleSiteID, code: "coupon_456")
+        let expectedCoupons = 2
+        
+        storage.insertSampleCoupon(readOnlyCoupon: coupon1)
+        storage.insertSampleCoupon(readOnlyCoupon: coupon2)
+        
+        // When
+        let coupons = try await sut.provideLocalPointOfSaleCoupons()
+        
+        // Then
+        #expect(coupons.count == expectedCoupons)
     }
 
     @Test func providePointOfSaleCoupons_when_one_coupon_in_store_then_one_coupon_returned() async throws {

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -48,7 +48,7 @@ struct PointOfSaleCouponServiceTests {
 
             do {
                 // Then
-                let coupons = try await sut.provideLocalPointOfSaleCoupons()
+                _ = try await sut.provideLocalPointOfSaleCoupons()
             } catch {
                 let expectedError = error as? PointOfSaleCouponServiceError
                 #expect(expectedError == .couponsDisabled)

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -7,7 +7,7 @@ struct PointOfSaleCouponServiceTests {
     private let couponStoreMethods: MockCouponStoreMethods
     private let settingStoreMethods: MockSettingStoreMethods
     private let storage: MockStorageManager
-    
+
     private let sampleSiteID: Int64 = 123
 
     init() {
@@ -21,27 +21,53 @@ struct PointOfSaleCouponServiceTests {
                          storage: storage
         )
     }
-    
+
     @Test func provideLocalPointOfSaleCoupons_when_zero_coupons_in_local_storage_then_provides_zero_coupons() async throws {
         // Given, When
         let coupons = try await sut.provideLocalPointOfSaleCoupons()
-        
+
         // Then
         #expect(coupons.isEmpty)
     }
-    
+
+    @Test func provideLocalPointOfSaleCoupons_when_disabled_then_expects_couponsDisabled_error() async throws {
+        // Given
+        settingStoreMethods.couponsEnabled = false
+
+        // When
+        await confirmation(expectedCount: 1) { confirmation in
+            settingStoreMethods.retrieveCouponSetting(siteID: sampleSiteID, onCompletion: { result in
+                switch result {
+                case let .success(isEnabled):
+                    #expect(isEnabled == false)
+                    confirmation()
+                case .failure:
+                    break
+                }
+            })
+
+            do {
+                // Then
+                let coupons = try await sut.provideLocalPointOfSaleCoupons()
+            } catch {
+                let expectedError = error as? PointOfSaleCouponServiceError
+                #expect(expectedError == .couponsDisabled)
+            }
+        }
+    }
+
     @Test func provideLocalPointOfSaleCoupons_when_some_coupons_in_local_storage_then_provides_some_coupons() async throws {
         // Given
         let coupon1 = Coupon.fake().copy(siteID: sampleSiteID, code: "coupon_123")
         let coupon2 = Coupon.fake().copy(siteID: sampleSiteID, code: "coupon_456")
         let expectedCoupons = 2
-        
+
         storage.insertSampleCoupon(readOnlyCoupon: coupon1)
         storage.insertSampleCoupon(readOnlyCoupon: coupon2)
-        
+
         // When
         let coupons = try await sut.provideLocalPointOfSaleCoupons()
-        
+
         // Then
         #expect(coupons.count == expectedCoupons)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
Continues the work on woomob-129 from our discussion CGPNUU63E/p1744265251464429-CGPNUU63E by separating first fetch via `provideLocalPointOfSaleCoupons` from subsequent fetches via `providePointOfSaleCoupons`

1. When we initially load coupons, or PTR, we'll call `loadFirstPage()`. This retrieves all coupons from local storage, but does not sync anything from remote. Only if this is empty, will sync from remote as a fallback check.
2. On infinite scrolling, the tracker will trigger `loadNextItems()`, which passes the tracked `pageNumber` to `fetchCoupons()`. This will fetch coupons from remote, sync local storage, and provide us with the new set of coupons.

Infinite scrolling is not polished yet to keep the PR small, but the core functionality should work as expected. For easier testing:

## Testing information

- Set `PointOfSaleCouponService.defaultPageSize` and `CouponsRemote.Default.pageSize` to a smaller number, like 5.
- Add this bit to the `ItemList`, just below `headerView`
```
 Button(action: {
                            let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
                            ServiceLocator.storageManager.performAndSave({ storage in
                                storage.deleteCoupons(siteID: siteID)
                            }, completion: {
                                //
                            }, on: .global())
                        },
                               label: { Text("Delete")}
                        )
```

- Run POS and go to the coupons tab, observe how all existing coupons in storage are loaded
- Tap "Delete" 
- Re-run the app
- Go back to coupons and observe how only the first 5 coupons load
- Scroll down till infinite scrolling is triggered, see 5 more
- Continue 

Attached [a recording here](https://indiemelon.mystagingwebsite.com/wp-content/uploads/2025/04/Screen-Recording-2025-04-10-at-18.01.38.mov), is a bit too big for GH and fails to upload.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
