### PR TITLE
[Woo POS] Coupons: Coupon in a list (Designer UI)

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -29,16 +29,7 @@ struct CouponRowView: View {
 
     var body: some View {
         HStack(spacing: Constants.horizontalElementSpacing) {
-            Rectangle()
-                .foregroundColor(.posSurfaceDim)
-                .overlay {
-                    Text(Image(systemName: "tag"))
-                        .font(.posButtonSymbolMedium)
-                        .foregroundColor(.posOnSurfaceVariantLowest)
-                }
-                .frame(width: dimension)
-                .frame(minHeight: dimension)
-                .accessibilityHidden(true)
+            POSCouponImageView(size: dimension)
                 .renderedIf(showImage)
 
             VStack(alignment: .leading, spacing: dynamicSpacing) {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
@@ -1,0 +1,54 @@
+import struct Yosemite.POSCoupon
+import SwiftUI
+
+struct CouponCardView: View {
+    private let coupon: POSCoupon
+
+    @ScaledMetric private var scale: CGFloat = 1.0
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    private var dimension: CGFloat {
+        min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
+    }
+
+    init(coupon: POSCoupon) {
+        self.coupon = coupon
+    }
+
+    var body: some View {
+        HStack(spacing: Constants.cardSpacing) {
+            POSCouponImageView(size: dimension)
+
+            VStack(alignment: .leading, spacing: Constants.textSpacing) {
+                Text(coupon.code)
+                    .foregroundStyle(Constants.titleColor)
+                    .multilineTextAlignment(.leading)
+                    .font(Constants.itemTitleFont)
+
+                Text(coupon.summary)
+                    .foregroundStyle(Constants.detailColor)
+                    .font(Constants.itemDetailFont)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
+            .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, minHeight: dimension)
+        .background(Constants.backgroundColor)
+        .posItemCardBorderStyles()
+    }
+}
+
+private extension CouponCardView {
+    typealias Constants = PointOfSaleItemListCardConstants
+}
+
+#if DEBUG
+#Preview {
+    CouponCardView(coupon: .init(id: .init(),
+                                 code: "Coupon-123",
+                                 summary: "10% off - All Products"))
+}
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -153,9 +153,7 @@ private struct ItemListRow: View {
             Button(action: {
                 posModel.addToCart(item)
             }, label: {
-                CouponRowView(couponItem: .init(id: coupon.id,
-                                                code: coupon.code,
-                                                summary: coupon.summary))
+                CouponCardView(coupon: coupon)
             })
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -126,6 +126,7 @@ private extension ItemListView {
             .foregroundStyle(Color.posOnSurface)
             .renderedIf(posModel.selectedItemType == .coupons)
         }
+        .dynamicTypeSize(...DynamicTypeSize.large)
         .renderedIf(shouldShowCoupons)
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
@@ -1,11 +1,6 @@
 import SwiftUI
 
 struct POSCouponImageView: View {
-    @ScaledMetric private var scale: CGFloat = 1.0
-    private var dimension: CGFloat {
-        min(Constants.couponCardSize * scale, Constants.maximumCouponCardSize)
-    }
-
     private let size: CGFloat
 
     init(size: CGFloat) {
@@ -20,19 +15,12 @@ struct POSCouponImageView: View {
                     .font(.posButtonSymbolMedium)
                     .foregroundColor(.posOnSurfaceVariantLowest)
             }
-            .frame(width: dimension)
-            .frame(minHeight: dimension)
+            .frame(width: size)
+            .frame(minHeight: size)
             .accessibilityHidden(true)
     }
 }
 
-private extension POSCouponImageView {
-    enum Constants {
-        static let couponCardSize: CGFloat = 96
-        static let maximumCouponCardSize: CGFloat = Self.couponCardSize * 1.5
-    }
-}
-
 #Preview {
-    POSCouponImageView(size: POSCouponImageView.Constants.couponCardSize)
+    POSCouponImageView(size: 100)
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct POSCouponImageView: View {
+    @ScaledMetric private var scale: CGFloat = 1.0
+    private var dimension: CGFloat {
+        min(Constants.couponCardSize * scale, Constants.maximumCouponCardSize)
+    }
+
+    private let size: CGFloat
+
+    init(size: CGFloat) {
+        self.size = size
+    }
+
+    var body: some View {
+        Rectangle()
+            .foregroundColor(.posSurfaceDim)
+            .overlay {
+                Text(Image(systemName: "tag"))
+                    .font(.posButtonSymbolMedium)
+                    .foregroundColor(.posOnSurfaceVariantLowest)
+            }
+            .frame(width: dimension)
+            .frame(minHeight: dimension)
+            .accessibilityHidden(true)
+    }
+}
+
+private extension POSCouponImageView {
+    enum Constants {
+        static let couponCardSize: CGFloat = 96
+        static let maximumCouponCardSize: CGFloat = Self.couponCardSize * 1.5
+    }
+}
+
+#Preview {
+    POSCouponImageView(size: POSCouponImageView.Constants.couponCardSize)
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
@@ -11,7 +11,7 @@ struct POSCouponImageView: View {
         Rectangle()
             .foregroundColor(.posSurfaceDim)
             .overlay {
-                Text(Image(systemName: "tag"))
+                Image(systemName: "tag")
                     .font(.posButtonSymbolMedium)
                     .foregroundColor(.posOnSurfaceVariantLowest)
             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		019630B62D02018C00219D80 /* TapToPayAwarenessMomentDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B52D02018400219D80 /* TapToPayAwarenessMomentDeterminer.swift */; };
 		019630B82D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B72D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift */; };
 		0196FF922DA802730063CEF1 /* POSCouponImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0196FF912DA802730063CEF1 /* POSCouponImageView.swift */; };
+		0196FF942DA8067A0063CEF1 /* CouponCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0196FF932DA806720063CEF1 /* CouponCardView.swift */; };
 		019A86842D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A86832D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift */; };
 		01AAD8142D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
@@ -3306,6 +3307,7 @@
 		019630B52D02018400219D80 /* TapToPayAwarenessMomentDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentDeterminer.swift; sourceTree = "<group>"; };
 		019630B72D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentDeterminerTests.swift; sourceTree = "<group>"; };
 		0196FF912DA802730063CEF1 /* POSCouponImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCouponImageView.swift; sourceTree = "<group>"; };
+		0196FF932DA806720063CEF1 /* CouponCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCardView.swift; sourceTree = "<group>"; };
 		019A86832D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayCardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
 		01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderSyncCouponsErrorMessageView.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
@@ -7595,6 +7597,7 @@
 				204C20452D35471400E6D9CF /* PointOfSaleItemListCardConstants.swift */,
 				027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */,
 				029149772D26658A00F7B3B3 /* VariationCardView.swift */,
+				0196FF932DA806720063CEF1 /* CouponCardView.swift */,
 				0291497C2D26CB2500F7B3B3 /* ChildItemList.swift */,
 				020556502D5DA45500E51059 /* GhostItemCardView.swift */,
 			);
@@ -16386,6 +16389,7 @@
 				205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */,
 				029D025C2C231A1F00CB1E75 /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift in Sources */,
 				01620C4E2C5394B200D3EA2F /* POSProgressViewStyle.swift in Sources */,
+				0196FF942DA8067A0063CEF1 /* CouponCardView.swift in Sources */,
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		019630B42D01DB4800219D80 /* TapToPayAwarenessMomentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B32D01DB4000219D80 /* TapToPayAwarenessMomentView.swift */; };
 		019630B62D02018C00219D80 /* TapToPayAwarenessMomentDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B52D02018400219D80 /* TapToPayAwarenessMomentDeterminer.swift */; };
 		019630B82D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019630B72D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift */; };
+		0196FF922DA802730063CEF1 /* POSCouponImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0196FF912DA802730063CEF1 /* POSCouponImageView.swift */; };
 		019A86842D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A86832D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift */; };
 		01AAD8142D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
@@ -3304,6 +3305,7 @@
 		019630B32D01DB4000219D80 /* TapToPayAwarenessMomentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentView.swift; sourceTree = "<group>"; };
 		019630B52D02018400219D80 /* TapToPayAwarenessMomentDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentDeterminer.swift; sourceTree = "<group>"; };
 		019630B72D0211F400219D80 /* TapToPayAwarenessMomentDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayAwarenessMomentDeterminerTests.swift; sourceTree = "<group>"; };
+		0196FF912DA802730063CEF1 /* POSCouponImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCouponImageView.swift; sourceTree = "<group>"; };
 		019A86832D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayCardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
 		01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderSyncCouponsErrorMessageView.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
@@ -6575,6 +6577,7 @@
 				683AC4AB2CEF019700FF0A5E /* POSSendReceiptView.swift */,
 				20D2CCA22C7E175700051705 /* WavesProgressViewStyle.swift */,
 				027ADB722D21812D009608DB /* POSItemImageView.swift */,
+				0196FF912DA802730063CEF1 /* POSCouponImageView.swift */,
 				027ADB742D218A8D009608DB /* POSItemCardBorderStylesModifier.swift */,
 				0295736A2D62B93300865E27 /* POSPageHeaderView.swift */,
 				0295CDBF2D6477C400865E27 /* POSNoticeView.swift */,
@@ -17034,6 +17037,7 @@
 				09F5DE5D27CF948000E5A4D2 /* BulkUpdateOptionsModel.swift in Sources */,
 				03076D36290C162E008EE839 /* WebViewSheet.swift in Sources */,
 				039B7E6329F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift in Sources */,
+				0196FF922DA802730063CEF1 /* POSCouponImageView.swift in Sources */,
 				450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */,
 				B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */,
 				CEE02AF82C1859B400B0B6AB /* MessageComposeView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Create a coupon row for the item list to look according to the designs FnDpCHVQ3Zpefad04ptbd4-fi-144_13612

- Created `CouponCardView` closely following the `SimpleProductCardView`
- Extracted `POSCouponImageView` to reuse between `CouponRowView` and `CouponCardView`

No other adjustments were needed to get the look from the designs. Any necessary loading row adjustments will be done in a separate task (WOOMOB-248). There may be little to no work there.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable `enableCouponsInPointOfSale` feature flag

1. Open POS
2. Select Coupons
3. Confirm they look according to designs FnDpCHVQ3Zpefad04ptbd4-fi-144_13612
4. Switch light/dark mode
5. Increase/decrease dynamic type size

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-10 at 17 23 26](https://github.com/user-attachments/assets/cd231ce5-8a90-4471-bfbe-8b7a67e9b237)

![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-10 at 17 05 09](https://github.com/user-attachments/assets/bcbc38b0-de49-4246-a87c-d06b8b670185)

![image](https://github.com/user-attachments/assets/7ada7a10-409f-4607-a41d-5d10fd45c180)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.