### PR TITLE
[Woo POS] Coupons: Retrieve settings from storage first, remote as fallback

### DIFF
--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -20,7 +20,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     private var siteID: Int64
     private let currencySettings: CurrencySettings
     private let currencyFormatter: CurrencyFormatter
-    private let storage: StorageManagerType?
+    private let storage: StorageManagerType
     private let couponStoreMethods: CouponStoreMethodsProtocol
     private let settingsStoreMethods: SettingStoreMethodsProtocol
 
@@ -87,10 +87,6 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 private extension PointOfSaleCouponService {
     @MainActor
     func fetchLocalCoupons() async -> PagedItems<POSItem> {
-        guard let storage = storage else {
-            return .init(items: [], hasMorePages: false)
-        }
-
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
                                           ascending: false)
@@ -136,15 +132,11 @@ private extension PointOfSaleCouponService {
     @MainActor
     private func checkStoreCouponSettings() async throws -> Bool {
         let settingID = Constants.enableCouponsSettingID
-        let storageSetting = storage?.viewStorage.loadSiteSetting(siteID: siteID, settingID: settingID)
+        let storageSetting = storage.viewStorage.loadSiteSetting(siteID: siteID, settingID: settingID)
 
-        switch storageSetting {
-        case let .some(setting):
-            if setting.value == Constants.enableCouponsSettingValue {
-                return true
-            } else {
-                return try await checkRemoteStoreCouponSettings()
-            }
+        switch storageSetting?.value {
+        case Constants.enableCouponsSettingValue:
+            return true
         default:
             return try await checkRemoteStoreCouponSettings()
         }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -134,12 +134,12 @@ private extension PointOfSaleCouponService {
 
     @MainActor
     private func checkStoreCouponSettings() async -> Bool {
-        let settingID = "woocommerce_enable_coupons"
+        let settingID = Constants.enableCouponsSettingID
         let storageSetting = storage?.viewStorage.loadSiteSetting(siteID: siteID, settingID: settingID)
 
         switch storageSetting {
         case let .some(setting):
-            if setting.value == "yes" {
+            if setting.value == Constants.enableCouponsSettingValue {
                 return true
             } else {
                 return await checkRemoteStoreCouponSettings()
@@ -165,6 +165,8 @@ private extension PointOfSaleCouponService {
 
 private extension PointOfSaleCouponService {
     enum Constants {
-        public static let defaultPageSize: Int = 25
+        static let defaultPageSize: Int = 25
+        static let enableCouponsSettingID: String = "woocommerce_enable_coupons"
+        static let enableCouponsSettingValue: String = "yes"
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -132,8 +132,25 @@ private extension PointOfSaleCouponService {
         }
     }
 
+    @MainActor
     private func checkStoreCouponSettings() async -> Bool {
-        await withCheckedContinuation { continuation in
+        let settingID = "woocommerce_enable_coupons"
+        let storageSetting = storage?.viewStorage.loadSiteSetting(siteID: siteID, settingID: settingID)
+
+        switch storageSetting {
+        case let .some(setting):
+            if setting.value == "yes" {
+                return true
+            } else {
+                return await checkRemoteStoreCouponSettings()
+            }
+        default:
+            return await checkRemoteStoreCouponSettings()
+        }
+    }
+
+    private func checkRemoteStoreCouponSettings() async -> Bool {
+        return await withCheckedContinuation { continuation in
             settingsStoreMethods.retrieveCouponSetting(siteID: siteID) { result in
                 switch result {
                 case let .success(isEnabled):

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -64,7 +64,15 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
-        await syncCouponsFromRemote(pageNumber: pageNumber)
+        do {
+            try await syncCouponsFromRemote(pageNumber: pageNumber)
+        } catch {
+            if try await checkRemoteStoreCouponSettings() {
+                throw error
+            } else {
+                throw PointOfSaleCouponServiceError.couponsDisabled
+            }
+        }
         let coupons = try await provideLocalPointOfSaleCoupons()
         return .init(items: coupons, hasMorePages: true)
     }
@@ -116,14 +124,19 @@ private extension PointOfSaleCouponService {
         }
     }
 
-    func syncCouponsFromRemote(pageNumber: Int) async {
-        await withCheckedContinuation { continuation in
+    func syncCouponsFromRemote(pageNumber: Int) async throws {
+        try await withCheckedThrowingContinuation { continuation in
             couponStoreMethods.synchronizeCoupons(
                 siteID: siteID,
                 pageNumber: pageNumber,
                 pageSize: Constants.defaultPageSize,
-                onCompletion: { _ in
-                    continuation.resume()
+                onCompletion: { result in
+                    switch result {
+                    case .success:
+                        continuation.resume()
+                    case .failure:
+                        continuation.resume(throwing: PointOfSaleCouponServiceError.couponsLoadingError)
+                    }
                 }
             )
         }

--- a/Yosemite/YosemiteTests/Mocks/MockCouponStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockCouponStoreMethods.swift
@@ -11,6 +11,7 @@ final class MockCouponStoreMethods: CouponStoreMethodsProtocol {
     var retrieveCalled = false
     var loadCouponsCalled = false
     var validateCalled = false
+    var shouldFailSync = false
 
     var onSynchronizeCalled: () -> Void = {}
 
@@ -19,7 +20,11 @@ final class MockCouponStoreMethods: CouponStoreMethodsProtocol {
                             pageSize: Int,
                             onCompletion: @escaping (Result<Bool, any Error>) -> Void) {
         synchronizeCalled = true
-        onCompletion(.success(true))
+        if shouldFailSync {
+            onCompletion(.failure(NSError(domain: "test", code: 0)))
+        } else {
+            onCompletion(.success(true))
+        }
         onSynchronizeCalled()
     }
 

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -72,6 +72,43 @@ struct PointOfSaleCouponServiceTests {
         #expect(coupons.count == expectedCoupons)
     }
 
+    @Test func provideLocalPointOfSaleCoupons_when_storage_has_enabled_setting_then_returns_coupons() async throws {
+        // Given
+        let setting = SiteSetting.fake().copy(siteID: sampleSiteID,
+                                            settingID: "woocommerce_enable_coupons",
+                                            value: "yes")
+        storage.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        let coupon = Coupon.fake().copy(siteID: sampleSiteID, code: "coupon_123")
+        storage.insertSampleCoupon(readOnlyCoupon: coupon)
+
+        // When
+        let coupons = try await sut.provideLocalPointOfSaleCoupons()
+
+        // Then
+        #expect(coupons.count == 1)
+        #expect(settingStoreMethods.retrieveCouponSettingCalled == false)
+    }
+
+    @Test func provideLocalPointOfSaleCoupons_when_storage_has_disabled_setting_then_checks_remote() async throws {
+        // Given
+        let setting = SiteSetting.fake().copy(siteID: sampleSiteID,
+                                            settingID: "woocommerce_enable_coupons",
+                                            value: "no")
+        storage.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        settingStoreMethods.couponsEnabled = true
+
+        // When
+        await confirmation(expectedCount: 1) { confirmation in
+            settingStoreMethods.retrieveCouponSetting(siteID: sampleSiteID) { _ in
+                confirmation()
+            }
+            _ = try? await sut.provideLocalPointOfSaleCoupons()
+        }
+
+        // Then
+        #expect(settingStoreMethods.retrieveCouponSettingCalled == true)
+    }
+
     @Test func providePointOfSaleCoupons_when_one_coupon_in_store_then_one_coupon_returned() async throws {
         // Given
         let coupon = Coupon.fake().copy(siteID: 123, code: "coupon")
@@ -120,5 +157,35 @@ struct PointOfSaleCouponServiceTests {
             try await _ = sut.providePointOfSaleCoupons(pageNumber: 0)
         }
 
+    }
+
+    @Test func providePointOfSaleCoupons_when_sync_fails_and_coupons_enabled_then_throws_couponsLoadingError() async throws {
+        // Given
+        settingStoreMethods.couponsEnabled = true
+        couponStoreMethods.shouldFailSync = true
+
+        // When
+        do {
+            _ = try await sut.providePointOfSaleCoupons(pageNumber: 0)
+        } catch {
+            // Then
+            let expectedError = error as? PointOfSaleCouponServiceError
+            #expect(expectedError == .couponsLoadingError)
+        }
+    }
+
+    @Test func providePointOfSaleCoupons_when_sync_fails_and_coupons_disabled_then_throws_couponsDisabled() async throws {
+        // Given
+        settingStoreMethods.couponsEnabled = false
+        couponStoreMethods.shouldFailSync = true
+
+        // When
+        do {
+            _ = try await sut.providePointOfSaleCoupons(pageNumber: 0)
+        } catch {
+            // Then
+            let expectedError = error as? PointOfSaleCouponServiceError
+            #expect(expectedError == .couponsDisabled)
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-280 

## Description
This PR moves the coupon `woocommerce_enable_coupons` setting check to local storage first, and keep the remote call as a fallback, so we avoid unnecessary remote calls when not needed.

## Testing information
1. Disable coupons from store
2. Add a breakpoint in the new function, somewhere around `storageSetting`
3. Navigate to coupons in POS, observe that you're presented with an error, and prompted to enable coupons
4. In the console, storageSetting value prop shows as "no"

```
<SiteSetting: 0x60000214f700> (entity: SiteSetting; id: 0x98a9b7822442aea6 <x-coredata://F1088342-A2AB-4498-A5DA-7B00218BEA92/SiteSetting/p7>; data: {
    label = "Enable coupons";
    settingDescription = "Enable the use of coupon codes";
    settingGroupKey = general;
    settingID = "woocommerce_enable_coupons";
    siteID = "-1";
    value = no;
})
```
5. Observe the remote call and fetching the value again as a fallback
6. Tap "Enable coupons"
7. Navigate back to coupons/exiting POS/reload the app
8. Observe the entity with storageSeting value as "yes"
```
<SiteSetting: 0x6000021470c0> (entity: SiteSetting; id: 0xac0b93ee11d8b6c1 <x-coredata://F1088342-A2AB-4498-A5DA-7B00218BEA92/SiteSetting/p7>; data: {
    label = "Enable coupons";
    settingDescription = "Enable the use of coupon codes";
    settingGroupKey = general;
    settingID = "woocommerce_enable_coupons";
    siteID = "-1";
    value = yes;
})
```
9. Assume that this setting does not exist in local storage, for this change the code to:

```
let settingID = Constants.enableCouponsSettingID
var storageSetting = storage?.viewStorage.loadSiteSetting(siteID: siteID, settingID: settingID)
storageSetting = nil
```
10. Run the app again and navigate to coupons, observe how falls back back into remote check and coupons are loaded.


<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

---

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
