### PR TITLE
[Woo POS] Expose item controllers for POS list views to use directly

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -80,7 +80,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
         switch base {
         case .root:
             await loadRootItems()
-        case .parent(let parent, _):
+        case .parent(let parent):
             await loadChildItems(for: parent)
         }
     }
@@ -104,7 +104,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
         switch base {
         case .root:
             await loadNextRootItems()
-        case .parent(let parent, _):
+        case .parent(let parent):
             await loadNextChildItems(for: parent)
         }
     }
@@ -197,7 +197,7 @@ private extension PointOfSaleItemsController {
         switch base {
         case .root:
             setRootLoadingState()
-        case .parent(let parent, _):
+        case .parent(let parent):
             setChildLoadingState(for: parent)
         }
     }
@@ -220,7 +220,7 @@ private extension PointOfSaleItemsController {
         switch base {
         case .root:
             setRootSearchingState()
-        case .parent(let parent, _):
+        case .parent(let parent):
             setChildSearchingState(for: parent)
         }
     }

--- a/WooCommerce/Classes/POS/Models/ItemListBaseItem.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListBaseItem.swift
@@ -2,15 +2,6 @@ import Foundation
 import enum Yosemite.POSItem
 
 enum ItemListBaseItem {
-    case root(ItemType)
-    case parent(POSItem, ItemType)
-
-    var itemType: ItemType {
-        switch self {
-        case .root(let type):
-            return type
-        case .parent(_, let type):
-            return type
-        }
-    }
+    case root
+    case parent(POSItem)
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -24,7 +24,7 @@ protocol PointOfSaleAggregateModelProtocol {
     func cancelCardPaymentsOnboarding()
     func trackCardPaymentsOnboardingShown()
 
-    var itemsController: PointOfSaleItemsControllerProtocol { get }
+    var purchasableItemsController: PointOfSaleItemsControllerProtocol { get }
     var purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol { get }
     var couponsController: PointOfSaleCouponsControllerProtocol { get }
 
@@ -59,7 +59,7 @@ protocol PointOfSaleAggregateModelProtocol {
     var orderState: PointOfSaleOrderState { orderController.orderState.externalState }
     private var internalOrderState: PointOfSaleInternalOrderState { orderController.orderState }
 
-    let itemsController: PointOfSaleItemsControllerProtocol
+    let purchasableItemsController: PointOfSaleItemsControllerProtocol
     let purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol
     let couponsController: PointOfSaleCouponsControllerProtocol
 
@@ -81,7 +81,7 @@ protocol PointOfSaleAggregateModelProtocol {
          analytics: Analytics = ServiceLocator.analytics,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
          paymentState: PointOfSalePaymentState = .card(.idle)) {
-        self.itemsController = itemsController
+        self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
         self.couponsController = couponsController
         self.cardPresentPaymentService = cardPresentPaymentService

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -24,12 +24,9 @@ protocol PointOfSaleAggregateModelProtocol {
     func cancelCardPaymentsOnboarding()
     func trackCardPaymentsOnboardingShown()
 
-    var itemsViewState: ItemsViewState { get }
-    var purchasableItemsSearchViewState: ItemsViewState { get }
-    var couponsViewState: ItemsViewState { get }
-
-    func loadItems(base: ItemListBaseItem) async
-    func loadNextItems(base: ItemListBaseItem) async
+    var itemsController: PointOfSaleItemsControllerProtocol { get }
+    var purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol { get }
+    var couponsController: PointOfSaleCouponsControllerProtocol { get }
 
     var cart: Cart { get }
     func addToCart(_ item: POSItem)
@@ -57,18 +54,14 @@ protocol PointOfSaleAggregateModelProtocol {
     var cardPresentPaymentOnboardingViewModel: CardPresentPaymentsOnboardingViewModel?
     private var onOnboardingCancellation: (() -> Void)?
 
-    var itemsViewState: ItemsViewState { itemsController.itemsViewState }
-    var purchasableItemsSearchViewState: ItemsViewState { purchasableItemsSearchController.itemsViewState }
-    var couponsViewState: ItemsViewState { couponsController.itemsViewState }
-
     private(set) var cart: Cart = .init()
 
     var orderState: PointOfSaleOrderState { orderController.orderState.externalState }
     private var internalOrderState: PointOfSaleInternalOrderState { orderController.orderState }
 
-    private let itemsController: PointOfSaleItemsControllerProtocol
-    private let purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol
-    private let couponsController: PointOfSaleCouponsControllerProtocol
+    let itemsController: PointOfSaleItemsControllerProtocol
+    let purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol
+    let couponsController: PointOfSaleCouponsControllerProtocol
 
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderController: PointOfSaleOrderControllerProtocol
@@ -102,46 +95,7 @@ protocol PointOfSaleAggregateModelProtocol {
     }
 }
 
-// MARK: - ItemList
-@available(iOS 17.0, *)
-extension PointOfSaleAggregateModel {
-    @MainActor
-    func loadItems(base: ItemListBaseItem) async {
-        await itemsController(for: base.itemType).loadItems(base: base)
-    }
-
-    @MainActor
-    func refreshItems(base: ItemListBaseItem) async {
-        await itemsController(for: base.itemType).refreshItems(base: base)
-    }
-
-    @MainActor
-    func loadNextItems(base: ItemListBaseItem) async {
-        await itemsController(for: base.itemType).loadNextItems(base: base)
-    }
-
-    @MainActor
-    func searchItems(searchTerm: String, base: ItemListBaseItem) async {
-        guard case .products = base.itemType else {
-            return
-        }
-        await purchasableItemsSearchController.searchItems(searchTerm: searchTerm, baseItem: base)
-    }
-
-    private func itemsController(for itemType: ItemType) -> PointOfSaleItemsControllerProtocol {
-        switch itemType {
-        case .products(let searching):
-            if searching {
-                return purchasableItemsSearchController
-            } else {
-                return itemsController
-            }
-        case .coupons:
-            return couponsController
-        }
-    }
-}
-
+// MARK: - Cart
 @available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     func addToCart(_ item: POSItem) {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct PointOfSaleItemListEmptyView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
-    private let baseItem: ItemListBaseItem
+    private let viewModel: PointOfSaleItemListEmptyViewModel
 
     private let onAction: (() -> Void)?
 
@@ -13,8 +13,8 @@ struct PointOfSaleItemListEmptyView: View {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
     }
 
-    init(base: ItemListBaseItem, onAction: (() -> Void)? = nil) {
-        self.baseItem = base
+    init(viewModel: PointOfSaleItemListEmptyViewModel, onAction: (() -> Void)? = nil) {
+        self.viewModel = viewModel
         self.onAction = onAction
     }
 
@@ -35,19 +35,19 @@ struct PointOfSaleItemListEmptyView: View {
 
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
 
-                Text(title)
+                Text(viewModel.title)
                     .accessibilityAddTraits(.isHeader)
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posHeadingBold)
 
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textSpacing)
 
-                Text(subtitle)
+                Text(viewModel.subtitle)
                     .foregroundStyle(Color.posOnSurface)
                     .font(.posBodyLargeRegular())
                     .padding([.leading, .trailing])
 
-                if let hint {
+                if let hint = viewModel.hint {
                     Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textSpacing)
                     Text(hint)
                         .foregroundStyle(Color.posOnSurfaceVariantHighest)
@@ -57,7 +57,7 @@ struct PointOfSaleItemListEmptyView: View {
 
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
 
-                if let onAction, let buttonTitle {
+                if let onAction, let buttonTitle = viewModel.buttonTitle {
                     Button(action: {
                         onAction()
                     }, label: {
@@ -79,13 +79,22 @@ struct PointOfSaleItemListEmptyView: View {
 }
 
 private extension PointOfSaleItemListEmptyView {
+    enum Constants {
+        static let iconSize: CGFloat = 100
+    }
+}
+
+struct PointOfSaleItemListEmptyViewModel {
+    let itemType: ItemType
+    let baseItem: ItemListBaseItem
+
     var title: String {
-        switch baseItem {
-        case .root(.products):
+        switch (baseItem, itemType) {
+        case (.root, .products):
             return Localization.emptyProductsTitle
-        case .root(.coupons):
+        case (.root, .coupons):
             return Localization.emptyCouponsTitle
-        case .parent(.variableParentProduct, _):
+        case (.parent, .products):
             return Localization.emptyVariableParentProductTitle
         default:
             assertionFailure("No title defined for \(baseItem)")
@@ -94,12 +103,12 @@ private extension PointOfSaleItemListEmptyView {
     }
 
     var subtitle: String {
-        switch baseItem {
-        case .root(.products):
+        switch (baseItem, itemType) {
+        case (.root, .products):
             return Localization.emptyProductsSubtitle
-        case .root(.coupons):
+        case (.root, .coupons):
             return Localization.emptyCouponsSubtitle
-        case .parent(.variableParentProduct, _):
+        case (.parent, .products):
             return Localization.emptyVariableParentProductSubtitle
         default:
             assertionFailure("No subtitle defined for \(baseItem)")
@@ -108,12 +117,12 @@ private extension PointOfSaleItemListEmptyView {
     }
 
     var hint: String? {
-        switch baseItem {
-        case .root(.products):
+        switch (baseItem, itemType) {
+        case (.root, .products):
             return Localization.emptyProductsHint
-        case .root(.coupons):
+        case (.root, .coupons):
             return nil
-        case .parent(.variableParentProduct, _):
+        case (.parent, .products):
             return Localization.emptyVariableParentProductHint
         default:
             assertionFailure("No hint defined for \(baseItem)")
@@ -122,17 +131,14 @@ private extension PointOfSaleItemListEmptyView {
     }
 
     var buttonTitle: String? {
-        switch baseItem {
-        case .root(.coupons):
+        switch itemType {
+        case .coupons:
             return Localization.emptyCouponsButtonTitle
         default:
             return nil
         }
     }
 
-    enum Constants {
-        static let iconSize: CGFloat = 100
-    }
     enum Localization {
         static let emptyProductsTitle = NSLocalizedString(
             "pos.pointOfSaleItemListEmptyView.emptyProductsTitle.1",

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -6,7 +6,10 @@ import Yosemite
 struct ChildItemList: View {
     private let parentItem: POSItem
     private let title: String
-    private let itemsStack: ItemsStackState
+    private var itemsStack: ItemsStackState {
+        itemsController.itemsViewState.itemsStack
+    }
+    private var itemsController: PointOfSaleItemsControllerProtocol
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.dismiss) private var dismiss
 
@@ -19,10 +22,10 @@ struct ChildItemList: View {
             .loading([])
     }
 
-    init(parentItem: POSItem, title: String, itemsStack: ItemsStackState) {
+    init(parentItem: POSItem, title: String, itemsController: PointOfSaleItemsControllerProtocol) {
         self.parentItem = parentItem
         self.title = title
-        self.itemsStack = itemsStack
+        self.itemsController = itemsController
     }
 
     var body: some View {
@@ -44,7 +47,7 @@ struct ChildItemList: View {
             guard state.items.isEmpty else {
                 return
             }
-            await posModel.loadItems(base: node)
+            await itemsController.loadItems(base: node)
         }
     }
 }
@@ -64,13 +67,12 @@ private extension ChildItemList {
         VStack(spacing: 0) {
             headerView
 
-            ItemList(state: state,
-                     itemsStack: itemsStack,
+            ItemList(itemsController: itemsController,
                      node: node)
                 .transition(.opacity)
                 .refreshable {
                     ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)
-                    await posModel.refreshItems(base: node)
+                    await itemsController.refreshItems(base: node)
                 }
         }
     }
@@ -93,7 +95,7 @@ private extension ChildItemList {
 
             PointOfSaleItemListErrorView(error: error, onAction: {
                 Task {
-                    await posModel.loadItems(base: node)
+                    await itemsController.loadItems(base: node)
                 }
             })
             .zIndex(1)
@@ -159,7 +161,7 @@ private extension ChildItemList {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsStack: itemsStack)
+    return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: itemsController)
         .environment(posModel)
 }
 
@@ -185,7 +187,7 @@ private extension ChildItemList {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsStack: itemsStack)
+    return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: itemsController)
         .environment(posModel)
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -7,7 +7,6 @@ struct ChildItemList: View {
     private let parentItem: POSItem
     private let title: String
     private var itemsController: PointOfSaleItemsControllerProtocol
-    @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.dismiss) private var dismiss
 
     private var node: ItemListBaseItem {
@@ -155,15 +154,7 @@ private extension ChildItemList {
                     )
                 ], hasMoreItems: false)])
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: itemsController,
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
     return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: itemsController)
-        .environment(posModel)
 }
 
 @available(iOS 17.0, *)
@@ -182,15 +173,7 @@ private extension ChildItemList {
             parentItem: .error(.errorOnLoadingVariations)
         ])
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: itemsController,
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
     return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: itemsController)
-        .environment(posModel)
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -11,7 +11,7 @@ struct ChildItemList: View {
     @Environment(\.dismiss) private var dismiss
 
     private var node: ItemListBaseItem {
-        .parent(parentItem, .products())
+        .parent(parentItem)
     }
 
     private var state: ItemListState {
@@ -78,7 +78,10 @@ private extension ChildItemList {
     var emptyView: some View {
         VStack {
             headerView
-            PointOfSaleItemListEmptyView(base: node)
+            PointOfSaleItemListEmptyView(
+                viewModel: PointOfSaleItemListEmptyViewModel(
+                    itemType: .products(search: false),
+                    baseItem: node))
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -6,9 +6,6 @@ import Yosemite
 struct ChildItemList: View {
     private let parentItem: POSItem
     private let title: String
-    private var itemsStack: ItemsStackState {
-        itemsController.itemsViewState.itemsStack
-    }
     private var itemsController: PointOfSaleItemsControllerProtocol
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.dismiss) private var dismiss
@@ -18,7 +15,7 @@ struct ChildItemList: View {
     }
 
     private var state: ItemListState {
-        itemsStack.itemStates[parentItem] ??
+        itemsController.itemsViewState.itemsStack.itemStates[parentItem] ??
             .loading([])
     }
 
@@ -154,6 +151,7 @@ private extension ChildItemList {
                         )
                     )
                 ], hasMoreItems: false)])
+    itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
     let posModel = PointOfSaleAggregateModel(
         itemsController: itemsController,
         purchasableItemsSearchController: PointOfSalePreviewItemsController(),
@@ -180,6 +178,7 @@ private extension ChildItemList {
         itemStates: [
             parentItem: .error(.errorOnLoadingVariations)
         ])
+    itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
     let posModel = PointOfSaleAggregateModel(
         itemsController: itemsController,
         purchasableItemsSearchController: PointOfSalePreviewItemsController(),

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -70,7 +70,7 @@ struct ItemList<HeaderView: View>: View {
                 // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
                 // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
                 NavigationLink(
-                    destination: ChildItemList(parentItem: activeItem, title: parentProduct.name, itemsController: posModel.itemsController),
+                    destination: ChildItemList(parentItem: activeItem, title: parentProduct.name, itemsController: posModel.purchasableItemsController),
                     isActive: Binding(
                         get: { activeNavigationItem != nil },
                         set: { if !$0 { activeNavigationItem = nil } }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -15,9 +15,9 @@ struct ItemList<HeaderView: View>: View {
 
     var state: ItemListState? {
         switch node {
-        case .root(let itemType):
+        case .root:
             itemsController.itemsViewState.itemsStack.root
-        case .parent(let posItem, let itemType):
+        case .parent(let posItem):
             itemsController.itemsViewState.itemsStack.itemStates[posItem]
         }
     }
@@ -206,7 +206,7 @@ private extension ItemListRow {
     )
     ItemList(
         itemsController: PointOfSalePreviewItemsController(),
-        node: .root(.products())
+        node: .root
     )
 }
 
@@ -220,7 +220,7 @@ private extension ItemListRow {
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
     ItemList(itemsController: PointOfSalePreviewItemsController(),
-             node: .root(.products()))
+             node: .root)
         .environment(posModel)
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -13,17 +13,27 @@ struct ItemList<HeaderView: View>: View {
     // Navigation only uses this on iOS 17
     @State private var activeNavigationItem: POSItem? = nil
 
-    let state: ItemListState
-    let itemsStack: ItemsStackState
+    var state: ItemListState? {
+        switch node {
+        case .root(let itemType):
+            itemsController.itemsViewState.itemsStack.root
+        case .parent(let posItem, let itemType):
+            itemsController.itemsViewState.itemsStack.itemStates[posItem]
+        }
+    }
+
+    var itemsStack: ItemsStackState {
+        itemsController.itemsViewState.itemsStack
+    }
+
+    private let itemsController: PointOfSaleItemsControllerProtocol
     private let node: ItemListBaseItem
     private let headerView: HeaderView
 
-    init(state: ItemListState,
-         itemsStack: ItemsStackState,
+    init(itemsController: PointOfSaleItemsControllerProtocol,
          node: ItemListBaseItem,
          @ViewBuilder headerView: () -> HeaderView = { EmptyView() }) {
-        self.state = state
-        self.itemsStack = itemsStack
+        self.itemsController = itemsController
         self.node = node
         self.headerView = headerView()
     }
@@ -36,14 +46,16 @@ struct ItemList<HeaderView: View>: View {
                     guard case .loaded(_, let hasMoreItems) = state,
                           hasMoreItems
                     else { return }
-                    await posModel.loadNextItems(base: node)
+                    await itemsController.loadNextItems(base: node)
                 },
                 content: {
                     LazyVStack(spacing: Constants.itemSpacing) {
                         headerView
 
-                        ForEach(state.items) { item in
-                            ItemListRow(item: item, itemsStack: itemsStack, activeNavigationItem: $activeNavigationItem)
+                        if let state {
+                            ForEach(state.items) { item in
+                                ItemListRow(item: item, itemsStack: itemsStack, activeNavigationItem: $activeNavigationItem)
+                            }
                         }
 
                         footerRows
@@ -59,10 +71,10 @@ struct ItemList<HeaderView: View>: View {
                 EmptyView()
             } else if let activeItem = activeNavigationItem,
                case let .variableParentProduct(parentProduct) = activeItem {
-                // This always uses the non-search itemsStack, otherwise it will have the search term and not work properly
+                // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
                 // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
                 NavigationLink(
-                    destination: ChildItemList(parentItem: activeItem, title: parentProduct.name, itemsStack: posModel.itemsViewState.itemsStack),
+                    destination: ChildItemList(parentItem: activeItem, title: parentProduct.name, itemsController: posModel.itemsController),
                     isActive: Binding(
                         get: { activeNavigationItem != nil },
                         set: { if !$0 { activeNavigationItem = nil } }
@@ -88,10 +100,10 @@ struct ItemList<HeaderView: View>: View {
             ItemListErrorCardView(errorState: errorState,
                                   buttonAction: {
                 Task { @MainActor in
-                    await posModel.loadNextItems(base: node)
+                    await itemsController.loadNextItems(base: node)
                 }
             })
-        case .loaded, .error, .empty:
+        case .loaded, .error, .empty, .none:
             EmptyView()
         }
     }
@@ -198,8 +210,7 @@ private extension ItemListRow {
         hasMoreItems: false
     )
     ItemList(
-        state: itemList,
-        itemsStack: .init(root: itemList, itemStates: [:]),
+        itemsController: PointOfSalePreviewItemsController(),
         node: .root(.products())
     )
 }
@@ -213,8 +224,7 @@ private extension ItemListRow {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    ItemList(state: .loading([]),
-             itemsStack: .init(root: .loading([]), itemStates: [:]),
+    ItemList(itemsController: PointOfSalePreviewItemsController(),
              node: .root(.products()))
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -22,10 +22,6 @@ struct ItemList<HeaderView: View>: View {
         }
     }
 
-    var itemsStack: ItemsStackState {
-        itemsController.itemsViewState.itemsStack
-    }
-
     private let itemsController: PointOfSaleItemsControllerProtocol
     private let node: ItemListBaseItem
     private let headerView: HeaderView
@@ -54,7 +50,7 @@ struct ItemList<HeaderView: View>: View {
 
                         if let state {
                             ForEach(state.items) { item in
-                                ItemListRow(item: item, itemsStack: itemsStack, activeNavigationItem: $activeNavigationItem)
+                                ItemListRow(item: item, activeNavigationItem: $activeNavigationItem)
                             }
                         }
 
@@ -117,7 +113,6 @@ private enum Constants {
 @available(iOS 17.0, *)
 private struct ItemListRow: View {
     let item: POSItem
-    let itemsStack: ItemsStackState
     @Binding var activeNavigationItem: POSItem?
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     let analytics: Analytics = ServiceLocator.analytics

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -14,10 +14,10 @@ struct ItemListView: View {
 
     @Binding var selectedItemType: ItemType
 
-    var itemListController: PointOfSaleItemsControllerProtocol {
+    var itemsController: PointOfSaleItemsControllerProtocol {
         switch selectedItemType {
         case .products(search: false):
-            posModel.itemsController
+            posModel.purchasableItemsController
         case .products(search: true):
             posModel.purchasableItemsSearchController
         case .coupons:
@@ -26,7 +26,7 @@ struct ItemListView: View {
     }
 
     private var itemListState: ItemListState {
-        itemListController.itemsViewState.itemsStack.root
+        itemsController.itemsViewState.itemsStack.root
     }
 
     @AppStorage(BannerState.isSimpleProductsOnlyBannerDismissedKey)
@@ -184,14 +184,14 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        ItemList(itemsController: itemListController, node: .root) {
+        ItemList(itemsController: itemsController, node: .root) {
             if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView
             }
         }
         .refreshable {
             ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
-            await itemListController.refreshItems(base: .root)
+            await itemsController.refreshItems(base: .root)
         }
     }
 
@@ -202,7 +202,7 @@ private extension ItemListView {
         case let .variableParentProduct(parentProduct):
             // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
             // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
-            ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: posModel.itemsController)
+            ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: posModel.purchasableItemsController)
         default:
             EmptyView()
         }
@@ -238,7 +238,7 @@ private extension ItemListView {
         default:
             PointOfSaleItemListErrorView(error: errorState, onAction: {
                 Task {
-                    await itemListController.loadItems(base: .root)
+                    await itemsController.loadItems(base: .root)
                 }
             })
         }
@@ -254,7 +254,7 @@ private extension ItemListView {
     func displayItemType(_ itemType: ItemType) {
         selectedItemType = itemType
         Task { @MainActor in
-            await itemListController.loadItems(base: .root)
+            await itemsController.loadItems(base: .root)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -14,7 +14,16 @@ struct ItemListView: View {
 
     @Binding var selectedItemType: ItemType
 
-    var itemListController: PointOfSaleItemsControllerProtocol
+    var itemListController: PointOfSaleItemsControllerProtocol {
+        switch selectedItemType {
+        case .products(search: false):
+            posModel.itemsController
+        case .products(search: true):
+            posModel.purchasableItemsSearchController
+        case .coupons:
+            posModel.couponsController
+        }
+    }
 
     private var itemListState: ItemListState {
         itemsStack.root
@@ -335,7 +344,7 @@ private extension ItemListView {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ItemListView(selectedItemType: .constant(.products(search: false)), itemListController: itemsController)
+    return ItemListView(selectedItemType: .constant(.products(search: false)))
         .environment(posModel)
 }
 
@@ -348,7 +357,7 @@ private extension ItemListView {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ItemListView(selectedItemType: .constant(.products(search: false)), itemListController: PointOfSalePreviewItemsController())
+    return ItemListView(selectedItemType: .constant(.products(search: false)))
         .environment(posModel)
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -26,11 +26,7 @@ struct ItemListView: View {
     }
 
     private var itemListState: ItemListState {
-        itemsStack.root
-    }
-
-    private var itemsStack: ItemsStackState {
-        itemListController.itemsViewState.itemsStack
+        itemListController.itemsViewState.itemsStack.root
     }
 
     @AppStorage(BannerState.isSimpleProductsOnlyBannerDismissedKey)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -14,21 +14,14 @@ struct ItemListView: View {
 
     @Binding var selectedItemType: ItemType
 
+    var itemListController: PointOfSaleItemsControllerProtocol
+
     private var itemListState: ItemListState {
         itemsStack.root
     }
 
     private var itemsStack: ItemsStackState {
-        switch selectedItemType {
-        case .products(let searching):
-            if searching {
-                return posModel.purchasableItemsSearchViewState.itemsStack
-            } else {
-                return posModel.itemsViewState.itemsStack
-            }
-        case .coupons:
-            return posModel.couponsViewState.itemsStack
-        }
+        itemListController.itemsViewState.itemsStack
     }
 
     @AppStorage(BannerState.isSimpleProductsOnlyBannerDismissedKey)
@@ -82,7 +75,7 @@ struct ItemListView: View {
         .posCouponCreationSheet(isPresented: $showCouponCreationModal, onSuccess: { couponItem in
             Task { @MainActor in
                 posModel.addToCart(couponItem)
-                await posModel.refreshItems(base: .root(.coupons))
+                await posModel.couponsController.refreshItems(base: .root(.coupons))
             }
         })
     }
@@ -105,7 +98,7 @@ private extension ItemListView {
                         .onChange(of: searchTerm) { oldValue, newValue in
                             Task {
                                 selectedItemType = .products(search: newValue.isNotEmpty)
-                                await posModel.searchItems(searchTerm: newValue, base: .root(.products(search: true)))
+                                await posModel.purchasableItemsSearchController.searchItems(searchTerm: newValue, baseItem: .root(.products(search: true)))
                             }
                         }
                     }
@@ -186,14 +179,14 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        ItemList(state: itemListState, itemsStack: itemsStack, node: .root(selectedItemType)) {
+        ItemList(itemsController: itemListController, node: .root(selectedItemType)) {
             if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView
             }
         }
         .refreshable {
             ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
-            await posModel.refreshItems(base: .root(selectedItemType))
+            await itemListController.refreshItems(base: .root(selectedItemType))
         }
     }
 
@@ -202,9 +195,9 @@ private extension ItemListView {
         // Note that navigation is handled by the ItemList in iOS 17, so any changes to this should be reflected in ItemListRow.
         switch parentItem {
         case let .variableParentProduct(parentProduct):
-            // This always uses the non-search itemsStack, otherwise it will have the search term and not work properly
+            // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
             // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
-            ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsStack: posModel.itemsViewState.itemsStack)
+            ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: posModel.itemsController)
         default:
             EmptyView()
         }
@@ -234,7 +227,7 @@ private extension ItemListView {
         default:
             PointOfSaleItemListErrorView(error: errorState, onAction: {
                 Task {
-                    await posModel.loadItems(base: .root(selectedItemType))
+                    await itemListController.loadItems(base: .root(selectedItemType))
                 }
             })
         }
@@ -250,7 +243,7 @@ private extension ItemListView {
     func displayItemType(_ itemType: ItemType) {
         selectedItemType = itemType
         Task { @MainActor in
-            await posModel.loadItems(base: .root(itemType))
+            await itemListController.loadItems(base: .root(itemType))
         }
     }
 }
@@ -342,7 +335,7 @@ private extension ItemListView {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ItemListView(selectedItemType: .constant(.products(search: false)))
+    return ItemListView(selectedItemType: .constant(.products(search: false)), itemListController: itemsController)
         .environment(posModel)
 }
 
@@ -355,7 +348,7 @@ private extension ItemListView {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ItemListView(selectedItemType: .constant(.products(search: false)))
+    return ItemListView(selectedItemType: .constant(.products(search: false)), itemListController: PointOfSalePreviewItemsController())
         .environment(posModel)
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -80,7 +80,7 @@ struct ItemListView: View {
         .posCouponCreationSheet(isPresented: $showCouponCreationModal, onSuccess: { couponItem in
             Task { @MainActor in
                 posModel.addToCart(couponItem)
-                await posModel.couponsController.refreshItems(base: .root(.coupons))
+                await posModel.couponsController.refreshItems(base: .root)
             }
         })
     }
@@ -103,7 +103,7 @@ private extension ItemListView {
                         .onChange(of: searchTerm) { oldValue, newValue in
                             Task {
                                 selectedItemType = .products(search: newValue.isNotEmpty)
-                                await posModel.purchasableItemsSearchController.searchItems(searchTerm: newValue, baseItem: .root(.products(search: true)))
+                                await posModel.purchasableItemsSearchController.searchItems(searchTerm: newValue, baseItem: .root)
                             }
                         }
                     }
@@ -184,14 +184,14 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        ItemList(itemsController: itemListController, node: .root(selectedItemType)) {
+        ItemList(itemsController: itemListController, node: .root) {
             if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView
             }
         }
         .refreshable {
             ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
-            await itemListController.refreshItems(base: .root(selectedItemType))
+            await itemListController.refreshItems(base: .root)
         }
     }
 
@@ -212,9 +212,15 @@ private extension ItemListView {
     var emptyView: some View {
         switch selectedItemType {
         case .products:
-            PointOfSaleItemListEmptyView(base: .root(selectedItemType))
+            PointOfSaleItemListEmptyView(
+                viewModel: PointOfSaleItemListEmptyViewModel(
+                    itemType: .products(search: false),
+                    baseItem: .root))
         case .coupons:
-            PointOfSaleItemListEmptyView(base: .root(selectedItemType)) {
+            PointOfSaleItemListEmptyView(
+                viewModel: PointOfSaleItemListEmptyViewModel(
+                    itemType: .coupons,
+                    baseItem: .root)) {
                 showCouponCreationModal = true
             }
         }
@@ -232,7 +238,7 @@ private extension ItemListView {
         default:
             PointOfSaleItemListErrorView(error: errorState, onAction: {
                 Task {
-                    await itemListController.loadItems(base: .root(selectedItemType))
+                    await itemListController.loadItems(base: .root)
                 }
             })
         }
@@ -248,7 +254,7 @@ private extension ItemListView {
     func displayItemType(_ itemType: ItemType) {
         selectedItemType = itemType
         Task { @MainActor in
-            await itemListController.loadItems(base: .root(itemType))
+            await itemListController.loadItems(base: .root)
         }
     }
 }
@@ -331,7 +337,7 @@ private extension ItemListView {
 #Preview("Loaded with all product types") {
     let itemsController = PointOfSalePreviewItemsController()
     Task { @MainActor in
-        await itemsController.loadItems(base: .root(.products()))
+        await itemsController.loadItems(base: .root)
     }
     let posModel = PointOfSaleAggregateModel(
         itemsController: itemsController,

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -17,12 +17,12 @@ struct PointOfSaleDashboardView: View {
         switch selectedItemType {
         case .products(let searching):
             if searching {
-                return posModel.purchasableItemsSearchViewState
+                return posModel.purchasableItemsSearchController.itemsViewState
             } else {
-                return posModel.itemsViewState
+                return posModel.itemsController.itemsViewState
             }
         case .coupons:
-            return posModel.couponsViewState
+            return posModel.couponsController.itemsViewState
         }
     }
 
@@ -38,7 +38,7 @@ struct PointOfSaleDashboardView: View {
                 case .error(let error):
                     PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
                         Task {
-                            await posModel.loadItems(base: .root(.products()))
+                            await posModel.itemsController.loadItems(base: .root(selectedItemType))
                         }
                     })
                 case .content:
@@ -94,7 +94,7 @@ struct PointOfSaleDashboardView: View {
             documentationView
         }
         .task {
-            await posModel.loadItems(base: .root(.products()))
+            await posModel.itemsController.loadItems(base: .root(.products()))
         }
         .ignoresSafeArea(.keyboard)
     }
@@ -103,9 +103,20 @@ struct PointOfSaleDashboardView: View {
         GeometryReader { geometry in
             HStack {
                 if posModel.orderStage == .building {
-                    ItemListView(selectedItemType: $selectedItemType)
-                        .accessibilitySortPriority(2)
-                        .transition(.move(edge: .leading))
+                    switch selectedItemType {
+                    case .products(search: true):
+                        ItemListView(selectedItemType: $selectedItemType, itemListController: posModel.purchasableItemsSearchController)
+                            .accessibilitySortPriority(2)
+                            .transition(.move(edge: .leading))
+                    case .products(search: false):
+                        ItemListView(selectedItemType: $selectedItemType, itemListController: posModel.itemsController)
+                            .accessibilitySortPriority(2)
+                            .transition(.move(edge: .leading))
+                    case .coupons:
+                        ItemListView(selectedItemType: $selectedItemType, itemListController: posModel.couponsController)
+                            .accessibilitySortPriority(2)
+                            .transition(.move(edge: .leading))
+                    }
                 }
 
                 if !posModel.paymentState.shownFullScreen {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -103,20 +103,9 @@ struct PointOfSaleDashboardView: View {
         GeometryReader { geometry in
             HStack {
                 if posModel.orderStage == .building {
-                    switch selectedItemType {
-                    case .products(search: true):
-                        ItemListView(selectedItemType: $selectedItemType, itemListController: posModel.purchasableItemsSearchController)
-                            .accessibilitySortPriority(2)
-                            .transition(.move(edge: .leading))
-                    case .products(search: false):
-                        ItemListView(selectedItemType: $selectedItemType, itemListController: posModel.itemsController)
-                            .accessibilitySortPriority(2)
-                            .transition(.move(edge: .leading))
-                    case .coupons:
-                        ItemListView(selectedItemType: $selectedItemType, itemListController: posModel.couponsController)
-                            .accessibilitySortPriority(2)
-                            .transition(.move(edge: .leading))
-                    }
+                    ItemListView(selectedItemType: $selectedItemType)
+                        .accessibilitySortPriority(2)
+                        .transition(.move(edge: .leading))
                 }
 
                 if !posModel.paymentState.shownFullScreen {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -19,7 +19,7 @@ struct PointOfSaleDashboardView: View {
             if searching {
                 return posModel.purchasableItemsSearchController.itemsViewState
             } else {
-                return posModel.itemsController.itemsViewState
+                return posModel.purchasableItemsController.itemsViewState
             }
         case .coupons:
             return posModel.couponsController.itemsViewState
@@ -40,7 +40,7 @@ struct PointOfSaleDashboardView: View {
                         Task {
                             switch selectedItemType {
                             case .products(search: false):
-                                await posModel.itemsController.loadItems(base: .root)
+                                await posModel.purchasableItemsController.loadItems(base: .root)
                             case .products(search: true):
                                 await posModel.purchasableItemsSearchController.loadItems(base: .root)
                             case .coupons:
@@ -101,7 +101,7 @@ struct PointOfSaleDashboardView: View {
             documentationView
         }
         .task {
-            await posModel.itemsController.loadItems(base: .root)
+            await posModel.purchasableItemsController.loadItems(base: .root)
         }
         .ignoresSafeArea(.keyboard)
     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -38,7 +38,14 @@ struct PointOfSaleDashboardView: View {
                 case .error(let error):
                     PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
                         Task {
-                            await posModel.itemsController.loadItems(base: .root(selectedItemType))
+                            switch selectedItemType {
+                            case .products(search: false):
+                                await posModel.itemsController.loadItems(base: .root)
+                            case .products(search: true):
+                                await posModel.purchasableItemsSearchController.loadItems(base: .root)
+                            case .coupons:
+                                await posModel.purchasableItemsSearchController.loadItems(base: .root)
+                            }
                         }
                     })
                 case .content:
@@ -94,7 +101,7 @@ struct PointOfSaleDashboardView: View {
             documentationView
         }
         .task {
-            await posModel.itemsController.loadItems(base: .root(.products()))
+            await posModel.itemsController.loadItems(base: .root)
         }
         .ignoresSafeArea(.keyboard)
     }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -99,7 +99,7 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
         case .root:
             itemsViewState = ItemsViewState(containerState: .content, itemsStack: ItemsStackState(root: .loaded(mockItems, hasMoreItems: true),
                                                                                                   itemStates: [:]))
-        case .parent(let parent, _):
+        case .parent(let parent):
             await loadInitialChildItems(for: parent)
         }
     }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -52,7 +52,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
-        await sut.loadItems(base: .root(.coupons))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)
@@ -69,7 +69,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
-        await sut.loadItems(base: .root(.coupons))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)
@@ -86,7 +86,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
-        await sut.refreshItems(base: .root(.coupons))
+        await sut.refreshItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)
@@ -103,7 +103,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
-        await sut.refreshItems(base: .root(.coupons))
+        await sut.refreshItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)
@@ -120,7 +120,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
-        await sut.loadNextItems(base: .root(.coupons))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)
@@ -137,7 +137,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
-        await sut.loadNextItems(base: .root(.coupons))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)
@@ -154,7 +154,7 @@ struct PointOfSaleCouponsControllerTests {
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
 
         // When
-        await sut.loadItems(base: .root(.coupons))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == expectedViewState)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -20,13 +20,13 @@ final class PointOfSaleItemsControllerTests {
 
         try #require(sut.itemsViewState.containerState == .loading)
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
@@ -46,7 +46,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == ItemsViewState(containerState: .content,
@@ -68,7 +68,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.shouldSimulateTwoPages = true
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == ItemsViewState(containerState: .content,
@@ -90,9 +90,9 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.itemPages = [expectedItems]
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
-        await sut.loadItems(base: .root(.products(search: false)))
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: .root)
 
         // Then
         guard case .loaded(let items, _) = sut.itemsViewState.itemsStack.root else {
@@ -129,7 +129,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState.containerState == .content)
@@ -151,7 +151,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == ItemsViewState(containerState: .content,
@@ -169,10 +169,10 @@ final class PointOfSaleItemsControllerTests {
         )
 
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         guard case .loaded(let items, _) = sut.itemsViewState.itemsStack.root else {
@@ -193,10 +193,10 @@ final class PointOfSaleItemsControllerTests {
 
         try #require(sut.itemsViewState.containerState == .loading)
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
@@ -213,10 +213,10 @@ final class PointOfSaleItemsControllerTests {
 
         itemProvider.shouldSimulateTwoPages = true
         itemProvider.shouldSimulateMorePages = true
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.root else {
@@ -240,11 +240,11 @@ final class PointOfSaleItemsControllerTests {
                                                                                 name: "Fake Parent",
                                                                                 productImageSource: nil,
                                                                                 productID: 12345))
-        let baseItem = ItemListBaseItem.parent(parentItem, .products(search: false))
+        let baseItem = ItemListBaseItem.parent(parentItem)
         itemProvider.shouldSimulateTwoPagesOfVariations = true
         itemProvider.shouldSimulateMorePagesOfVariations = true
 
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
         await sut.loadItems(base: baseItem)
 
         // When
@@ -272,10 +272,10 @@ final class PointOfSaleItemsControllerTests {
                                                                                 name: "Fake Parent",
                                                                                 productImageSource: nil,
                                                                                 productID: 12345))
-        let baseItem = ItemListBaseItem.parent(parentItem, .products(search: false))
+        let baseItem = ItemListBaseItem.parent(parentItem)
         itemProvider.shouldSimulateTwoPagesOfVariations = true
 
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
         await sut.loadItems(base: baseItem)
 
         itemProvider.errorToThrow = MockError.requestFailed
@@ -306,7 +306,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState.containerState == .content)
@@ -330,7 +330,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState.containerState == .error(expectedError))
@@ -348,12 +348,12 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.containerState == .loading)
 
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         itemProvider.errorToThrow = MockError.requestFailed
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState.containerState == .content)
@@ -379,7 +379,7 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.containerState == .loading)
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.root else {
@@ -400,7 +400,7 @@ final class PointOfSaleItemsControllerTests {
         )
 
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         guard case .loaded = sut.itemsViewState.itemsStack.root else {
             Issue.record("Expected loaded ItemList state, but got \(sut.itemsViewState.itemsStack.root)")
@@ -410,7 +410,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState.containerState == .content)
@@ -433,15 +433,15 @@ final class PointOfSaleItemsControllerTests {
         )
 
         itemProvider.shouldSimulateTwoPages = true
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         itemProvider.errorToThrow = MockError.requestFailed
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 2)
         itemProvider.spyLastRequestedPageNumber = 0
 
         // When
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
@@ -461,7 +461,7 @@ final class PointOfSaleItemsControllerTests {
         itemProvider.itemPages = [expectedItems]
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == ItemsViewState(containerState: .content,
@@ -480,12 +480,12 @@ final class PointOfSaleItemsControllerTests {
 
         let expectedItems = MockPointOfSaleItemService.makeInitialItems()
         itemProvider.itemPages = [expectedItems]
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
         // When
         itemProvider.shouldReturnZeroItems = true
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         #expect(sut.itemsViewState == ItemsViewState(containerState: .content,
@@ -503,12 +503,12 @@ final class PointOfSaleItemsControllerTests {
             itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory(siteID: 1, credentials: nil)
         )
 
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
 
         // When
         itemProvider.shouldReturnZeroItems = true
-        await sut.loadNextItems(base: .root(.products(search: false)))
+        await sut.loadNextItems(base: .root)
 
         // Then
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
@@ -525,7 +525,7 @@ final class PointOfSaleItemsControllerTests {
 
         let initialItems = MockPointOfSaleItemService.makeInitialItems()
         itemProvider.itemPages = [initialItems]
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
         try #require(sut.itemsViewState.itemsStack.root.items == initialItems)
 
         await confirmation() { confirmation in
@@ -541,7 +541,7 @@ final class PointOfSaleItemsControllerTests {
             }
 
             // When
-            await sut.loadItems(base: .root(.products(search: false)))
+            await sut.loadItems(base: .root)
         }
     }
 
@@ -569,7 +569,7 @@ final class PointOfSaleItemsControllerTests {
             }
 
             // When
-            await sut.loadItems(base: .root(.products(search: false)))
+            await sut.loadItems(base: .root)
         }
     }
 
@@ -587,13 +587,13 @@ final class PointOfSaleItemsControllerTests {
                                                                               productImageSource: nil,
                                                                               productID: 125))
         itemProvider.itemPages = [[parentItem]]
-        await sut.loadItems(base: .root(.products(search: false)))
-        await sut.loadItems(base: .parent(parentItem, .products(search: false)))
+        await sut.loadItems(base: .root)
+        await sut.loadItems(base: .parent(parentItem))
         let itemStates = sut.itemsViewState.itemsStack.itemStates
         try #require(itemStates != [:])
 
         // When
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
 
         // Then
         try #require(sut.itemsViewState.itemsStack.itemStates == itemStates)
@@ -612,11 +612,11 @@ final class PointOfSaleItemsControllerTests {
                                                                               name: "Parent product",
                                                                               productImageSource: nil,
                                                                               productID: 125))
-        let baseItem = ItemListBaseItem.parent(parentItem, .products(search: false))
+        let baseItem = ItemListBaseItem.parent(parentItem)
         itemProvider.itemPages = [[parentItem]]
 
         // Loads initial items.
-        await sut.loadItems(base: .root(.products(search: false)))
+        await sut.loadItems(base: .root)
         await sut.loadItems(base: baseItem)
 
         let initialChildItems = sut.itemsViewState.itemsStack.itemStates[parentItem]?.items ?? []
@@ -651,7 +651,7 @@ final class PointOfSaleItemsControllerTests {
                                                                               name: "Parent product",
                                                                               productImageSource: nil,
                                                                               productID: 125))
-        let baseItem = ItemListBaseItem.parent(parentItem, .products(search: false))
+        let baseItem = ItemListBaseItem.parent(parentItem)
 
         itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
         try #require(sut.itemsViewState.containerState == .loading)
@@ -681,7 +681,7 @@ final class PointOfSaleItemsControllerTests {
                                                                               name: "Parent product",
                                                                               productImageSource: nil,
                                                                               productID: 125))
-        let baseItem = ItemListBaseItem.parent(parentItem, .products(search: false))
+        let baseItem = ItemListBaseItem.parent(parentItem)
 
         itemProvider.shouldSimulateTwoPagesOfVariations = true
         await sut.loadItems(base: baseItem)
@@ -712,7 +712,7 @@ final class PointOfSaleItemsControllerTests {
         )
 
         // When
-        await sut.searchItems(searchTerm: "green mug", baseItem: .root(.products(search: true)))
+        await sut.searchItems(searchTerm: "green mug", baseItem: .root)
 
         // Then
         let fetchStrategy = try #require(itemProvider.spyItemsFetchStrategy as? PointOfSaleSearchPurchasableItemFetchStrategy)

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -27,31 +27,25 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
 
     var orderState: WooCommerce.PointOfSaleOrderState
 
-    var itemsViewState: WooCommerce.ItemsViewState
+    var purchasableItemsController: any WooCommerce.PointOfSaleItemsControllerProtocol
 
-    var purchasableItemsSearchViewState: WooCommerce.ItemsViewState
+    var purchasableItemsSearchController: any WooCommerce.PointOfSaleSearchingItemsControllerProtocol
 
-    var couponsViewState: WooCommerce.ItemsViewState
+    var couponsController: any WooCommerce.PointOfSaleCouponsControllerProtocol
 
     var blockReturnToItemSelection: Bool = false
 
     init(cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected,
-         itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                         itemsStack: ItemsStackState(root: .loading([]),
-                                                                                     itemStates: [:])),
-         purchasableItemsSearchViewState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                                          itemsStack: ItemsStackState(root: .loading([]),
-                                                                                                      itemStates: [:])),
-         couponsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                           itemsStack: ItemsStackState(root: .loading([]),
-                                                                                       itemStates: [:])),
+         purchasableItemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),
+         purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol = MockPointOfSalePurchasableItemsSearchController(),
+         couponsController: PointOfSaleCouponsControllerProtocol = MockPointOfSaleCouponsController(),
          orderStage: PointOfSaleOrderStage = .building,
          orderState: PointOfSaleOrderState = .idle,
          paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.cardReaderConnectionStatus = cardReaderConnectionStatus
-        self.itemsViewState = itemsViewState
-        self.purchasableItemsSearchViewState = purchasableItemsSearchViewState
-        self.couponsViewState = couponsViewState
+        self.purchasableItemsController = purchasableItemsController
+        self.purchasableItemsSearchController = purchasableItemsSearchController
+        self.couponsController = couponsController
         self.orderStage = orderStage
         self.orderState = orderState
         self.paymentState = paymentState


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR exposes the items controllers, and then switches between them in the `ItemListView`.

`ItemList` and `ChildItemList` (mostly) don't know what controller they're using, they have it passed in by the `ItemListView` as we swap between them.

Initially, in 452247f I did the switching in the dashboard view and then had one `ItemListView` per controller... but I actually think this is better. When we have searching for multiple item types, we might want to change the responsibilities of the `ItemListView` or add another intermediate view, to simplify knowing which controller we're searching... but equally, it might work fairly neatly.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the coupons and search feature flags
1. Launch the app and navigate to POS
2. Use the items list, search, and coupons to build and edit a cart
3. Add a coupon to the store
4. Refresh, and simulate errors/recovery
5. Observe that the lists work as expected

N.B. the search list is far from perfect, but it's all behind a feature flag. I'll improve it further in future PRs

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air running iOS 17.7.3, and a simulator running 18.3

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.