### PR TITLE
[Woo POS][Products search] Make remote products search more predictable

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -41,18 +41,21 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
 
 @available(iOS 17.0, *)
 @Observable final class PointOfSaleItemsController: PointOfSaleSearchingItemsControllerProtocol {
-    var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                        itemsStack: ItemsStackState(root: .loading([]),
-                                                                                    itemStates: [:]))
+    var itemsViewState: ItemsViewState
     private let paginationTracker: AsyncPaginationTracker
     private var childPaginationTrackers: [POSItem: AsyncPaginationTracker] = [:]
     private var itemProvider: PointOfSaleItemServiceProtocol
     private let itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory
     private var fetchStrategy: PointOfSalePurchasableItemFetchStrategy
 
-    init(itemProvider: PointOfSaleItemServiceProtocol, itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory) {
+    init(itemProvider: PointOfSaleItemServiceProtocol,
+         itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory,
+         initialState: ItemsViewState = ItemsViewState(containerState: .loading,
+                                                       itemsStack: ItemsStackState(root: .loading([]),
+                                                                                   itemStates: [:]))) {
         self.itemProvider = itemProvider
         self.itemFetchStrategyFactory = itemFetchStrategyFactory
+        self.itemsViewState = initialState
         self.paginationTracker = .init()
         self.fetchStrategy = itemFetchStrategyFactory.defaultStrategy
     }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -74,7 +74,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
     @MainActor
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async {
         fetchStrategy = itemFetchStrategyFactory.searchStrategy(searchTerm: searchTerm)
-        setLoadingState(base: baseItem)
+        setSearchingState(base: baseItem)
         await loadFirstPage(base: baseItem)
     }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -268,8 +268,6 @@ private extension PointOfSaleItemsController {
             }
             return pagedItems.hasMorePages
         } catch PointOfSaleItemServiceError.requestCancelled {
-            itemsViewState.containerState = .content
-            itemsViewState.itemsStack.root = .loaded(itemsViewState.itemsStack.root.items, hasMoreItems: true)
             // Assume that we have more pages since we'd made a request, and it was cancelled
             return true
         }
@@ -300,9 +298,6 @@ private extension PointOfSaleItemsController {
             updateState(for: parentItem, to: .loaded(allItems, hasMoreItems: pagedItems.hasMorePages))
             return pagedItems.hasMorePages
         } catch PointOfSaleItemServiceError.requestCancelled {
-            itemsViewState.containerState = .content
-            updateState(for: parentItem, to: .loaded(itemsViewState.itemsStack.itemStates[parentItem]?.items ?? [],
-                                                     hasMoreItems: true))
             // Assume that we have more pages since we'd made a request, and it was cancelled
             return true
         }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -14,6 +14,8 @@ struct ItemListView: View {
 
     @Binding var selectedItemType: ItemType
 
+    @State private var searchTask: Task<Void, Never>?
+
     var itemsController: PointOfSaleItemsControllerProtocol {
         switch selectedItemType {
         case .products(search: false):
@@ -101,9 +103,19 @@ private extension ItemListView {
                             Text("Search")
                         }
                         .onChange(of: searchTerm) { oldValue, newValue in
-                            Task {
-                                selectedItemType = .products(search: newValue.isNotEmpty)
+                            selectedItemType = .products(search: newValue.isNotEmpty)
+                            let shouldDebounceNextSearchRequest = searchTask != nil
+                            searchTask?.cancel()
+
+                            searchTask = Task {
+                                if shouldDebounceNextSearchRequest {
+                                    try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
+                                }
+
+                                guard !Task.isCancelled else { return }
+
                                 await posModel.purchasableItemsSearchController.searchItems(searchTerm: newValue, baseItem: .root)
+                                searchTask = nil
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -15,6 +15,7 @@ struct ItemListView: View {
     @Binding var selectedItemType: ItemType
 
     @State private var searchTask: Task<Void, Never>?
+    @State private var didFinishSearch = true
 
     var itemsController: PointOfSaleItemsControllerProtocol {
         switch selectedItemType {
@@ -104,7 +105,8 @@ private extension ItemListView {
                         }
                         .onChange(of: searchTerm) { oldValue, newValue in
                             selectedItemType = .products(search: newValue.isNotEmpty)
-                            let shouldDebounceNextSearchRequest = searchTask != nil
+
+                            let shouldDebounceNextSearchRequest = !didFinishSearch
                             searchTask?.cancel()
 
                             searchTask = Task {
@@ -114,8 +116,13 @@ private extension ItemListView {
 
                                 guard !Task.isCancelled else { return }
 
+                                didFinishSearch = false
+
                                 await posModel.purchasableItemsSearchController.searchItems(searchTerm: newValue, baseItem: .root)
-                                searchTask = nil
+
+                                if !Task.isCancelled {
+                                    didFinishSearch = true
+                                }
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -106,6 +106,16 @@ private extension ItemListView {
                         .onChange(of: searchTerm) { oldValue, newValue in
                             selectedItemType = .products(search: newValue.isNotEmpty)
 
+                            // The debouncing logic is a little tricky, because the loading state is held in the controller.
+                            // Arguably, we should use view state `isSearching` for this, so the UI is independent of the request timing.
+
+                            // As the user types, we don't want to send every keystroke to the remote, so we debounce the requests.
+                            // However, we don't want to debounce the first keystroke of a new search, so that the loading
+                            // state shows immediately and the UI feels responsive.
+
+                            // So, if the last search was finished, we don't debounce the first character. If it didn't
+                            // finish i.e. it is still ongoing, we debounce the next keystrokes by 300ms. In either case,
+                            // the ongoing search is redundant now there's a new search term, so we cancel it.
                             let shouldDebounceNextSearchRequest = !didFinishSearch
                             searchTask?.cancel()
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -46,7 +46,9 @@ struct HubMenu: View {
                             purchasableItemsSearchController: PointOfSaleItemsController(
                                 itemProvider: PointOfSaleItemService(
                                     currencySettings: ServiceLocator.currencySettings),
-                                itemFetchStrategyFactory: viewModel.posItemFetchStrategyFactory),
+                                itemFetchStrategyFactory: viewModel.posItemFetchStrategyFactory,
+                            initialState: .init(containerState: .content,
+                                                itemsStack: .init(root: .loaded([], hasMoreItems: true), itemStates: [:]))),
                             couponsController: PointOfSaleCouponsController(itemProvider: viewModel.posCouponProvider),
                             onPointOfSaleModeActiveStateChange: { isEnabled in
                                 viewModel.updateDefaultConfigurationForPointOfSale(isEnabled)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -367,63 +367,6 @@ final class PointOfSaleItemsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func loadItems_when_request_is_cancelled_then_state_is_loaded() async throws {
-        // Given
-        let itemProvider = MockPointOfSaleItemService()
-        let sut = PointOfSaleItemsController(
-            itemProvider: itemProvider,
-            itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory(siteID: 1, credentials: nil)
-        )
-
-        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
-        try #require(sut.itemsViewState.containerState == .loading)
-
-        // When
-        await sut.loadItems(base: .root)
-
-        // Then
-        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.root else {
-            Issue.record("Expected loaded ItemList state, but got \(sut.itemsViewState.itemsStack.root)")
-            return
-        }
-        #expect(items.count == 0)
-        #expect(hasMoreItems)
-    }
-
-    @available(iOS 17.0, *)
-    @Test func loadNextItems_when_request_is_cancelled_then_state_is_loaded() async throws {
-        // Given
-        let itemProvider = MockPointOfSaleItemService()
-        let sut = PointOfSaleItemsController(
-            itemProvider: itemProvider,
-            itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory(siteID: 1, credentials: nil)
-        )
-
-        itemProvider.shouldSimulateTwoPages = true
-        await sut.loadItems(base: .root)
-
-        guard case .loaded = sut.itemsViewState.itemsStack.root else {
-            Issue.record("Expected loaded ItemList state, but got \(sut.itemsViewState.itemsStack.root)")
-            return
-        }
-
-        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
-
-        // When
-        await sut.loadNextItems(base: .root)
-
-        // Then
-        #expect(sut.itemsViewState.containerState == .content)
-
-        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.root else {
-            Issue.record("Expected loaded ItemList state, but got \(sut.itemsViewState.itemsStack.root)")
-            return
-        }
-        #expect(items.count == 2)
-        #expect(hasMoreItems)
-    }
-
-    @available(iOS 17.0, *)
     @Test func loadNextItems_after_itemProvider_throws_error_then_the_same_page_is_requested_next() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -636,70 +579,6 @@ final class PointOfSaleItemsControllerTests {
             // When
             await sut.loadItems(base: baseItem)
         }
-    }
-
-    @available(iOS 17.0, *)
-    @Test func loadChildItems_when_request_is_cancelled_then_state_is_loaded() async throws {
-        // Given
-        let itemProvider = MockPointOfSaleItemService()
-        let sut = PointOfSaleItemsController(
-            itemProvider: itemProvider,
-            itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory(siteID: 1, credentials: nil)
-        )
-
-        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
-                                                                              name: "Parent product",
-                                                                              productImageSource: nil,
-                                                                              productID: 125))
-        let baseItem = ItemListBaseItem.parent(parentItem)
-
-        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
-        try #require(sut.itemsViewState.containerState == .loading)
-
-        // When
-        await sut.loadItems(base: baseItem)
-
-        // Then
-        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.itemStates[parentItem] else {
-            Issue.record("Expected loaded ItemList state, but got \(String(describing: sut.itemsViewState.itemsStack.itemStates[parentItem]))")
-            return
-        }
-        #expect(items.count == 0)
-        #expect(hasMoreItems)
-    }
-
-    @available(iOS 17.0, *)
-    @Test func loadNextChildItems_when_request_is_cancelled_then_state_is_loaded() async throws {
-        // Given
-        let itemProvider = MockPointOfSaleItemService()
-        let sut = PointOfSaleItemsController(
-            itemProvider: itemProvider,
-            itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory(siteID: 1, credentials: nil)
-        )
-
-        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
-                                                                              name: "Parent product",
-                                                                              productImageSource: nil,
-                                                                              productID: 125))
-        let baseItem = ItemListBaseItem.parent(parentItem)
-
-        itemProvider.shouldSimulateTwoPagesOfVariations = true
-        await sut.loadItems(base: baseItem)
-
-        itemProvider.errorToThrow = PointOfSaleItemServiceError.requestCancelled
-
-        // When
-        await sut.loadNextItems(base: baseItem)
-
-        // Then
-        #expect(sut.itemsViewState.containerState == .content)
-
-        guard case .loaded(let items, let hasMoreItems) = sut.itemsViewState.itemsStack.itemStates[parentItem] else {
-            Issue.record("Expected loaded ItemList state, but got \(String(describing: sut.itemsViewState.itemsStack.itemStates[parentItem]))")
-            return
-        }
-        #expect(items.count == 2)
-        #expect(hasMoreItems)
     }
 
     @available(iOS 17.0, *)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-149
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR improves the loading state for searches, and debounces each search preventing multiple requests being made for intermediate keystrokes.

As part of this PR, a previously required workaround for pull-to-refresh issues was removed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Enable the product search feature flag
2. Launch the app and navigate to POS
3. Search for products – observe (using a network proxy tool) that searches are only sent after a break in typing (apart from the first letter)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The current behaviour is to start a search immediately when a key is typed, so that we show the loading state. Further keypresses are debounced by 300ms, reducing the number of searches while the user is typing.

We have to keep track of whether a search finished, to ensure that we correctly debounce new searches.

This behaviour might change with the development of the final UI – e.g. it may feel better to keep the empty state on screen while the initial search term is typed out, so not show the loading indicator immediately.

At the moment, we also reuse the same ItemView rather than layering a new one on top. That doesn't have any functionality implications at this stage, but with the new component and empty state it will probably not remain that way much longer.

I've tested this on an iPad Air running iOS 17.7.3

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f17bb3f7-6d01-472a-9931-1b8b953808dc


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are adde