### PR TITLE
[Woo POS] Coupons: V2 Design Updates

### DIFF
--- a/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posError.colorset/Contents.json
+++ b/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posError.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x38",
-          "green" : "0x36",
-          "red" : "0xD6"
+          "blue" : "0x68",
+          "green" : "0x63",
+          "red" : "0xF8"
         }
       },
       "idiom" : "universal"
@@ -35,4 +35,4 @@
     "author" : "xcode",
     "version" : 1
   }
-} 
+}

--- a/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posOnError.colorset/Contents.json
+++ b/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posOnError.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFF"
+          "blue" : "0x17",
+          "green" : "0x15",
+          "red" : "0x10"
         }
       },
       "idiom" : "universal"
@@ -35,4 +35,4 @@
     "author" : "xcode",
     "version" : 1
   }
-} 
+}

--- a/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posOnSuccess.colorset/Contents.json
+++ b/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posOnSuccess.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x17",
-          "green" : "0x15",
-          "red" : "0x10"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"
@@ -35,4 +35,4 @@
     "author" : "xcode",
     "version" : 1
   }
-} 
+}

--- a/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posSuccess.colorset/Contents.json
+++ b/WooCommerce/Classes/POS/Colors/POSColorPalette.xcassets/posSuccess.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x82",
-          "green" : "0xE7",
-          "red" : "0x06"
+          "blue" : "0x2A",
+          "green" : "0xA3",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x82",
-          "green" : "0xE7",
-          "red" : "0x06"
+          "blue" : "0x5A",
+          "green" : "0xD1",
+          "red" : "0x1E"
         }
       },
       "idiom" : "universal"
@@ -35,4 +35,4 @@
     "author" : "xcode",
     "version" : 1
   }
-} 
+}

--- a/WooCommerce/Classes/POS/Presentation/CartRowRemoveButton.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartRowRemoveButton.swift
@@ -7,11 +7,11 @@ struct CartRowRemoveButton: View {
         Button(action: {
             action()
         }, label: {
-            Text(Image(systemName: "xmark.circle"))
-                .font(.posButtonSymbolMedium)
+            Text(Image(systemName: "trash"))
+                .font(.posButtonSymbolSmall)
         })
         .accessibilityLabel(Localization.removeFromCartAccessibilityLabel)
-        .foregroundColor(Color.posOnSurfaceVariantLowest)
+        .foregroundColor(Color.posOnSurfaceVariantHighest)
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -27,9 +27,20 @@ struct CouponRowView: View {
         min(Constants.couponCardSize * scale, Constants.maximumCouponCardSize)
     }
 
+    private var couponImageState: POSCouponImageState {
+        switch couponRowState {
+        case .invalid:
+            .error
+        case .valid:
+            .success
+        default:
+            .normal
+        }
+    }
+
     var body: some View {
         HStack(spacing: Constants.horizontalElementSpacing) {
-            POSCouponImageView(size: dimension)
+            POSCouponImageView(size: dimension, state: couponImageState)
                 .renderedIf(showImage)
 
             VStack(alignment: .leading, spacing: dynamicSpacing) {

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -28,14 +28,14 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
                     Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
 
                     VStack(spacing: POSSpacing.medium) {
-                        Button(retryActionTitle, action: {
-                            posModel.removeAllCouponsFromCart()
-                            retryHandler()
+                        Button(Localization.editOrderTitle, action: {
+                            posModel.addMoreToCart()
                         })
                         .buttonStyle(POSFilledButtonStyle(size: .normal))
 
-                        Button(Localization.editOrderTitle, action: {
-                            posModel.addMoreToCart()
+                        Button(retryActionTitle, action: {
+                            posModel.removeAllCouponsFromCart()
+                            retryHandler()
                         })
                         .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                     }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
@@ -1,19 +1,49 @@
 import SwiftUI
 
+enum POSCouponImageState {
+    case success
+    case error
+    case normal
+}
+
 struct POSCouponImageView: View {
     private let size: CGFloat
+    private let state: POSCouponImageState
 
-    init(size: CGFloat) {
+    init(size: CGFloat, state: POSCouponImageState = .normal) {
         self.size = size
+        self.state = state
+    }
+
+    private var foregroundColor: Color {
+        switch state {
+        case .success:
+            return .posSuccess
+        case .error:
+            return .posError
+        case .normal:
+            return .posSurfaceDim
+        }
+    }
+
+    private var tagColor: Color {
+        switch state {
+        case .success:
+            return .posOnSuccess
+        case .error:
+            return .posOnError
+        case .normal:
+            return .posOnSurfaceVariantLowest
+        }
     }
 
     var body: some View {
         Rectangle()
-            .foregroundColor(.posSurfaceDim)
+            .foregroundColor(foregroundColor)
             .overlay {
                 Image(systemName: "tag")
                     .font(.posButtonSymbolMedium)
-                    .foregroundColor(.posOnSurfaceVariantLowest)
+                    .foregroundColor(tagColor)
             }
             .frame(width: size)
             .frame(minHeight: size)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->\

Design updates
- Color Updates: posSuccess, posOnSuccess, posError, posOnError
- Coupon Cards thumbnail colors
- Error Screen: switch Edit Order and Remove Coupon buttons
- Delete Button: Change to trash icon

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites: Enable `enableCouponsInPointOfSale` feature flag

1. Open POS
2. Add valid coupon
3. And product
4. Confirm removal icon is now a trash icon, check light and dark modes
5. Check out
6. After order loads, confirm coupon thumbnail turns green, check light and dark modes
7. Come back
8. Remove valid coupon, add invalid coupon
9. Check out
10. After order fails to load, confirm coupon thumbnail turns red, check light and dark modes

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11 inch M3 18.4 Simulator. Additionally verified how new posError and posSuccess colors look in other views.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-04-14 at 21 06 28](https://github.com/user-attachments/assets/a0cbbf2b-552c-4316-a51a-af73eea67da9)
![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-04-14 at 21 06 25](https://github.com/user-attachments/assets/446cd99c-435e-4bd3-ae2b-25a2b699e44d)
![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-04-14 at 21 06 12](https://github.com/user-attachments/assets/12ff602d-a45e-4757-bd38-e266b430f439)
![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-04-14 at 21 06 09](https://github.com/user-attachments/assets/2900d270-389a-4aac-9979-2d9d6b4599cd)
![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-04-14 at 21 06 02](https://github.com/user-attachments/assets/1bcbba51-1156-4541-9103-f3d91f2f6eba)
![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-04-14 at 21 05 59](https://github.com/user-attachments/assets/b5eebfb6-096e-4fc7-94c9-d49a3359cdf8)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
