### PR TITLE
[Woo POS] Coupons: Pagination - Wrap Up

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -41,6 +41,12 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleItemsControllerProtoco
             return
         }
 
+        let currentItems = itemsViewState.itemsStack.root.items
+        let currentItemStates = itemsViewState.itemsStack.itemStates
+        itemsViewState.containerState = .content
+        itemsViewState.itemsStack = ItemsStackState(root: .loading(currentItems),
+                                                   itemStates: currentItemStates)
+
         do {
             _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
                 guard let self else { return true }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -27,16 +27,11 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleItemsControllerProtoco
 
     @MainActor
     func loadItems(base: ItemListBaseItem) async {
-        // TODO:
-        // Handle unhappy path:
-        // Depending on the error type (failed to load vs coupons disabled) we want to show a different CTA choice
         await loadFirstPage()
     }
 
     @MainActor
     func refreshItems(base: ItemListBaseItem) async {
-        // TODO:
-        // Handle unhappy path
         await loadFirstPage()
     }
 
@@ -81,7 +76,11 @@ private extension PointOfSaleCouponsController {
             if !storedCoupons.isEmpty {
                 setCouponsLoadedViewState(storedCoupons, hasMoreItems: true)
             }
-            _ = try await fetchCoupons(pageNumber: 1)
+
+            try await paginationTracker.resync { [weak self] pageNumber in
+                guard let self else { return true }
+                return try await fetchCoupons(pageNumber: pageNumber)
+            }
         } catch {
             if let couponError = error as? PointOfSaleCouponServiceError {
                 setCouponsErrorViewState(couponError)

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -55,7 +55,8 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleItemsControllerProtoco
         } catch {
             itemsViewState.containerState = .content
             itemsViewState.itemsStack = ItemsStackState(root: .inlineError(currentItems,
-                                                                           error: .errorOnLoadingCouponsNextPage),
+                                                                           error: .errorOnLoadingCouponsNextPage,
+                                                                           context: .pagination),
                                                         itemStates: currentItemStates)
         }
     }
@@ -134,7 +135,12 @@ private extension PointOfSaleCouponsController {
 
         switch couponError {
         case .couponsLoadingError:
-            stackState = ItemsStackState(root: .error(.errorOnLoadingCoupons), itemStates: [:])
+            let items = itemsViewState.itemsStack.root.items
+            if items.isEmpty {
+                stackState = ItemsStackState(root: .error(.errorOnLoadingCoupons), itemStates: [:])
+            } else {
+                stackState = ItemsStackState(root: .inlineError(items, error: .errorOnRefreshingCoupons, context: .refresh), itemStates: [:])
+            }
         case .couponsDisabled:
             stackState = ItemsStackState(root: .error(.errorCouponsDisabled), itemStates: [:])
         case .couponsEnablingError:

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -53,8 +53,10 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleItemsControllerProtoco
                 return try await fetchCoupons(pageNumber: pageNumber)
             }
         } catch {
-            // TODO: Error handling
-            debugPrint(error)
+            itemsViewState.containerState = .content
+            itemsViewState.itemsStack = ItemsStackState(root: .inlineError(currentItems,
+                                                                           error: .errorOnLoadingCouponsNextPage),
+                                                        itemStates: currentItemStates)
         }
     }
 
@@ -96,24 +98,17 @@ private extension PointOfSaleCouponsController {
 
     @MainActor
     func fetchCoupons(pageNumber: Int) async throws -> Bool {
-        do {
-            let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber)
+        let pagedCoupons = try await couponProvider.providePointOfSaleCoupons(pageNumber: pageNumber)
 
-            let allCoupons = pagedCoupons.items
-            let hasMoreItems = pagedCoupons.hasMorePages
+        let allCoupons = pagedCoupons.items
+        let hasMoreItems = pagedCoupons.hasMorePages
 
-            if allCoupons.isEmpty {
-                setCouponsEmptyViewState()
-            } else {
-                setCouponsLoadedViewState(allCoupons, hasMoreItems: hasMoreItems)
-            }
-            return pagedCoupons.hasMorePages
-        } catch {
-            if let couponError = error as? PointOfSaleCouponServiceError {
-                setCouponsErrorViewState(couponError)
-            }
-            return true
+        if allCoupons.isEmpty {
+            setCouponsEmptyViewState()
+        } else {
+            setCouponsLoadedViewState(allCoupons, hasMoreItems: hasMoreItems)
         }
+        return pagedCoupons.hasMorePages
     }
 }
 

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -124,7 +124,8 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
         } catch {
             itemsViewState.containerState = .content
             itemsViewState.itemsStack = ItemsStackState(root: .inlineError(currentItems,
-                                                                           error: .errorOnLoadingProductsNextPage),
+                                                                           error: .errorOnLoadingProductsNextPage,
+                                                                           context: .pagination),
                                                         itemStates: currentItemStates)
         }
     }
@@ -159,7 +160,8 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
             }
         } catch {
             updateState(for: parent, to: .inlineError(currentItems,
-                                                      error: PointOfSaleErrorState.errorOnLoadingVariationsNextPage))
+                                                      error: PointOfSaleErrorState.errorOnLoadingVariationsNextPage,
+                                                      context: .pagination))
         }
     }
 

--- a/WooCommerce/Classes/POS/Models/ItemListState.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListState.swift
@@ -3,9 +3,14 @@ import enum Yosemite.POSItem
 enum ItemListState {
     case loading(_ currentItems: [POSItem])
     case loaded(_ items: [POSItem], hasMoreItems: Bool)
-    case inlineError(_ items: [POSItem], error: PointOfSaleErrorState)
+    case inlineError(_ items: [POSItem], error: PointOfSaleErrorState, context: InlineErrorContext)
     case error(PointOfSaleErrorState)
     case empty
+
+    enum InlineErrorContext {
+        case refresh
+        case pagination
+    }
 
     var isLoading: Bool {
         switch self {
@@ -58,7 +63,7 @@ extension ItemListState {
         switch self {
         case .loading(let items),
                 .loaded(let items, _),
-                .inlineError(let items, _):
+                .inlineError(let items, _, _):
             return items
         case .error, .empty:
             return []

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -10,6 +10,7 @@ struct PointOfSaleErrorState: Equatable {
         case couponsLoadError
         case couponsDisabled
         case couponsNextPageError
+        case couponsRefreshError
     }
 
     let errorType: ErrorType
@@ -79,6 +80,14 @@ struct PointOfSaleErrorState: Equatable {
             title: Constants.failedToLoadCouponsNextPageTitle,
             subtitle: Constants.failedToLoadCouponsNextPageSubtitle,
             buttonText: Constants.failedToLoadCouponsNextPageButtonTitle)
+    }
+
+    static var errorOnRefreshingCoupons: Self {
+        PointOfSaleErrorState(
+            errorType: .couponsRefreshError,
+            title: Constants.failedToRefreshCouponsTitle,
+            subtitle: Constants.failedToRefreshCouponsSubtitle,
+            buttonText: Constants.failedToRefreshCouponsButtonTitle)
     }
 
     enum Constants {
@@ -211,6 +220,21 @@ struct PointOfSaleErrorState: Equatable {
             value: "Try again",
             comment: "Text for the button appearing on the coupon list screen when there's an error loading a page of coupons " +
             "after the first. Shown inline with the previously loaded coupons above."
+        )
+        static let failedToRefreshCouponsTitle = NSLocalizedString(
+            "pos.itemList.failedToRefreshCouponsTitle",
+            value: "Error refreshing coupons",
+            comment: "Title appearing on the coupon list screen when there's an error refreshing coupons."
+        )
+        static let failedToRefreshCouponsSubtitle = NSLocalizedString(
+            "pos.itemList.failedToRefreshCouponsSubtitle",
+            value: "Give it another go?",
+            comment: "Subtitle appearing on the coupon list screen when there's an error refreshing coupons."
+        )
+        static let failedToRefreshCouponsButtonTitle = NSLocalizedString(
+            "pos.itemList.failedToRefreshCouponsButtonTitle",
+            value: "Retry",
+            comment: "Text for the button appearing on the coupon list screen when there's an error refreshing coupons."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -9,6 +9,7 @@ struct PointOfSaleErrorState: Equatable {
         case couponsNotFound
         case couponsLoadError
         case couponsDisabled
+        case couponsNextPageError
     }
 
     let errorType: ErrorType
@@ -70,6 +71,14 @@ struct PointOfSaleErrorState: Equatable {
             title: Constants.loadingCouponsDisabledTitle,
             subtitle: Constants.loadingCouponsDisabledSubtitle,
             buttonText: Constants.loadingCouponsDisabledAction)
+    }
+
+    static var errorOnLoadingCouponsNextPage: Self {
+        PointOfSaleErrorState(
+            errorType: .couponsNextPageError,
+            title: Constants.failedToLoadCouponsNextPageTitle,
+            subtitle: Constants.failedToLoadCouponsNextPageSubtitle,
+            buttonText: Constants.failedToLoadCouponsNextPageButtonTitle)
     }
 
     enum Constants {
@@ -184,6 +193,24 @@ struct PointOfSaleErrorState: Equatable {
             "pos.itemList.enablingCouponsErrorRetry",
             value: "Retry",
             comment: "Text of the button appearing on the coupon list screen when there's an error enabling coupons setting in the store.."
+        )
+        static let failedToLoadCouponsNextPageTitle = NSLocalizedString(
+            "pos.itemList.failedToLoadCouponsNextPageTitle",
+            value: "Failed to load more coupons",
+            comment: "Text appearing on the coupon list screen when there's an error loading a page of coupons after the first. " +
+            "Shown inline with the previously loaded coupons above."
+        )
+        static let failedToLoadCouponsNextPageSubtitle = NSLocalizedString(
+            "pos.itemList.failedToLoadCouponsNextPageSubtitle",
+            value: "An error occurred while loading coupons.",
+            comment: "Text appearing on the coupon list screen as subtitle when there's an error loading a page of coupons " +
+            "after the first. Shown inline with the previously loaded coupons above."
+        )
+        static let failedToLoadCouponsNextPageButtonTitle = NSLocalizedString(
+            "pos.itemList.failedToLoadCouponsNextPageButtonTitle",
+            value: "Try again",
+            comment: "Text for the button appearing on the coupon list screen when there's an error loading a page of coupons " +
+            "after the first. Shown inline with the previously loaded coupons above."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -48,6 +48,8 @@ struct ItemList<HeaderView: View>: View {
                     LazyVStack(spacing: Constants.itemSpacing) {
                         headerView
 
+                        headerRows
+
                         if let state {
                             ForEach(state.items) { item in
                                 ItemListRow(item: item, activeNavigationItem: $activeNavigationItem)
@@ -92,14 +94,28 @@ struct ItemList<HeaderView: View>: View {
             } else {
                 GhostItemCardView()
             }
-        case .inlineError(_, let errorState):
+        case .inlineError(_, let errorState, .pagination):
             ItemListErrorCardView(errorState: errorState,
                                   buttonAction: {
                 Task { @MainActor in
                     await itemsController.loadNextItems(base: node)
                 }
             })
-        case .loaded, .error, .empty, .none:
+        case .loaded, .error, .empty, .none, .inlineError(_, _, .refresh):
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder var headerRows: some View {
+        switch state {
+        case .inlineError(_, let errorState, .refresh):
+            ItemListErrorCardView(errorState: errorState,
+                                  buttonAction: {
+                Task { @MainActor in
+                    await itemsController.loadItems(base: .root)
+                }
+            })
+        case .loaded, .error, .empty, .none, .loading, .inlineError(_, _, .pagination):
             EmptyView()
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -62,7 +62,7 @@ struct ItemListView: View {
             switch itemListState {
             case .loading(let items),
                     .loaded(let items, _),
-                    .inlineError(let items, _):
+                    .inlineError(let items, _, _):
                 listView(items)
             case .error(let errorState):
                 errorView(errorState)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -283,7 +283,9 @@ private extension ItemListView {
     func displayItemType(_ itemType: ItemType) {
         selectedItemType = itemType
         Task { @MainActor in
-            await itemsController.loadItems(base: .root)
+            if itemListState.items.isEmpty {
+                await itemsController.loadItems(base: .root)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -102,6 +102,9 @@ struct PointOfSaleDashboardView: View {
         }
         .task {
             await posModel.purchasableItemsController.loadItems(base: .root)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale) {
+                await posModel.couponsController.loadItems(base: .root)
+            }
         }
         .ignoresSafeArea(.keyboard)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		0196FF922DA802730063CEF1 /* POSCouponImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0196FF912DA802730063CEF1 /* POSCouponImageView.swift */; };
 		0196FF942DA8067A0063CEF1 /* CouponCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0196FF932DA806720063CEF1 /* CouponCardView.swift */; };
 		019A86842D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A86832D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift */; };
+		01A3093C2DAE768600B672F6 /* MockPointOfSaleCouponService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A3093B2DAE768000B672F6 /* MockPointOfSaleCouponService.swift */; };
 		01AAD8142D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
 		01ADC1382C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */; };
@@ -3310,6 +3311,7 @@
 		0196FF912DA802730063CEF1 /* POSCouponImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCouponImageView.swift; sourceTree = "<group>"; };
 		0196FF932DA806720063CEF1 /* CouponCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCardView.swift; sourceTree = "<group>"; };
 		019A86832D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayCardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
+		01A3093B2DAE768000B672F6 /* MockPointOfSaleCouponService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSaleCouponService.swift; sourceTree = "<group>"; };
 		01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderSyncCouponsErrorMessageView.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift; sourceTree = "<group>"; };
@@ -7821,6 +7823,7 @@
 		02CD3BFC2C35D01600E575C4 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				01A3093B2DAE768000B672F6 /* MockPointOfSaleCouponService.swift */,
 				68503C352DA53E0800C07909 /* MockPointOfSaleCouponsController.swift */,
 				02CD3BFD2C35D04C00E575C4 /* MockCardPresentPaymentService.swift */,
 				6801E4162D0FFF0100F9DF46 /* MockReceiptService.swift */,
@@ -17824,6 +17827,7 @@
 				FEED57FA2686544D00E47FD9 /* RoleErrorViewModelTests.swift in Sources */,
 				0388E1AA29E04715007DF84D /* MockDeepLinkNavigator.swift in Sources */,
 				022C7D7729793ABE0036568D /* PaidDomainSelectorDataProviderTests.swift in Sources */,
+				01A3093C2DAE768600B672F6 /* MockPointOfSaleCouponService.swift in Sources */,
 				03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */,
 				CEEF742C2B9A052300B03948 /* OrdersReportCardViewModelTests.swift in Sources */,
 				AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -2,48 +2,6 @@
 import Testing
 import Foundation
 
-import protocol Yosemite.PointOfSaleItemServiceProtocol
-import protocol Yosemite.PointOfSaleCouponServiceProtocol
-import enum Yosemite.POSItem
-import struct Yosemite.POSCoupon
-import struct Yosemite.PagedItems
-import struct Yosemite.POSVariableParentProduct
-import enum Yosemite.PointOfSaleCouponServiceError
-
-final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
-    var shouldReturnZeroItems = false
-    var errorToThrow: PointOfSaleCouponServiceError?
-
-    func provideLocalPointOfSaleCoupons() async throws -> [Yosemite.POSItem] {
-        []
-    }
-
-    func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
-        if let error = errorToThrow {
-            throw error
-        }
-        if shouldReturnZeroItems {
-            return .init(items: [], hasMorePages: false)
-        } else {
-            return .init(items: Self.makeInitialCoupons(),
-                         hasMorePages: false)
-        }
-    }
-
-    static func makeInitialCoupons() -> [POSItem] {
-        let coupon1 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84A")) ?? UUID(), code: "VALID1"))
-        let coupon2 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84B")) ?? UUID(), code: "VALID2"))
-        let coupon3 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84C")) ?? UUID(), code: "VALID3"))
-        return [coupon1, coupon2, coupon3]
-    }
-
-    func enableCoupons() async throws {
-        if let error = errorToThrow {
-            throw error
-        }
-    }
-}
-
 struct PointOfSaleCouponsControllerTests {
     @available(iOS 17.0, *)
     @Test func loadItems_when_empty_coupons_then_results_in_empty_state() async throws {
@@ -194,6 +152,69 @@ struct PointOfSaleCouponsControllerTests {
         _ = await sut.enableCoupons()
 
         // Then
+        #expect(sut.itemsViewState == expectedViewState)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func loadNextItems_when_loadNextItems_fails_then_sets_inlineError_state_and_preserves_items() async throws {
+        // Given
+        let couponProvider = MockPointOfSaleCouponService()
+        let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
+        couponProvider.shouldSimulateTwoPages = true
+        await sut.loadItems(base: .root)
+        let currentItems = sut.itemsViewState.itemsStack.root.items
+        couponProvider.errorToThrow = .couponsLoadingError
+
+        // When
+        await sut.loadNextItems(base: .root)
+
+        // Then
+        let expectedItemStackState = ItemsStackState(root: .inlineError(currentItems, error: .errorOnLoadingCouponsNextPage), itemStates: [:])
+        let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
+        #expect(sut.itemsViewState == expectedViewState)
+
+        guard case .inlineError(let items, let error) = sut.itemsViewState.itemsStack.root else {
+            Issue.record("Expected inlineError state")
+            return
+        }
+        #expect(items == currentItems)
+        #expect(error == .errorOnLoadingCouponsNextPage)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func loadNextItems_when_loadNextItems_then_loads_second_page() async throws {
+        // Given
+        let couponProvider = MockPointOfSaleCouponService()
+        let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
+        couponProvider.shouldSimulateTwoPages = true
+        await sut.loadItems(base: .root)
+
+        // When
+        await sut.loadNextItems(base: .root)
+
+        // Then
+        let expectedItems = MockPointOfSaleCouponService.makeSecondPageCoupons()
+        let expectedItemStackState = ItemsStackState(root: .loaded(expectedItems, hasMoreItems: false), itemStates: [:])
+        let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
+        #expect(sut.itemsViewState == expectedViewState)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func loadNextItems_when_loadNextItems_with_more_items_then_sets_hasMoreItems() async throws {
+        // Given
+        let couponProvider = MockPointOfSaleCouponService()
+        let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
+        couponProvider.shouldSimulateTwoPages = true
+        couponProvider.shouldSimulateMorePages = true
+        await sut.loadItems(base: .root)
+
+        // When
+        await sut.loadNextItems(base: .root)
+
+        // Then
+        let expectedItems = MockPointOfSaleCouponService.makeSecondPageCoupons()
+        let expectedItemStackState = ItemsStackState(root: .loaded(expectedItems, hasMoreItems: true), itemStates: [:])
+        let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
         #expect(sut.itemsViewState == expectedViewState)
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -187,7 +187,10 @@ struct PointOfSaleCouponsControllerTests {
         await sut.loadNextItems(base: .root)
 
         // Then
-        let expectedItemStackState = ItemsStackState(root: .inlineError(currentItems, error: .errorOnLoadingCouponsNextPage, context: .pagination), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .inlineError(currentItems,
+                                                                        error: .errorOnLoadingCouponsNextPage,
+                                                                        context: .pagination),
+                                                     itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
         #expect(sut.itemsViewState == expectedViewState)
     }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -156,6 +156,24 @@ struct PointOfSaleCouponsControllerTests {
     }
 
     @available(iOS 17.0, *)
+    @Test func loadItems_when_fails_then_sets_inlineError_state_and_preserves_items() async throws {
+        // Given
+        let couponProvider = MockPointOfSaleCouponService()
+        let sut = PointOfSaleCouponsController(itemProvider: couponProvider)
+        await sut.loadItems(base: .root)
+        let currentItems = sut.itemsViewState.itemsStack.root.items
+        couponProvider.errorToThrow = .couponsLoadingError
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        let expectedItemStackState = ItemsStackState(root: .inlineError(currentItems, error: .errorOnRefreshingCoupons, context: .refresh), itemStates: [:])
+        let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
+        #expect(sut.itemsViewState == expectedViewState)
+    }
+
+    @available(iOS 17.0, *)
     @Test func loadNextItems_when_loadNextItems_fails_then_sets_inlineError_state_and_preserves_items() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -169,16 +187,9 @@ struct PointOfSaleCouponsControllerTests {
         await sut.loadNextItems(base: .root)
 
         // Then
-        let expectedItemStackState = ItemsStackState(root: .inlineError(currentItems, error: .errorOnLoadingCouponsNextPage), itemStates: [:])
+        let expectedItemStackState = ItemsStackState(root: .inlineError(currentItems, error: .errorOnLoadingCouponsNextPage, context: .pagination), itemStates: [:])
         let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
         #expect(sut.itemsViewState == expectedViewState)
-
-        guard case .inlineError(let items, let error) = sut.itemsViewState.itemsStack.root else {
-            Issue.record("Expected inlineError state")
-            return
-        }
-        #expect(items == currentItems)
-        #expect(error == .errorOnLoadingCouponsNextPage)
     }
 
     @available(iOS 17.0, *)

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -284,12 +284,13 @@ final class PointOfSaleItemsControllerTests {
         await sut.loadNextItems(base: baseItem)
 
         // Then
-        guard case .inlineError(let items, let errorState) = sut.itemsViewState.itemsStack.itemStates[parentItem] else {
+        guard case .inlineError(let items, let errorState, let context) = sut.itemsViewState.itemsStack.itemStates[parentItem] else {
             Issue.record("Expected inlineError ItemList state, but got \(sut.itemsViewState)")
             return
         }
         #expect(items.count == 2)
         #expect(errorState == PointOfSaleErrorState.errorOnLoadingVariationsNextPage)
+        #expect(context == .pagination)
     }
 
     @available(iOS 17.0, *)
@@ -358,12 +359,13 @@ final class PointOfSaleItemsControllerTests {
         // Then
         #expect(sut.itemsViewState.containerState == .content)
 
-        guard case .inlineError(let items, let errorState) = sut.itemsViewState.itemsStack.root else {
+        guard case .inlineError(let items, let errorState, let context) = sut.itemsViewState.itemsStack.root else {
             Issue.record("Expected inlineError ItemList state, but got \(sut.itemsViewState)")
             return
         }
         #expect(items.count == 2)
         #expect(errorState == PointOfSaleErrorState.errorOnLoadingProductsNextPage)
+        #expect(context == .pagination)
     }
 
     @available(iOS 17.0, *)

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponService.swift
@@ -1,0 +1,54 @@
+import Foundation
+import protocol Yosemite.PointOfSaleItemServiceProtocol
+import protocol Yosemite.PointOfSaleCouponServiceProtocol
+import enum Yosemite.POSItem
+import struct Yosemite.POSCoupon
+import struct Yosemite.PagedItems
+import struct Yosemite.POSVariableParentProduct
+import enum Yosemite.PointOfSaleCouponServiceError
+
+final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
+    var shouldReturnZeroItems = false
+    var errorToThrow: PointOfSaleCouponServiceError?
+    var shouldSimulateTwoPages = false
+    var shouldSimulateMorePages = false
+
+    func provideLocalPointOfSaleCoupons() async throws -> [Yosemite.POSItem] {
+        []
+    }
+
+    func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+        if let error = errorToThrow {
+            throw error
+        }
+        if shouldReturnZeroItems {
+            return .init(items: [], hasMorePages: false)
+        }
+        if shouldSimulateTwoPages {
+            return pageNumber > 1 ?
+                .init(items: Self.makeSecondPageCoupons(), hasMorePages: shouldSimulateMorePages):
+                .init(items: Self.makeInitialCoupons(), hasMorePages: shouldSimulateTwoPages)
+        }
+        return .init(items: Self.makeInitialCoupons(), hasMorePages: false)
+    }
+
+    static func makeInitialCoupons() -> [POSItem] {
+        let coupon1 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84A")) ?? UUID(), code: "VALID1"))
+        let coupon2 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84B")) ?? UUID(), code: "VALID2"))
+        let coupon3 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84C")) ?? UUID(), code: "VALID3"))
+        return [coupon1, coupon2, coupon3]
+    }
+
+    static func makeSecondPageCoupons() -> [POSItem] {
+        let coupon4 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84D")) ?? UUID(), code: "VALID4"))
+        let coupon5 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84E")) ?? UUID(), code: "VALID5"))
+        let coupon6 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84F")) ?? UUID(), code: "VALID6"))
+        return [coupon4, coupon5, coupon6]
+    }
+
+    func enableCoupons() async throws {
+        if let error = errorToThrow {
+            throw error
+        }
+    }
+}

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -66,7 +66,9 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
         do {
-            try await syncCouponsFromRemote(pageNumber: pageNumber)
+            let hasMorePages = try await syncCouponsFromRemote(pageNumber: pageNumber)
+            let coupons = try await provideLocalPointOfSaleCoupons()
+            return .init(items: coupons, hasMorePages: hasMorePages)
         } catch {
             if try await checkRemoteStoreCouponSettings() {
                 throw error
@@ -74,8 +76,6 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                 throw PointOfSaleCouponServiceError.couponsDisabled
             }
         }
-        let coupons = try await provideLocalPointOfSaleCoupons()
-        return .init(items: coupons, hasMorePages: true)
     }
 
     @MainActor
@@ -125,7 +125,10 @@ private extension PointOfSaleCouponService {
         }
     }
 
-    func syncCouponsFromRemote(pageNumber: Int) async throws {
+    /// Suncing local coupons storage with remote
+    /// - Parameter pageNumber: Number of page that should be retrieved.
+    /// - Returns: True if there are more pages to sync
+    func syncCouponsFromRemote(pageNumber: Int) async throws -> Bool  {
         try await withCheckedThrowingContinuation { continuation in
             couponStoreMethods.synchronizeCoupons(
                 siteID: siteID,
@@ -133,8 +136,8 @@ private extension PointOfSaleCouponService {
                 pageSize: Constants.defaultPageSize,
                 onCompletion: { result in
                     switch result {
-                    case .success:
-                        continuation.resume()
+                    case .success(let hasMorePages):
+                        continuation.resume(returning: hasMorePages)
                     case .failure:
                         continuation.resume(throwing: PointOfSaleCouponServiceError.couponsLoadingError)
                     }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -116,7 +116,7 @@ private extension PointOfSaleCouponService {
             let storageCoupons = resultsController.fetchedObjects
             return mapCouponsToPOSItems(coupons: storageCoupons)
         } catch {
-            debugPrint("Failed to load coupons from storage:", error)
+            DDLogError("Failed to load coupons from storage: \(error)")
             return []
         }
     }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -51,23 +51,29 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                   storage: storage)
     }
 
-    // Provides an array of coupons that are stored locally, it does not accept any sort of pagination
+    // Provides an array of coupons that are stored locally
+    // It does not accept any sort of pagination
+    // Limited to default page size to match remote results
     @MainActor
     public func provideLocalPointOfSaleCoupons() async throws -> [POSItem] {
+        return try await provideLocalPointOfSaleCoupons(limit: Constants.defaultPageSize)
+    }
+
+    @MainActor
+    private func provideLocalPointOfSaleCoupons(limit: Int?) async throws -> [POSItem] {
         let couponsEnabled = try await checkStoreCouponSettings()
         if !couponsEnabled {
             throw PointOfSaleCouponServiceError.couponsDisabled
         }
 
-        let localCoupons = await fetchLocalCoupons()
-        return localCoupons.items
+        return fetchLocalCoupons(limit: limit)
     }
 
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
         do {
             let hasMorePages = try await syncCouponsFromRemote(pageNumber: pageNumber)
-            let coupons = try await provideLocalPointOfSaleCoupons()
+            let coupons = try await provideLocalPointOfSaleCoupons(limit: nil)
             return .init(items: coupons, hasMorePages: hasMorePages)
         } catch {
             if try await checkRemoteStoreCouponSettings() {
@@ -95,23 +101,23 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
 private extension PointOfSaleCouponService {
     @MainActor
-    func fetchLocalCoupons() async -> PagedItems<POSItem> {
+    func fetchLocalCoupons(limit: Int? = nil) -> [POSItem] {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
                                           ascending: false)
 
         let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
                                                                  matching: predicate,
+                                                                 fetchLimit: limit,
                                                                  sortedBy: [descriptor])
 
         do {
             try resultsController.performFetch()
             let storageCoupons = resultsController.fetchedObjects
-            let posItems = mapCouponsToPOSItems(coupons: storageCoupons)
-            return .init(items: posItems, hasMorePages: true)
+            return mapCouponsToPOSItems(coupons: storageCoupons)
         } catch {
             debugPrint("Failed to load coupons from storage:", error)
-            return .init(items: [], hasMorePages: false)
+            return []
         }
     }
 

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -134,7 +134,7 @@ private extension PointOfSaleCouponService {
     /// Suncing local coupons storage with remote
     /// - Parameter pageNumber: Number of page that should be retrieved.
     /// - Returns: True if there are more pages to sync
-    func syncCouponsFromRemote(pageNumber: Int) async throws -> Bool  {
+    func syncCouponsFromRemote(pageNumber: Int) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
             couponStoreMethods.synchronizeCoupons(
                 siteID: siteID,

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -69,10 +69,15 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
         return fetchLocalCoupons(limit: limit)
     }
 
+    /// Syncs with the remote and provides all currently loaded coupons.
+    /// - Parameter pageNumber: The page number to fetch from the remote.
+    /// - Returns: All currently loaded coupons.
     @MainActor
     public func providePointOfSaleCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
         do {
+            // Update local storage with data from the remote
             let hasMorePages = try await syncCouponsFromRemote(pageNumber: pageNumber)
+            // Return all local coupons, including updated ones from the remote
             let coupons = try await provideLocalPointOfSaleCoupons(limit: nil)
             return .init(items: coupons, hasMorePages: hasMorePages)
         } catch {

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -131,7 +131,7 @@ private extension PointOfSaleCouponService {
         }
     }
 
-    /// Suncing local coupons storage with remote
+    /// Syncing local coupons storage with remote
     /// - Parameter pageNumber: Number of page that should be retrieved.
     /// - Returns: True if there are more pages to sync
     func syncCouponsFromRemote(pageNumber: Int) async throws -> Bool {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR aims to wrap up pagination functionality with coupons. 

- Updated page tracking and `hasMorePages` logic
- Added loading state for pagination
- Added error state for pagination
- Stopped reloading coupons and products each time the tab is opened, only when there's no data
- Started preloading coupons when POS is opened

### Has more pages check

`PointOfSaleCouponsService` uses `CouponStore.synchronizeCoupons`, which already has built-in pagination check functionality. It doesn't use `X-WP-TotalPages` and checks if the returned result is smaller or equal to the page size. If it's smaller, it means there are no pages to load. 

At the moment,  `PointOfSaleCouponsService` didn't use the result of `synchronizeCoupons` so there were infinite page loading issues.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:
- Enable `enableCouponsInPointOfSale` feature flag.
- Have a store with more than 25 coupons or decrease `defaultPageSize` in `PointOfSaleCouponService`

## Happy Path
1. Open POS
2. Switch to Coupons
3. Confirm the data was already preloaded
4. Scroll down
5. Confirm the loading state is shown at the bottom while the next page is loading
6. Confirm the data loads
7.  Switch between tabs
8. Confirm the data is not reloaded

## Unhappy Path
1. Open POS
2. Switch to Coupons
3. Turn off network / simulate another type of issue
4. Scroll down
5. Confirm the error state is shown under the last row
6. Turn on network
8. Tap retry
9. Confirm the next page loads
10. Switch between tabs
11. Confirm the data is not reloaded

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11 Inch M3 iOS 18.4
Confirmed that there's no more infinite loading, and network requests are not made when there are no more pages to load.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/416a6761-c0f1-4c5c-a2ac-7cbadd6844ab

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
