### PR TITLE
[Woo POS][Product Search] Pre-search UI: Save recent searches

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -9,7 +9,7 @@ import enum Yosemite.PointOfSaleItemServiceError
 import struct Yosemite.POSVariableParentProduct
 import class Yosemite.Store
 
-enum ItemType {
+enum ItemListType {
     case products(search: Bool = false)
     case coupons
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -8,10 +8,20 @@ import protocol Yosemite.PointOfSalePurchasableItemFetchStrategy
 import enum Yosemite.PointOfSaleItemServiceError
 import struct Yosemite.POSVariableParentProduct
 import class Yosemite.Store
+import enum Yosemite.POSItemType
 
 enum ItemListType {
     case products(search: Bool = false)
     case coupons
+
+    var itemType: POSItemType {
+        switch self {
+        case .coupons:
+            return .coupon
+        case .products(search: let search):
+            return .product
+        }
+    }
 }
 
 @available(iOS 17.0, *)

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -37,7 +37,7 @@ protocol PointOfSaleAggregateModelProtocol {
     func addMoreToCart()
     func startNewCart()
     
-    func saveSearchTerm(_ term: String, for itemType: ItemType)
+    func saveSearchTerm(_ term: String, for itemListType: ItemListType)
 
     var orderState: PointOfSaleOrderState { get }
     func checkOut() async
@@ -141,8 +141,8 @@ extension PointOfSaleAggregateModel {
 // MARK: - Search
 @available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
-    func saveSearchTerm(_ term: String, for itemType: ItemType) {
-        DDLogInfo("POS: Saving search term '\(term)' for item type: \(itemType)")
+    func saveSearchTerm(_ term: String, for itemListType: ItemListType) {
+        DDLogInfo("POS: Saving search term '\(term)' for item type: \(itemListType)")
     }
 }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -38,7 +38,7 @@ protocol PointOfSaleAggregateModelProtocol {
     func removeAllCouponsFromCart()
     func addMoreToCart()
     func startNewCart()
-    
+
     func saveSearchTerm(_ term: String, for itemType: POSItemType)
     func searchHistory(for itemType: POSItemType) -> [String]
 
@@ -150,7 +150,7 @@ extension PointOfSaleAggregateModel {
     func saveSearchTerm(_ term: String, for itemType: POSItemType) {
         searchHistoryService.saveSuccessfulSearch(term: term, for: itemType)
     }
-    
+
     func searchHistory(for itemType: POSItemType) -> [String] {
         return searchHistoryService.searchHistory(for: itemType)
     }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -36,6 +36,8 @@ protocol PointOfSaleAggregateModelProtocol {
     func removeAllCouponsFromCart()
     func addMoreToCart()
     func startNewCart()
+    
+    func saveSearchTerm(_ term: String, for itemType: ItemType)
 
     var orderState: PointOfSaleOrderState { get }
     func checkOut() async
@@ -133,6 +135,14 @@ extension PointOfSaleAggregateModel {
         orderStage = .building
         paymentState = .card(.idle)
         cardPresentPaymentInlineMessage = nil
+    }
+}
+
+// MARK: - Search
+@available(iOS 17.0, *)
+extension PointOfSaleAggregateModel {
+    func saveSearchTerm(_ term: String, for itemType: ItemType) {
+        DDLogInfo("POS: Saving search term '\(term)' for item type: \(itemType)")
     }
 }
 

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -9,6 +9,8 @@ import struct Yosemite.OrderItem
 import struct Yosemite.POSCoupon
 import enum Yosemite.POSItem
 import enum Yosemite.SystemStatusAction
+import class Yosemite.POSSearchHistoryService
+import enum Yosemite.POSItemType
 
 @available(iOS 17.0, *)
 protocol PointOfSaleAggregateModelProtocol {
@@ -37,7 +39,8 @@ protocol PointOfSaleAggregateModelProtocol {
     func addMoreToCart()
     func startNewCart()
     
-    func saveSearchTerm(_ term: String, for itemListType: ItemListType)
+    func saveSearchTerm(_ term: String, for itemType: POSItemType)
+    func searchHistory(for itemType: POSItemType) -> [String]
 
     var orderState: PointOfSaleOrderState { get }
     func checkOut() async
@@ -69,6 +72,7 @@ protocol PointOfSaleAggregateModelProtocol {
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
+    private let searchHistoryService: POSSearchHistoryService
 
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
@@ -82,6 +86,7 @@ protocol PointOfSaleAggregateModelProtocol {
          orderController: PointOfSaleOrderControllerProtocol,
          analytics: Analytics = ServiceLocator.analytics,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
+         searchHistoryService: POSSearchHistoryService = POSSearchHistoryService(),
          paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -90,6 +95,7 @@ protocol PointOfSaleAggregateModelProtocol {
         self.orderController = orderController
         self.analytics = analytics
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
+        self.searchHistoryService = searchHistoryService
         self.paymentState = paymentState
         publishCardReaderConnectionStatus()
         publishPaymentMessages()
@@ -141,8 +147,12 @@ extension PointOfSaleAggregateModel {
 // MARK: - Search
 @available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
-    func saveSearchTerm(_ term: String, for itemListType: ItemListType) {
-        DDLogInfo("POS: Saving search term '\(term)' for item type: \(itemListType)")
+    func saveSearchTerm(_ term: String, for itemType: POSItemType) {
+        searchHistoryService.saveSuccessfulSearch(term: term, for: itemType)
+    }
+    
+    func searchHistory(for itemType: POSItemType) -> [String] {
+        return searchHistoryService.searchHistory(for: itemType)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -85,11 +85,11 @@ private extension PointOfSaleItemListEmptyView {
 }
 
 struct PointOfSaleItemListEmptyViewModel {
-    let itemType: ItemType
+    let itemListType: ItemListType
     let baseItem: ItemListBaseItem
 
     var title: String {
-        switch (baseItem, itemType) {
+        switch (baseItem, itemListType) {
         case (.root, .products):
             return Localization.emptyProductsTitle
         case (.root, .coupons):
@@ -103,7 +103,7 @@ struct PointOfSaleItemListEmptyViewModel {
     }
 
     var subtitle: String {
-        switch (baseItem, itemType) {
+        switch (baseItem, itemListType) {
         case (.root, .products):
             return Localization.emptyProductsSubtitle
         case (.root, .coupons):
@@ -117,7 +117,7 @@ struct PointOfSaleItemListEmptyViewModel {
     }
 
     var hint: String? {
-        switch (baseItem, itemType) {
+        switch (baseItem, itemListType) {
         case (.root, .products):
             return Localization.emptyProductsHint
         case (.root, .coupons):
@@ -131,7 +131,7 @@ struct PointOfSaleItemListEmptyViewModel {
     }
 
     var buttonTitle: String? {
-        switch itemType {
+        switch itemListType {
         case .coupons:
             return Localization.emptyCouponsButtonTitle
         default:

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -85,7 +85,7 @@ private extension ChildItemList {
             headerView
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(
-                    itemType: .products(search: false),
+                    itemListType: .products(search: false),
                     baseItem: node))
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -7,6 +7,7 @@ struct ChildItemList: View {
     private let parentItem: POSItem
     private let title: String
     private var itemsController: PointOfSaleItemsControllerProtocol
+    private let itemActionHandler: POSItemActionHandler
     @Environment(\.dismiss) private var dismiss
 
     private var node: ItemListBaseItem {
@@ -18,10 +19,14 @@ struct ChildItemList: View {
             .loading([])
     }
 
-    init(parentItem: POSItem, title: String, itemsController: PointOfSaleItemsControllerProtocol) {
+    init(parentItem: POSItem,
+         title: String,
+         itemsController: PointOfSaleItemsControllerProtocol,
+         itemActionHandler: POSItemActionHandler) {
         self.parentItem = parentItem
         self.title = title
         self.itemsController = itemsController
+        self.itemActionHandler = itemActionHandler
     }
 
     var body: some View {
@@ -65,7 +70,7 @@ private extension ChildItemList {
 
             ItemList(itemsController: itemsController,
                      node: node,
-                     searchTerm: nil)
+                     itemActionHandler: itemActionHandler)
                 .transition(.opacity)
                 .refreshable {
                     ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)
@@ -155,7 +160,11 @@ private extension ChildItemList {
                     )
                 ], hasMoreItems: false)])
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
-    return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: itemsController)
+
+    return ChildItemList(parentItem: parentItem,
+                         title: parentProduct.name,
+                         itemsController: itemsController,
+                         itemActionHandler: PointOfSalePreviewItemActionHandler())
 }
 
 @available(iOS 17.0, *)
@@ -174,7 +183,10 @@ private extension ChildItemList {
             parentItem: .error(.errorOnLoadingVariations)
         ])
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
-    return ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: itemsController)
+    return ChildItemList(parentItem: parentItem,
+                         title: parentProduct.name,
+                         itemsController: itemsController,
+                         itemActionHandler: PointOfSalePreviewItemActionHandler())
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -64,7 +64,8 @@ private extension ChildItemList {
             headerView
 
             ItemList(itemsController: itemsController,
-                     node: node)
+                     node: node,
+                     searchTerm: nil)
                 .transition(.opacity)
                 .refreshable {
                     ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -9,6 +9,7 @@ struct ItemList<HeaderView: View>: View {
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @StateObject private var infiniteScrollTriggerDeterminer = ThresholdInfiniteScrollTriggerDeterminer()
+    private let searchTerm: String?
 
     // Navigation only uses this on iOS 17
     @State private var activeNavigationItem: POSItem? = nil
@@ -28,9 +29,11 @@ struct ItemList<HeaderView: View>: View {
 
     init(itemsController: PointOfSaleItemsControllerProtocol,
          node: ItemListBaseItem,
+         searchTerm: String?,
          @ViewBuilder headerView: () -> HeaderView = { EmptyView() }) {
         self.itemsController = itemsController
         self.node = node
+        self.searchTerm = searchTerm
         self.headerView = headerView()
     }
 
@@ -50,7 +53,7 @@ struct ItemList<HeaderView: View>: View {
 
                         if let state {
                             ForEach(state.items) { item in
-                                ItemListRow(item: item, activeNavigationItem: $activeNavigationItem)
+                                ItemListRow(item: item, searchTerm: searchTerm, activeNavigationItem: $activeNavigationItem)
                             }
                         }
 
@@ -113,6 +116,7 @@ private enum Constants {
 @available(iOS 17.0, *)
 private struct ItemListRow: View {
     let item: POSItem
+    var searchTerm: String?
     @Binding var activeNavigationItem: POSItem?
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     let analytics: Analytics = ServiceLocator.analytics
@@ -206,7 +210,8 @@ private extension ItemListRow {
     )
     ItemList(
         itemsController: PointOfSalePreviewItemsController(),
-        node: .root
+        node: .root,
+        searchTerm: nil
     )
 }
 
@@ -220,7 +225,8 @@ private extension ItemListRow {
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
     ItemList(itemsController: PointOfSalePreviewItemsController(),
-             node: .root)
+             node: .root,
+             searchTerm: nil)
         .environment(posModel)
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -9,7 +9,6 @@ struct ItemList<HeaderView: View>: View {
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @StateObject private var infiniteScrollTriggerDeterminer = ThresholdInfiniteScrollTriggerDeterminer()
-    private let searchTerm: String?
 
     // Navigation only uses this on iOS 17
     @State private var activeNavigationItem: POSItem? = nil
@@ -26,14 +25,15 @@ struct ItemList<HeaderView: View>: View {
     private let itemsController: PointOfSaleItemsControllerProtocol
     private let node: ItemListBaseItem
     private let headerView: HeaderView
+    private let itemActionHandler: POSItemActionHandler
 
     init(itemsController: PointOfSaleItemsControllerProtocol,
          node: ItemListBaseItem,
-         searchTerm: String?,
+         itemActionHandler: POSItemActionHandler,
          @ViewBuilder headerView: () -> HeaderView = { EmptyView() }) {
         self.itemsController = itemsController
         self.node = node
-        self.searchTerm = searchTerm
+        self.itemActionHandler = itemActionHandler
         self.headerView = headerView()
     }
 
@@ -53,7 +53,7 @@ struct ItemList<HeaderView: View>: View {
 
                         if let state {
                             ForEach(state.items) { item in
-                                ItemListRow(item: item, searchTerm: searchTerm, activeNavigationItem: $activeNavigationItem)
+                                ItemListRow(item: item, itemActionHandler: itemActionHandler, activeNavigationItem: $activeNavigationItem)
                             }
                         }
 
@@ -73,7 +73,10 @@ struct ItemList<HeaderView: View>: View {
                 // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
                 // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
                 NavigationLink(
-                    destination: ChildItemList(parentItem: activeItem, title: parentProduct.name, itemsController: posModel.purchasableItemsController),
+                    destination: ChildItemList(parentItem: activeItem,
+                                               title: parentProduct.name,
+                                               itemsController: posModel.purchasableItemsController,
+                                               itemActionHandler: itemActionHandler),
                     isActive: Binding(
                         get: { activeNavigationItem != nil },
                         set: { if !$0 { activeNavigationItem = nil } }
@@ -116,7 +119,7 @@ private enum Constants {
 @available(iOS 17.0, *)
 private struct ItemListRow: View {
     let item: POSItem
-    var searchTerm: String?
+    let itemActionHandler: POSItemActionHandler
     @Binding var activeNavigationItem: POSItem?
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     let analytics: Analytics = ServiceLocator.analytics
@@ -125,8 +128,7 @@ private struct ItemListRow: View {
         switch item {
         case let .simpleProduct(product):
             Button(action: {
-                posModel.addToCart(item)
-                analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
+                itemActionHandler.handleTap(item)
             }, label: {
                 SimpleProductCardView(product: product)
             })
@@ -157,14 +159,13 @@ private struct ItemListRow: View {
             }
         case let .variation(variation):
             Button(action: {
-                posModel.addToCart(item)
-                analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
+                itemActionHandler.handleTap(item)
             }, label: {
                 VariationCardView(variation: variation)
             })
         case let .coupon(coupon):
             Button(action: {
-                posModel.addToCart(item)
+                itemActionHandler.handleTap(item)
             }, label: {
                 CouponCardView(coupon: coupon)
             })
@@ -211,7 +212,7 @@ private extension ItemListRow {
     ItemList(
         itemsController: PointOfSalePreviewItemsController(),
         node: .root,
-        searchTerm: nil
+        itemActionHandler: PointOfSalePreviewItemActionHandler()
     )
 }
 
@@ -226,7 +227,7 @@ private extension ItemListRow {
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
     ItemList(itemsController: PointOfSalePreviewItemsController(),
              node: .root,
-             searchTerm: nil)
+             itemActionHandler: PointOfSalePreviewItemActionHandler())
         .environment(posModel)
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
@@ -1,0 +1,40 @@
+import Foundation
+import enum Yosemite.POSItem
+import protocol WooFoundation.Analytics
+
+/// Protocol for handling actions on POS items
+@available(iOS 17.0, *)
+protocol POSItemActionHandler {
+    /// Handles a tap on an item
+    /// - Parameter item: The item that was tapped
+    func handleTap(_ item: POSItem)
+}
+
+/// Standard handler for handling item taps without any special context
+@available(iOS 17.0, *)
+final class StandardPOSItemActionHandler: POSItemActionHandler {
+    private let posModel: PointOfSaleAggregateModelProtocol
+    private let analytics: Analytics
+
+    init(posModel: PointOfSaleAggregateModelProtocol, analytics: Analytics = ServiceLocator.analytics) {
+        self.posModel = posModel
+        self.analytics = analytics
+    }
+
+    func handleTap(_ item: POSItem) {
+        posModel.addToCart(item)
+
+        trackTapAnalytics(for: item)
+    }
+
+    private func trackTapAnalytics(for item: POSItem) {
+        switch item {
+        case .simpleProduct:
+            analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
+        case .variation:
+            analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
+        default:
+            break
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
@@ -8,6 +8,25 @@ protocol POSItemActionHandler {
     /// Handles a tap on an item
     /// - Parameter item: The item that was tapped
     func handleTap(_ item: POSItem)
+    /// Tracks analytics for a tap on an item
+    /// - Parameter for: The item that was tapped
+    /// - Parameter using: The analytics service to track to
+    func trackTapAnalytics(for item: POSItem, using analytics: Analytics)
+}
+
+@available(iOS 17.0, *)
+extension POSItemActionHandler {
+    /// Default implementation for analytics tracking – it still needs to be called
+    func trackTapAnalytics(for item: POSItem, using analytics: Analytics) {
+        switch item {
+        case .simpleProduct:
+            analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
+        case .variation:
+            analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
+        default:
+            break
+        }
+    }
 }
 
 /// Standard handler for handling item taps without any special context
@@ -24,17 +43,29 @@ final class StandardPOSItemActionHandler: POSItemActionHandler {
     func handleTap(_ item: POSItem) {
         posModel.addToCart(item)
 
-        trackTapAnalytics(for: item)
+        trackTapAnalytics(for: item, using: analytics)
+    }
+}
+
+/// Handler for handling taps on search result items, saving the search term
+@available(iOS 17.0, *)
+final class SearchResultItemActionHandler: POSItemActionHandler {
+    private let posModel: PointOfSaleAggregateModelProtocol
+    private let searchTerm: String
+    private let itemType: ItemType
+    private let analytics: Analytics
+
+    init(posModel: PointOfSaleAggregateModelProtocol, searchTerm: String, itemType: ItemType, analytics: Analytics = ServiceLocator.analytics) {
+        self.posModel = posModel
+        self.searchTerm = searchTerm
+        self.itemType = itemType
+        self.analytics = analytics
     }
 
-    private func trackTapAnalytics(for item: POSItem) {
-        switch item {
-        case .simpleProduct:
-            analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
-        case .variation:
-            analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
-        default:
-            break
-        }
+    func handleTap(_ item: POSItem) {
+        posModel.saveSearchTerm(searchTerm, for: itemType)
+
+        posModel.addToCart(item)
+        trackTapAnalytics(for: item, using: analytics)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
@@ -52,18 +52,21 @@ final class StandardPOSItemActionHandler: POSItemActionHandler {
 final class SearchResultItemActionHandler: POSItemActionHandler {
     private let posModel: PointOfSaleAggregateModelProtocol
     private let searchTerm: String
-    private let itemType: ItemListType
+    private let itemListType: ItemListType
     private let analytics: Analytics
 
-    init(posModel: PointOfSaleAggregateModelProtocol, searchTerm: String, itemType: ItemListType, analytics: Analytics = ServiceLocator.analytics) {
+    init(posModel: PointOfSaleAggregateModelProtocol,
+         searchTerm: String,
+         itemListType: ItemListType,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.posModel = posModel
         self.searchTerm = searchTerm
-        self.itemType = itemType
+        self.itemListType = itemListType
         self.analytics = analytics
     }
 
     func handleTap(_ item: POSItem) {
-        posModel.saveSearchTerm(searchTerm, for: itemType)
+        posModel.saveSearchTerm(searchTerm, for: itemListType.itemType)
 
         posModel.addToCart(item)
         trackTapAnalytics(for: item, using: analytics)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
@@ -52,10 +52,10 @@ final class StandardPOSItemActionHandler: POSItemActionHandler {
 final class SearchResultItemActionHandler: POSItemActionHandler {
     private let posModel: PointOfSaleAggregateModelProtocol
     private let searchTerm: String
-    private let itemType: ItemType
+    private let itemType: ItemListType
     private let analytics: Analytics
 
-    init(posModel: PointOfSaleAggregateModelProtocol, searchTerm: String, itemType: ItemType, analytics: Analytics = ServiceLocator.analytics) {
+    init(posModel: PointOfSaleAggregateModelProtocol, searchTerm: String, itemType: ItemListType, analytics: Analytics = ServiceLocator.analytics) {
         self.posModel = posModel
         self.searchTerm = searchTerm
         self.itemType = itemType

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -213,8 +213,6 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        let actionHandler: POSItemActionHandler = StandardPOSItemActionHandler(posModel: posModel)
-
         ItemList(
             itemsController: itemsController,
             node: .root,
@@ -230,6 +228,15 @@ private extension ItemListView {
         }
     }
 
+    private var actionHandler: POSItemActionHandler {
+        switch selectedItemType {
+        case .products(search: false), .coupons:
+            StandardPOSItemActionHandler(posModel: posModel)
+        case .products(search: true):
+            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemType: selectedItemType)
+        }
+    }
+
     @ViewBuilder
     func childListView(parentItem: POSItem) -> some View {
         // Note that navigation is handled by the ItemList in iOS 17, so any changes to this should be reflected in ItemListRow.
@@ -237,7 +244,6 @@ private extension ItemListView {
         case let .variableParentProduct(parentProduct):
             // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
             // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
-            let actionHandler = StandardPOSItemActionHandler(posModel: posModel)
             ChildItemList(
                 parentItem: parentItem,
                 title: parentProduct.name,

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -233,7 +233,7 @@ private extension ItemListView {
         case .products(search: false), .coupons:
             StandardPOSItemActionHandler(posModel: posModel)
         case .products(search: true):
-            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemType: selectedItemListType)
+            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemListType: selectedItemListType)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -12,13 +12,13 @@ struct ItemListView: View {
 
     @State private var searchTerm: String = ""
 
-    @Binding var selectedItemType: ItemType
+    @Binding var selectedItemListType: ItemListType
 
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
 
     var itemsController: PointOfSaleItemsControllerProtocol {
-        switch selectedItemType {
+        switch selectedItemListType {
         case .products(search: false):
             posModel.purchasableItemsController
         case .products(search: true):
@@ -99,12 +99,12 @@ private extension ItemListView {
             POSPageHeaderView(title: Localization.title, trailingContent: {
                 HStack {
                     if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS),
-                       case .products = selectedItemType {
+                       case .products = selectedItemListType {
                         TextField(text: $searchTerm) {
                             Text("Search")
                         }
                         .onChange(of: searchTerm) { oldValue, newValue in
-                            selectedItemType = .products(search: newValue.isNotEmpty)
+                            selectedItemListType = .products(search: newValue.isNotEmpty)
 
                             // The debouncing logic is a little tricky, because the loading state is held in the controller.
                             // Arguably, we should use view state `isSearching` for this, so the UI is independent of the request timing.
@@ -160,19 +160,19 @@ private extension ItemListView {
     var temporaryProductsCouponsSwitcher: some View {
         HStack {
             Button(action: {
-                displayItemType(.products(search: searchTerm.isNotEmpty))
+                displayItemListType(.products(search: searchTerm.isNotEmpty))
             }, label: {
                 Text("Products")
             })
             Button(action: {
-                displayItemType(.coupons)
+                displayItemListType(.coupons)
             }, label: {
                 Text("Coupons")
             })
 
             Spacer()
 
-            if case .coupons = selectedItemType, itemListState.isLoaded || itemListState.isEmpty {
+            if case .coupons = selectedItemListType, itemListState.isLoaded || itemListState.isEmpty {
                 Button(action: {
                     showCouponCreationModal = true
                 }, label: {
@@ -229,11 +229,11 @@ private extension ItemListView {
     }
 
     private var actionHandler: POSItemActionHandler {
-        switch selectedItemType {
+        switch selectedItemListType {
         case .products(search: false), .coupons:
             StandardPOSItemActionHandler(posModel: posModel)
         case .products(search: true):
-            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemType: selectedItemType)
+            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemType: selectedItemListType)
         }
     }
 
@@ -257,16 +257,16 @@ private extension ItemListView {
 
     @ViewBuilder
     var emptyView: some View {
-        switch selectedItemType {
+        switch selectedItemListType {
         case .products:
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(
-                    itemType: .products(search: false),
+                    itemListType: .products(search: false),
                     baseItem: .root))
         case .coupons:
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(
-                    itemType: .coupons,
+                    itemListType: .coupons,
                     baseItem: .root)) {
                 showCouponCreationModal = true
             }
@@ -298,8 +298,8 @@ private extension ItemListView {
         itemListState.eligibleToShowSimpleProductsBanner && !isHeaderBannerDismissed
     }
 
-    func displayItemType(_ itemType: ItemType) {
-        selectedItemType = itemType
+    func displayItemListType(_ itemListType: ItemListType) {
+        selectedItemListType = itemListType
         Task { @MainActor in
             await itemsController.loadItems(base: .root)
         }
@@ -393,7 +393,7 @@ private extension ItemListView {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ItemListView(selectedItemType: .constant(.products(search: false)))
+    return ItemListView(selectedItemListType: .constant(.products(search: false)))
         .environment(posModel)
 }
 
@@ -406,7 +406,7 @@ private extension ItemListView {
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
-    return ItemListView(selectedItemType: .constant(.products(search: false)))
+    return ItemListView(selectedItemListType: .constant(.products(search: false)))
         .environment(posModel)
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -213,7 +213,7 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        ItemList(itemsController: itemsController, node: .root) {
+        ItemList(itemsController: itemsController, node: .root, searchTerm: searchTerm) {
             if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView
             }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -213,7 +213,13 @@ private extension ItemListView {
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
-        ItemList(itemsController: itemsController, node: .root, searchTerm: searchTerm) {
+        let actionHandler: POSItemActionHandler = StandardPOSItemActionHandler(posModel: posModel)
+
+        ItemList(
+            itemsController: itemsController,
+            node: .root,
+            itemActionHandler: actionHandler
+        ) {
             if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
                 bannerCardView
             }
@@ -231,7 +237,13 @@ private extension ItemListView {
         case let .variableParentProduct(parentProduct):
             // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
             // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
-            ChildItemList(parentItem: parentItem, title: parentProduct.name, itemsController: posModel.purchasableItemsController)
+            let actionHandler = StandardPOSItemActionHandler(posModel: posModel)
+            ChildItemList(
+                parentItem: parentItem,
+                title: parentProduct.name,
+                itemsController: posModel.purchasableItemsController,
+                itemActionHandler: actionHandler
+            )
         default:
             EmptyView()
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -11,10 +11,10 @@ struct PointOfSaleDashboardView: View {
 
     @State private var floatingSize: CGSize = .zero
 
-    @State var selectedItemType: ItemType = .products(search: false)
+    @State var selectedItemListType: ItemListType = .products(search: false)
 
     private var itemsViewState: ItemsViewState {
-        switch selectedItemType {
+        switch selectedItemListType {
         case .products(let searching):
             if searching {
                 return posModel.purchasableItemsSearchController.itemsViewState
@@ -38,7 +38,7 @@ struct PointOfSaleDashboardView: View {
                 case .error(let error):
                     PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
                         Task {
-                            switch selectedItemType {
+                            switch selectedItemListType {
                             case .products(search: false):
                                 await posModel.purchasableItemsController.loadItems(base: .root)
                             case .products(search: true):
@@ -110,7 +110,7 @@ struct PointOfSaleDashboardView: View {
         GeometryReader { geometry in
             HStack {
                 if posModel.orderStage == .building {
-                    ItemListView(selectedItemType: $selectedItemType)
+                    ItemListView(selectedItemListType: $selectedItemListType)
                         .accessibilitySortPriority(2)
                         .transition(.move(edge: .leading))
                 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -120,6 +120,11 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
     }
 }
 
+@available(iOS 17.0, *)
+final class PointOfSalePreviewItemActionHandler: POSItemActionHandler {
+    func handleTap(_ item: Yosemite.POSItem) { }
+}
+
 private var mockItems: [POSItem] {
     return [
         .simpleProduct(POSSimpleProduct(id: UUID(), name: "Product 1", formattedPrice: "$1.00", productID: 1, price: "1.00")),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -853,6 +853,7 @@
 		205E794F2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */; };
 		205E79512C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */; };
 		20600F8B2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20600F8A2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift */; };
+		206643552DAE9333002D5191 /* POSItemActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643542DAE9333002D5191 /* POSItemActionHandler.swift */; };
 		20716F342D9DA289008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20716F332D9DA289008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */; };
 		207176922D9DA32C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207176912D9DA32C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift */; };
@@ -4109,6 +4110,7 @@
 		205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift; sourceTree = "<group>"; };
 		205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift; sourceTree = "<group>"; };
 		20600F8A2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift; sourceTree = "<group>"; };
+		206643542DAE9333002D5191 /* POSItemActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemActionHandler.swift; sourceTree = "<group>"; };
 		20716F332D9DA289008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		207176912D9DA32C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockPointOfSalePurchasableItemFetchStrategy.swift; path = ../Notifications/MockPointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentTapToPayReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -7598,6 +7600,7 @@
 				026826A42BF59DF60036F959 /* SimpleProductCardView.swift */,
 				204C20452D35471400E6D9CF /* PointOfSaleItemListCardConstants.swift */,
 				027ADB6D2D1BF5E3009608DB /* ParentProductCardView.swift */,
+				206643542DAE9333002D5191 /* POSItemActionHandler.swift */,
 				029149772D26658A00F7B3B3 /* VariationCardView.swift */,
 				0196FF932DA806720063CEF1 /* CouponCardView.swift */,
 				0291497C2D26CB2500F7B3B3 /* ChildItemList.swift */,
@@ -15146,9 +15149,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -15327,9 +15334,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -15366,9 +15377,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -15930,6 +15945,7 @@
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
 				022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */,
 				2602A63F27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift in Sources */,
+				206643552DAE9333002D5191 /* POSItemActionHandler.swift in Sources */,
 				E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */,
 				027EB57029C062DD003CE551 /* StoreOnboardingLaunchStoreCoordinator.swift in Sources */,
 				866016512B47F8F800B4047E /* ProductSelector+Blaze.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -78,5 +78,5 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
 
     func pointOfSaleClosed() { }
 
-    func saveSearchTerm(_ term: String, for itemType: ItemType) { }
+    func saveSearchTerm(_ term: String, for itemListType: ItemListType) { }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import WooCommerce
 import enum Yosemite.POSItem
 import protocol Yosemite.POSOrderableItem
+import enum Yosemite.POSItemType
 
 @available(iOS 17.0, *)
 final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
@@ -78,5 +79,9 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
 
     func pointOfSaleClosed() { }
 
-    func saveSearchTerm(_ term: String, for itemListType: ItemListType) { }
+    func saveSearchTerm(_ term: String, for itemType: POSItemType) { }
+
+    func searchHistory(for itemType: Yosemite.POSItemType) -> [String] {
+        return []
+    }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -77,4 +77,6 @@ final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     func startNewCart() { }
 
     func pointOfSaleClosed() { }
+
+    func saveSearchTerm(_ term: String, for itemType: ItemType) { }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -155,6 +155,9 @@
 		077F39E526A5C98200ABEADC /* SystemStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		204CBD2F2D43C516006FF89A /* PaymentsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CBD2E2D43C516006FF89A /* PaymentsError.swift */; };
+		206643572DAEABF7002D5191 /* POSSearchHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */; };
+		206643592DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */; };
+		2066435B2DAEAC76002D5191 /* POSItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2066435A2DAEAC76002D5191 /* POSItemType.swift */; };
 		20716F322D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20716F312D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */; };
 		207D2D1B2CFA06BD00F79204 /* POSCartItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */; };
 		207D2D1D2CFA0CEF00F79204 /* MockPOSOrderableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */; };
@@ -710,6 +713,9 @@
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStoreTests.swift; sourceTree = "<group>"; };
 		204CBD2E2D43C516006FF89A /* PaymentsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsError.swift; sourceTree = "<group>"; };
+		206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryService.swift; sourceTree = "<group>"; };
+		206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryServiceTests.swift; sourceTree = "<group>"; };
+		2066435A2DAEAC76002D5191 /* POSItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemType.swift; sourceTree = "<group>"; };
 		20716F312D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCartItemTests.swift; sourceTree = "<group>"; };
 		207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrderableItem.swift; sourceTree = "<group>"; };
@@ -1569,6 +1575,7 @@
 			children = (
 				016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */,
 				687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */,
+				206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */,
 			);
 			path = PointOfSale;
 			sourceTree = "<group>";
@@ -1577,14 +1584,16 @@
 			isa = PBXGroup;
 			children = (
 				68B681172D925B170098D5CD /* PointOfSaleCouponService.swift */,
-				6823533E2D82A90A00F24470 /* POSCoupon.swift */,
+				2095A6482D9D81C900CA1849 /* PointOfSaleItemFetchStrategyFactory.swift */,
+				68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */,
 				6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */,
+				2095A64A2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift */,
+				6823533E2D82A90A00F24470 /* POSCoupon.swift */,
+				206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */,
 				68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */,
 				027ADB6B2D1BF3AD009608DB /* POSVariableParentProduct.swift */,
-				68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */,
-				2095A64A2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift */,
-				2095A6482D9D81C900CA1849 /* PointOfSaleItemFetchStrategyFactory.swift */,
 				029149752D2663AB00F7B3B3 /* POSVariation.swift */,
+				2066435A2DAEAC76002D5191 /* POSItemType.swift */,
 			);
 			path = PointOfSale;
 			sourceTree = "<group>";
@@ -2355,9 +2364,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2397,6 +2410,7 @@
 				CECE6BBE2BA9DE3200A57C1F /* WCAnalyticsCustomer+ReadOnlyConvertible.swift in Sources */,
 				02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */,
 				03F3AFE728097D6400E328BE /* CardPresentPaymentsPlugin.swift in Sources */,
+				2066435B2DAEAC76002D5191 /* POSItemType.swift in Sources */,
 				68B681182D925B190098D5CD /* PointOfSaleCouponService.swift in Sources */,
 				B52E0032211A440D00700FDE /* Order+ReadOnlyType.swift in Sources */,
 				CE606D9C2BE3BCC4001CB424 /* ShippingMethod+ReadOnlyConvertible.swift in Sources */,
@@ -2674,6 +2688,7 @@
 				45E4620E2684C45500011BF2 /* Country+ReadOnlyConvertible.swift in Sources */,
 				7455D4672141B57600FA8C1F /* TopEarnerStats+ReadOnlyConvertible.swift in Sources */,
 				B56C1EBE20EABD2B00D749F9 /* ResultsController.swift in Sources */,
+				206643572DAEABF7002D5191 /* POSSearchHistoryService.swift in Sources */,
 				CE4FD4542350FC0100A16B31 /* OrderItemRefund+ReadOnlyConvertible.swift in Sources */,
 				DE3C5B21286BF2270049E6AA /* MockSystemStatusActionHandler.swift in Sources */,
 				247CE7D02582E1C100F9D9D1 /* MockSessionManager.swift in Sources */,
@@ -2808,6 +2823,7 @@
 				0286A1BE2A0CC4810099EF94 /* MockFeatureFlagRemote.swift in Sources */,
 				20D035002CDBBD6400C0F901 /* CommonReaderConfigProviderTests.swift in Sources */,
 				0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */,
+				206643592DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift in Sources */,
 				D8652E4826307A5000350F37 /* MockReceiptPrinterService.swift in Sources */,
 				020B2F9623BDE4DD00BD79AD /* ProductStoreTests+Validation.swift in Sources */,
 				02E262C0238CE80100B79588 /* StorageShippingSettingsServiceTests.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSItemType.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSItemType.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum POSItemType {
+    case product
+    case variation
+    case coupon
+}

--- a/Yosemite/Yosemite/PointOfSale/POSSearchHistoryService.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSSearchHistoryService.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Service for managing search history in the Point of Sale
+@available(iOS 17.0, *)
+public final class POSSearchHistoryService {
+    private let maxHistorySize: Int
+    private var searchHistory: [POSItemType: [String]] = [:]
+
+    /// Initializes a new search history service
+    /// - Parameter maxHistorySize: Maximum number of search terms to keep in history per item type
+    public init(maxHistorySize: Int = 10) {
+        self.maxHistorySize = maxHistorySize
+    }
+
+    /// Saves a successful search term to the history
+    /// - Parameters:
+    ///   - term: The search term to save
+    ///   - itemType: The type of item being searched
+    public func saveSuccessfulSearch(term: String, for itemType: POSItemType) {
+        DDLogInfo("POS: Saving search term '\(term)' for item type: \(itemType)")
+
+        if searchHistory[itemType] == nil {
+            searchHistory[itemType] = []
+        }
+
+        searchHistory[itemType]?.removeAll { $0 == term }
+
+        searchHistory[itemType]?.insert(term, at: 0)
+
+        if let count = searchHistory[itemType]?.count, count > maxHistorySize {
+            searchHistory[itemType] = searchHistory[itemType]?.dropLast(count - maxHistorySize)
+        }
+
+        let allSearchTerms = searchHistory[itemType]?.joined(separator: ", ") ?? "[none]"
+        DDLogInfo("POS: Saved search terms for item type: \(itemType) – \(allSearchTerms)")
+    }
+
+    /// Retrieves the search history for a specific item type
+    /// - Parameter itemType: The type of item to get search history for
+    /// - Returns: An array of search terms, ordered from most recent to oldest
+    public func searchHistory(for itemType: POSItemType) -> [String] {
+        return searchHistory[itemType] ?? []
+    }
+
+    /// Clears the search history for a specific item type
+    /// - Parameter itemType: The type of item to clear search history for
+    public func clearSearchHistory(for itemType: POSItemType) {
+        searchHistory[itemType] = []
+    }
+
+    /// Clears all search history
+    public func clearAllSearchHistory() {
+        searchHistory.removeAll()
+    }
+}

--- a/Yosemite/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
@@ -1,0 +1,149 @@
+import Testing
+import Foundation
+@testable import Yosemite
+
+struct POSSearchHistoryServiceTests {
+    @available(iOS 17.0, *)
+    @Test func saveSuccessfulSearch_saves_term_to_history() {
+        // Given
+        let sut = POSSearchHistoryService()
+        let itemType: POSItemType = .product
+
+        // When
+        sut.saveSuccessfulSearch(term: "test", for: itemType)
+
+        // Then
+        let history = sut.searchHistory(for: itemType)
+        #expect(history.count == 1)
+        #expect(history.first == "test")
+    }
+
+    @available(iOS 17.0, *)
+    @Test func saveSuccessfulSearch_orders_terms_by_recency() {
+        // Given
+        let sut = POSSearchHistoryService()
+        let itemType: POSItemType = .product
+
+        // When
+        sut.saveSuccessfulSearch(term: "first", for: itemType)
+        sut.saveSuccessfulSearch(term: "second", for: itemType)
+        sut.saveSuccessfulSearch(term: "third", for: itemType)
+
+        // Then
+        let history = sut.searchHistory(for: itemType)
+        #expect(history.count == 3)
+        #expect(history[0] == "third")
+        #expect(history[1] == "second")
+        #expect(history[2] == "first")
+    }
+
+    @available(iOS 17.0, *)
+    @Test func saveSuccessfulSearch_removes_duplicates() {
+        // Given
+        let sut = POSSearchHistoryService()
+        let itemType: POSItemType = .product
+
+        // When
+        sut.saveSuccessfulSearch(term: "test", for: itemType)
+        sut.saveSuccessfulSearch(term: "another", for: itemType)
+        sut.saveSuccessfulSearch(term: "test", for: itemType)
+
+        // Then
+        let history = sut.searchHistory(for: itemType)
+        #expect(history.count == 2)
+        #expect(history[0] == "test")
+        #expect(history[1] == "another")
+    }
+
+    @available(iOS 17.0, *)
+    @Test func saveSuccessfulSearch_respects_max_history_size() {
+        // Given
+        let maxHistorySize = 3
+        let sut = POSSearchHistoryService(maxHistorySize: maxHistorySize)
+        let itemType: POSItemType = .product
+
+        // When
+        sut.saveSuccessfulSearch(term: "first", for: itemType)
+        sut.saveSuccessfulSearch(term: "second", for: itemType)
+        sut.saveSuccessfulSearch(term: "third", for: itemType)
+        sut.saveSuccessfulSearch(term: "fourth", for: itemType)
+
+        // Then
+        let history = sut.searchHistory(for: itemType)
+        #expect(history.count == maxHistorySize)
+        #expect(history[0] == "fourth")
+        #expect(history[1] == "third")
+        #expect(history[2] == "second")
+    }
+
+    @available(iOS 17.0, *)
+    @Test func searchHistory_returns_empty_array_for_unknown_item_type() {
+        // Given
+        let sut = POSSearchHistoryService()
+        let itemType: POSItemType = .coupon
+
+        // When
+        let history = sut.searchHistory(for: itemType)
+
+        // Then
+        #expect(history.isEmpty)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func clearSearchHistory_clears_history_for_specific_item_type() {
+        // Given
+        let sut = POSSearchHistoryService()
+        let productsType: POSItemType = .product
+        let couponsType: POSItemType = .coupon
+
+        sut.saveSuccessfulSearch(term: "product", for: productsType)
+        sut.saveSuccessfulSearch(term: "coupon", for: couponsType)
+
+        // When
+        sut.clearSearchHistory(for: productsType)
+
+        // Then
+        #expect(sut.searchHistory(for: productsType).isEmpty)
+        #expect(sut.searchHistory(for: couponsType).count == 1)
+        #expect(sut.searchHistory(for: couponsType).first == "coupon")
+    }
+
+    @available(iOS 17.0, *)
+    @Test func clearAllSearchHistory_clears_all_history() {
+        // Given
+        let sut = POSSearchHistoryService()
+        let productsType: POSItemType = .product
+        let couponsType: POSItemType = .coupon
+
+        sut.saveSuccessfulSearch(term: "product", for: productsType)
+        sut.saveSuccessfulSearch(term: "coupon", for: couponsType)
+
+        // When
+        sut.clearAllSearchHistory()
+
+        // Then
+        #expect(sut.searchHistory(for: productsType).isEmpty)
+        #expect(sut.searchHistory(for: couponsType).isEmpty)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func search_history_is_separate_for_different_item_types() {
+        // Given
+        let sut = POSSearchHistoryService()
+        let productsType: POSItemType = .product
+        let couponsType: POSItemType = .coupon
+
+        // When
+        sut.saveSuccessfulSearch(term: "product", for: productsType)
+        sut.saveSuccessfulSearch(term: "coupon", for: couponsType)
+
+        // Then
+        let productsHistory = sut.searchHistory(for: productsType)
+        let couponsHistory = sut.searchHistory(for: couponsType)
+
+        #expect(productsHistory.count == 1)
+        #expect(productsHistory.first == "product")
+        #expect(couponsHistory.count == 1)
+        #expect(couponsHistory.first == "coupon")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of WOOMOB-314
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds support for saving recent search terms, in order that we can later display them in the pre-search UI.

Search terms are sent to a new `POSSearchHistoryService`, and stored in a local array. For the moment, they'll be cleared every time you leave the POS, but in a later PR we'll store them in Core Data or somewhere more persistent.

We only store "successful" searches, defined as those which resulted in an item being added to the cart.

Note that at the moment, we just save one list of search terms; they'll be shared across different sites. I'll change that when we use a more persistent backing store.

There's no visible changes in the UI or UX from this PR, but you can test it using the temporary console logs added for the purpose.



## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the Search feature flag

1. Launch the app and navigate to POS
2. Type a search term – observe that no messages about storing the search term have been logged to the console yet
3. Type a different search term
4. Tap one of the new search results – observe that now, the console shows messages saying that the term is saved and showing the list of saved search terms
5. Delete your search term to go back to the main list
6. Start a new search, and tap a search result when you do – observe that the previously saved terms are still in the list.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

In support of this change, I've altered how the tap action works on item lists. We now inject an action handler to the item list, so that we can handle taps differently on identical-appearing items in different lists.

Additionally, I've clarified that `ItemType` is actually `ItemListType`, as it includes details of whether we're in a searched context.

It's worth checking that the analytics are still correctly logged, and that coupons, variations, and products can all still be added to the cart. I've tested this in addition to the steps listed above.

Tested on an iPad Air running iOS 17.7.3, and a simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/b20cb61b-3de5-44b2-9273-8aa6c3988b39




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.