### PR TITLE
[Woo POS][Product Search] Pre search UI – Show recent searches

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
@@ -115,7 +115,7 @@ struct RecentSearchCard: View {
         Rectangle()
             .foregroundColor(.posSurfaceDim)
             .overlay {
-                Text(Image(systemName: "magnifyingglass"))
+                Image(systemName: "magnifyingglass")
                     .font(.posButtonSymbolLarge)
                     .foregroundColor(.posOnSurfaceVariantLowest)
             }

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
@@ -77,7 +77,13 @@ private extension POSRecentSearchesView {
     }
 }
 
-private struct RecentSearchCard: View {
+struct RecentSearchCard: View {
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    private var dimension: CGFloat {
+        min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
+    }
+
     let searchTerm: String
     let onSearchSelected: (String) -> Void
 
@@ -85,20 +91,37 @@ private struct RecentSearchCard: View {
         Button(action: {
             onSearchSelected(searchTerm)
         }) {
-            HStack {
-                Image(systemName: "magnifyingglass")
-                    .accessibilityHidden(true)
-                    .foregroundColor(.posOnSurfaceVariantLowest)
+            HStack(spacing: Constants.cardSpacing) {
+                searchIcon
+                    .frame(width: dimension, height: dimension)
+
                 Text(searchTerm)
-                    .lineLimit(1)
-                    .font(.posBodyMediumRegular())
+                    .lineLimit(2)
+                    .foregroundStyle(Constants.titleColor)
+                    .multilineTextAlignment(.leading)
+                    .font(Constants.itemTitleFont)
+                    .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
+                    .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
+
                 Spacer()
             }
-            .padding(POSPadding.medium)
-            .background(Color(.systemBackground))
-            .cornerRadius(POSCornerRadiusStyle.medium.value)
-            .posShadow(.medium)
         }
-        .buttonStyle(PlainButtonStyle())
+        .frame(maxWidth: .infinity, idealHeight: dimension)
+        .background(Constants.backgroundColor)
+        .posItemCardBorderStyles()
     }
+
+    private var searchIcon: some View {
+        Rectangle()
+            .foregroundColor(.posSurfaceDim)
+            .overlay {
+                Text(Image(systemName: "magnifyingglass"))
+                    .font(.posButtonSymbolLarge)
+                    .foregroundColor(.posOnSurfaceVariantLowest)
+            }
+    }
+}
+
+private extension RecentSearchCard {
+    typealias Constants = PointOfSaleItemListCardConstants
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+@available(iOS 17.0, *)
+struct POSRecentSearchesView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    let savedSearches: [String]
+    let onSearchSelected: (String) -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: POSSpacing.medium) {
+                if savedSearches.isEmpty {
+                    Text(Localization.recentSearchesEmptyListText)
+                        .foregroundColor(.posOnSurface)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                        .padding(.top, POSPadding.medium)
+                } else {
+                    // Column header
+                    Label {
+                        Text(Localization.recentSearchesTitle)
+                            .font(POSFontStyle.posBodyMediumBold)
+                            .foregroundColor(.posOnSurface)
+                            .accessibilityAddTraits(.isHeader)
+                    } icon: {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .foregroundColor(.posOnSurface)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.top, POSPadding.medium)
+
+                    // Grid of saved searches
+                    LazyVGrid(
+                        columns: gridColumns,
+                        alignment: .leading,
+                        spacing: POSSpacing.medium
+                    ) {
+                        ForEach(savedSearches, id: \.self) { searchTerm in
+                            RecentSearchCard(searchTerm: searchTerm, onSearchSelected: onSearchSelected)
+                        }
+                    }
+                    .padding(.horizontal, POSPadding.medium)
+                }
+            }
+            .padding(.bottom, POSPadding.medium)
+        }
+    }
+
+    private var gridColumns: [GridItem] {
+        if dynamicTypeSize.isAccessibilitySize {
+            // Single column for accessibility sizes
+            return [GridItem(.flexible(), spacing: POSSpacing.medium)]
+        } else {
+            // Two equal columns for normal sizes
+            return [
+                GridItem(.flexible(), spacing: POSSpacing.medium),
+                GridItem(.flexible(), spacing: POSSpacing.medium)
+            ]
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+private extension POSRecentSearchesView {
+    enum Localization {
+        static let recentSearchesTitle = NSLocalizedString(
+            "pos.itemsearch.before.search.recentSearches.title",
+            value: "Recent searches",
+            comment: "Title for the list of recent searches shown before a search term is typed in POS")
+
+        static let recentSearchesEmptyListText = NSLocalizedString(
+            "pos.itemsearch.before.search.recentSearches.emptyListText",
+            value: "No recent searches",
+            comment: "Text shown when there's nothing to show before a search term is typed in POS")
+
+    }
+}
+
+private struct RecentSearchCard: View {
+    let searchTerm: String
+    let onSearchSelected: (String) -> Void
+
+    var body: some View {
+        Button(action: {
+            onSearchSelected(searchTerm)
+        }) {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .accessibilityHidden(true)
+                    .foregroundColor(.posOnSurfaceVariantLowest)
+                Text(searchTerm)
+                    .lineLimit(1)
+                    .font(.posBodyMediumRegular())
+                Spacer()
+            }
+            .padding(POSPadding.medium)
+            .background(Color(.systemBackground))
+            .cornerRadius(POSCornerRadiusStyle.medium.value)
+            .posShadow(.medium)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -11,6 +11,7 @@ struct ItemListView: View {
     @State private var showSimpleProductsModal: Bool = false
 
     @State private var searchTerm: String = ""
+    @FocusState private var isSearchFieldFocused: Bool
 
     @Binding var selectedItemListType: ItemListType
 
@@ -59,15 +60,21 @@ struct ItemListView: View {
         VStack(spacing: 0) {
             headerView
 
-            switch itemListState {
-            case .loading(let items),
-                    .loaded(let items, _),
-                    .inlineError(let items, _, _):
-                listView(items)
-            case .error(let errorState):
-                errorView(errorState)
-            case .empty:
-                emptyView
+            if isSearchFieldFocused && searchTerm.isEmpty {
+                Text("Recent searches go here")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.posSurface)
+            } else {
+                switch itemListState {
+                case .loading(let items),
+                        .loaded(let items, _),
+                        .inlineError(let items, _, _):
+                    listView(items)
+                case .error(let errorState):
+                    errorView(errorState)
+                case .empty:
+                    emptyView
+                }
             }
         }
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
@@ -100,10 +107,7 @@ private extension ItemListView {
                 HStack {
                     if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS),
                        case .products = selectedItemListType {
-                        TextField(text: $searchTerm) {
-                            Text("Search")
-                        }
-                        .onChange(of: searchTerm) { oldValue, newValue in
+                        searchField.onChange(of: searchTerm) { oldValue, newValue in
                             selectedItemListType = .products(search: newValue.isNotEmpty)
 
                             // The debouncing logic is a little tricky, because the loading state is held in the controller.
@@ -154,6 +158,25 @@ private extension ItemListView {
                     .padding(.horizontal, Constants.bannerCardPadding)
                     .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             }
+        }
+    }
+
+    var searchField: some View {
+        HStack(spacing: POSSpacing.small) {
+            if isSearchFieldFocused || searchTerm.isNotEmpty {
+                Button(action: {
+                    searchTerm = ""
+                    isSearchFieldFocused = false
+                }) {
+                    Image(systemName: "chevron.backward")
+                        .foregroundColor(.posOnSurface)
+                }
+            }
+
+            TextField(text: $searchTerm) {
+                Text("Search")
+            }
+            .focused($isSearchFieldFocused)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -61,9 +61,13 @@ struct ItemListView: View {
             headerView
 
             if isSearchFieldFocused && searchTerm.isEmpty {
-                Text("Recent searches go here")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.posSurface)
+                POSRecentSearchesView(
+                    savedSearches: posModel.searchHistory(for: .product),
+                    onSearchSelected: { search in
+                        searchTerm = search
+                    }
+                )
+                .background(Color.posSurface)
             } else {
                 switch itemListState {
                 case .loading(let items),

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -62,7 +62,7 @@ struct ItemListView: View {
 
             if isSearchFieldFocused && searchTerm.isEmpty {
                 POSRecentSearchesView(
-                    savedSearches: posModel.searchHistory(for: .product),
+                    savedSearches: posModel.searchHistory(for: selectedItemListType.itemType),
                     onSearchSelected: { search in
                         searchTerm = search
                     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -896,6 +896,7 @@
 		20AE33C52B0510BF00527B60 /* PaymentsMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */; };
 		20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C62B0510D200527B60 /* HubMenuDestination.swift */; };
 		20B0D65E2AD45BDE0059735A /* TapToPayEducationContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* TapToPayEducationContactlessLimitViewModelTests.swift */; };
+		20B9EC6A2DAFFB7A00512EF5 /* POSRecentSearchesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9EC692DAFFB7A00512EF5 /* POSRecentSearchesView.swift */; };
 		20BBD62C2B3060A300A903F6 /* AddOrderComponentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BBD62B2B3060A300A903F6 /* AddOrderComponentsSection.swift */; };
 		20BCF6EE2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6ED2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift */; };
 		20BCF6F02B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */; };
@@ -4156,6 +4157,7 @@
 		20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsMenuDestination.swift; sourceTree = "<group>"; };
 		20AE33C62B0510D200527B60 /* HubMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubMenuDestination.swift; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* TapToPayEducationContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayEducationContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
+		20B9EC692DAFFB7A00512EF5 /* POSRecentSearchesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSRecentSearchesView.swift; sourceTree = "<group>"; };
 		20BBD62B2B3060A300A903F6 /* AddOrderComponentsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOrderComponentsSection.swift; sourceTree = "<group>"; };
 		20BCF6ED2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewViewModel.swift; sourceTree = "<group>"; };
 		20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -7281,6 +7283,7 @@
 				016A77672D9D24A30004FCD6 /* Coupons */,
 				026A50262D2F6BBF002C42C2 /* Infinite Scroll */,
 				029149792D2682DF00F7B3B3 /* Item Selector */,
+				20B9EC682DAFFB3800512EF5 /* Item Search */,
 				01620C4C2C5394A400D3EA2F /* Reusable Views */,
 				02E71DB42C118C470036C2FD /* Card Present Payments */,
 				026826B02BF59E170036F959 /* CardReaderConnection */,
@@ -8433,6 +8436,14 @@
 				20D3D4342C65E640004CE6E3 /* OrdersDestination.swift */,
 			);
 			path = Destinations;
+			sourceTree = "<group>";
+		};
+		20B9EC682DAFFB3800512EF5 /* Item Search */ = {
+			isa = PBXGroup;
+			children = (
+				20B9EC692DAFFB7A00512EF5 /* POSRecentSearchesView.swift */,
+			);
+			path = "Item Search";
 			sourceTree = "<group>";
 		};
 		20BBD62A2B30608200A903F6 /* AddOrderComponentsSection */ = {
@@ -17301,6 +17312,7 @@
 				02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */,
 				020B640F29C194CF001C5BD9 /* StoreOnboardingStoreLaunchedView.swift in Sources */,
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
+				20B9EC6A2DAFFB7A00512EF5 /* POSRecentSearchesView.swift in Sources */,
 				CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */,
 				039B7E6529F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift in Sources */,
 				20F7B12F2D12CBE700C08193 /* ItemsViewState.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of WOOMOB-314
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a pre-search view to the search, so when you focus the search field without a search term, we show previous searches.

Tapping a search populates the search field and performs the search.

I've also added a `<` button to leave search mode. The button is currently a little tricky to tap but will be improved when I do more UI polish.

There's some copy pasted code relating to image sizes from the products cards. I'm going to factor that out in another PR tomorrow but it just made this one confusing to do it here, and it's already copied to various places.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `searchProductsInPOS` flag

1. Launch the app and navigate to POS
2. Type a search term which matches some products
3. Tap one of the results
4. Delete your search term
5. Observe that the saved search is shown
6. Tap it; observe that it's searched again

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I took some care with the adaptivity and accessibility in this PR, but it'll change over the coming PRs when we add popular products, so don't feel you need to test that in detail just now if you don't want to. I have tested it.

One accessibility improvement I plan to explore is hiding the image at larger dynamic type sizes, as we do on the cart. I'll do that right at the end though, it may not feel right with products in this list as it's pretty important for identifying them.

I've tested on an iPad Air running iOS 17.7.3 and a simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/221cb5b8-edb1-421a-9f75-1ec31c05f53d


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.