### PR TITLE
Fix an issue where a draft variable product cannot be published

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [internal] Improved login flow during Jetpack Setup for accounts using emails marked as suspicious [https://github.com/woocommerce/woocommerce-ios/pull/15491]
 - [internal] Update Sentry to 8.46.0 to allow building with Xcode 16.3 [https://github.com/woocommerce/woocommerce-ios/pull/15503]
+- [*] Product Form: Fixed an issue where a draft variable product cannot be published [https://github.com/woocommerce/woocommerce-ios/pull/15513]
 
 22.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -601,7 +601,7 @@ extension ProductFormViewModel {
                 }
             }
         case .edit:
-            guard hasChangesExcludingImageUploads() else {
+            guard hasChangesExcludingImageUploads(productModelToSave: productModelToSave) else {
                 /// Skip product update if there are no changes
                 saveProductImagesWhenNoneIsPendingUploadAnymore()
                 onCompletion(.success(product))
@@ -662,9 +662,9 @@ extension ProductFormViewModel {
 //
 private extension ProductFormViewModel {
 
-    func hasChangesExcludingImageUploads() -> Bool {
-        let hasProductChanges = product.product.copy(images: []) != originalProduct.product.copy(images: [])
-        let hasUploadedImageChanges = product.images.map(\.imageID) != originalProduct.images.map(\.imageID)
+    func hasChangesExcludingImageUploads(productModelToSave: EditableProductModel) -> Bool {
+        let hasProductChanges = productModelToSave.product.copy(images: []) != originalProduct.product.copy(images: [])
+        let hasUploadedImageChanges = productModelToSave.images.map(\.imageID) != originalProduct.images.map(\.imageID)
         return hasProductChanges || hasUploadedImageChanges || password != originalPassword || isNewTemplateProduct()
 
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -236,6 +236,33 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         XCTAssertTrue(productImagesUploader.saveProductImagesWhenNoneIsPendingUploadAnymoreWasCalled)
         XCTAssertFalse(updateProductTriggered)
     }
+
+    func test_saveProductRemotely_when_draft_variable_product_saved_with_published_status_then_saves_with_published_status() throws {
+        // Given
+        let product = Product.fake().copy(
+            productID: 123,
+            productTypeKey: ProductType.variable.rawValue,
+            statusKey: ProductStatus.draft.rawValue
+        )
+        let viewModel = createViewModel(product: product, formType: .edit)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let ProductAction.updateProduct(product, onCompletion) = action {
+                onCompletion(.success(product.copy(statusKey: product.statusKey)))
+            }
+        }
+
+        // When
+        var savedProduct: EditableProductModel?
+        waitForExpectation { expectation in
+            viewModel.saveProductRemotely(status: .published) { result in
+                savedProduct = try? result.get()
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertEqual(savedProduct?.status, .published)
+    }
 }
 
 private extension ProductFormViewModel_SaveTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

`saveProductRemotely` uses `hasChangesExcludingImageUploads` check to determine whether to save the product remotely. However, `hasChangesExcludingImageUploads` doesn't use the latest `productModelToSave` that has updated status. It causes problems when trying to publish draft variable products. `hasChangesExcludingImageUploads` would always return `false` when only status is changed.

This is a regression from 21.7 -> 21.8 introduced in https://github.com/woocommerce/woocommerce-ios/pull/15052.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Product
2. New
3. Variable Product
4. Variations
5. Generate a variation
6. Add name
7. Tap save
8. Tap publish
9. Confirm the product is published

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Added `test_saveProductRemotely_when_draft_variable_product_saved_with_published_status_then_saves_with_published_status` that tests specifically this case.

Change `hasChangesExcludingImageUploads(productModelToSave: productModelToSave)` to `hasChangesExcludingImageUploads(productModelToSave: product)` and observe the test fail.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://github.com/user-attachments/assets/8fea9245-0bb4-49ab-9729-a8c4f05f3a42

### After

https://github.com/user-attachments/assets/476b227e-c3f0-4018-9037-197f3e521f25

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
