### PR TITLE
[Woo POS][Products Search] Extract local site settings storage

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		2095A64B2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2095A64A2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift */; };
 		209AD3CC2AC1A68800825D76 /* WooPaymentsPayoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */; };
 		209AD3CE2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */; };
+		20B9F7842DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9F7832DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift */; };
 		20BCF6F22B0E554500954840 /* SystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F12B0E554500954840 /* SystemStatusService.swift */; };
 		20BCF6F52B0E57AB00954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */; };
 		20CF75B82CF4C3B900ACCF4A /* MockPOSOrdersRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */; };
@@ -723,6 +724,7 @@
 		2095A64A2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutService.swift; sourceTree = "<group>"; };
 		209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverview.swift; sourceTree = "<group>"; };
+		20B9F7832DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSpecificAppSettingsStoreMethods.swift; sourceTree = "<group>"; };
 		20BCF6F12B0E554500954840 /* SystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusService.swift; sourceTree = "<group>"; };
 		20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockSystemStatusService.swift; path = ../../../WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift; sourceTree = "<group>"; };
 		20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrdersRemote.swift; sourceTree = "<group>"; };
@@ -1140,6 +1142,7 @@
 			children = (
 				012848DB2D9ED55700A9C69B /* SettingStoreMethods.swift */,
 				016A89D72D9D6DAE0004FCD6 /* CouponStoreMethods.swift */,
+				20B9F7832DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2428,6 +2431,7 @@
 				247CE8402582F39900F9D9D1 /* MockActionHandler.swift in Sources */,
 				247CE7C82582DF5500F9D9D1 /* MockStoresManager.swift in Sources */,
 				BAB3737927964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift in Sources */,
+				20B9F7842DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift in Sources */,
 				D83B093525DECFCC00B21F45 /* CardPresentPaymentAction.swift in Sources */,
 				B52E0030211A439E00700FDE /* Account+ReadOnlyType.swift in Sources */,
 				4591A6B0274BB23000F51DCD /* OrderDateRangeFilter.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 		209AD3CC2AC1A68800825D76 /* WooPaymentsPayoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */; };
 		209AD3CE2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */; };
 		20B9F7842DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9F7832DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift */; };
+		20B9F7892DB118AE00512EF5 /* SiteSpecificAppSettingsStoreMethodsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9F7882DB118AE00512EF5 /* SiteSpecificAppSettingsStoreMethodsTests.swift */; };
+		20B9F78B2DB11A7D00512EF5 /* MockSiteSpecificAppSettingsStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9F78A2DB11A7D00512EF5 /* MockSiteSpecificAppSettingsStoreMethods.swift */; };
 		20BCF6F22B0E554500954840 /* SystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F12B0E554500954840 /* SystemStatusService.swift */; };
 		20BCF6F52B0E57AB00954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */; };
 		20CF75B82CF4C3B900ACCF4A /* MockPOSOrdersRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */; };
@@ -725,6 +727,8 @@
 		209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutService.swift; sourceTree = "<group>"; };
 		209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverview.swift; sourceTree = "<group>"; };
 		20B9F7832DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSpecificAppSettingsStoreMethods.swift; sourceTree = "<group>"; };
+		20B9F7882DB118AE00512EF5 /* SiteSpecificAppSettingsStoreMethodsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSpecificAppSettingsStoreMethodsTests.swift; sourceTree = "<group>"; };
+		20B9F78A2DB11A7D00512EF5 /* MockSiteSpecificAppSettingsStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSiteSpecificAppSettingsStoreMethods.swift; sourceTree = "<group>"; };
 		20BCF6F12B0E554500954840 /* SystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusService.swift; sourceTree = "<group>"; };
 		20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockSystemStatusService.swift; path = ../../../WooCommerce/WooCommerceTests/Mocks/MockSystemStatusService.swift; sourceTree = "<group>"; };
 		20CF75B72CF4C3AD00ACCF4A /* MockPOSOrdersRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrdersRemote.swift; sourceTree = "<group>"; };
@@ -1338,6 +1342,14 @@
 			path = Payments;
 			sourceTree = "<group>";
 		};
+		20B9F7852DB1187A00512EF5 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				20B9F7882DB118AE00512EF5 /* SiteSpecificAppSettingsStoreMethodsTests.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		20BCF6F32B0E558500954840 /* SystemStatus */ = {
 			isa = PBXGroup;
 			children = (
@@ -1845,6 +1857,7 @@
 		B5BC736620D1AA8F00B5B6FA /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				20B9F7852DB1187A00512EF5 /* Helpers */,
 				5758EB3124DC961E009ED8A6 /* AppSettings */,
 				57264570250BE2CE005BBD7C /* Order */,
 				578CE7862475D6FA00492EBF /* ProductReview */,
@@ -2061,6 +2074,7 @@
 				20BCF6F42B0E57AB00954840 /* MockSystemStatusService.swift */,
 				20716F312D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */,
 				20D035012CDBBE2A00C0F901 /* MockCardReaderCapableRemote.swift */,
+				20B9F78A2DB11A7D00512EF5 /* MockSiteSpecificAppSettingsStoreMethods.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2844,6 +2858,7 @@
 				02E7FFD92562234F00C53030 /* MockShippingLabelRemote.swift in Sources */,
 				D4CBAE5C26D401BC00BBE6D1 /* AnnouncementsStoreTests.swift in Sources */,
 				EEB4E2CD29B04CE900371C3C /* MockStoreOnboardingTasksRemote.swift in Sources */,
+				20B9F7892DB118AE00512EF5 /* SiteSpecificAppSettingsStoreMethodsTests.swift in Sources */,
 				45E462162684D9C000011BF2 /* DataStoreTests.swift in Sources */,
 				B53A56A0211245E0000776C9 /* MockStorageManager+Sample.swift in Sources */,
 				453305FB245AEDCB00264E50 /* SitePostStoreTests.swift in Sources */,
@@ -2863,6 +2878,7 @@
 				CE606DA22BE3C331001CB424 /* ShippingMethodStoreTests.swift in Sources */,
 				20716F322D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift in Sources */,
 				03FBDA2E2632A9B400ACE257 /* MockCouponsRemote.swift in Sources */,
+				20B9F78B2DB11A7D00512EF5 /* MockSiteSpecificAppSettingsStoreMethods.swift in Sources */,
 				DED91DF42AD67E9400CDCC53 /* BlazeStoreTests.swift in Sources */,
 				016A776B2D9D30C90004FCD6 /* PointOfSaleCouponServiceTests.swift in Sources */,
 				B5C9DE252087FF20006B910A /* MockActionsProcessor.swift in Sources */,

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -10,6 +10,8 @@ public class AppSettingsStore: Store {
 
     private let generalAppSettings: GeneralAppSettingsStorage
 
+    private let siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethods
+
     /// Designated initaliser
     ///
     public init(dispatcher: Dispatcher,
@@ -18,6 +20,7 @@ public class AppSettingsStore: Store {
                 generalAppSettings: GeneralAppSettingsStorage) {
         self.fileStorage = fileStorage
         self.generalAppSettings = generalAppSettings
+        self.siteSpecificAppSettingsStoreMethods = SiteSpecificAppSettingsStoreMethods(fileStorage: fileStorage)
         super.init(dispatcher: dispatcher,
                    storageManager: storageManager,
                    network: NullNetwork())
@@ -39,11 +42,6 @@ public class AppSettingsStore: Store {
     lazy var customSelectedProvidersURL: URL = {
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
         return documents!.appendingPathComponent(Constants.customShipmentProvidersFileName)
-    }()
-
-    private lazy var generalStoreSettingsFileURL: URL! = {
-        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        return documents!.appendingPathComponent(Constants.generalStoreSettingsFileName)
     }()
 
     /// URL to the plist file that we use to determine the settings applied in Orders
@@ -966,29 +964,11 @@ private extension AppSettingsStore {
 private extension AppSettingsStore {
 
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
-        guard let existingData: GeneralStoreSettingsBySite = try? fileStorage.data(for: generalStoreSettingsFileURL),
-              let storeSettings = existingData.storeSettingsBySite[siteID] else {
-            return GeneralStoreSettings()
-        }
-
-        return storeSettings
+        siteSpecificAppSettingsStoreMethods.getStoreSettings(for: siteID)
     }
 
     func setStoreSettings(settings: GeneralStoreSettings, for siteID: Int64, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
-        var storeSettingsBySite: [Int64: GeneralStoreSettings] = [:]
-        if let existingData: GeneralStoreSettingsBySite = try? fileStorage.data(for: generalStoreSettingsFileURL) {
-            storeSettingsBySite = existingData.storeSettingsBySite
-        }
-
-        storeSettingsBySite[siteID] = settings
-
-        do {
-            try fileStorage.write(GeneralStoreSettingsBySite(storeSettingsBySite: storeSettingsBySite), to: generalStoreSettingsFileURL)
-            onCompletion?(.success(()))
-        } catch {
-            onCompletion?(.failure(error))
-            DDLogError("⛔️ Saving store settings to file failed. Error: \(error)")
-        }
+        siteSpecificAppSettingsStoreMethods.setStoreSettings(settings: settings, for: siteID, onCompletion: onCompletion)
     }
 
     // Store unique identifier
@@ -1024,11 +1004,7 @@ private extension AppSettingsStore {
     }
 
     func resetGeneralStoreSettings() {
-        do {
-            try fileStorage.deleteFile(at: generalStoreSettingsFileURL)
-        } catch {
-            DDLogError("⛔️ Deleting store settings file failed. Error: \(error)")
-        }
+        siteSpecificAppSettingsStoreMethods.resetStoreSettings()
     }
 }
 
@@ -1311,7 +1287,6 @@ private enum Constants {
     // MARK: File Names
     static let shipmentProvidersFileName = "shipment-providers.plist"
     static let customShipmentProvidersFileName = "custom-shipment-providers.plist"
-    static let generalStoreSettingsFileName = "general-store-settings.plist"
     static let ordersSettings = "orders-settings.plist"
     static let productsSettings = "products-settings.plist"
     static let orderFilterHistory = "order-filter-history.plist"

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -986,14 +986,11 @@ private extension AppSettingsStore {
     // Store unique identifier
 
     func setStoreID(siteID: Int64, id: String?) {
-        let storeSettings = getStoreSettings(for: siteID)
-        let updatedSettings = storeSettings.copy(storeID: id)
-        setStoreSettings(settings: updatedSettings, for: siteID)
+        siteSpecificAppSettingsStoreMethods.setStoreID(siteID: siteID, id: id)
     }
 
     func getStoreID(siteID: Int64, onCompletion: (String?) -> Void) {
-        let storeSettings = getStoreSettings(for: siteID)
-        onCompletion(storeSettings.storeID)
+        siteSpecificAppSettingsStoreMethods.getStoreID(siteID: siteID, onCompletion: onCompletion)
     }
 
     // Telemetry data

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -10,17 +10,29 @@ public class AppSettingsStore: Store {
 
     private let generalAppSettings: GeneralAppSettingsStorage
 
-    private let siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethods
+    private let siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol
 
     /// Designated initaliser
     ///
-    public init(dispatcher: Dispatcher,
+    public convenience init(dispatcher: Dispatcher,
                 storageManager: StorageManagerType,
                 fileStorage: FileStorage,
                 generalAppSettings: GeneralAppSettingsStorage) {
+        self.init(dispatcher: dispatcher,
+             storageManager: storageManager,
+             fileStorage: fileStorage,
+             generalAppSettings: generalAppSettings,
+             siteSpecificAppSettingsStoreMethods: nil)
+    }
+
+    init(dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         fileStorage: FileStorage,
+         generalAppSettings: GeneralAppSettingsStorage,
+         siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol?) {
         self.fileStorage = fileStorage
         self.generalAppSettings = generalAppSettings
-        self.siteSpecificAppSettingsStoreMethods = SiteSpecificAppSettingsStoreMethods(fileStorage: fileStorage)
+        self.siteSpecificAppSettingsStoreMethods = siteSpecificAppSettingsStoreMethods ?? SiteSpecificAppSettingsStoreMethods(fileStorage: fileStorage)
         super.init(dispatcher: dispatcher,
                    storageManager: storageManager,
                    network: NullNetwork())

--- a/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Storage
+
+/// Methods for managing site-specific app settings
+///
+public struct SiteSpecificAppSettingsStoreMethods {
+    private let fileStorage: FileStorage
+    private let generalStoreSettingsFileURL: URL
+
+    /// Default URL for storing general store settings
+    ///
+    public static var defaultGeneralStoreSettingsFileURL: URL {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        return documents!.appendingPathComponent(Constants.generalStoreSettingsFileName)
+    }
+
+    public init(fileStorage: FileStorage, generalStoreSettingsFileURL: URL = defaultGeneralStoreSettingsFileURL) {
+        self.fileStorage = fileStorage
+        self.generalStoreSettingsFileURL = generalStoreSettingsFileURL
+    }
+}
+
+// MARK: - Store Settings
+public extension SiteSpecificAppSettingsStoreMethods {
+    func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
+        guard let existingData: GeneralStoreSettingsBySite = try? fileStorage.data(for: generalStoreSettingsFileURL),
+              let storeSettings = existingData.storeSettingsBySite[siteID] else {
+            return GeneralStoreSettings()
+        }
+
+        return storeSettings
+    }
+
+    func setStoreSettings(settings: GeneralStoreSettings, for siteID: Int64, onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        var storeSettingsBySite: [Int64: GeneralStoreSettings] = [:]
+        if let existingData: GeneralStoreSettingsBySite = try? fileStorage.data(for: generalStoreSettingsFileURL) {
+            storeSettingsBySite = existingData.storeSettingsBySite
+        }
+
+        storeSettingsBySite[siteID] = settings
+
+        do {
+            try fileStorage.write(GeneralStoreSettingsBySite(storeSettingsBySite: storeSettingsBySite), to: generalStoreSettingsFileURL)
+            onCompletion?(.success(()))
+        } catch {
+            onCompletion?(.failure(error))
+            DDLogError("⛔️ Saving store settings to file failed. Error: \(error)")
+        }
+    }
+
+    func resetStoreSettings() {
+        do {
+            try fileStorage.deleteFile(at: generalStoreSettingsFileURL)
+        } catch {
+            DDLogError("⛔️ Deleting store settings file failed. Error: \(error)")
+        }
+    }
+}
+
+// MARK: - Constants
+private enum Constants {
+    static let generalStoreSettingsFileName = "general-store-settings.plist"
+} 

--- a/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -11,7 +11,7 @@ protocol SiteSpecificAppSettingsStoreMethodsProtocol {
 
 /// Methods for managing site-specific app settings
 ///
-public struct SiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol {
+struct SiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol {
     private let fileStorage: FileStorage
     private let generalStoreSettingsFileURL: URL
 
@@ -29,7 +29,7 @@ public struct SiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreM
 }
 
 // MARK: - Store Settings
-public extension SiteSpecificAppSettingsStoreMethods {
+extension SiteSpecificAppSettingsStoreMethods {
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         guard let existingData: GeneralStoreSettingsBySite = try? fileStorage.data(for: generalStoreSettingsFileURL),
               let storeSettings = existingData.storeSettingsBySite[siteID] else {

--- a/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -1,9 +1,17 @@
 import Foundation
 import Storage
 
+protocol SiteSpecificAppSettingsStoreMethodsProtocol {
+    func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings
+    func setStoreSettings(settings: GeneralStoreSettings, for siteID: Int64, onCompletion: ((Result<Void, Error>) -> Void)?)
+    func resetStoreSettings()
+    func setStoreID(siteID: Int64, id: String?)
+    func getStoreID(siteID: Int64, onCompletion: (String?) -> Void)
+}
+
 /// Methods for managing site-specific app settings
 ///
-public struct SiteSpecificAppSettingsStoreMethods {
+public struct SiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol {
     private let fileStorage: FileStorage
     private let generalStoreSettingsFileURL: URL
 
@@ -55,9 +63,20 @@ public extension SiteSpecificAppSettingsStoreMethods {
             DDLogError("⛔️ Deleting store settings file failed. Error: \(error)")
         }
     }
+
+    func setStoreID(siteID: Int64, id: String?) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(storeID: id)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func getStoreID(siteID: Int64, onCompletion: (String?) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        onCompletion(storeSettings.storeID)
+    }
 }
 
 // MARK: - Constants
 private enum Constants {
     static let generalStoreSettingsFileName = "general-store-settings.plist"
-} 
+}

--- a/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -1,0 +1,47 @@
+@testable import Yosemite
+import Storage
+
+final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol {
+    var getStoreSettingsCalled = false
+    var setStoreSettingsCalled = false
+    var resetStoreSettingsCalled = false
+    var setStoreIDCalled = false
+    var getStoreIDCalled = false
+    var spySetStoreID: String? = nil
+    var spySetStoreIDSiteID: Int64? = nil
+
+    var spyGetStoreID: String? = nil
+    var spyGetStoreIDSiteID: Int64? = nil
+
+    var mockStoreSettings = GeneralStoreSettings()
+    var mockStoreID: String?
+    var mockError: Error?
+
+    func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
+        getStoreSettingsCalled = true
+        return mockStoreSettings
+    }
+
+    func setStoreSettings(settings: GeneralStoreSettings, for siteID: Int64, onCompletion: ((Result<Void, Error>) -> Void)?) {
+        setStoreSettingsCalled = true
+        if let error = mockError {
+            onCompletion?(.failure(error))
+        } else {
+            onCompletion?(.success(()))
+        }
+    }
+
+    func resetStoreSettings() {
+        resetStoreSettingsCalled = true
+    }
+
+    func setStoreID(siteID: Int64, id: String?) {
+        setStoreIDCalled = true
+        mockStoreID = id
+    }
+
+    func getStoreID(siteID: Int64, onCompletion: (String?) -> Void) {
+        getStoreIDCalled = true
+        onCompletion(mockStoreID)
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -10,20 +10,28 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     var spySetStoreID: String? = nil
     var spySetStoreIDSiteID: Int64? = nil
 
-    var spyGetStoreID: String? = nil
     var spyGetStoreIDSiteID: Int64? = nil
 
-    var mockStoreSettings = GeneralStoreSettings()
+    var storeSettings = GeneralStoreSettings()
     var mockStoreID: String?
     var mockError: Error?
 
+    var currentSiteID: Int64 = 1
+
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         getStoreSettingsCalled = true
-        return mockStoreSettings
+        return storeSettings
     }
 
     func setStoreSettings(settings: GeneralStoreSettings, for siteID: Int64, onCompletion: ((Result<Void, Error>) -> Void)?) {
         setStoreSettingsCalled = true
+
+        guard siteID == currentSiteID else {
+            onCompletion?(.success(()))
+            return
+        }
+
+        storeSettings = settings
         if let error = mockError {
             onCompletion?(.failure(error))
         } else {
@@ -33,15 +41,22 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
 
     func resetStoreSettings() {
         resetStoreSettingsCalled = true
+        storeSettings = GeneralStoreSettings()
     }
 
     func setStoreID(siteID: Int64, id: String?) {
         setStoreIDCalled = true
+        spySetStoreID = id
+        spySetStoreIDSiteID = siteID
+        guard siteID == currentSiteID else {
+            return
+        }
         mockStoreID = id
     }
 
     func getStoreID(siteID: Int64, onCompletion: (String?) -> Void) {
         getStoreIDCalled = true
+        spyGetStoreIDSiteID = siteID
         onCompletion(mockStoreID)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -54,6 +54,7 @@ final class AppSettingsStoreTests: XCTestCase {
         fileStorage = MockInMemoryStorage()
         generalAppSettings = GeneralAppSettingsStorage(fileStorage: fileStorage!)
         mockSiteSpecificAppSettingsStoreMethods = MockSiteSpecificAppSettingsStoreMethods()
+        mockSiteSpecificAppSettingsStoreMethods.currentSiteID = TestConstants.siteID
         subject = AppSettingsStore(dispatcher: dispatcher!,
                                    storageManager: storageManager!,
                                    fileStorage: fileStorage!,
@@ -533,28 +534,26 @@ final class AppSettingsStoreTests: XCTestCase {
 
     func test_setStoreID_stores_the_store_id_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
         let storeID = "test-store-id"
 
         // When
-        let action = AppSettingsAction.setStoreID(siteID: siteID, id: storeID)
+        let action = AppSettingsAction.setStoreID(siteID: TestConstants.siteID, id: storeID)
         subject?.onAction(action)
 
         // Then
         XCTAssertTrue(mockSiteSpecificAppSettingsStoreMethods.setStoreIDCalled)
-        XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spySetStoreIDSiteID, siteID)
+        XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spySetStoreIDSiteID, TestConstants.siteID)
         XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spySetStoreID, storeID)
     }
 
     func test_getStoreID_retrieves_the_saved_store_id() throws {
         // Given
-        let siteID: Int64 = 1234
         let expectedStoreID = "test-store-id"
         mockSiteSpecificAppSettingsStoreMethods.mockStoreID = expectedStoreID
 
         // When
         let retrievedStoreID: String? = waitFor { promise in
-            let action = AppSettingsAction.getStoreID(siteID: siteID) { id in
+            let action = AppSettingsAction.getStoreID(siteID: TestConstants.siteID) { id in
                 promise(id)
             }
             self.subject?.onAction(action)
@@ -562,104 +561,61 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mockSiteSpecificAppSettingsStoreMethods.getStoreIDCalled)
-        XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spyGetStoreIDSiteID, siteID)
+        XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spyGetStoreIDSiteID, TestConstants.siteID)
         XCTAssertEqual(retrievedStoreID, expectedStoreID)
     }
 
     func test_saving_isTelemetryAvailable_works_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
         let initialTime = Date(timeIntervalSince1970: 100)
 
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(isTelemetryAvailable: true,
-                                                                                                             telemetryLastReportedTime: initialTime)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(isTelemetryAvailable: true,
+                                                                                     telemetryLastReportedTime: initialTime)
 
         // When
-        let action = AppSettingsAction.setTelemetryAvailability(siteID: siteID, isAvailable: false)
+        let action = AppSettingsAction.setTelemetryAvailability(siteID: TestConstants.siteID, isAvailable: false)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        XCTAssertEqual(false, settingsForSite?.isTelemetryAvailable)
+        XCTAssertEqual(false, settingsForSite.isTelemetryAvailable)
 
         // The other properties should be kept
-        XCTAssertEqual(initialTime, settingsForSite?.telemetryLastReportedTime)
-    }
-
-    func test_saving_isTelemetryAvailable_works_correctly_when_the_settings_file_does_not_exist() throws {
-        // Given
-        let siteID: Int64 = 1234
-
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
-
-        // When
-        let action = AppSettingsAction.setTelemetryAvailability(siteID: siteID, isAvailable: true)
-        subject?.onAction(action)
-
-        // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
-
-        XCTAssertEqual(true, settingsForSite?.isTelemetryAvailable)
+        XCTAssertEqual(initialTime, settingsForSite.telemetryLastReportedTime)
     }
 
     func test_saving_telemetryLastReportedTime_works_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
         let initialTime = Date(timeIntervalSince1970: 100)
         let newTime = Date(timeIntervalSince1970: 500)
 
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(isTelemetryAvailable: true,
-                                                                                                             telemetryLastReportedTime: initialTime)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(isTelemetryAvailable: true,
+                                                                                     telemetryLastReportedTime: initialTime)
 
         // When
-        let action = AppSettingsAction.setTelemetryLastReportedTime(siteID: siteID, time: newTime)
+        let action = AppSettingsAction.setTelemetryLastReportedTime(siteID: TestConstants.siteID, time: newTime)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        XCTAssertEqual(newTime, settingsForSite?.telemetryLastReportedTime)
+        XCTAssertEqual(newTime, settingsForSite.telemetryLastReportedTime)
 
         // The other properties should be kept
-        XCTAssertEqual(true, settingsForSite?.isTelemetryAvailable)
-    }
-
-    func test_saving_telemetryLastReportedTime_works_correctly_when_the_settings_file_does_not_exist() throws {
-        // Given
-        let siteID: Int64 = 1234
-        let newTime = Date(timeIntervalSince1970: 500)
-
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
-
-        // When
-        let action = AppSettingsAction.setTelemetryLastReportedTime(siteID: siteID, time: newTime)
-        subject?.onAction(action)
-
-        // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
-
-        XCTAssertEqual(newTime, settingsForSite?.telemetryLastReportedTime)
+        XCTAssertEqual(true, settingsForSite.isTelemetryAvailable)
     }
 
     func test_getTelemetryInfo_returns_correct_saved_data() throws {
         // Given
-        let siteID: Int64 = 1234
         let initialTime = Date(timeIntervalSince1970: 100)
 
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(isTelemetryAvailable: true,
-                                                                                                             telemetryLastReportedTime: initialTime)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(isTelemetryAvailable: true,
+                                                                                     telemetryLastReportedTime: initialTime)
 
         // When
         let data: (isAvailable: Bool, telemetryLastReportedTime: Date?) = waitFor { promise in
-            let action = AppSettingsAction.getTelemetryInfo(siteID: siteID) { isAvailable, telemetryLastReportedTime in
+            let action = AppSettingsAction.getTelemetryInfo(siteID: TestConstants.siteID) { isAvailable, telemetryLastReportedTime in
                 promise((isAvailable, telemetryLastReportedTime))
             }
             self.subject?.onAction(action)
@@ -672,12 +628,10 @@ final class AppSettingsStoreTests: XCTestCase {
 
     func test_getTelemetryInfo_returns_correct_default_data() throws {
         // Given
-        let siteID: Int64 = 1234
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
 
         // When
         let data: (isAvailable: Bool, telemetryLastReportedTime: Date?) = waitFor { promise in
-            let action = AppSettingsAction.getTelemetryInfo(siteID: siteID) { isAvailable, telemetryLastReportedTime in
+            let action = AppSettingsAction.getTelemetryInfo(siteID: TestConstants.siteID) { isAvailable, telemetryLastReportedTime in
                 promise((isAvailable, telemetryLastReportedTime))
             }
             self.subject?.onAction(action)
@@ -690,12 +644,10 @@ final class AppSettingsStoreTests: XCTestCase {
 
     func test_simplePaymentsToggleTaxes_returns_correct_default_data() throws {
         // Given
-        let siteID: Int64 = 1234
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
-            let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: siteID) { result in
+            let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: TestConstants.siteID) { result in
                 promise(result)
             }
             self.subject?.onAction(action)
@@ -707,14 +659,12 @@ final class AppSettingsStoreTests: XCTestCase {
 
     func test_simplePaymentsToggleTaxes_returns_correct_saved_data() throws {
         // Given
-        let siteID: Int64 = 1234
-
-        let action = AppSettingsAction.setSimplePaymentsTaxesToggleState(siteID: siteID, isOn: true) { _ in }
+        let action = AppSettingsAction.setSimplePaymentsTaxesToggleState(siteID: TestConstants.siteID, isOn: true) { _ in }
         self.subject?.onAction(action)
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
-            let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: siteID) { result in
+            let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: TestConstants.siteID) { result in
                 promise(result)
             }
             self.subject?.onAction(action)
@@ -726,64 +676,48 @@ final class AppSettingsStoreTests: XCTestCase {
 
     func test_saving_preferredInPersonPaymentGateway_works_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
         let initialTime = Date(timeIntervalSince1970: 100)
         let preferredGateway = "woocommerce-payments"
 
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(isTelemetryAvailable: true,
-                                                                                                             telemetryLastReportedTime: initialTime)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(isTelemetryAvailable: true,
+                                                                                     telemetryLastReportedTime: initialTime)
 
         // When
-        let action = AppSettingsAction.setPreferredInPersonPaymentGateway(siteID: siteID, gateway: preferredGateway)
+        let action = AppSettingsAction.setPreferredInPersonPaymentGateway(siteID: TestConstants.siteID, gateway: preferredGateway)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        XCTAssertEqual(preferredGateway, settingsForSite?.preferredInPersonPaymentGateway)
+        XCTAssertEqual(preferredGateway, settingsForSite.preferredInPersonPaymentGateway)
 
         // The other properties should be kept
-        XCTAssertEqual(initialTime, settingsForSite?.telemetryLastReportedTime)
+        XCTAssertEqual(initialTime, settingsForSite.telemetryLastReportedTime)
     }
 
     func test_saving_preferredInPersonPaymentGateway_works_correctly_when_the_settings_file_does_not_exist() throws {
         // Given
-        let siteID: Int64 = 1234
         let preferredGateway = "woocommerce-payments"
 
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
-
         // When
-        let action = AppSettingsAction.setPreferredInPersonPaymentGateway(siteID: siteID, gateway: preferredGateway)
+        let action = AppSettingsAction.setPreferredInPersonPaymentGateway(siteID: TestConstants.siteID, gateway: preferredGateway)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        XCTAssertEqual(preferredGateway, settingsForSite?.preferredInPersonPaymentGateway)
-
+        XCTAssertEqual(preferredGateway, settingsForSite.preferredInPersonPaymentGateway)
     }
 
     func test_resetGeneralStoreSettings_resets_all_settings() throws {
         // Given
-        let siteID: Int64 = 1234
-        let initialTime = Date(timeIntervalSince1970: 100)
-
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(isTelemetryAvailable: true,
-                                                                                                             telemetryLastReportedTime: initialTime)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
 
         // When
         let action = AppSettingsAction.resetGeneralStoreSettings
         subject?.onAction(action)
 
         // Then
-        XCTAssertEqual(true, fileStorage?.deleteIsHit)
-        let savedSettings: GeneralStoreSettingsBySite? = try fileStorage?.data(for: expectedGeneralStoreSettingsFileURL)
-        XCTAssertNil(savedSettings)
+        XCTAssertTrue(mockSiteSpecificAppSettingsStoreMethods.resetStoreSettingsCalled)
     }
 }
 
@@ -793,7 +727,6 @@ extension AppSettingsStoreTests {
 
     func test_setFeatureAnnouncementDismissed_for_campaign_when_remindAfterDays_is_nil_then_dismissal_is_stored_with_no_reminder_date() throws {
         // Given
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
         // When
         let action = AppSettingsAction.setFeatureAnnouncementDismissed(campaign: .linkedProductsPromo, remindAfterDays: nil, onCompletion: nil)
         subject?.onAction(action)
@@ -813,8 +746,6 @@ extension AppSettingsStoreTests {
         // Given
         let currentTime = Date()
 
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
-
         // When
         let action = AppSettingsAction.setFeatureAnnouncementDismissed(campaign: .linkedProductsPromo, remindAfterDays: 0, onCompletion: nil)
         subject?.onAction(action)
@@ -831,8 +762,6 @@ extension AppSettingsStoreTests {
         // Given
         let remindAfterDays = 14
         let twoWeeksTime = Calendar.current.date(byAdding: .day, value: remindAfterDays, to: Date())!
-
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
 
         // When
         let action = AppSettingsAction.setFeatureAnnouncementDismissed(campaign: .linkedProductsPromo, remindAfterDays: remindAfterDays, onCompletion: nil)
@@ -851,8 +780,6 @@ extension AppSettingsStoreTests {
         let remindAfterDays = 7
         let oneWeekTime = Calendar.current.date(byAdding: .day, value: remindAfterDays, to: Date())!
 
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
-
         // When
         let action = AppSettingsAction.setFeatureAnnouncementDismissed(campaign: .linkedProductsPromo, remindAfterDays: remindAfterDays, onCompletion: nil)
         subject?.onAction(action)
@@ -867,8 +794,6 @@ extension AppSettingsStoreTests {
 
     func test_setFeatureAnnouncementDismissed_with_another_campaign_previously_dismissed_keeps_values_for_both() throws {
         // Given
-        try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
-
         let currentTime = Date()
 
         let settings = createAppSettings(featureAnnouncementCampaignSettings: [.test: .init(dismissedDate: currentTime, remindAfter: nil)])
@@ -892,8 +817,6 @@ extension AppSettingsStoreTests {
 
     func test_getFeatureAnnouncementVisibility_without_stored_setting_calls_completion_with_visibility_true() throws {
         // Given
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-
         // When
         let result: Result<Bool, Error> = waitFor { promise in
             let action = AppSettingsAction.getFeatureAnnouncementVisibility(campaign: .linkedProductsPromo) { result in
@@ -909,7 +832,6 @@ extension AppSettingsStoreTests {
 
     func test_getFeatureAnnouncementVisibility_with_stored_dismissDate_and_no_remindAfter_calls_completion_with_visibility_false() throws {
         // Given
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
         let date = Date(timeIntervalSince1970: 100)
 
         let settings = createAppSettings(featureAnnouncementCampaignSettings: [.linkedProductsPromo: .init(dismissedDate: date, remindAfter: nil)])
@@ -930,7 +852,6 @@ extension AppSettingsStoreTests {
 
     func test_getFeatureAnnouncementVisibility_with_stored_dismissDate_and_future_remindAfter_calls_completion_with_visibility_false() throws {
         // Given
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
         let dismissedDate = Date()
         let oneMinute = Calendar.current.date(byAdding: .minute, value: 1, to: dismissedDate)
 
@@ -1033,7 +954,7 @@ extension AppSettingsStoreTests {
         // Given
         let siteIDA: Int64 = 1
         let siteIDB: Int64 = 2
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.currentSiteID = siteIDB
         let action = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: siteIDA, cardReaderType: .other)
         subject?.onAction(action)
 
@@ -1051,14 +972,12 @@ extension AppSettingsStoreTests {
 
     func test_loadSiteHasAtLeastOneIPPTransactionFinished_when_it_is_marked_via_first_transactions_for_that_site_returns_true() throws {
         // Given
-        let siteID: Int64 = 1
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let action = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: siteID, cardReaderType: .other)
+        let action = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: TestConstants.siteID, cardReaderType: .other)
         subject?.onAction(action)
 
         // When
         let result: Bool = waitFor { promise in
-            let action = AppSettingsAction.loadSiteHasAtLeastOneIPPTransactionFinished(siteID: siteID) { result in
+            let action = AppSettingsAction.loadSiteHasAtLeastOneIPPTransactionFinished(siteID: TestConstants.siteID) { result in
                 promise(result)
             }
             self.subject?.onAction(action)
@@ -1070,11 +989,10 @@ extension AppSettingsStoreTests {
 
     func test_given_no_data_has_been_stored_loadFirstInPersonPaymentsTransactionDate_returns_nil() throws {
         // Given
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
 
         // When
         let actualValue = waitFor { promise in
-            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: 1, cardReaderType: .tapToPay) { maybeDate in
+            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: TestConstants.siteID, cardReaderType: .tapToPay) { maybeDate in
                 promise(maybeDate)
             }
             self.subject?.onAction(action)
@@ -1086,14 +1004,12 @@ extension AppSettingsStoreTests {
 
     func test_given_a_date_was_previously_stored_for_the_site_and_reader_loadFirstInPersonPaymentsTransactionDate_returns_that_date() throws {
         // Given
-        let siteID: Int64 = 1
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: siteID, cardReaderType: .tapToPay)
+        let updateAction = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: TestConstants.siteID, cardReaderType: .tapToPay)
         subject?.onAction(updateAction)
 
         // When
         let actualValue = waitFor { promise in
-            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: siteID, cardReaderType: .tapToPay) { maybeDate in
+            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: TestConstants.siteID, cardReaderType: .tapToPay) { maybeDate in
                 promise(maybeDate)
             }
             self.subject?.onAction(action)
@@ -1106,13 +1022,12 @@ extension AppSettingsStoreTests {
 
     func test_given_a_date_was_only_previously_stored_for_another_site_loadFirstInPersonPaymentsTransactionDate_returns_nil() throws {
         // Given
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
         let updateAction = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: 1, cardReaderType: .tapToPay)
         subject?.onAction(updateAction)
 
         // When
         let actualValue = waitFor { promise in
-            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: 100, cardReaderType: .tapToPay) { maybeDate in
+            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: TestConstants.siteID, cardReaderType: .tapToPay) { maybeDate in
                 promise(maybeDate)
             }
             self.subject?.onAction(action)
@@ -1124,14 +1039,12 @@ extension AppSettingsStoreTests {
 
     func test_given_a_date_was_only_previously_stored_for_another_reader_loadFirstInPersonPaymentsTransactionDate_returns_nil() throws {
         // Given
-        let siteID: Int64 = 1
-        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: siteID, cardReaderType: .stripeM2)
+        let updateAction = AppSettingsAction.storeInPersonPaymentsTransactionIfFirst(siteID: TestConstants.siteID, cardReaderType: .stripeM2)
         subject?.onAction(updateAction)
 
         // When
         let actualValue = waitFor { promise in
-            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: siteID, cardReaderType: .tapToPay) { maybeDate in
+            let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: TestConstants.siteID, cardReaderType: .tapToPay) { maybeDate in
                 promise(maybeDate)
             }
             self.subject?.onAction(action)
@@ -1143,52 +1056,43 @@ extension AppSettingsStoreTests {
 
     func test_setSelectedTaxRateID_works_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
         let storedTaxRateID: Int64 = 4321
 
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(selectedTaxRateID: 0)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(selectedTaxRateID: 0)
 
         // When
-        let action = AppSettingsAction.setSelectedTaxRateID(id: storedTaxRateID, siteID: siteID)
+        let action = AppSettingsAction.setSelectedTaxRateID(id: storedTaxRateID, siteID: TestConstants.siteID)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        XCTAssertEqual(storedTaxRateID, settingsForSite?.selectedTaxRateID)
+        XCTAssertEqual(storedTaxRateID, settingsForSite.selectedTaxRateID)
     }
 
     func test_setSelectedTaxRateID_when_nil_then_erases_the_value() throws {
         // Given
-        let siteID: Int64 = 1234
-
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(selectedTaxRateID: 34)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(selectedTaxRateID: 34)
 
         // When
-        let action = AppSettingsAction.setSelectedTaxRateID(id: nil, siteID: siteID)
+        let action = AppSettingsAction.setSelectedTaxRateID(id: nil, siteID: TestConstants.siteID)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        XCTAssertNil(settingsForSite?.selectedTaxRateID)
+        XCTAssertNil(settingsForSite.selectedTaxRateID)
     }
 
     func test_loadSelectedTaxRateID_works_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
         let storedTaxRateID: Int64 = 4321
 
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(selectedTaxRateID: storedTaxRateID)])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(selectedTaxRateID: storedTaxRateID)
 
         // When
         var loadedTaxRateID: Int64?
-        let action = AppSettingsAction.loadSelectedTaxRateID(siteID: siteID) { taxRateID in
+        let action = AppSettingsAction.loadSelectedTaxRateID(siteID: TestConstants.siteID) { taxRateID in
             loadedTaxRateID = taxRateID
         }
         subject?.onAction(action)
@@ -1205,18 +1109,16 @@ extension AppSettingsStoreTests {
             AnalyticsCard(type: .products, enabled: true),
             AnalyticsCard(type: .sessions, enabled: false)
         ]
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         let action = AppSettingsAction.setAnalyticsHubCards(siteID: TestConstants.siteID, cards: analyticsCards)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(analyticsCards, settingsForSite?.analyticsHubCards)
+        assertEqual(analyticsCards, settingsForSite.analyticsHubCards)
     }
 
     func test_loadAnalyticsHubCards_works_correctly() throws {
@@ -1227,9 +1129,7 @@ extension AppSettingsStoreTests {
             AnalyticsCard(type: .products, enabled: true),
             AnalyticsCard(type: .sessions, enabled: false)
         ]
-        let storeSettings = GeneralStoreSettings(analyticsHubCards: storedAnalyticsCards)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(analyticsHubCards: storedAnalyticsCards)
 
         // When
         var loadedAnalyticsCards: [AnalyticsCard]?
@@ -1244,8 +1144,7 @@ extension AppSettingsStoreTests {
 
     func test_loadAnalyticsHubCards_returns_nil_when_no_cards_are_saved() throws {
         // Given
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var loadedAnalyticsCards: [AnalyticsCard]?
@@ -1262,41 +1161,33 @@ extension AppSettingsStoreTests {
 
     func test_setCustomStatsTimeRange_works_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
-
         let fromDate = Date(timeIntervalSince1970: 1677486077) // Feb 27, 2023
         let toDate = Date(timeIntervalSince1970: 1709022077) // Feb 27, 2024
         let customTimeRange = StatsTimeRangeV4.custom(from: fromDate, to: toDate)
 
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
-        let action = AppSettingsAction.setCustomStatsTimeRange(siteID: siteID, timeRange: customTimeRange)
+        let action = AppSettingsAction.setCustomStatsTimeRange(siteID: TestConstants.siteID, timeRange: customTimeRange)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(customTimeRange.rawValue, settingsForSite?.customStatsTimeRange)
+        assertEqual(customTimeRange.rawValue, settingsForSite.customStatsTimeRange)
     }
 
     func test_loadCustomStatsTimeRange_works_correctly() throws {
         // Given
-        let siteID: Int64 = 1234
-
         let fromDate = Date(timeIntervalSince1970: 1677486077) // Feb 27, 2023
         let toDate = Date(timeIntervalSince1970: 1709022077) // Feb 27, 2024
         let customTimeRange = StatsTimeRangeV4.custom(from: fromDate, to: toDate)
 
-        let storeSettings = GeneralStoreSettings(customStatsTimeRange: customTimeRange.rawValue)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(customStatsTimeRange: customTimeRange.rawValue)
 
         // When
         var loadedCustomTimeRange: StatsTimeRangeV4?
-        let action = AppSettingsAction.loadCustomStatsTimeRange(siteID: siteID) { timeRange in
+        let action = AppSettingsAction.loadCustomStatsTimeRange(siteID: TestConstants.siteID) { timeRange in
             loadedCustomTimeRange = timeRange
         }
         subject?.onAction(action)
@@ -1307,13 +1198,11 @@ extension AppSettingsStoreTests {
 
     func test_loadCustomStatsTimeRange_returns_nil_when_no_custom_range_is_saved() throws {
         // Given
-        let siteID: Int64 = 1234
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var customTimeRange: StatsTimeRangeV4?
-        let action = AppSettingsAction.loadCustomStatsTimeRange(siteID: siteID) { timeRange in
+        let action = AppSettingsAction.loadCustomStatsTimeRange(siteID: TestConstants.siteID) { timeRange in
             customTimeRange = timeRange
         }
         subject?.onAction(action)
@@ -1331,18 +1220,16 @@ extension AppSettingsStoreTests {
             DashboardCard(type: .topPerformers, availability: .show, enabled: true),
             DashboardCard(type: .blaze, availability: .show, enabled: true)
         ]
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         let action = AppSettingsAction.setDashboardCards(siteID: TestConstants.siteID, cards: dashboardCards)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(dashboardCards, settingsForSite?.dashboardCards)
+        assertEqual(dashboardCards, settingsForSite.dashboardCards)
     }
 
     func test_loadDashboardCards_works_correctly() throws {
@@ -1353,9 +1240,7 @@ extension AppSettingsStoreTests {
             DashboardCard(type: .topPerformers, availability: .show, enabled: true),
             DashboardCard(type: .blaze, availability: .show, enabled: true)
         ]
-        let storeSettings = GeneralStoreSettings(dashboardCards: storedDashboardCards)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(dashboardCards: storedDashboardCards)
 
         // When
         var loadedDashboardCards: [DashboardCard]?
@@ -1370,8 +1255,7 @@ extension AppSettingsStoreTests {
 
     func test_loadDashboardCards_returns_nil_when_no_cards_are_saved() throws {
         // Given
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var loadedDashboardCards: [DashboardCard]?
@@ -1389,26 +1273,22 @@ extension AppSettingsStoreTests {
     func test_setLastSelectedPerformanceTimeRange_works_correctly() throws {
         // Given
         let timeRange = StatsTimeRangeV4.thisYear
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         let action = AppSettingsAction.setLastSelectedPerformanceTimeRange(siteID: TestConstants.siteID, timeRange: timeRange)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(timeRange.rawValue, settingsForSite?.lastSelectedPerformanceTimeRange)
+        assertEqual(timeRange.rawValue, settingsForSite.lastSelectedPerformanceTimeRange)
     }
 
     func test_loadLastSelectedPerformanceTimeRange_works_correctly() throws {
         // Given
         let timeRange = StatsTimeRangeV4.thisYear
-        let storeSettings = GeneralStoreSettings(lastSelectedPerformanceTimeRange: timeRange.rawValue)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(lastSelectedPerformanceTimeRange: timeRange.rawValue)
 
         // When
         var loadedTimeRange: StatsTimeRangeV4?
@@ -1423,8 +1303,7 @@ extension AppSettingsStoreTests {
 
     func test_loadLastSelectedPerformanceTimeRange_returns_nil_when_no_data_was_saved() throws {
         // Given
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var loadedTimeRange: StatsTimeRangeV4?
@@ -1442,26 +1321,22 @@ extension AppSettingsStoreTests {
     func test_setLastSelectedTopPerformersTimeRange_works_correctly() throws {
         // Given
         let timeRange = StatsTimeRangeV4.thisWeek
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         let action = AppSettingsAction.setLastSelectedTopPerformersTimeRange(siteID: TestConstants.siteID, timeRange: timeRange)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(timeRange.rawValue, settingsForSite?.lastSelectedTopPerformersTimeRange)
+        assertEqual(timeRange.rawValue, settingsForSite.lastSelectedTopPerformersTimeRange)
     }
 
     func test_loadLastSelectedTopPerformersTimeRange_works_correctly() throws {
         // Given
         let timeRange = StatsTimeRangeV4.thisWeek
-        let storeSettings = GeneralStoreSettings(lastSelectedTopPerformersTimeRange: timeRange.rawValue)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(lastSelectedTopPerformersTimeRange: timeRange.rawValue)
 
         // When
         var loadedTimeRange: StatsTimeRangeV4?
@@ -1476,8 +1351,7 @@ extension AppSettingsStoreTests {
 
     func test_loadLastSelectedTopPerformersTimeRange_returns_nil_when_no_data_was_saved() throws {
         // Given
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var loadedTimeRange: StatsTimeRangeV4?
@@ -1495,26 +1369,22 @@ extension AppSettingsStoreTests {
     func test_setLastSelectedMostActiveCouponsTimeRange_works_correctly() throws {
         // Given
         let timeRange = StatsTimeRangeV4.thisMonth
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         let action = AppSettingsAction.setLastSelectedMostActiveCouponsTimeRange(siteID: TestConstants.siteID, timeRange: timeRange)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(timeRange.rawValue, settingsForSite?.lastSelectedMostActiveCouponsTimeRange)
+        assertEqual(timeRange.rawValue, settingsForSite.lastSelectedMostActiveCouponsTimeRange)
     }
 
     func test_loadLastSelectedMostActiveCouponsTimeRange_works_correctly() throws {
         // Given
         let timeRange = StatsTimeRangeV4.thisMonth
-        let storeSettings = GeneralStoreSettings(lastSelectedMostActiveCouponsTimeRange: timeRange.rawValue)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(lastSelectedMostActiveCouponsTimeRange: timeRange.rawValue)
 
         // When
         var loadedTimeRange: StatsTimeRangeV4?
@@ -1529,8 +1399,7 @@ extension AppSettingsStoreTests {
 
     func test_loadLastSelectedMostActiveCouponsTimeRange_returns_nil_when_no_data_was_saved() throws {
         // Given
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var loadedTimeRange: StatsTimeRangeV4?
@@ -1548,26 +1417,22 @@ extension AppSettingsStoreTests {
     func test_setLastSelectedStockType_works_correctly() throws {
         // Given
         let stockType = "lowstock"
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         let action = AppSettingsAction.setLastSelectedStockType(siteID: TestConstants.siteID, type: stockType)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(stockType, settingsForSite?.lastSelectedStockType)
+        assertEqual(stockType, settingsForSite.lastSelectedStockType)
     }
 
     func test_loadLastSelectedStockType_works_correctly() throws {
         // Given
         let stockType = "lowstock"
-        let storeSettings = GeneralStoreSettings(lastSelectedStockType: stockType)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(lastSelectedStockType: stockType)
 
         // When
         var loadedStockType: String?
@@ -1582,8 +1447,7 @@ extension AppSettingsStoreTests {
 
     func test_loadLastSelectedStockType_returns_nil_when_no_data_was_saved() throws {
         // Given
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var loadedStockType: String?
@@ -1601,26 +1465,22 @@ extension AppSettingsStoreTests {
     func test_setLastSelectedOrderStatus_works_correctly() throws {
         // Given
         let status = "pending"
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         let action = AppSettingsAction.setLastSelectedOrderStatus(siteID: TestConstants.siteID, status: status)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+        let settingsForSite = mockSiteSpecificAppSettingsStoreMethods.storeSettings
 
-        assertEqual(status, settingsForSite?.lastSelectedOrderStatus)
+        assertEqual(status, settingsForSite.lastSelectedOrderStatus)
     }
 
     func test_loadLastSelectedOrderStatus_works_correctly() throws {
         // Given
         let status = "pending"
-        let storeSettings = GeneralStoreSettings(lastSelectedOrderStatus: status)
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings(lastSelectedOrderStatus: status)
 
         // When
         var loadedOrderStatus: String?
@@ -1635,8 +1495,7 @@ extension AppSettingsStoreTests {
 
     func test_loadLastSelectedOrderStatus_returns_nil_when_no_data_was_saved() throws {
         // Given
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        mockSiteSpecificAppSettingsStoreMethods.storeSettings = GeneralStoreSettings()
 
         // When
         var loadedOrderStatus: String?
@@ -1687,10 +1546,5 @@ private extension AppSettingsStoreTests {
             isCustomFieldsTopBannerDismissed: false
         )
         return settings
-    }
-
-    var expectedGeneralStoreSettingsFileURL: URL {
-        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        return documents!.appendingPathComponent("general-store-settings.plist")
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -627,8 +627,6 @@ final class AppSettingsStoreTests: XCTestCase {
     }
 
     func test_getTelemetryInfo_returns_correct_default_data() throws {
-        // Given
-
         // When
         let data: (isAvailable: Bool, telemetryLastReportedTime: Date?) = waitFor { promise in
             let action = AppSettingsAction.getTelemetryInfo(siteID: TestConstants.siteID) { isAvailable, telemetryLastReportedTime in
@@ -643,8 +641,6 @@ final class AppSettingsStoreTests: XCTestCase {
     }
 
     func test_simplePaymentsToggleTaxes_returns_correct_default_data() throws {
-        // Given
-
         // When
         let result: Result<Bool, Error> = waitFor { promise in
             let action = AppSettingsAction.getSimplePaymentsTaxesToggleState(siteID: TestConstants.siteID) { result in
@@ -710,8 +706,6 @@ final class AppSettingsStoreTests: XCTestCase {
     }
 
     func test_resetGeneralStoreSettings_resets_all_settings() throws {
-        // Given
-
         // When
         let action = AppSettingsAction.resetGeneralStoreSettings
         subject?.onAction(action)
@@ -726,7 +720,6 @@ final class AppSettingsStoreTests: XCTestCase {
 extension AppSettingsStoreTests {
 
     func test_setFeatureAnnouncementDismissed_for_campaign_when_remindAfterDays_is_nil_then_dismissal_is_stored_with_no_reminder_date() throws {
-        // Given
         // When
         let action = AppSettingsAction.setFeatureAnnouncementDismissed(campaign: .linkedProductsPromo, remindAfterDays: nil, onCompletion: nil)
         subject?.onAction(action)
@@ -816,7 +809,6 @@ extension AppSettingsStoreTests {
     }
 
     func test_getFeatureAnnouncementVisibility_without_stored_setting_calls_completion_with_visibility_true() throws {
-        // Given
         // When
         let result: Result<Bool, Error> = waitFor { promise in
             let action = AppSettingsAction.getFeatureAnnouncementVisibility(campaign: .linkedProductsPromo) { result in
@@ -988,8 +980,6 @@ extension AppSettingsStoreTests {
     }
 
     func test_given_no_data_has_been_stored_loadFirstInPersonPaymentsTransactionDate_returns_nil() throws {
-        // Given
-
         // When
         let actualValue = waitFor { promise in
             let action = AppSettingsAction.loadFirstInPersonPaymentsTransactionDate(siteID: TestConstants.siteID, cardReaderType: .tapToPay) { maybeDate in

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -43,13 +43,22 @@ final class AppSettingsStoreTests: XCTestCase {
     ///
     private var subject: AppSettingsStore?
 
+    /// Mock Site Specific App Settings Store Methods
+
+    private var mockSiteSpecificAppSettingsStoreMethods: MockSiteSpecificAppSettingsStoreMethods!
+
     override func setUp() {
         super.setUp()
         dispatcher = Dispatcher()
         storageManager = MockStorageManager()
         fileStorage = MockInMemoryStorage()
         generalAppSettings = GeneralAppSettingsStorage(fileStorage: fileStorage!)
-        subject = AppSettingsStore(dispatcher: dispatcher!, storageManager: storageManager!, fileStorage: fileStorage!, generalAppSettings: generalAppSettings!)
+        mockSiteSpecificAppSettingsStoreMethods = MockSiteSpecificAppSettingsStoreMethods()
+        subject = AppSettingsStore(dispatcher: dispatcher!,
+                                   storageManager: storageManager!,
+                                   fileStorage: fileStorage!,
+                                   generalAppSettings: generalAppSettings!,
+                                   siteSpecificAppSettingsStoreMethods: mockSiteSpecificAppSettingsStoreMethods)
         subject?.selectedProvidersURL = TestConstants.fileURL!
         subject?.customSelectedProvidersURL = TestConstants.customFileURL!
     }
@@ -60,6 +69,7 @@ final class AppSettingsStoreTests: XCTestCase {
         fileStorage = nil
         generalAppSettings = nil
         subject = nil
+        mockSiteSpecificAppSettingsStoreMethods = nil
         super.tearDown()
     }
 
@@ -524,29 +534,26 @@ final class AppSettingsStoreTests: XCTestCase {
     func test_setStoreID_stores_the_store_id_correctly() throws {
         // Given
         let siteID: Int64 = 1234
-
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        let storeID = "test-store-id"
 
         // When
-        let action = AppSettingsAction.setStoreID(siteID: siteID, id: "sample-store-uuid")
+        let action = AppSettingsAction.setStoreID(siteID: siteID, id: storeID)
         subject?.onAction(action)
 
         // Then
-        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
-        let settingsForSite = savedSettings.storeSettingsBySite[siteID]
-
-        XCTAssertEqual(settingsForSite?.storeID, "sample-store-uuid")
+        XCTAssertTrue(mockSiteSpecificAppSettingsStoreMethods.setStoreIDCalled)
+        XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spySetStoreIDSiteID, siteID)
+        XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spySetStoreID, storeID)
     }
 
     func test_getStoreID_retrieves_the_saved_store_id() throws {
         // Given
         let siteID: Int64 = 1234
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(storeID: "sample-store-uuid")])
-        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+        let expectedStoreID = "test-store-id"
+        mockSiteSpecificAppSettingsStoreMethods.mockStoreID = expectedStoreID
 
         // When
-        let storeID: String? = waitFor { promise in
+        let retrievedStoreID: String? = waitFor { promise in
             let action = AppSettingsAction.getStoreID(siteID: siteID) { id in
                 promise(id)
             }
@@ -554,7 +561,9 @@ final class AppSettingsStoreTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(storeID, "sample-store-uuid")
+        XCTAssertTrue(mockSiteSpecificAppSettingsStoreMethods.getStoreIDCalled)
+        XCTAssertEqual(mockSiteSpecificAppSettingsStoreMethods.spyGetStoreIDSiteID, siteID)
+        XCTAssertEqual(retrievedStoreID, expectedStoreID)
     }
 
     func test_saving_isTelemetryAvailable_works_correctly() throws {

--- a/Yosemite/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import Yosemite
+import Storage
+
+final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
+    private var sut: SiteSpecificAppSettingsStoreMethods!
+    private var fileStorage: MockFileStorage!
+    private let siteID: Int64 = 123
+
+    override func setUp() {
+        super.setUp()
+        fileStorage = MockFileStorage()
+        sut = SiteSpecificAppSettingsStoreMethods(fileStorage: fileStorage)
+    }
+
+    override func tearDown() {
+        sut = nil
+        fileStorage = nil
+        super.tearDown()
+    }
+
+    // MARK: - Store Settings Tests
+
+    func test_getStoreSettings_returns_default_settings_when_no_data_exists() {
+        // When
+        let settings = sut.getStoreSettings(for: siteID)
+
+        // Then
+        XCTAssertEqual(settings, GeneralStoreSettings())
+    }
+
+    func test_getStoreSettings_returns_saved_settings_when_data_exists() throws {
+        // Given
+        let expectedSettings = GeneralStoreSettings(storeID: "test-store")
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: expectedSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        let settings = sut.getStoreSettings(for: siteID)
+
+        // Then
+        XCTAssertEqual(settings.storeID, expectedSettings.storeID)
+    }
+
+    func test_setStoreSettings_saves_settings_successfully() throws {
+        // Given
+        let settings = GeneralStoreSettings(storeID: "test-store")
+        let expectation = self.expectation(description: "Settings saved")
+
+        // When
+        sut.setStoreSettings(settings: settings, for: siteID) { result in
+            switch result {
+            case .success:
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Expected success but got failure")
+            }
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.storeID, settings.storeID)
+    }
+
+    func test_setStoreSettings_preserves_existing_settings_for_other_sites() throws {
+        // Given
+        let otherSiteID: Int64 = 456
+        let otherSiteSettings = GeneralStoreSettings(storeID: "other-store")
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [otherSiteID: otherSiteSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        let newSettings = GeneralStoreSettings(storeID: "test-store")
+        let expectation = self.expectation(description: "Settings saved")
+
+        // When
+        sut.setStoreSettings(settings: newSettings, for: siteID) { result in
+            switch result {
+            case .success:
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Expected success but got failure")
+            }
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.storeID, newSettings.storeID)
+        XCTAssertEqual(savedData.storeSettingsBySite[otherSiteID]?.storeID, otherSiteSettings.storeID)
+    }
+
+    func test_resetStoreSettings_deletes_the_settings_file() throws {
+        // Given
+        let settings = GeneralStoreSettings(storeID: "test-store")
+        try fileStorage.write(GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: settings]),
+                            to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        sut.resetStoreSettings()
+
+        // Then
+        XCTAssertTrue(fileStorage.deleteIsHit)
+    }
+
+    // MARK: - Store ID Tests
+
+    func test_setStoreID_updates_store_settings() throws {
+        // Given
+        let storeID = "test-store-id"
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
+        try fileStorage.write(existingSettings, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        sut.setStoreID(siteID: siteID, id: storeID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.storeID, storeID)
+    }
+
+    func test_getStoreID_retrieves_saved_store_id() throws {
+        // Given
+        let storeID = "test-store-id"
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(storeID: storeID)])
+        try fileStorage.write(existingSettings, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        var retrievedStoreID: String?
+        sut.getStoreID(siteID: siteID) { id in
+            retrievedStoreID = id
+        }
+
+        // Then
+        XCTAssertEqual(retrievedStoreID, storeID)
+    }
+}
+
+// MARK: - Mock FileStorage
+
+private class MockFileStorage: FileStorage {
+    var data: [URL: Any] = [:]
+    var dataWriteIsHit = false
+    var deleteIsHit = false
+
+    func data<T>(for url: URL) throws -> T where T: Decodable {
+        guard let data = data[url] as? T else {
+            throw AppSettingsStoreErrors.readPListFromFileStorage
+        }
+        return data
+    }
+
+    func write<T>(_ data: T, to url: URL) throws where T: Encodable {
+        self.data[url] = data
+        dataWriteIsHit = true
+    }
+
+    func deleteFile(at url: URL) throws {
+        data.removeValue(forKey: url)
+        deleteIsHit = true
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of WOOMOB-314
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR extracts the site-specific local app settings storage interface, so it can be used elsewhere in Yosemite apart from the AppSettingsStorage.

In a future PR, this'll be used from `POSSearchHistoryService` to store the saved searches.

This is a refactoring PR, so there's no behaviour changes included. Some examples of areas which are impacted by the change:

- Storing/retrieving date ranges for analytics
- Customising dashboard cards
- Saving a tax base in Order Creation
- Storing favourite products (TIL that's possible! We should consider using it in POS.)

Apologies that it's so big. The tests are a bit of a struggle really; I guess this is what happens when they're too coupled to the underlying file saving implementation. I'm pretty sure I've done the fixes correctly... but arguably we could delete a lot of the tests in `AppSettingsStoreTests` now, let me know what you think about that.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Run unit tests
2. Build and run the app, try some of the affected areas above

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested various areas on an iPhone 15 running iOS 18.4, and an iPad Air running iOS 17.7.3

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/cbbdf7db-7dff-4e99-a2bc-ccb857d77b57


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.