### PR TITLE
[Woo POS][Product Search] Pre-search UI: Persist recent searches

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -113,7 +113,8 @@ extension Storage.GeneralStoreSettings {
         lastSelectedMostActiveCouponsTimeRange: CopiableProp<String> = .copy,
         lastSelectedStockType: NullableCopiableProp<String> = .copy,
         lastSelectedOrderStatus: NullableCopiableProp<String> = .copy,
-        favoriteProductIDs: CopiableProp<[Int64]> = .copy
+        favoriteProductIDs: CopiableProp<[Int64]> = .copy,
+        searchTermsByKey: CopiableProp<[String: [String]]> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -133,6 +134,7 @@ extension Storage.GeneralStoreSettings {
         let lastSelectedStockType = lastSelectedStockType ?? self.lastSelectedStockType
         let lastSelectedOrderStatus = lastSelectedOrderStatus ?? self.lastSelectedOrderStatus
         let favoriteProductIDs = favoriteProductIDs ?? self.favoriteProductIDs
+        let searchTermsByKey = searchTermsByKey ?? self.searchTermsByKey
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -152,7 +154,8 @@ extension Storage.GeneralStoreSettings {
             lastSelectedMostActiveCouponsTimeRange: lastSelectedMostActiveCouponsTimeRange,
             lastSelectedStockType: lastSelectedStockType,
             lastSelectedOrderStatus: lastSelectedOrderStatus,
-            favoriteProductIDs: favoriteProductIDs
+            favoriteProductIDs: favoriteProductIDs,
+            searchTermsByKey: searchTermsByKey
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -78,6 +78,10 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var favoriteProductIDs: [Int64]
 
+    /// Search terms history for different item types in the Point of Sale.
+    ///
+    public var searchTermsByKey: [String: [String]]
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -95,7 +99,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 lastSelectedMostActiveCouponsTimeRange: String = "",
                 lastSelectedStockType: String? = nil,
                 lastSelectedOrderStatus: String? = nil,
-                favoriteProductIDs: [Int64] = []) {
+                favoriteProductIDs: [Int64] = [],
+                searchTermsByKey: [String: [String]] = [:]) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -114,6 +119,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.lastSelectedStockType = lastSelectedStockType
         self.lastSelectedOrderStatus = lastSelectedOrderStatus
         self.favoriteProductIDs = favoriteProductIDs
+        self.searchTermsByKey = searchTermsByKey
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -133,7 +139,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              lastSelectedTopPerformersTimeRange: lastSelectedTopPerformersTimeRange,
                              lastSelectedStockType: lastSelectedStockType,
                              lastSelectedOrderStatus: lastSelectedOrderStatus,
-                             favoriteProductIDs: favoriteProductIDs)
+                             favoriteProductIDs: favoriteProductIDs,
+                             searchTermsByKey: searchTermsByKey)
     }
 }
 
@@ -165,6 +172,7 @@ extension GeneralStoreSettings {
         self.lastSelectedOrderStatus = try container.decodeIfPresent(String.self, forKey: .lastSelectedOrderStatus)
         self.favoriteProductIDs = try container.decodeIfPresent([Int64].self,
                                                                 forKey: .favoriteProductIDs) ?? []
+        self.searchTermsByKey = try container.decodeIfPresent([String: [String]].self, forKey: .searchTermsByKey) ?? [:]
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -9,7 +9,7 @@ import struct Yosemite.OrderItem
 import struct Yosemite.POSCoupon
 import enum Yosemite.POSItem
 import enum Yosemite.SystemStatusAction
-import class Yosemite.POSSearchHistoryService
+import protocol Yosemite.POSSearchHistoryProviding
 import enum Yosemite.POSItemType
 
 @available(iOS 17.0, *)
@@ -72,7 +72,7 @@ protocol PointOfSaleAggregateModelProtocol {
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
-    private let searchHistoryService: POSSearchHistoryService
+    private let searchHistoryService: POSSearchHistoryProviding
 
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
@@ -86,7 +86,7 @@ protocol PointOfSaleAggregateModelProtocol {
          orderController: PointOfSaleOrderControllerProtocol,
          analytics: Analytics = ServiceLocator.analytics,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
-         searchHistoryService: POSSearchHistoryService? = nil,
+         searchHistoryService: POSSearchHistoryProviding,
          paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -95,9 +95,7 @@ protocol PointOfSaleAggregateModelProtocol {
         self.orderController = orderController
         self.analytics = analytics
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
-        self.searchHistoryService = searchHistoryService ?? POSSearchHistoryService(
-            siteID: ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
-        )
+        self.searchHistoryService = searchHistoryService
         self.paymentState = paymentState
         publishCardReaderConnectionStatus()
         publishPaymentMessages()

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -86,7 +86,7 @@ protocol PointOfSaleAggregateModelProtocol {
          orderController: PointOfSaleOrderControllerProtocol,
          analytics: Analytics = ServiceLocator.analytics,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
-         searchHistoryService: POSSearchHistoryService = POSSearchHistoryService(),
+         searchHistoryService: POSSearchHistoryService? = nil,
          paymentState: PointOfSalePaymentState = .card(.idle)) {
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -95,7 +95,9 @@ protocol PointOfSaleAggregateModelProtocol {
         self.orderController = orderController
         self.analytics = analytics
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
-        self.searchHistoryService = searchHistoryService
+        self.searchHistoryService = searchHistoryService ?? POSSearchHistoryService(
+            siteID: ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
+        )
         self.paymentState = paymentState
         publishCardReaderConnectionStatus()
         publishPaymentMessages()

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -175,7 +175,8 @@ private extension CardReaderConnectionStatusView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics()
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService()
     )
     VStack {
         CardReaderConnectionStatusView()

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -129,7 +129,8 @@ private extension PointOfSalePaymentSuccessView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     return PointOfSalePaymentSuccessView(
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
                                                       paymentMethod: .card)

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -354,7 +354,8 @@ private extension CartView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     return CartView()
         .environment(posModel)
 }
@@ -367,7 +368,8 @@ private extension CartView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     posModel.addToCart(.simpleProduct(.init(id: UUID(),
                                             name: "Sample Product",
                                             formattedPrice: "$10.00",

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -3,7 +3,6 @@ import enum Yosemite.POSItem
 import protocol WooFoundation.Analytics
 import struct Yosemite.POSVariableParentProduct
 
-
 /// Displays a list of POS items or placeholder card based on the given state.
 @available(iOS 17.0, *)
 struct ItemList<HeaderView: View>: View {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -3,6 +3,7 @@ import enum Yosemite.POSItem
 import protocol WooFoundation.Analytics
 import struct Yosemite.POSVariableParentProduct
 
+
 /// Displays a list of POS items or placeholder card based on the given state.
 @available(iOS 17.0, *)
 struct ItemList<HeaderView: View>: View {
@@ -240,7 +241,8 @@ private extension ItemListRow {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     ItemList(itemsController: PointOfSalePreviewItemsController(),
              node: .root,
              itemActionHandler: PointOfSalePreviewItemActionHandler())

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -421,7 +421,8 @@ private extension ItemListView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     return ItemListView(selectedItemListType: .constant(.products(search: false)))
         .environment(posModel)
 }
@@ -434,7 +435,8 @@ private extension ItemListView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     return ItemListView(selectedItemListType: .constant(.products(search: false)))
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -143,7 +143,8 @@ private extension POSFloatingControlView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .primary)
         .environment(posModel)
@@ -158,7 +159,8 @@ private extension POSFloatingControlView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     paymentService.readerConnectionStatus = .connected(.init(name: "", batteryLevel: 0.6))
     return POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .primary)
@@ -173,7 +175,8 @@ private extension POSFloatingControlView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .secondary)
         .environment(posModel)

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -94,7 +94,8 @@ private extension PaymentsActionButtons {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     PaymentsActionButtons(isShowingSendReceiptView: .constant(false), isShowingReceiptNotEligibleBanner: .constant(true))
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -203,7 +203,8 @@ private extension PointOfSaleCollectCashView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     PointOfSaleCollectCashView(orderTotal: "$1.23")
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -216,7 +216,8 @@ private extension PointOfSaleDashboardView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     return NavigationStack {
         PointOfSaleDashboardView()
             .environment(posModel)
@@ -233,7 +234,8 @@ private extension PointOfSaleDashboardView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: .init(root: .loading([]), itemStates: [:]))
     return NavigationStack {
         PointOfSaleDashboardView()

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import protocol Yosemite.POSSearchHistoryProviding
 
 @available(iOS 17.0, *)
 struct PointOfSaleEntryPointView: View {
@@ -13,6 +14,7 @@ struct PointOfSaleEntryPointView: View {
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderController: PointOfSaleOrderControllerProtocol
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
+    private let searchHistoryService: POSSearchHistoryProviding
 
     init(itemsController: PointOfSaleItemsControllerProtocol,
          purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol,
@@ -20,7 +22,8 @@ struct PointOfSaleEntryPointView: View {
          onPointOfSaleModeActiveStateChange: @escaping ((Bool) -> Void),
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderController: PointOfSaleOrderControllerProtocol,
-         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking) {
+         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
+         searchHistoryService: POSSearchHistoryProviding) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
 
         self.itemsController = itemsController
@@ -29,6 +32,7 @@ struct PointOfSaleEntryPointView: View {
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderController = orderController
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
+        self.searchHistoryService = searchHistoryService
     }
 
     var body: some View {
@@ -50,7 +54,8 @@ struct PointOfSaleEntryPointView: View {
                 couponsController: couponsController,
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker)
+                collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+                searchHistoryService: searchHistoryService)
         }
         .environmentObject(posModalManager)
         .onAppear {
@@ -73,6 +78,7 @@ struct PointOfSaleEntryPointView: View {
                               onPointOfSaleModeActiveStateChange: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
                               orderController: PointOfSalePreviewOrderController(),
-                              collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+                              collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+                              searchHistoryService: PointOfSalePreviewHistoryService())
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -164,7 +164,8 @@ private extension POSSendReceiptView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     POSSendReceiptView(isShowingSendReceiptView: .constant(true))
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -461,7 +461,8 @@ private extension TotalsView {
         couponsController: PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics())
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: PointOfSalePreviewHistoryService())
     TotalsView()
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -15,6 +15,8 @@ import struct Yosemite.OrderItem
 import protocol Yosemite.PointOfSalePurchasableItemFetchStrategy
 import struct Yosemite.POSProduct
 import struct Yosemite.ProductVariation
+import protocol Yosemite.POSSearchHistoryProviding
+import enum Yosemite.POSItemType
 import Combine
 
 // MARK: - PreviewProvider helpers
@@ -123,6 +125,18 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
 @available(iOS 17.0, *)
 final class PointOfSalePreviewItemActionHandler: POSItemActionHandler {
     func handleTap(_ item: Yosemite.POSItem) { }
+}
+
+final class PointOfSalePreviewHistoryService: POSSearchHistoryProviding {
+    func saveSuccessfulSearch(term: String, for itemType: POSItemType) {}
+
+    func searchHistory(for itemType: POSItemType) -> [String] {
+        return []
+    }
+
+    func clearSearchHistory(for itemType: POSItemType) {}
+
+    func clearAllSearchHistory() {}
 }
 
 private var mockItems: [POSItem] {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -56,7 +56,8 @@ struct HubMenu: View {
                             cardPresentPaymentService: cardPresentPaymentService,
                             orderController: PointOfSaleOrderController(orderService: orderService,
                                                                         receiptService: receiptService),
-                            collectOrderPaymentAnalyticsTracker: viewModel.collectOrderPaymentAnalyticsTracker)
+                            collectOrderPaymentAnalyticsTracker: viewModel.collectOrderPaymentAnalyticsTracker,
+                            searchHistoryService: POSSearchHistoryService(siteID: viewModel.siteID))
                     } else {
                         // TODO: When we have a singleton for the card payment service, this should not be required.
                         Text("Error creating card payment service")

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -5,6 +5,8 @@ import protocol Yosemite.POSOrderableItem
 import enum Yosemite.POSItem
 @testable import struct Yosemite.POSSimpleProduct
 import struct Yosemite.Order
+import protocol Yosemite.POSSearchHistoryProviding
+import enum Yosemite.POSItemType
 import Combine
 
 struct PointOfSaleAggregateModelTests {
@@ -18,7 +20,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             // Then
             #expect(sut.orderStage == .building)
         }
@@ -32,7 +35,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             sut.addToCart(makeItem())
             await sut.checkOut()
             try #require(sut.orderStage == .finalizing)
@@ -55,7 +59,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             sut.addToCart(makeItem())
 
             // When
@@ -74,7 +79,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             sut.addToCart(makeItem())
             await sut.checkOut()
             try #require(sut.orderStage == .finalizing)
@@ -106,7 +112,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             try #require(sut.cart.isEmpty)
             let item = makeItem()
 
@@ -126,7 +133,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             let items = [makeItem(), makeItem(), makeItem()]
 
             // When
@@ -145,7 +153,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             let item = makeItem(name: "Item 1")
             let anotherItem = makeItem(name: "Item 2")
 
@@ -171,7 +180,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             let item = makeItem(name: "Item 1")
             let anotherItem = makeItem(name: "Item 2")
 
@@ -201,7 +211,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
             let item = makeItem()
 
             // When
@@ -232,7 +243,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             sut.addToCart(makeItem())
 
@@ -254,7 +266,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             sut.addToCart(makeItem())
             sut.addToCart(makeItem())
@@ -279,7 +292,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             sut.addToCart(makeItem())
             sut.removeAllItemsFromCart()
@@ -303,7 +317,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             sut.addToCart(makeItem())
             cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
@@ -327,7 +342,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: orderController,
                                                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
 
             // When
             try await sut.sendReceipt(to: "")
@@ -349,7 +365,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: orderController,
                                                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
 
             do {
                 // When
@@ -373,7 +390,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             sut.addToCart(makeItem())
 
@@ -402,7 +420,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             // Then
             #expect(sut.paymentState == .card(.idle))
@@ -419,6 +438,7 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService(),
                 paymentState: .card(.cardPaymentSuccessful))
 
             // When
@@ -439,7 +459,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
             try #require(sut.cardPresentPaymentInlineMessage != nil)
@@ -462,6 +483,7 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService(),
                 paymentState: .card(.cardPaymentSuccessful))
 
             // When
@@ -482,12 +504,14 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             cardPresentPaymentService.paymentEvent = .show(
                 eventDetails: .tapSwipeOrInsertCard(
                     inputMethods: [.tap, .swipe, .insert],
-                    cancelPayment: {}))
+                    cancelPayment: {})
+            )
             try #require(sut.cardPresentPaymentInlineMessage != nil)
 
             // When
@@ -508,7 +532,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             // When
             await sut.startCashPayment()
@@ -529,7 +554,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             // When
             await sut.startCashPayment()
@@ -549,7 +575,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             await sut.startCashPayment()
             #expect(sut.paymentState == .cash(.collectingCash))
 
@@ -571,7 +598,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             #expect(sut.orderStage == .building)
 
             await sut.checkOut()
@@ -603,7 +631,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             // When
             cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
@@ -627,7 +656,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             struct TestError: Error {}
 
             // When paymentIntentCreationError event is received
@@ -657,7 +687,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             struct TestError: Error {}
             await sut.checkOut()
 
@@ -690,7 +721,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             cardPresentPaymentService.connectedReader = nil
 
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$1.00", orderTotalDecimal: 1)
@@ -722,7 +754,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$0.01", orderTotalDecimal: 0.01)
 
@@ -744,7 +777,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$0.00", orderTotalDecimal: 0.0)
 
@@ -766,7 +800,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
 
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$1.00", orderTotalDecimal: 1)
@@ -799,7 +834,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             orderController.orderStateToReturn = makeLoadedOrderState(cartTotal: "$1.00")
             await orderController.syncOrder(for: .init(), retryHandler: {})
 
@@ -827,7 +863,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
             let onboardingViewModel = CardPresentPaymentsOnboardingViewModel(
                 fixedState: .pluginNotActivated(plugin: .stripe),
                 useCase: MockCardPresentPaymentsOnboardingUseCase(initial: .pluginNotActivated(plugin: .stripe))
@@ -865,7 +902,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             sut.addToCart(makeItem())
 
@@ -896,7 +934,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             sut.addToCart(makeItem())
 
@@ -918,7 +957,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             //When
             sut.connectCardReader()
@@ -938,7 +978,8 @@ struct PointOfSaleAggregateModelTests {
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
                 analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                searchHistoryService: MockPOSSearchHistoryService())
 
             //When
             sut.disconnectCardReader()
@@ -956,7 +997,8 @@ struct PointOfSaleAggregateModelTests {
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 cardPresentPaymentService: cardPresentPaymentService,
                                                 orderController: orderController,
-                                                collectOrderPaymentAnalyticsTracker: analyticsTracker)
+                                                collectOrderPaymentAnalyticsTracker: analyticsTracker,
+                                                searchHistoryService: MockPOSSearchHistoryService())
 
             // When
             await sut.checkOut()
@@ -975,7 +1017,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: analyticsTracker)
+                                                collectOrderPaymentAnalyticsTracker: analyticsTracker,
+                                                searchHistoryService: MockPOSSearchHistoryService())
             // When
             await sut.cancelCashPayment()
 
@@ -994,7 +1037,8 @@ struct PointOfSaleAggregateModelTests {
                                                 cardPresentPaymentService: MockCardPresentPaymentService(),
                                                 orderController: MockPointOfSaleOrderController(),
                                                 analytics: mockAnalytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker())
+                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
+                                                searchHistoryService: MockPOSSearchHistoryService())
 
             // When
             await sut.startCashPayment()
@@ -1023,4 +1067,16 @@ private func makeLoadedOrderState(cartTotal: String = "",
         PointOfSaleOrderTotals(cartTotal: cartTotal, orderTotal: orderTotal, taxTotal: taxTotal, orderTotalDecimal: orderTotalDecimal),
         order
     )
+}
+
+private struct MockPOSSearchHistoryService: POSSearchHistoryProviding {
+    func saveSuccessfulSearch(term: String, for itemType: POSItemType) {}
+
+    func searchHistory(for itemType: POSItemType) -> [String] {
+        return []
+    }
+
+    func clearSearchHistory(for itemType: POSItemType) {}
+
+    func clearAllSearchHistory() {}
 }

--- a/Yosemite/Yosemite/PointOfSale/POSItemType.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSItemType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum POSItemType {
+public enum POSItemType: CaseIterable {
     case product
     case variation
     case coupon

--- a/Yosemite/Yosemite/PointOfSale/POSItemType.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSItemType.swift
@@ -5,3 +5,16 @@ public enum POSItemType {
     case variation
     case coupon
 }
+
+extension POSItemType {
+    var storedSearchHistoryKey: String {
+        switch self {
+        case .product:
+            return "product_search_terms"
+        case .variation:
+            return "variation_search_terms"
+        case .coupon:
+            return "coupon_search_terms"
+        }
+    }
+}

--- a/Yosemite/Yosemite/PointOfSale/POSSearchHistoryService.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSSearchHistoryService.swift
@@ -1,15 +1,23 @@
 import Foundation
+import Storage
 
 /// Service for managing search history in the Point of Sale
-@available(iOS 17.0, *)
 public final class POSSearchHistoryService {
     private let maxHistorySize: Int
-    private var searchHistory: [POSItemType: [String]] = [:]
+    private let siteID: Int64
+    private let siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol
 
     /// Initializes a new search history service
-    /// - Parameter maxHistorySize: Maximum number of search terms to keep in history per item type
-    public init(maxHistorySize: Int = 10) {
+    /// - Parameters:
+    ///   - maxHistorySize: Maximum number of search terms to keep in history per item type
+    ///   - siteID: The site ID to store search history for
+    ///   - siteSpecificAppSettingsStoreMethods: The store methods to use for persistent storage
+    public init(maxHistorySize: Int = 10,
+                siteID: Int64,
+                siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol? = nil) {
         self.maxHistorySize = maxHistorySize
+        self.siteID = siteID
+        self.siteSpecificAppSettingsStoreMethods = siteSpecificAppSettingsStoreMethods ?? SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
     }
 
     /// Saves a successful search term to the history
@@ -19,19 +27,23 @@ public final class POSSearchHistoryService {
     public func saveSuccessfulSearch(term: String, for itemType: POSItemType) {
         DDLogInfo("POS: Saving search term '\(term)' for item type: \(itemType)")
 
-        if searchHistory[itemType] == nil {
-            searchHistory[itemType] = []
+        var searchTerms = siteSpecificAppSettingsStoreMethods.getSearchTerms(for: itemType, siteID: siteID)
+
+        // Remove the term if it already exists
+        searchTerms.removeAll { $0 == term }
+
+        // Add the term at the beginning
+        searchTerms.insert(term, at: 0)
+
+        // Trim to max size if needed
+        if searchTerms.count > maxHistorySize {
+            searchTerms = Array(searchTerms.dropLast(searchTerms.count - maxHistorySize))
         }
 
-        searchHistory[itemType]?.removeAll { $0 == term }
+        // Save the updated terms
+        siteSpecificAppSettingsStoreMethods.setSearchTerms(searchTerms, for: itemType, siteID: siteID)
 
-        searchHistory[itemType]?.insert(term, at: 0)
-
-        if let count = searchHistory[itemType]?.count, count > maxHistorySize {
-            searchHistory[itemType] = searchHistory[itemType]?.dropLast(count - maxHistorySize)
-        }
-
-        let allSearchTerms = searchHistory[itemType]?.joined(separator: ", ") ?? "[none]"
+        let allSearchTerms = searchTerms.joined(separator: ", ")
         DDLogInfo("POS: Saved search terms for item type: \(itemType) – \(allSearchTerms)")
     }
 
@@ -39,17 +51,20 @@ public final class POSSearchHistoryService {
     /// - Parameter itemType: The type of item to get search history for
     /// - Returns: An array of search terms, ordered from most recent to oldest
     public func searchHistory(for itemType: POSItemType) -> [String] {
-        return searchHistory[itemType] ?? []
+        return siteSpecificAppSettingsStoreMethods.getSearchTerms(for: itemType, siteID: siteID)
     }
 
     /// Clears the search history for a specific item type
     /// - Parameter itemType: The type of item to clear search history for
     public func clearSearchHistory(for itemType: POSItemType) {
-        searchHistory[itemType] = []
+        siteSpecificAppSettingsStoreMethods.setSearchTerms([], for: itemType, siteID: siteID)
     }
 
     /// Clears all search history
     public func clearAllSearchHistory() {
-        searchHistory.removeAll()
+        // Clear search history for all item types
+        POSItemType.allCases.forEach { itemType in
+            clearSearchHistory(for: itemType)
+        }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/POSSearchHistoryService.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSSearchHistoryService.swift
@@ -1,8 +1,15 @@
 import Foundation
 import Storage
 
+public protocol POSSearchHistoryProviding {
+    func saveSuccessfulSearch(term: String, for itemType: POSItemType)
+    func searchHistory(for itemType: POSItemType) -> [String]
+    func clearSearchHistory(for itemType: POSItemType)
+    func clearAllSearchHistory()
+}
+
 /// Service for managing search history in the Point of Sale
-public final class POSSearchHistoryService {
+public final class POSSearchHistoryService: POSSearchHistoryProviding {
     private let maxHistorySize: Int
     private let siteID: Int64
     private let siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol

--- a/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -81,7 +81,7 @@ extension SiteSpecificAppSettingsStoreMethods {
 }
 
 // MARK: - Search History
-public extension SiteSpecificAppSettingsStoreMethods {
+extension SiteSpecificAppSettingsStoreMethods {
     func getSearchTerms(for itemType: POSItemType, siteID: Int64) -> [String] {
         let storeSettings = getStoreSettings(for: siteID)
         let key = itemType.storedSearchHistoryKey

--- a/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -7,6 +7,10 @@ protocol SiteSpecificAppSettingsStoreMethodsProtocol {
     func resetStoreSettings()
     func setStoreID(siteID: Int64, id: String?)
     func getStoreID(siteID: Int64, onCompletion: (String?) -> Void)
+
+    // Search history methods
+    func getSearchTerms(for itemType: POSItemType, siteID: Int64) -> [String]
+    func setSearchTerms(_ terms: [String], for itemType: POSItemType, siteID: Int64)
 }
 
 /// Methods for managing site-specific app settings
@@ -73,6 +77,24 @@ public extension SiteSpecificAppSettingsStoreMethods {
     func getStoreID(siteID: Int64, onCompletion: (String?) -> Void) {
         let storeSettings = getStoreSettings(for: siteID)
         onCompletion(storeSettings.storeID)
+    }
+}
+
+// MARK: - Search History
+public extension SiteSpecificAppSettingsStoreMethods {
+    func getSearchTerms(for itemType: POSItemType, siteID: Int64) -> [String] {
+        let storeSettings = getStoreSettings(for: siteID)
+        let key = itemType.storedSearchHistoryKey
+        return storeSettings.searchTermsByKey[key] ?? []
+    }
+
+    func setSearchTerms(_ terms: [String], for itemType: POSItemType, siteID: Int64) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let key = itemType.storedSearchHistoryKey
+        var updatedSearchTermsByKey = storeSettings.searchTermsByKey
+        updatedSearchTermsByKey[key] = terms
+        let updatedSettings = storeSettings.copy(searchTermsByKey: updatedSearchTermsByKey)
+        setStoreSettings(settings: updatedSettings, for: siteID)
     }
 }
 

--- a/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Storage
 
-protocol SiteSpecificAppSettingsStoreMethodsProtocol {
+public protocol SiteSpecificAppSettingsStoreMethodsProtocol {
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings
     func setStoreSettings(settings: GeneralStoreSettings, for siteID: Int64, onCompletion: ((Result<Void, Error>) -> Void)?)
     func resetStoreSettings()

--- a/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -18,6 +18,16 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
 
     var currentSiteID: Int64 = 1
 
+    // Search terms properties
+    var getSearchTermsCalled = false
+    var setSearchTermsCalled = false
+    var spyGetSearchTermsItemType: POSItemType?
+    var spyGetSearchTermsSiteID: Int64?
+    var spySetSearchTermsItemType: POSItemType?
+    var spySetSearchTermsSiteID: Int64?
+    var spySetSearchTerms: [String]?
+    var mockSearchTerms: [String] = []
+
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         getStoreSettingsCalled = true
         return storeSettings
@@ -58,5 +68,20 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
         getStoreIDCalled = true
         spyGetStoreIDSiteID = siteID
         onCompletion(mockStoreID)
+    }
+
+    // Search terms methods
+    func getSearchTerms(for itemType: POSItemType, siteID: Int64) -> [String] {
+        getSearchTermsCalled = true
+        spyGetSearchTermsItemType = itemType
+        spyGetSearchTermsSiteID = siteID
+        return mockSearchTerms
+    }
+
+    func setSearchTerms(_ terms: [String], for itemType: POSItemType, siteID: Int64) {
+        setSearchTermsCalled = true
+        spySetSearchTermsItemType = itemType
+        spySetSearchTermsSiteID = siteID
+        spySetSearchTerms = terms
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -25,8 +25,7 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     var spyGetSearchTermsSiteID: Int64?
     var spySetSearchTermsItemType: POSItemType?
     var spySetSearchTermsSiteID: Int64?
-    var spySetSearchTerms: [String]?
-    var mockSearchTerms: [String] = []
+    var mockSearchTerms: [POSItemType: [String]] = [:]
 
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         getStoreSettingsCalled = true
@@ -75,13 +74,13 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
         getSearchTermsCalled = true
         spyGetSearchTermsItemType = itemType
         spyGetSearchTermsSiteID = siteID
-        return mockSearchTerms
+        return mockSearchTerms[itemType] ?? []
     }
 
     func setSearchTerms(_ terms: [String], for itemType: POSItemType, siteID: Int64) {
         setSearchTermsCalled = true
         spySetSearchTermsItemType = itemType
         spySetSearchTermsSiteID = siteID
-        spySetSearchTerms = terms
+        mockSearchTerms[itemType] = terms
     }
 }

--- a/Yosemite/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
@@ -9,10 +9,11 @@ struct POSSearchHistoryServiceTests {
 
     init() {
         mockStoreMethods = MockSiteSpecificAppSettingsStoreMethods()
+        mockStoreMethods.currentSiteID = siteID
         sut = POSSearchHistoryService(maxHistorySize: 10, siteID: siteID, siteSpecificAppSettingsStoreMethods: mockStoreMethods)
     }
 
-    @Test func saveSuccessfulSearch_saves_term_to_history() {
+    @Test func saveSuccessfulSearch_saves_term_to_history() throws {
         // Given
         let itemType: POSItemType = .product
 
@@ -20,12 +21,12 @@ struct POSSearchHistoryServiceTests {
         sut.saveSuccessfulSearch(term: "test", for: itemType)
 
         // Then
-        let history = sut.searchHistory(for: itemType)
+        let history = try #require(mockStoreMethods.mockSearchTerms[itemType])
         #expect(history.count == 1)
         #expect(history.first == "test")
     }
 
-    @Test func saveSuccessfulSearch_orders_terms_by_recency() {
+    @Test func saveSuccessfulSearch_orders_terms_by_recency() throws {
         // Given
         let itemType: POSItemType = .product
 
@@ -35,7 +36,7 @@ struct POSSearchHistoryServiceTests {
         sut.saveSuccessfulSearch(term: "third", for: itemType)
 
         // Then
-        let history = sut.searchHistory(for: itemType)
+        let history = try #require(mockStoreMethods.mockSearchTerms[itemType])
         #expect(history.count == 3)
         #expect(history[0] == "third")
         #expect(history[1] == "second")
@@ -43,7 +44,7 @@ struct POSSearchHistoryServiceTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func saveSuccessfulSearch_removes_duplicates() {
+    @Test func saveSuccessfulSearch_removes_duplicates() throws {
         // Given
         let itemType: POSItemType = .product
 
@@ -53,13 +54,13 @@ struct POSSearchHistoryServiceTests {
         sut.saveSuccessfulSearch(term: "test", for: itemType)
 
         // Then
-        let history = sut.searchHistory(for: itemType)
+        let history = try #require(mockStoreMethods.mockSearchTerms[itemType])
         #expect(history.count == 2)
         #expect(history[0] == "test")
         #expect(history[1] == "another")
     }
 
-    @Test func saveSuccessfulSearch_respects_max_history_size() {
+    @Test func saveSuccessfulSearch_respects_max_history_size() throws {
         // Given
         let sut = POSSearchHistoryService(maxHistorySize: 3, siteID: siteID, siteSpecificAppSettingsStoreMethods: mockStoreMethods)
         let itemType: POSItemType = .product
@@ -71,7 +72,7 @@ struct POSSearchHistoryServiceTests {
         sut.saveSuccessfulSearch(term: "fourth", for: itemType)
 
         // Then
-        let history = sut.searchHistory(for: itemType)
+        let history = try #require(mockStoreMethods.mockSearchTerms[itemType])
         #expect(history.count == 3)
         #expect(history[0] == "fourth")
         #expect(history[1] == "third")
@@ -89,52 +90,48 @@ struct POSSearchHistoryServiceTests {
         #expect(history.isEmpty)
     }
 
-    @Test func clearSearchHistory_clears_history_for_specific_item_type() {
+    @Test func clearSearchHistory_clears_history_for_specific_item_type() throws {
         // Given
-        let productsType: POSItemType = .product
-        let couponsType: POSItemType = .coupon
-
-        sut.saveSuccessfulSearch(term: "product", for: productsType)
-        sut.saveSuccessfulSearch(term: "coupon", for: couponsType)
+        sut.saveSuccessfulSearch(term: "product", for: .product)
+        sut.saveSuccessfulSearch(term: "coupon", for: .coupon)
 
         // When
-        sut.clearSearchHistory(for: productsType)
+        sut.clearSearchHistory(for: .product)
 
         // Then
-        #expect(sut.searchHistory(for: productsType).isEmpty)
-        #expect(sut.searchHistory(for: couponsType).count == 1)
-        #expect(sut.searchHistory(for: couponsType).first == "coupon")
+        let productsSearchHistory = try #require(mockStoreMethods.mockSearchTerms[.product])
+        let couponsSearchHistory = try #require(mockStoreMethods.mockSearchTerms[.coupon])
+        #expect(productsSearchHistory.isEmpty)
+        #expect(couponsSearchHistory.count == 1)
+        #expect(couponsSearchHistory.first == "coupon")
     }
 
-    @Test func clearAllSearchHistory_clears_all_history() {
+    @Test func clearAllSearchHistory_clears_all_history() throws {
         // Given
-        let productsType: POSItemType = .product
-        let couponsType: POSItemType = .coupon
-
-        sut.saveSuccessfulSearch(term: "product", for: productsType)
-        sut.saveSuccessfulSearch(term: "coupon", for: couponsType)
+        mockStoreMethods.mockSearchTerms[.product] = ["product"]
+        mockStoreMethods.mockSearchTerms[.coupon] = ["coupon"]
 
         // When
         sut.clearAllSearchHistory()
 
         // Then
-        #expect(sut.searchHistory(for: productsType).isEmpty)
-        #expect(sut.searchHistory(for: couponsType).isEmpty)
+        #expect(mockStoreMethods.setSearchTermsCalled)
+        let productsSearchHistory = try #require(mockStoreMethods.mockSearchTerms[.product])
+        let couponsSearchHistory = try #require(mockStoreMethods.mockSearchTerms[.coupon])
+        #expect(productsSearchHistory.isEmpty)
+        #expect(couponsSearchHistory.isEmpty)
     }
 
     @Test func search_history_is_separate_for_different_item_types() {
         // Given
-        let productsType: POSItemType = .product
-        let couponsType: POSItemType = .coupon
+        mockStoreMethods.mockSearchTerms[.product] = ["product"]
+        mockStoreMethods.mockSearchTerms[.coupon] = ["coupon"]
 
         // When
-        sut.saveSuccessfulSearch(term: "product", for: productsType)
-        sut.saveSuccessfulSearch(term: "coupon", for: couponsType)
+        let productsHistory = sut.searchHistory(for: .product)
+        let couponsHistory = sut.searchHistory(for: .coupon)
 
         // Then
-        let productsHistory = sut.searchHistory(for: productsType)
-        let couponsHistory = sut.searchHistory(for: couponsType)
-
         #expect(productsHistory.count == 1)
         #expect(productsHistory.first == "product")
         #expect(couponsHistory.count == 1)

--- a/Yosemite/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
@@ -3,10 +3,17 @@ import Foundation
 @testable import Yosemite
 
 struct POSSearchHistoryServiceTests {
-    @available(iOS 17.0, *)
+    private var sut: POSSearchHistoryService!
+    private var mockStoreMethods: MockSiteSpecificAppSettingsStoreMethods!
+    private let siteID: Int64 = 123
+
+    init() {
+        mockStoreMethods = MockSiteSpecificAppSettingsStoreMethods()
+        sut = POSSearchHistoryService(maxHistorySize: 10, siteID: siteID, siteSpecificAppSettingsStoreMethods: mockStoreMethods)
+    }
+
     @Test func saveSuccessfulSearch_saves_term_to_history() {
         // Given
-        let sut = POSSearchHistoryService()
         let itemType: POSItemType = .product
 
         // When
@@ -18,10 +25,8 @@ struct POSSearchHistoryServiceTests {
         #expect(history.first == "test")
     }
 
-    @available(iOS 17.0, *)
     @Test func saveSuccessfulSearch_orders_terms_by_recency() {
         // Given
-        let sut = POSSearchHistoryService()
         let itemType: POSItemType = .product
 
         // When
@@ -40,7 +45,6 @@ struct POSSearchHistoryServiceTests {
     @available(iOS 17.0, *)
     @Test func saveSuccessfulSearch_removes_duplicates() {
         // Given
-        let sut = POSSearchHistoryService()
         let itemType: POSItemType = .product
 
         // When
@@ -55,11 +59,9 @@ struct POSSearchHistoryServiceTests {
         #expect(history[1] == "another")
     }
 
-    @available(iOS 17.0, *)
     @Test func saveSuccessfulSearch_respects_max_history_size() {
         // Given
-        let maxHistorySize = 3
-        let sut = POSSearchHistoryService(maxHistorySize: maxHistorySize)
+        let sut = POSSearchHistoryService(maxHistorySize: 3, siteID: siteID, siteSpecificAppSettingsStoreMethods: mockStoreMethods)
         let itemType: POSItemType = .product
 
         // When
@@ -70,16 +72,14 @@ struct POSSearchHistoryServiceTests {
 
         // Then
         let history = sut.searchHistory(for: itemType)
-        #expect(history.count == maxHistorySize)
+        #expect(history.count == 3)
         #expect(history[0] == "fourth")
         #expect(history[1] == "third")
         #expect(history[2] == "second")
     }
 
-    @available(iOS 17.0, *)
     @Test func searchHistory_returns_empty_array_for_unknown_item_type() {
         // Given
-        let sut = POSSearchHistoryService()
         let itemType: POSItemType = .coupon
 
         // When
@@ -89,10 +89,8 @@ struct POSSearchHistoryServiceTests {
         #expect(history.isEmpty)
     }
 
-    @available(iOS 17.0, *)
     @Test func clearSearchHistory_clears_history_for_specific_item_type() {
         // Given
-        let sut = POSSearchHistoryService()
         let productsType: POSItemType = .product
         let couponsType: POSItemType = .coupon
 
@@ -108,10 +106,8 @@ struct POSSearchHistoryServiceTests {
         #expect(sut.searchHistory(for: couponsType).first == "coupon")
     }
 
-    @available(iOS 17.0, *)
     @Test func clearAllSearchHistory_clears_all_history() {
         // Given
-        let sut = POSSearchHistoryService()
         let productsType: POSItemType = .product
         let couponsType: POSItemType = .coupon
 
@@ -126,10 +122,8 @@ struct POSSearchHistoryServiceTests {
         #expect(sut.searchHistory(for: couponsType).isEmpty)
     }
 
-    @available(iOS 17.0, *)
     @Test func search_history_is_separate_for_different_item_types() {
         // Given
-        let sut = POSSearchHistoryService()
         let productsType: POSItemType = .product
         let couponsType: POSItemType = .coupon
 

--- a/Yosemite/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
@@ -134,6 +134,117 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
         // Then
         XCTAssertEqual(retrievedStoreID, storeID)
     }
+
+    // MARK: - Search Terms Tests
+
+    func test_getSearchTerms_returns_empty_array_when_no_terms_exist() {
+        // When
+        let terms = sut.getSearchTerms(for: .product, siteID: siteID)
+
+        // Then
+        XCTAssertTrue(terms.isEmpty)
+    }
+
+    func test_getSearchTerms_returns_saved_terms() throws {
+        // Given
+        let expectedTerms = ["term1", "term2", "term3"]
+        let storeSettings = GeneralStoreSettings(searchTermsByKey: ["product_search_terms": expectedTerms])
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        let terms = sut.getSearchTerms(for: .product, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(terms, expectedTerms)
+    }
+
+    func test_setSearchTerms_saves_terms_successfully() throws {
+        // Given
+        let terms = ["term1", "term2", "term3"]
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
+        try fileStorage.write(existingSettings, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        sut.setSearchTerms(terms, for: .product, siteID: siteID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"], terms)
+    }
+
+    func test_setSearchTerms_preserves_existing_terms_for_other_item_types() throws {
+        // Given
+        let existingTerms = ["existing1", "existing2"]
+        let storeSettings = GeneralStoreSettings(searchTermsByKey: ["variation_search_terms": existingTerms])
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        let newTerms = ["new1", "new2"]
+        sut.setSearchTerms(newTerms, for: .product, siteID: siteID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"], newTerms)
+        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["variation_search_terms"], existingTerms)
+    }
+
+    func test_setSearchTerms_preserves_existing_terms_for_other_sites() throws {
+        // Given
+        let otherSiteID: Int64 = 456
+        let otherSiteTerms = ["other1", "other2"]
+        let storeSettings = GeneralStoreSettings(searchTermsByKey: ["product_search_terms": otherSiteTerms])
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [otherSiteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        let newTerms = ["new1", "new2"]
+        sut.setSearchTerms(newTerms, for: .product, siteID: siteID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"], newTerms)
+        XCTAssertEqual(savedData.storeSettingsBySite[otherSiteID]?.searchTermsByKey["product_search_terms"], otherSiteTerms)
+    }
+
+    func test_resetStoreSettings_clears_search_terms() throws {
+        // Given
+        let terms = ["term1", "term2"]
+        let storeSettings = GeneralStoreSettings(searchTermsByKey: ["product_search_terms": terms])
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        sut.resetStoreSettings()
+
+        // Then
+        XCTAssertTrue(fileStorage.deleteIsHit)
+        let savedTerms = sut.getSearchTerms(for: .product, siteID: siteID)
+        XCTAssertTrue(savedTerms.isEmpty)
+    }
+
+    func test_search_terms_work_for_all_item_types() throws {
+        // Given
+        let productTerms = ["product1", "product2"]
+        let variationTerms = ["variation1", "variation2"]
+        let couponTerms = ["coupon1", "coupon2"]
+        let storeSettings = GeneralStoreSettings(searchTermsByKey: [
+            "product_search_terms": productTerms,
+            "variation_search_terms": variationTerms,
+            "coupon_search_terms": couponTerms
+        ])
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        let retrievedProductTerms = sut.getSearchTerms(for: .product, siteID: siteID)
+        let retrievedVariationTerms = sut.getSearchTerms(for: .variation, siteID: siteID)
+        let retrievedCouponTerms = sut.getSearchTerms(for: .coupon, siteID: siteID)
+
+        // Then
+        XCTAssertEqual(retrievedProductTerms, productTerms)
+        XCTAssertEqual(retrievedVariationTerms, variationTerms)
+        XCTAssertEqual(retrievedCouponTerms, couponTerms)
+    }
 }
 
 // MARK: - Mock FileStorage


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-314
Merge after: #15514
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR uses the newly-extracted `SiteSpecificAppSettingsStoreMethods` to store and retrieve the search history, for `POSSearchHistoryService`.

With this change, search terms are saved and shown as pre-search UI on a per-site, per-device basis.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `searchProductsInPOS` feature flag

1. Launch the app and open POS
2. Tap the search field; observe that there are no saved searches
3. Search for something, and tap on a result
4. Clear the search field; observe that the search term you used is now saved.
5. Exit POS and come back
6. Tap the search field; observe that your previous search term is still there
7. Switch to a different site and repeat; observe that nothing is saved
8. Go back to your first site; observe that the original search term is shown again
9. Force quit the app and repeat; observe that the original search term is shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested this on an iPad Air running iOS 17.7.3, and a simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ccf81314-9be7-441f-bc36-da435200d00c


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.