### PR TITLE
[Woo POS] Coupons: Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -141,6 +141,12 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleCashCollectPaymentSuccess,
             WooAnalyticsStat.pointOfSaleCashPaymentTapped,
             WooAnalyticsStat.pointOfSaleCashPaymentFailed,
+            WooAnalyticsStat.pointOfSaleProductsTapped,
+            WooAnalyticsStat.pointOfSaleCouponsTapped,
+            WooAnalyticsStat.pointOfSaleCouponsCreateTapped,
+            WooAnalyticsStat.pointOfSaleCouponsPullToRefresh,
+            WooAnalyticsStat.pointOfSaleCouponAddedToCart,
+            WooAnalyticsStat.pointOfSaleCouponRemovedFromCart,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -196,7 +196,8 @@ private extension TracksProvider {
             WooAnalyticsStat.paymentsFlowCollect,
 
             // Coupons
-            WooAnalyticsStat.couponSettingEnabled
+            WooAnalyticsStat.couponSettingEnabled,
+            WooAnalyticsStat.couponCreationSuccess,
         ]
 
         guard Self.isPOSModeActive, pointOfSaleEventList.contains(event) else {

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -194,6 +194,9 @@ private extension TracksProvider {
             WooAnalyticsStat.paymentsFlowCanceled,
             WooAnalyticsStat.paymentsFlowFailed,
             WooAnalyticsStat.paymentsFlowCollect,
+
+            // Coupons
+            WooAnalyticsStat.couponSettingEnabled
         ]
 
         guard Self.isPOSModeActive, pointOfSaleEventList.contains(event) else {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1301,6 +1301,12 @@ enum WooAnalyticsStat: String {
     case pointOfSaleViewDocsTapped = "view_docs_tapped"
     case pointOfSaleReaderReadyForCardPayment = "reader_ready_for_card_payment"
     case pointOfSaleCashCollectPaymentSuccess = "cash_collect_payment_success"
+    case pointOfSaleProductsTapped = "products_tapped"
+    case pointOfSaleCouponsTapped = "coupons_tapped"
+    case pointOfSaleCouponsCreateTapped = "coupons_create_tapped"
+    case pointOfSaleCouponsPullToRefresh = "coupons_pull_to_refresh"
+    case pointOfSaleCouponAddedToCart = "coupon_added_to_cart"
+    case pointOfSaleCouponRemovedFromCart = "coupon_removed_from_cart"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -12,6 +12,7 @@ extension WooAnalyticsEvent {
             static let paymentsOnboardingState = "onboarding_state"
             static let itemType = "product_type"
             static let itemsInCart = "items_in_cart"
+            static let couponsInCart = "coupons_in_cart"
             static let millisecondsSinceCustomerInteractionStarted = "milliseconds_since_customer_interaction_started"
             static let millisecondsSinceOrderSyncSuccess = "milliseconds_since_order_sync_success"
             static let millisecondsSinceReaderReadyToCollect = "milliseconds_since_reader_ready_to_collect_payment"
@@ -33,9 +34,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSaleAddItemToCart, properties: [Key.itemType: type.analyticsValue])
         }
 
-        static func checkoutTapped(_ itemsInCart: Int) -> WooAnalyticsEvent {
+        static func checkoutTapped(productsInCart: Int, couponsInCart: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSaleCheckoutTapped,
-                              properties: [Key.itemsInCart: itemsInCart])
+                              properties: [Key.itemsInCart: productsInCart,
+                                           Key.couponsInCart: couponsInCart])
         }
 
         /// Tracks the time elapsed preparing reader for payment, after successful order creation

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -84,10 +84,7 @@ protocol PointOfSaleOrderControllerProtocol {
             return .success(.newOrder)
         } catch {
             self.order = nil
-            analytics.track(event: WooAnalyticsEvent.Orders.orderCreationFailed(
-                usesGiftCard: false,
-                errorContext: String(describing: error),
-                errorDescription: error.localizedDescription))
+            trackOrderCreationFailed(error: error)
             setOrderStateToError(error, retryHandler: retryHandler)
             return .failure(SyncOrderStateError.syncFailure)
         }
@@ -266,6 +263,29 @@ extension PointOfSaleOrderController {
     enum PointOfSaleOrderControllerError: Error {
         case noSiteID
         case noOrder
+    }
+}
+
+
+@available(iOS 17.0, *)
+private extension PointOfSaleOrderController {
+    func trackOrderCreationFailed(error: Error) {
+        let errorContext: String
+        let errorDescription: String
+
+        if let couponsError = CouponsError(underlyingError: error) {
+            errorContext = couponsError.code
+            errorDescription = couponsError.message
+        } else {
+            errorContext = String(describing: error)
+            errorDescription = error.localizedDescription
+        }
+
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationFailed(
+            usesGiftCard: false,
+            errorContext: errorContext,
+            errorDescription: errorDescription)
+        )
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -328,6 +328,7 @@ private extension CartView {
                                                                         couponItem: couponItem),
                               showImage: $shouldShowItemImages,
                               onItemRemoveTapped: posModel.orderStage == .building ? {
+                    ServiceLocator.analytics.track(.pointOfSaleCouponRemovedFromCart)
                     posModel.remove(cartCouponItem: couponItem)
                 } : nil)
                 .id(couponItem.id)

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -340,8 +340,14 @@ private extension CartView {
 @available(iOS 17.0, *)
 private extension CartView {
     func trackCheckoutTapped() {
-        let itemsInCart = posModel.cart.items.count
-        ServiceLocator.analytics.track(event: .PointOfSale.checkoutTapped(itemsInCart))
+        let products = posModel.cart.items.count
+        let coupons = posModel.cart.coupons.count
+        ServiceLocator.analytics.track(
+            event: .PointOfSale.checkoutTapped(
+                productsInCart: products,
+                couponsInCart: coupons
+            )
+        )
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
@@ -23,6 +23,8 @@ extension POSItemActionHandler {
             analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
         case .variation:
             analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
+        case .coupon:
+            analytics.track(.pointOfSaleCouponAddedToCart)
         default:
             break
         }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -307,6 +307,7 @@ private extension ItemListView {
             PointOfSaleItemListErrorView(error: errorState, onAction: {
                 Task {
                     await posModel.couponsController.enableCoupons()
+                    ServiceLocator.analytics.track(.couponSettingEnabled)
                 }
             })
         default:

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -251,7 +251,7 @@ private extension ItemListView {
             }
         }
         .refreshable {
-            ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
+            trackPullToRefresh()
             await itemsController.refreshItems(base: .root)
         }
     }
@@ -335,12 +335,7 @@ private extension ItemListView {
             }
         }
 
-        switch itemListType {
-        case .products:
-            ServiceLocator.analytics.track(.pointOfSaleProductsTapped)
-        case .coupons:
-            ServiceLocator.analytics.track(.pointOfSaleCouponsTapped)
-        }
+        trackSelectedItemListTypeTapped(itemListType)
     }
 }
 
@@ -413,6 +408,27 @@ private extension ItemListView {
             value: "Learn More",
             comment: "Link to more information within the product selector header banner, which explains current POS limitations"
         )
+    }
+}
+
+@available(iOS 17.0, *)
+private extension ItemListView {
+    func trackSelectedItemListTypeTapped(_ type: ItemListType) {
+        switch type {
+        case .products:
+            ServiceLocator.analytics.track(.pointOfSaleProductsTapped)
+        case .coupons:
+            ServiceLocator.analytics.track(.pointOfSaleCouponsTapped)
+        }
+    }
+
+    func trackPullToRefresh() {
+        switch selectedItemListType {
+        case .products:
+            ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
+        case .coupons:
+            ServiceLocator.analytics.track(.pointOfSaleCouponsPullToRefresh)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -202,6 +202,7 @@ private extension ItemListView {
             if case .coupons = selectedItemListType, itemListState.isLoaded || itemListState.isEmpty {
                 Button(action: {
                     showCouponCreationModal = true
+                    ServiceLocator.analytics.track(.pointOfSaleCouponsCreateTapped)
                 }, label: {
                     Text(Image(systemName: "plus.circle.fill"))
                 })

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -333,6 +333,13 @@ private extension ItemListView {
                 await itemsController.loadItems(base: .root)
             }
         }
+
+        switch itemListType {
+        case .products:
+            ServiceLocator.analytics.track(.pointOfSaleProductsTapped)
+        case .coupons:
+            ServiceLocator.analytics.track(.pointOfSaleCouponsTapped)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -34,6 +34,7 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
                         .buttonStyle(POSFilledButtonStyle(size: .normal))
 
                         Button(retryActionTitle, action: {
+                            ServiceLocator.analytics.track(.pointOfSaleCouponRemovedFromCart)
                             posModel.removeAllCouponsFromCart()
                             retryHandler()
                         })

--- a/Yosemite/Yosemite/Stores/CouponsError.swift
+++ b/Yosemite/Yosemite/Stores/CouponsError.swift
@@ -2,6 +2,7 @@ import Foundation
 import Networking
 
 public struct CouponsError: Error, LocalizedError {
+    public let code: String = Constants.invalidCouponCode
     public let message: String
     public let underlyingError: Error
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add missing analytics events for the POS Coupons implementation.

Specs:

Name | Event
-- | --
Coupon settings enabled. Existing event with _pos prefix when the coupon is enabled. | `pos_coupon_settings_enabled`
Coupon created. Existing event with _pos prefix when the coupon is created. | `pos_coupon_creation_success`
Checkout with coupons Existing pos_checkout_tapped event with a new coupons_in_cart parameter. | `pos_checkout_tapped` New parameter:coupons_in_cart : Integer
Checkout with coupons failed. Existing `pos_order_creation_failed` with improved error_context. | `pos_order_creation_failed` Update parameter:error_context to specific error `woocommerce_rest_invalid_coupon` rather than the whole error message since it's difficult to filter it out.

<h3 id="new-events" class="heading-node" data-pm-slice="1 4 []">New Events</h3><p class="text-node">We will track the new data using the same conventions as products in POS.</p>


Name | Event
-- | --
Products section tapped. | `pos_products_tapped`
Coupons section tapped. | `pos_coupons_tapped`
Coupon creation tapped. |`pos_coupons_create_tapped`
Coupons pull to refresh. | `pos_coupons_pull_to_refresh`
Coupon added to the cart. | `pos_coupon_added_to_cart`
Coupon removed from cart. Track also when "Remove coupon" button is tapped on an error. | `pos_coupon_removed_from_cart`

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:
- Disable `Enable the use of coupon codes` setting in WooCommerce->Settings
- Enable `enableCouponsInPointOfSale` feature flag

1. Open POS and switch to the Coupons tab -> `pos_coupons_tapped` should be tracked
2. Tap 'Enable Coupons'  -> `pos_coupon_settings_enabled` should be tracked
3. Tap '+'  -> `pos_coupons_create_tapped` should be tracked
4. Create a coupon -> `pos_coupon_creation_success` should be tracked
6. Add coupon to cart -> `pos_coupon_added_to_cart` should be tracked
7. Remove coupon from cart -> `pos_coupon_removed_from_cart` should be tracked
8. Pull to refresh -> `pos_coupons_pull_to_refresh` should be tracked
9. Add coupon and products to cart, tap checkout -> `pos_checkout_tapped` should be tracked with `coupons_in_cart` parameter and number of coupons added to cart
10. Return to edit order, add invalid coupon, checkout -> `pos_order_creation_failed` should be tracked with `error_context` set to `woocommerce_rest_invalid_coupon`

Registration PRs of new events:
- https://github.com/Automattic/tracks-events-registration/pull/2803
- https://github.com/Automattic/tracks-events-registration/pull/2804
- https://github.com/Automattic/tracks-events-registration/pull/2805
- https://github.com/Automattic/tracks-events-registration/pull/2806
- https://github.com/Automattic/tracks-events-registration/pull/2807
- https://github.com/Automattic/tracks-events-registration/pull/2808
- https://github.com/Automattic/tracks-events-registration/pull/2809
- https://github.com/Automattic/tracks-events-registration/pull/2810

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11 Inch M2 iOS 18.2 Simulator

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
