### PR TITLE
Fix blurry product thumbnails

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [internal] Improved login flow during Jetpack Setup for accounts using emails marked as suspicious [https://github.com/woocommerce/woocommerce-ios/pull/15491]
 - [internal] Update Sentry to 8.46.0 to allow building with Xcode 16.3 [https://github.com/woocommerce/woocommerce-ios/pull/15503]
 - [*] Product Form: Fixed an issue where a draft variable product cannot be published [https://github.com/woocommerce/woocommerce-ios/pull/15513]
+- [internal] Fixed the issue where some product thumbnails appeared blurry [https://github.com/woocommerce/woocommerce-ios/pull/15517]
 
 22.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductImageThumbnail.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductImageThumbnail.swift
@@ -14,7 +14,7 @@ struct ProductImageThumbnail<Placeholder: View>: View {
     ///
     private var imageProcessor: ImageProcessor {
         let screenPixelScale = UIScreen.main.scale
-        let sideSize = productImageSize * screenPixelScale
+        let sideSize = productImageSize * screenPixelScale * scale
         let pixelSize = CGSize(
             width: sideSize,
             height: sideSize

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductImageThumbnail.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductImageThumbnail.swift
@@ -13,10 +13,16 @@ struct ProductImageThumbnail<Placeholder: View>: View {
     /// Image processor to resize images in a background thread to avoid blocking the UI
     ///
     private var imageProcessor: ImageProcessor {
-        ResizingImageProcessor(referenceSize:
-                .init(width: productImageSize * scale,
-                      height: productImageSize * scale),
-                               mode: .aspectFill)
+        let screenPixelScale = UIScreen.main.scale
+        let sideSize = productImageSize * screenPixelScale
+        let pixelSize = CGSize(
+            width: sideSize,
+            height: sideSize
+        )
+        return ResizingImageProcessor(
+            referenceSize: pixelSize,
+            mode: .aspectFill
+        )
     }
 
     init(productImageURL: URL?,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: WOOMOB-75
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description

Adds Pixel density / screen resolution `UIScreen.main.scale` multiplier to calculate image pixel size in `ResizingImageProcessor`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Build from `trunk`. 
- Make sure the Shipping extension is enabled.
- In the app navigate to the "Orders" and select an order eligible for a shipping label
- The "Create shipping label" button should be visible. Tap it.
- On newly appeared "Create Shipping Labels" screen expand the "N items" view.
- Presented product thumbnails will look blurry. Compare to product thumbnails in previous screen or in Products tab.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Build from current branch.
- Follow same steps to repro.
- Product thumbnails should look sharp.
- Consider tweaking larger font in iOS accessibility settings.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After
--- | ---
![Снимок экрана 2025-04-17 в 18 13 48](https://github.com/user-attachments/assets/b38e882a-b108-4ce8-a39e-b993067dbb0d) | ![Снимок экрана 2025-04-17 в 18 10 40](https://github.com/user-attachments/assets/65d963ee-c80d-4389-be00-98601e94d44c)

Before (Large) | After (Large)
--- | ---
![Снимок экрана 2025-04-17 в 17 57 22](https://github.com/user-attachments/assets/becafa02-08d1-47c5-a634-ae757b225e55) | ![Снимок экрана 2025-04-17 в 18 00 01](https://github.com/user-attachments/assets/acf4fa86-42c5-4242-8360-1fbaf0632a8c)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
