### PR TITLE
[Woo POS] Make a Preview aggregate model helper function

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -169,15 +169,7 @@ private extension CardReaderConnectionStatusView {
 
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService()
-    )
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     VStack {
         CardReaderConnectionStatusView()
             .background(Color.posSurfaceContainerLow)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -169,12 +169,11 @@ private extension CardReaderConnectionStatusView {
 
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     VStack {
         CardReaderConnectionStatusView()
             .background(Color.posSurfaceContainerLow)
             .frame(height: 80)
-            .environment(posModel)
+            .environment(POSPreviewHelpers.makePreviewAggregateModel())
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -123,14 +123,7 @@ private extension PointOfSalePaymentSuccessView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     return PointOfSalePaymentSuccessView(
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
                                                       paymentMethod: .card)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -123,11 +123,10 @@ private extension PointOfSalePaymentSuccessView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
-    return PointOfSalePaymentSuccessView(
+    PointOfSalePaymentSuccessView(
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
                                                       paymentMethod: .card)
     )
-    .environment(posModel)
+    .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -348,28 +348,14 @@ private extension CartView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     return CartView()
         .environment(posModel)
 }
 
 @available(iOS 17.0, *)
 #Preview("Cart with one item") {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     posModel.addToCart(.simpleProduct(.init(id: UUID(),
                                             name: "Sample Product",
                                             formattedPrice: "$10.00",

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -348,9 +348,8 @@ private extension CartView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
-    return CartView()
-        .environment(posModel)
+    CartView()
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
 @available(iOS 17.0, *)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -234,14 +234,7 @@ private extension ItemListRow {
 
 @available(iOS 17.0, *)
 #Preview("Loading") {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     ItemList(itemsController: PointOfSalePreviewItemsController(),
              node: .root,
              itemActionHandler: PointOfSalePreviewItemActionHandler())

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -234,11 +234,10 @@ private extension ItemListRow {
 
 @available(iOS 17.0, *)
 #Preview("Loading") {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     ItemList(itemsController: PointOfSalePreviewItemsController(),
              node: .root,
              itemActionHandler: PointOfSalePreviewItemActionHandler())
-        .environment(posModel)
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -422,9 +422,8 @@ private extension ItemListView {
 
 @available(iOS 17.0, *)
 #Preview("Loading") {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
-    return ItemListView(selectedItemListType: .constant(.products(search: false)))
-        .environment(posModel)
+    ItemListView(selectedItemListType: .constant(.products(search: false)))
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -415,28 +415,14 @@ private extension ItemListView {
     Task { @MainActor in
         await itemsController.loadItems(base: .root)
     }
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: itemsController,
-        purchasableItemsSearchController: itemsController,
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel(itemsController: itemsController)
     return ItemListView(selectedItemListType: .constant(.products(search: false)))
         .environment(posModel)
 }
 
 @available(iOS 17.0, *)
 #Preview("Loading") {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     return ItemListView(selectedItemListType: .constant(.products(search: false)))
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -137,14 +137,7 @@ private extension POSFloatingControlView {
 
 @available(iOS 17.0, *)
 #Preview("Reader Disconnected") {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .primary)
         .environment(posModel)
@@ -153,15 +146,10 @@ private extension POSFloatingControlView {
 @available(iOS 17.0, *)
 #Preview("Reader Connected") {
     let paymentService = CardPresentPaymentPreviewService()
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
     paymentService.readerConnectionStatus = .connected(.init(name: "", batteryLevel: 0.6))
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel(
+        cardPresentPaymentService: paymentService
+    )
     return POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .primary)
         .environment(posModel)
@@ -169,14 +157,7 @@ private extension POSFloatingControlView {
 
 @available(iOS 17.0, *)
 #Preview("Secondary/disabled Background") {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .secondary)
         .environment(posModel)

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -137,10 +137,9 @@ private extension POSFloatingControlView {
 
 @available(iOS 17.0, *)
 #Preview("Reader Disconnected") {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .primary)
-        .environment(posModel)
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
 @available(iOS 17.0, *)
@@ -157,10 +156,9 @@ private extension POSFloatingControlView {
 
 @available(iOS 17.0, *)
 #Preview("Secondary/disabled Background") {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
         .environment(\.posBackgroundAppearance, .secondary)
-        .environment(posModel)
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -88,8 +88,7 @@ private extension PaymentsActionButtons {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     PaymentsActionButtons(isShowingSendReceiptView: .constant(false), isShowingReceiptNotEligibleBanner: .constant(true))
-        .environment(posModel)
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -88,14 +88,7 @@ private extension PaymentsActionButtons {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     PaymentsActionButtons(isShowingSendReceiptView: .constant(false), isShowingReceiptNotEligibleBanner: .constant(true))
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -197,8 +197,7 @@ private extension PointOfSaleCollectCashView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     PointOfSaleCollectCashView(orderTotal: "$1.23")
-        .environment(posModel)
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -197,14 +197,7 @@ private extension PointOfSaleCollectCashView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     PointOfSaleCollectCashView(orderTotal: "$1.23")
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -210,17 +210,9 @@ private extension PointOfSaleDashboardView {
 
 @available(iOS 17.0, *)
 #Preview("Container loading state") {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
     return NavigationStack {
         PointOfSaleDashboardView()
-            .environment(posModel)
+            .environment(POSPreviewHelpers.makePreviewAggregateModel())
             .environmentObject(POSModalManager())
     }
 }
@@ -228,15 +220,8 @@ private extension PointOfSaleDashboardView {
 @available(iOS 17.0, *)
 #Preview("Content loading state") {
     let itemsController = PointOfSalePreviewItemsController()
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: itemsController,
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: .init(root: .loading([]), itemStates: [:]))
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel(itemsController: itemsController)
     return NavigationStack {
         PointOfSaleDashboardView()
             .environment(posModel)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -158,8 +158,7 @@ private extension POSSendReceiptView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     POSSendReceiptView(isShowingSendReceiptView: .constant(true))
-        .environment(posModel)
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -158,14 +158,7 @@ private extension POSSendReceiptView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     POSSendReceiptView(isShowingSendReceiptView: .constant(true))
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -455,14 +455,7 @@ private extension TotalsView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = PointOfSaleAggregateModel(
-        itemsController: PointOfSalePreviewItemsController(),
-        purchasableItemsSearchController: PointOfSalePreviewItemsController(),
-        couponsController: PointOfSalePreviewCouponsController(),
-        cardPresentPaymentService: CardPresentPaymentPreviewService(),
-        orderController: PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
-        searchHistoryService: PointOfSalePreviewHistoryService())
+    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     TotalsView()
         .environment(posModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -455,8 +455,7 @@ private extension TotalsView {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-    let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     TotalsView()
-        .environment(posModel)
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 #endif

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -1,6 +1,7 @@
 #if DEBUG
 
 import Foundation
+import WooFoundation
 import protocol Yosemite.PointOfSaleItemServiceProtocol
 import enum Yosemite.POSItem
 import struct Yosemite.POSSimpleProduct
@@ -183,6 +184,29 @@ final class POSConnectivityObserverPreview: ConnectivityObserver {
     func startObserving() {}
 
     func stopObserving() {}
+}
+
+@available(iOS 17.0, *)
+struct POSPreviewHelpers {
+    static func makePreviewAggregateModel(
+        itemsController: PointOfSaleSearchingItemsControllerProtocol = PointOfSalePreviewItemsController(),
+        purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol = PointOfSalePreviewItemsController(),
+        couponsController: PointOfSaleCouponsControllerProtocol = PointOfSalePreviewCouponsController(),
+        cardPresentPaymentService: CardPresentPaymentFacade = CardPresentPaymentPreviewService(),
+        orderController: PointOfSaleOrderControllerProtocol = PointOfSalePreviewOrderController(),
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = POSCollectOrderPaymentAnalytics(),
+        searchHistoryService: POSSearchHistoryProviding = PointOfSalePreviewHistoryService()
+    ) -> PointOfSaleAggregateModel {
+        return PointOfSaleAggregateModel(
+            itemsController: itemsController,
+            purchasableItemsSearchController: purchasableItemsSearchController,
+            couponsController: couponsController,
+            cardPresentPaymentService: cardPresentPaymentService,
+            orderController: orderController,
+            collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+            searchHistoryService: searchHistoryService
+        )
+    }
 }
 
 #endif


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR moves our `posModel` creation for previews to a helper function, to stop us having to make changes to all the view preview definitions every time we add a dependency to the aggregate model.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Build the app

Open a view which has `.environment(posModel)` or `environment(POSPreviewHelpers.makePreviewAggregateModel())` in its preview definition; check that the preview renders without crashing.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I don't tend to use previews in our code base because they're so slow, and I don't think it's worth the time to check every single one, but I have checked a few with the above.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### With the helper method
![CleanShot 2025-04-18 at 10 00 03@2x](https://github.com/user-attachments/assets/be5d6469-31d4-4bd5-a88e-bc1b3b3a13f7)

### Without passing an aggregate model
![CleanShot 2025-04-18 at 10 00 35@2x](https://github.com/user-attachments/assets/afd15df2-7919-4929-92dc-bf280e7f4079)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.