### PR TITLE
[Woo POS] Coupons: Error/empty/disabled states design pass-through

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleErrorState.swift
@@ -97,8 +97,8 @@ struct PointOfSaleErrorState: Equatable {
             comment: "Title appearing on the coupon list screen when there's an error loading coupons."
         )
         static let loadingCouponsErrorSubtitle = NSLocalizedString(
-            "pos.itemList.loadingCouponsErrorSubtitle",
-            value: "Error loading coupons",
+            "pos.itemList.loadingCouponsErrorSubtitle2",
+            value: "Give it another go?",
             comment: "Subtitle appearing on the coupon list screen when there's an error loading coupons."
         )
         static let loadingCouponsErrorRetry = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -173,8 +173,8 @@ struct PointOfSaleItemListEmptyViewModel {
         )
 
         static let emptyCouponsTitle = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.emptyCouponsTitle",
-            value: "No coupons found.",
+            "pos.pointOfSaleItemListEmptyView.emptyCouponsTitle2",
+            value: "No coupons found",
             comment: "Text appearing on the coupon list screen when there's no coupons found."
         )
         static let emptyCouponsSubtitle = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-253

## Description
This PR addresses any UI/Copy issues found, copy and UI wise, when checking error/empty/disabled states:
- Removes a dot from `No coupons found` error
- Updates `loadingCouponsErrorSubtitle` to show `Give it another go?`, as we do with products.

I've left some comments in pdfdoF-6TA#comment-8031-p2 which are resolved in favor of not changing these further.

## Testing
- Return an empty list of coupons from the coupon service, the error message should show `No coupons found`
- Return `.errorOnLoadingCoupons` case from the coupons controller, the inline error message when attempting to load more items should show `Give it another go?` as subtitle. i.e:
```
    @MainActor
    func loadNextItems(base: ItemListBaseItem) async {
        itemsViewState.containerState = .content
        let currentItems = itemsViewState.itemsStack.root.items
        let currentItemStates = itemsViewState.itemsStack.itemStates
        itemsViewState.itemsStack = ItemsStackState(root: .inlineError(currentItems,
                                                                       error: .errorOnLoadingCoupons,
                                                                       context: .pagination),
                                                    itemStates: currentItemStates)
        return
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
