### PR TITLE
[Woo POS] Coupons: Filter out expired coupons from appearing in POS

### DIFF
--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -127,12 +127,16 @@ private extension PointOfSaleCouponService {
     }
 
     func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
-        coupons.compactMap { coupon in
-                .coupon(POSCoupon(
-                    id: UUID(),
-                    code: coupon.code,
-                    summary: coupon.summary(currencySettings: currencySettings)
-                ))
+        let now = Date()
+        let nonExpiredCoupons = coupons.filter { coupon in
+            guard let expirationDate = coupon.dateExpires else { return true }
+            return expirationDate >= now
+        }
+
+        return nonExpiredCoupons.compactMap { coupon in
+                .coupon(POSCoupon(id: UUID(),
+                                  code: coupon.code,
+                                  summary: coupon.summary(currencySettings: currencySettings)))
         }
     }
 

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -135,6 +135,29 @@ struct PointOfSaleCouponServiceTests {
         #expect(coupons.items.count == 2)
     }
 
+    @Test func providePointOfSaleCoupons_when_coupons_expired_then_only_provides_non_expired_coupons() async throws {
+        // Given
+        let now = Date()
+        let noExpiration: Date? = nil
+        let expiresTomorrow: Date = Calendar.current.date(byAdding: .day, value: 1, to: now) ?? Date()
+        let expiredYesterday: Date = Calendar.current.date(byAdding: .day, value: -1, to: now) ?? Date()
+
+        let validCouponWithNoExpiration = Coupon.fake().copy(siteID: 123, code: "ok_coupon_forever", dateExpires: noExpiration)
+        storage.insertSampleCoupon(readOnlyCoupon: validCouponWithNoExpiration)
+
+        let validCouponExpiresTomorrow = Coupon.fake().copy(siteID: 123, code: "ok_coupon_for_some_time", dateExpires: expiresTomorrow)
+        storage.insertSampleCoupon(readOnlyCoupon: validCouponExpiresTomorrow)
+
+        let expiredCoupon = Coupon.fake().copy(siteID: 123, code: "expired_coupon", dateExpires: expiredYesterday)
+        storage.insertSampleCoupon(readOnlyCoupon: expiredCoupon)
+
+        // When
+        let coupons = try await sut.providePointOfSaleCoupons(pageNumber: 0)
+
+        // Then
+        #expect(coupons.items.count == 2)
+    }
+
     @Test func providePointOfSaleCoupons_when_no_coupons_then_synchronize_called() async throws {
         try await _ = sut.providePointOfSaleCoupons(pageNumber: 0)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-246

This PR intercepts mapping coupons to POSItems, and filters out those that are expired (if any), so are not shown in POS while still working normally for the rest of the app:

| POS | App |
|--------|--------|
| ![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-04-21 at 11 40 27](https://github.com/user-attachments/assets/01db121f-16e1-4ad2-a955-88ba7de6da11) | ![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-04-21 at 11 40 19](https://github.com/user-attachments/assets/b4ec2b40-3adb-4bee-9ab7-c04f51067845) |


Caveat: The coupon properties seem to be a bit miss leading: By the API [documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#coupon-properties) I'd expected we'd have two properties:
```
date_expires: The date the coupon expires, in the site's timezone.
date_expires_gmt: The date the coupon expires, as GMT (UTC).
```

However we only use `date_expires` in the app, which is received as UTC anyway from the site. ie: my testing site is in UTC+7, but the coupon expiration date assigned on creation is still in UTC:
```
dateExpires    Foundation.Date?    2025-04-14 00:00:00 UTC 
```

## Testing information
- Create a coupon, and set it expiration date to the past, publish it.
- Navigate to Menu > Coupons > Observe how the coupon appears normally in the app as `expired`
- Now in POS, observe how the coupon does not appear in the Coupon list.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
