### PR TITLE
Shipping Labels: Update shipment tabs for purchased labels

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -506,7 +506,7 @@ extension OrderDetailsViewModel {
                 return
             }
             if dataSource.isEligibleForWooShipping {
-                let viewModel = WooShippingCreateLabelsViewModel(order: order, shippingLabel: shippingLabel)
+                let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedShippingLabel: shippingLabel)
                 let shippingLabelDetailsViewController = WooShippingCreateLabelsViewHostingController(viewModel: viewModel)
                 viewController.present(shippingLabelDetailsViewController, animated: true)
             } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -8,7 +8,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     private let order: Order
     private let stores: StoresManager
     private let currencyFormatter: CurrencyFormatter
-    private let onLabelPurchase: (() -> Void)?
+    private let onLabelPurchase: ((ShippingLabel) -> Void)?
     private var subscriptions: Set<AnyCancellable> = []
 
     @Published var hazmatCategory: ShippingLabelHazmatCategory?
@@ -135,7 +135,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          debounceDuration: Double = 1,
-         onLabelPurchase: (() -> Void)? = nil) {
+         onLabelPurchase: ((ShippingLabel) -> Void)? = nil) {
         self.order = order
         self.stores = stores
         self.shipment = shipment
@@ -191,6 +191,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         }
         shippingLabel = purchasedLabel
         postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: purchasedLabel)
+        onLabelPurchase?(purchasedLabel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -201,7 +201,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Initialize the view model from an existing shipping label.
     init(order: Order,
-         shippingLabel: ShippingLabel,
+         selectedShippingLabel: ShippingLabel,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          stores: StoresManager = ServiceLocator.stores) {
@@ -211,8 +211,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
-        self.originAddress = shippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
-        self.destinationAddress = shippingLabel.destinationAddress.toWooShippingAddress()
+        self.originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
+        self.destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
         self.destinationAddressStatus = .verified
         self.onLabelPurchase = nil
         self.stores = stores
@@ -226,8 +226,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
         updateShipmentDetailsViewModels()
 
-        Task {
+        Task { @MainActor in
             await loadRequiredData()
+
+            // After shipment configs are updated, shipments are updated with purchased label details
+            // Update the selected tab now by comparing the purchased labels with the initial selected label.
+            if let matchingIndex = shipments.firstIndex(where: { $0.purchasedLabelID == selectedShippingLabel.shippingLabelID }) {
+                selectedShipmentIndex = matchingIndex
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -18,6 +18,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let itemsDataSource: WooShippingItemsDataSource
     private var destinationEmail: String?
     private let stores: StoresManager
+    private let currencySettings: CurrencySettings
     private var subscriptions: Set<AnyCancellable> = []
 
     private(set) var orderItems: WooShippingItemsViewModel
@@ -175,6 +176,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.itemsDataSource = itemsDataSource
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.onLabelPurchase = onLabelPurchase
+        self.currencySettings = currencySettings
         self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
         self.destinationEmail = order.shippingAddress?.email ?? order.billingAddress?.email
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
@@ -210,6 +212,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.shippingLabels = order.shippingLabels
         self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
+        self.currencySettings = currencySettings
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
         self.destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
@@ -462,8 +465,14 @@ private extension WooShippingCreateLabelsViewModel {
                                                        shippingLabel: matchingShippingLabel,
                                                        originAddress: $selectedOriginAddress.eraseToAnyPublisher(),
                                                        destinationAddress: $destinationAddress.eraseToAnyPublisher(),
-                                                       stores: stores) { [weak self] in
-                guard let self else { return }
+                                                       stores: stores) { [weak self] newLabel in
+                guard let self, let index = shipments.firstIndex(where: { $0.id == shipment.id }) else { return }
+                shippingLabels.append(newLabel)
+                shipments[index] = Shipment(contents: shipment.contents,
+                                            purchasedLabelID: newLabel.shippingLabelID,
+                                            currency: order.currency,
+                                            currencySettings: currencySettings,
+                                            shippingSettingsService: shippingSettingsService)
                 onLabelPurchase?(markOrderComplete)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -247,12 +247,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                 }
             }
 
-            let totalOrderItems = order.items.map(\.quantity).reduce(0, +)
-            if totalOrderItems > 1 {
-                // Only fetch shipments info if there are more than one order items.
-                group.addTask {
-                    await self.loadShipmentsInfo()
-                }
+            group.addTask {
+                await self.loadShipmentsInfo()
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -170,6 +170,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
+        self.shippingLabels = order.shippingLabels
         let itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.itemsDataSource = itemsDataSource
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
@@ -206,7 +207,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores) {
         self.order = order
         self.shippingSettingsService = shippingSettingsService
-        self.shippingLabels = [shippingLabel]
+        self.shippingLabels = order.shippingLabels
         self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -185,7 +185,11 @@ struct TopTabView<Content: View>: View {
                         }
                         .padding(.horizontal, tabsContainerHorizontalPadding)
                         .onAppear {
-                            selectTab(in: scrollViewProxy, at: selectedTab)
+                            /// Handle state change asynchronously to ensure
+                            /// the view is safely updated in the next runloop
+                            DispatchQueue.main.async {
+                                selectTab(in: scrollViewProxy, at: selectedTab)
+                            }
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -184,6 +184,9 @@ struct TopTabView<Content: View>: View {
                             .coordinateSpace(name: Constants.tabsHorizontalStackNameSpace)
                         }
                         .padding(.horizontal, tabsContainerHorizontalPadding)
+                        .onAppear {
+                            selectTab(in: scrollViewProxy, at: selectedTab)
+                        }
                     }
                 }
                 Divider()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -137,7 +137,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.originAddresses.addresses, [originAddress])
     }
 
-    func test_shipping_config_is_not_loaded_if_order_contains_one_item() {
+    func test_shipping_config_is_loaded_if_order_contains_one_item() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let error = NetworkError.notFound(response: nil)
@@ -171,7 +171,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         waitUntil {
             viewModel.state != .loading
         }
-        XCTAssertFalse(loadedConfig)
+        XCTAssertTrue(loadedConfig)
     }
 
     func test_shipping_config_is_loaded_if_order_contains_more_than_one_item() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-337
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes issues showing purchased labels when multiple shipments for an order exist.

The solution:
- Update the shipping label list with the labels from the injected order.
- Update the shipment tabs after purchasing a label.
- Update the selected tab when opening the shipping label form from a purchased label on the order detail screen.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a test store with the Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with several physical products
- Select Create shipping label > Split shipment > move items into different shipments > Done.
- Proceed to purchase a label for one of the shipments. 
- After the purchase completes, confirm that the shipment tab is updated correctly to indicate that the label has been purchased.
- Navigate back to the order detail screen, then tap Create shipping label again.
- Confirm that the purchased label is displayed correctly.
- Continue purchasing labels for all the shipments.
- Navigate back to the order details screen and select any of the purchased labels.
- Confirm that the correct shipment tab is displayed on the shipping label form.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Confirmed the above tests in simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Displaying purchased labels in shipment tabs:


https://github.com/user-attachments/assets/eee0af5d-98dd-4d88-9e7e-59ad6727da24

Updating shipment tabs upon purchase completion:


https://github.com/user-attachments/assets/4f6df5f2-126d-4b87-9d91-8c69cf65c99e

Navigating from purchased labels:


https://github.com/user-attachments/assets/91f6dfc9-33e2-4fad-ad67-b235a15d967f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
