### PR TITLE
[Woo POS][Product Search] Empty state updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -10,7 +10,15 @@ struct PointOfSaleItemListEmptyView: View {
     @State private var viewWidth: CGFloat = 0
 
     private var shouldShowErrorIcon: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale) else {
+            return false
+        }
+        switch viewModel.itemListType {
+        case .coupons, .products(search: false):
+            return true
+        case .products(search: true):
+            return false
+        }
     }
 
     init(viewModel: PointOfSaleItemListEmptyViewModel, onAction: (() -> Void)? = nil) {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 17.0, *)
 struct PointOfSaleItemListEmptyView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
@@ -8,6 +9,8 @@ struct PointOfSaleItemListEmptyView: View {
     private let onAction: (() -> Void)?
 
     @State private var viewWidth: CGFloat = 0
+
+    @Environment(\.keyboardObserver) private var keyboard
 
     private var shouldShowErrorIcon: Bool {
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale) else {
@@ -79,13 +82,14 @@ struct PointOfSaleItemListEmptyView: View {
             Spacer()
         }
         .multilineTextAlignment(.center)
-        .padding(.bottom, floatingControlAreaSize.height)
+        .padding(.bottom, keyboard.keyboardHeight <= 0 ? floatingControlAreaSize.height : 0)
         .measureWidth { width in
             viewWidth = width
         }
     }
 }
 
+@available(iOS 17.0, *)
 private extension PointOfSaleItemListEmptyView {
     enum Constants {
         static let iconSize: CGFloat = 100

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -90,7 +90,9 @@ struct PointOfSaleItemListEmptyViewModel {
 
     var title: String {
         switch (baseItem, itemListType) {
-        case (.root, .products):
+        case (.root, .products(search: true)):
+            return Localization.emptyProductsSearchTitle
+        case (.root, .products(search: false)):
             return Localization.emptyProductsTitle
         case (.root, .coupons):
             return Localization.emptyCouponsTitle
@@ -104,7 +106,9 @@ struct PointOfSaleItemListEmptyViewModel {
 
     var subtitle: String {
         switch (baseItem, itemListType) {
-        case (.root, .products):
+        case (.root, .products(search: true)):
+            return Localization.emptyProductsSearchSubtitle
+        case (.root, .products(search: false)):
             return Localization.emptyProductsSubtitle
         case (.root, .coupons):
             return Localization.emptyCouponsSubtitle
@@ -118,7 +122,9 @@ struct PointOfSaleItemListEmptyViewModel {
 
     var hint: String? {
         switch (baseItem, itemListType) {
-        case (.root, .products):
+        case (.root, .products(search: true)):
+            return Localization.emptyProductsSearchHint
+        case (.root, .products(search: false)):
             return Localization.emptyProductsHint
         case (.root, .coupons):
             return nil
@@ -154,6 +160,22 @@ struct PointOfSaleItemListEmptyViewModel {
             "pos.pointOfSaleItemListEmptyView.emptyProductsHint.1",
             value: "To add one, exit POS and go to Products.",
             comment: "Text hinting the merchant to create a product."
+        )
+
+        static let emptyProductsSearchTitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyProductsSearchTitle",
+            value: "No products found.",
+            comment: "Text appearing on screen when a POS product search returns no results."
+        )
+        static let emptyProductsSearchSubtitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyProductsSearchSubtitle",
+            value: "Try adjusting your search term – searching part of a product name may help.",
+            comment: "Subtitle text suggesting to modify search terms when no products are found in the POS product search."
+        )
+        static let emptyProductsSearchHint = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyProductsSearchHint",
+            value: "Variation names can't be searched, so use the parent product name.",
+            comment: "Text providing additional search tips when no products are found in the POS product search."
         )
 
         static let emptyVariableParentProductTitle = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -33,18 +33,13 @@ struct PointOfSaleItemListEmptyView: View {
         ScrollableVStack {
             Spacer()
             VStack(alignment: .center, spacing: POSSpacing.none) {
-                if shouldShowErrorIcon {
-                    POSErrorExclamationMark(size: .large)
-                } else {
-                    Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: Constants.iconSize, height: Constants.iconSize)
-                        .foregroundColor(.posOnSurfaceVariantHighest)
-                        .renderedIf(!dynamicTypeSize.isAccessibilitySize)
-                }
+                let shouldShowIcon: Bool = !dynamicTypeSize.isAccessibilitySize && keyboard.keyboardHeight <= 0
 
-                Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
+                if shouldShowIcon {
+                    icon
+
+                    Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
+                }
 
                 Text(viewModel.title)
                     .accessibilityAddTraits(.isHeader)
@@ -83,8 +78,23 @@ struct PointOfSaleItemListEmptyView: View {
         }
         .multilineTextAlignment(.center)
         .padding(.bottom, keyboard.keyboardHeight <= 0 ? floatingControlAreaSize.height : 0)
+        .animation(.default, value: keyboard.keyboardHeight)
         .measureWidth { width in
             viewWidth = width
+        }
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        if shouldShowErrorIcon {
+            POSErrorExclamationMark(size: .large)
+                .accessibilityHidden(true)
+        } else {
+            Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Constants.iconSize, height: Constants.iconSize)
+                .foregroundColor(.posOnSurfaceVariantHighest)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -296,12 +296,12 @@ private extension ItemListView {
         case .products:
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(
-                    itemListType: .products(search: false),
+                    itemListType: selectedItemListType,
                     baseItem: .root))
         case .coupons:
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(
-                    itemListType: .coupons,
+                    itemListType: selectedItemListType,
                     baseItem: .root)) {
                 showCouponCreationModal = true
             }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -58,6 +58,7 @@ struct PointOfSaleEntryPointView: View {
                 searchHistoryService: searchHistoryService)
         }
         .environmentObject(posModalManager)
+        .injectKeyboardObserver()
         .onAppear {
             onPointOfSaleModeActiveStateChange(true)
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/KeyboardObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/KeyboardObserver.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import Combine
+
+@available(iOS 17.0, *)
+@Observable
+final class KeyboardObserver {
+    private(set) var isKeyboardVisible: Bool = false
+    private(set) var keyboardHeight: CGFloat = 0
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillShowNotification)
+            .merge(with: NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardDidShowNotification))
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleKeyboardShow(notification: notification)
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillHideNotification)
+            .merge(with: NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardDidHideNotification))
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.keyboardHeight = 0
+                self?.isKeyboardVisible = false
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleKeyboardShow(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let frameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        let keyboardFrame = frameValue.cgRectValue
+        self.keyboardHeight = keyboardFrame.height
+        self.isKeyboardVisible = true
+    }
+}
+
+
+@available(iOS 17.0, *)
+private struct KeyboardObserverKey: EnvironmentKey {
+    static var defaultValue: KeyboardObserver {
+        KeyboardObserver()
+    }
+}
+
+@available(iOS 17.0, *)
+extension EnvironmentValues {
+    var keyboardObserver: KeyboardObserver {
+        get { self[KeyboardObserverKey.self] }
+        set { self[KeyboardObserverKey.self] = newValue }
+    }
+}
+
+@available(iOS 17.0, *)
+struct KeyboardObserverProvider: ViewModifier {
+    @State private var observer = KeyboardObserver()
+
+    func body(content: Content) -> some View {
+        content.environment(\.keyboardObserver, observer)
+    }
+}
+
+@available(iOS 17.0, *)
+extension View {
+    func injectKeyboardObserver() -> some View {
+        modifier(KeyboardObserverProvider())
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -886,6 +886,7 @@
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		209B7A682CEB6742003BDEF0 /* PointOfSalePaymentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */; };
 		209CA0EE2B50070D0073D1AC /* WooTabContainerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */; };
+		209E96BD2DB681B50089F3D2 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */; };
 		209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EEF8F2C762ED5007969A4 /* POSModalManager.swift */; };
 		20A130EB2C5A27190058022F /* PointOfSaleAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */; };
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
@@ -4150,6 +4151,7 @@
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePaymentState.swift; sourceTree = "<group>"; };
 		209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooTabContainerController.swift; sourceTree = "<group>"; };
+		209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		209EEF8F2C762ED5007969A4 /* POSModalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalManager.swift; sourceTree = "<group>"; };
 		209FC9C42228DA65BD11D65E /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAssetsTests.swift; sourceTree = "<group>"; };
@@ -9674,6 +9676,7 @@
 				CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */,
 				DE8AA0B42BBEBE590084D2CC /* ViewControllerContainer.swift */,
 				CE9F60112C09D53500652E0A /* FeedbackBannerPopover.swift */,
+				209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -16112,6 +16115,7 @@
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
 				035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */,
 				205E79512C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift in Sources */,
+				209E96BD2DB681B50089F3D2 /* KeyboardObserver.swift in Sources */,
 				03F5CB012A0BA3D40026877A /* ModalOverlay.swift in Sources */,
 				02C37B7D2967B72A00F0CF9E /* FreeStagingDomainView.swift in Sources */,
 				01C9C59F2DA3D98400CD81D8 /* CartRowRemoveButton.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-330
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the empty state view to have sensible messages for empty search results, including continuing to use the magnifier image for this case. If Wagner provides another image similar to the new alert image, we can use that instead for empty searches, but it may not be ready before release in 22.3 and this one makes more sense than an error-style alert.

I've also added an `Observable` keyboard observer so we can tell when the keyboard is showing, and how big it is without relying on Combine or notifications directly in the views. It's injected to all of POS, so could also be used for cash and email receipt views.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `searchProductsInPOS` feature flag

1. Launch the app and navigate to POS
2. Enter a search term with no results
3. Observe that a products-specific error state is shown
4. Dismiss the keyboard; observe that the icon is shown in the error state
5. Switch to a floating keyboard; observe that it is laid out as if the keyboard was not shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

We should test all the empty states; Products and Variations especially, but Coupons too.

I've tested with, and without, the coupons feature flag on. I tested using an iPad Air running iOS 17.7.3, and a simulator running 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/874a7cfb-13aa-4a9e-abac-56f09196a903




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.