### PR TITLE
Implement shipment tab pre-selection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -155,6 +155,14 @@ struct TopTabView<Content: View>: View {
                                                     /// Append a new width when the number of tabs increases.
                                                     tabWidths.append(geometry.size.width)
                                                 }
+
+                                                if index == selectedTab {
+                                                    /// The `ForEach` loop might iterate in reverse.
+                                                    /// As a result, `tabWidths` could be incomplete by the time the selected index is reached.
+                                                    /// It's safer to rely on the geometry of a specific tab instead.
+                                                    underlineTabWith(tabGeometry: geometry)
+                                                    scrollFocusTab(in: scrollViewProxy, at: index)
+                                                }
                                             }
                                         })
                                 }
@@ -170,10 +178,10 @@ struct TopTabView<Content: View>: View {
                             )
                             .onChange(of: selectedTab, perform: { newSelectedTab in
                                 withAnimation {
-                                    scrollViewProxy.scrollTo(newSelectedTab, anchor: .center)
-                                    underlineOffset = calculateOffset(index: newSelectedTab)
+                                    selectTab(in: scrollViewProxy, at: newSelectedTab)
                                 }
                             })
+                            .coordinateSpace(name: Constants.tabsHorizontalStackNameSpace)
                         }
                         .padding(.horizontal, tabsContainerHorizontalPadding)
                     }
@@ -273,6 +281,27 @@ struct TopTabView<Content: View>: View {
         }
     }
 
+    private func selectTab(in scrollView: ScrollViewProxy, at index: Int) {
+        let offset = calculateOffset(index: index)
+
+        scrollFocusTab(in: scrollView, at: index)
+        underlineTabAt(offset: offset)
+    }
+
+    private func underlineTabAt(offset: CGFloat) {
+        underlineOffset = offset
+    }
+
+    private func underlineTabWith(tabGeometry: GeometryProxy) {
+        let frame = tabGeometry.frame(in: .named(Constants.tabsHorizontalStackNameSpace))
+        let offset = frame.minX - tabPadding
+        underlineTabAt(offset: offset)
+    }
+
+    private func scrollFocusTab(in scrollView: ScrollViewProxy, at index: Int) {
+        scrollView.scrollTo(index, anchor: .center)
+    }
+
     enum DragState {
         case inactive
         case dragging(translation: CGSize)
@@ -303,6 +332,10 @@ struct TopTabView<Content: View>: View {
 
     private enum Colors {
         static var selected: Color { .withColorStudio(name: .wooCommercePurple, shade: .shade50) }
+    }
+
+    private enum Constants {
+        static var tabsHorizontalStackNameSpace: String { "TabsHorizontalStack" }
     }
 }
 


### PR DESCRIPTION
Addresses part of WOOMOB-338

## Description

The inconsistency between the selected tab and underline selection was revealed during PR testing:
https://github.com/woocommerce/woocommerce-ios/pull/15483#pullrequestreview-2751270479
The underline selection remained on initial position while a different tab was actually selected.

## Steps to reproduce

The testing/repro scenario assumes triggering the "Back" navigation. I suggest to run under iOS simulator where the "back" action is available by pressing the `ESC` button on computer keyboard.

- Log in to a test store with WooShipping set up.
- Open a completed order with more than one physical item of different quantities.
- Tap Create shipping label > Split shipments > move items into separate shipments
- Make N > 2 of separate shipments.
- Select any shipment tab but first. I'd go with the last one.
- Press `ESC` on computer keyboard to navigate back and close the "Split Shipments" screen.
- Tap on "Split shipments" again.
- The opened "Split shipments" will reveal misalignment between tab selection and underline.

## Testing information

- Repeat testing steps.
- The opened "Split shipments" screen should preserve previous split setup. It should also correctly pre-select the previously selected tab. Underline and focus should be aligned.

## Demo

https://github.com/user-attachments/assets/e8a14b05-382e-49f1-8e28-0e1d7ef8aee6

## Screenshots

Before | After
--- | ---
<img width="398" alt="Снимок экрана 2025-04-21 в 17 30 38" src="https://github.com/user-attachments/assets/65354e5f-bdd2-4441-8fee-e172e1523b72" /> | <img width="398" alt="Снимок экрана 2025-04-21 в 17 32 06" src="https://github.com/user-attachments/assets/42647a07-cd79-496f-aed2-e8ce683ec79f" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.