### PR TITLE
Conditionally restrict "New shipment" option

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
@@ -6,6 +6,7 @@ struct MoveToShipmentNoticeViewModel {
         case newShipment
     }
 
+    let allItemsSelected: Bool
     let selectedItemsCount: Int
     let existingShipmentsCount: Int
     let currentShipmentIndex: Int?
@@ -65,10 +66,11 @@ private extension MoveToShipmentNotice {
                     })
                 }
             }
-
-            Button(Localization.newShipment, action: {
-                onMoving(.newShipment)
-            })
+            if !viewModel.allItemsSelected {
+                Button(Localization.newShipment, action: {
+                    onMoving(.newShipment)
+                })
+            }
         } label: {
             HStack(spacing: Layout.horizontalSpacing) {
                 Text(Localization.moveTo)
@@ -123,7 +125,8 @@ extension MoveToShipmentNotice {
 }
 
 #Preview {
-    MoveToShipmentNotice(viewModel: MoveToShipmentNoticeViewModel(selectedItemsCount: 4,
+    MoveToShipmentNotice(viewModel: MoveToShipmentNoticeViewModel(allItemsSelected: false,
+                                                                  selectedItemsCount: 4,
                                                                   existingShipmentsCount: 3,
                                                                   currentShipmentIndex: 1),
                          onMoving: { _ in })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -381,15 +381,19 @@ private extension WooShippingSplitShipmentsViewModel {
             .map { $0.packageItem.quantity }
             .reduce(0, +).intValue
 
-        if shipments.count == 1 &&
-            selectedItemsCount == totalItemCount {
+        let allItemsSelected = selectedItemsCount == totalItemCount
+
+        if shipments.count == 1 && allItemsSelected {
             // do not allow moving all items if there is only one shipment at the moment
             return moveToNoticeViewModel = nil
         }
 
-        moveToNoticeViewModel = MoveToShipmentNoticeViewModel(selectedItemsCount: selectedItemsCount,
-                                                              existingShipmentsCount: shipments.count,
-                                                              currentShipmentIndex: currentIndex)
+        moveToNoticeViewModel = MoveToShipmentNoticeViewModel(
+            allItemsSelected: allItemsSelected,
+            selectedItemsCount: selectedItemsCount,
+            existingShipmentsCount: shipments.count,
+            currentShipmentIndex: currentIndex
+        )
     }
 
     /// Configures the labels in the section header.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -181,6 +181,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
 
         // Then
         let moveToNoticeViewModel = try XCTUnwrap(viewModel.moveToNoticeViewModel)
+        XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, false)
         XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 1)
         XCTAssertEqual(moveToNoticeViewModel.existingShipmentsCount, 1)
         XCTAssertEqual(moveToNoticeViewModel.currentShipmentIndex, 0)
@@ -204,6 +205,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
 
         // Then
         let moveToNoticeViewModel = try XCTUnwrap(viewModel.moveToNoticeViewModel)
+        XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, false)
         XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 3)
         XCTAssertEqual(moveToNoticeViewModel.existingShipmentsCount, 2)
         XCTAssertEqual(moveToNoticeViewModel.currentShipmentIndex, 0)
@@ -227,6 +229,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
 
         // Then
         let moveToNoticeViewModel = try XCTUnwrap(viewModel.moveToNoticeViewModel)
+        XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, true)
         XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 5)
         XCTAssertEqual(moveToNoticeViewModel.existingShipmentsCount, 2)
         XCTAssertEqual(moveToNoticeViewModel.currentShipmentIndex, 0)


### PR DESCRIPTION
Addresses part of WOOMOB-338

## Description

When creating a new shipment by selecting all items, it results in an issue where a N+1 shipment gets created according to notice. This pr addresses the issue by restricting the "New shipment" option appearing in case if all items of the current shipment are selected.

## Steps to reproduce

- Log in to a test store with WooShipping set up.
- Open a completed order with more than one physical item of different quantities.
- Tap Create shipping label > Split shipments > move items into separate shipments
- Open the newly created shipment tab.
- Select all items.
- Tap on "Move to" -> "New shipment"
- The info toast will appear saying that items were moved to shipment N+1.

<img width="276" alt="Снимок экрана 2025-04-21 в 18 25 51" src="https://github.com/user-attachments/assets/2665cb09-a63e-4064-9258-7ae577e30b5b" /> <img width="277" alt="Снимок экрана 2025-04-21 в 18 25 57" src="https://github.com/user-attachments/assets/3530ba7a-3518-4d15-b99e-8da7e5386caf" />

## Testing information

- Follow the testing steps until all items selection.
- Tap on "Move to"
- Make sure that the "New shipment" option doesn't appear.
- Deselect one of items to make the selection incomplete.
- Tap on "Move to" again.
- The "New shipment" option should now be available.

## Screenshots

Before | After
--- | ---
![Simulator Screenshot - iPhone 16 Pro - 2025-04-21 at 18 17 45](https://github.com/user-attachments/assets/4198f533-b78e-4a89-868b-5992f0046dc9) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-21 at 18 16 29](https://github.com/user-attachments/assets/385b169c-3314-4438-8231-3523c9b4edca)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.