### PR TITLE
[Woo POS] Hide Check Out button until purchasable items (products / variable products) are added

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -126,20 +126,13 @@ struct CartView: View {
                     Spacer()
                 }
 
-                switch posModel.orderStage {
-                case .building:
-                    if posModel.cart.isEmpty {
-                        EmptyView()
-                    } else {
-                        checkoutButton
-                            .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
-                            .padding(.vertical, Constants.checkoutButtonVerticalPadding)
-                            .accessibilityAddTraits(.isHeader)
-                            .if(shouldApplyFooterTopShadow, transform: { $0.applyEdgeShadow(backgroundColor: backgroundColor, edges: .top) })
-                            .zIndex(1)
-                    }
-                case .finalizing:
-                    EmptyView()
+                if viewHelper.shouldShowCheckout(orderStage: posModel.orderStage, cart: posModel.cart) {
+                    checkoutButton
+                        .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
+                        .padding(.vertical, Constants.checkoutButtonVerticalPadding)
+                        .accessibilityAddTraits(.isHeader)
+                        .if(shouldApplyFooterTopShadow, transform: { $0.applyEdgeShadow(backgroundColor: backgroundColor, edges: .top) })
+                        .zIndex(1)
                 }
             }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)

--- a/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
@@ -21,6 +21,12 @@ struct CartViewHelper {
     func shouldShowClearCartButton(cart: Cart, orderStage: PointOfSaleOrderStage) -> Bool {
         cart.isNotEmpty && orderStage == .building
     }
+
+    func shouldShowCheckout(orderStage: PointOfSaleOrderStage, cart: Cart) -> Bool {
+        guard case .building = orderStage else { return false }
+
+        return cart.purchasableItems.isNotEmpty
+    }
 }
 
 private extension PointOfSalePaymentState {

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
@@ -164,6 +164,30 @@ struct CartViewHelperTests {
                                    orderState: .error(.other("Some other error"), {}),
                                    couponItem: coupon) == .idle)
     }
+
+    @Test func shouldShowCheckout_when_not_building_stage_returns_false() async throws {
+        // Given
+        let cart = Cart(purchasableItems: [makeItem()])
+
+        // When, Then
+        #expect(sut.shouldShowCheckout(orderStage: .finalizing, cart: cart) == false)
+    }
+
+    @Test func shouldShowCheckout_when_building_stage_and_empty_cart_returns_false() async throws {
+        // Given
+        let cart = Cart()
+
+        // When, Then
+        #expect(sut.shouldShowCheckout(orderStage: .building, cart: cart) == false)
+    }
+
+    @Test func shouldShowCheckout_when_building_stage_and_cart_has_purchasable_items_returns_true() async throws {
+        // Given
+        let cart = Cart(purchasableItems: [makeItem()])
+
+        // When, Then
+        #expect(sut.shouldShowCheckout(orderStage: .building, cart: cart) == true)
+    }
 }
 
 private func makeItem() -> Cart.PurchasableItem {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Check Out button shouldn't be visible with only coupons in the cart. This was the intended behavior broken by some other changes last week. @iamgabrielma thanks for noticing and reporting.

This time, also adding tests.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable coupons feature flag

1. Open POS
2. Add a coupon
3. Confirm Check Out button doesn't appear
4. Add a product
5. Confirm Check Out button appears
6. Remove a coupon
7. Confirm Check Out button stays 
8. Remove a product
9. Confirm Check Out button disappears

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11 M2 iOS 18.2 simulator, added unit tests

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
