### PR TITLE
[Woo POS] Update POSPageHeaderView to accept selected state

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -10,20 +10,6 @@ import struct Yosemite.POSVariableParentProduct
 import class Yosemite.Store
 import enum Yosemite.POSItemType
 
-enum ItemListType {
-    case products(search: Bool = false)
-    case coupons
-
-    var itemType: POSItemType {
-        switch self {
-        case .coupons:
-            return .coupon
-        case .products(search: let search):
-            return .product
-        }
-    }
-}
-
 @available(iOS 17.0, *)
 protocol PointOfSaleItemsControllerProtocol {
     ///

--- a/WooCommerce/Classes/POS/Models/ItemListType.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListType.swift
@@ -1,0 +1,33 @@
+import enum Yosemite.POSItemType
+
+enum ItemListType {
+    case products(search: Bool = false)
+    case coupons
+
+    var itemType: POSItemType {
+        switch self {
+        case .coupons:
+            return .coupon
+        case .products(search: let search):
+            return .product
+        }
+    }
+
+    var isProducts: Bool {
+        switch self {
+        case .products:
+            return true
+        case .coupons:
+            return false
+        }
+    }
+
+    var isCoupons: Bool {
+        switch self {
+        case .products:
+            return false
+        case .coupons:
+            return true
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -182,6 +182,7 @@ private extension ItemListView {
         var items = [
             POSPageHeaderItem(
                 title: Localization.productsTitle,
+                isSelected: selectedItemListType.isProducts,
                 action: {
                     displayItemListType(.products(search: searchTerm.isNotEmpty))
                 }
@@ -192,6 +193,7 @@ private extension ItemListView {
             items.append(
                 POSPageHeaderItem(
                     title: Localization.couponsTitle,
+                    isSelected: selectedItemListType.isCoupons,
                     action: {
                         displayItemListType(.coupons)
                     }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -139,6 +139,8 @@ private enum Constants {
 
 @available(iOS 17.0, *)
 #Preview {
+    @Previewable @State var isProductsSelected: Bool = true
+
     VStack(spacing: 20) {
         // Header without back button.
         POSPageHeaderView(
@@ -210,12 +212,11 @@ private enum Constants {
             .foregroundColor(.posOnSurface)
         }
 
-        @State var isProductsSelected: Bool = true
         // Header with two items and trailing content.
         POSPageHeaderView(
             items: [
-                .init(title: "Products", isSelected: isProductsSelected),
-                .init(title: "Coupons", isSelected: !isProductsSelected)
+                .init(title: "Products", isSelected: isProductsSelected) { isProductsSelected.toggle() },
+                .init(title: "Coupons", isSelected: !isProductsSelected) { isProductsSelected.toggle() }
             ]
         ) {
             HStack(spacing: 16) {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -16,11 +16,13 @@ struct POSPageHeaderItem: Identifiable {
     let id = UUID()
     let title: String
     let subtitle: String?
+    let isSelected: Bool
     let action: (() -> Void)?
 
-    init(title: String, subtitle: String? = nil, action: (() -> Void)? = nil) {
+    init(title: String, subtitle: String? = nil, isSelected: Bool, action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
+        self.isSelected = isSelected
         self.action = action
     }
 }
@@ -41,15 +43,13 @@ struct POSPageHeaderView<TrailingContent: View>: View {
         backButtonConfiguration != nil
     }
 
-    @State private var selectedItemIndex: Int = 0
-
     init(
         title: String,
         subtitle: String? = nil,
         backButtonConfiguration: POSPageHeaderBackButtonConfiguration? = nil,
         @ViewBuilder trailingContent: () -> TrailingContent = { EmptyView() }
     ) {
-        self.items = [.init(title: title, subtitle: subtitle)]
+        self.items = [.init(title: title, subtitle: subtitle, isSelected: true)]
         self.backButtonConfiguration = backButtonConfiguration
         self.trailingContent = trailingContent()
     }
@@ -74,7 +74,6 @@ struct POSPageHeaderView<TrailingContent: View>: View {
                 ForEach(0..<items.count, id: \.self) { index in
                     VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
                         Button(action: {
-                            selectedItemIndex = index
                             items[index].action?()
                         }) {
                             Text(items[index].title)
@@ -82,9 +81,9 @@ struct POSPageHeaderView<TrailingContent: View>: View {
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.5)
                                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                                .foregroundColor(selectedItemIndex == index ? .posOnSurface : .posOnSurfaceVariantLowest)
+                                .foregroundColor(items[index].isSelected ? .posOnSurface : .posOnSurfaceVariantLowest)
                         }
-                        .disabled(selectedItemIndex == index)
+                        .disabled(items[index].isSelected)
                         .accessibilityElement()
                         .accessibilityAddTraits(items.count == 1 ? .isHeader : [.isHeader, .isButton])
                         .accessibilityLabel(items[index].title)
@@ -211,11 +210,12 @@ private enum Constants {
             .foregroundColor(.posOnSurface)
         }
 
+        @State var isProductsSelected: Bool = true
         // Header with two items and trailing content.
         POSPageHeaderView(
             items: [
-                .init(title: "Products"),
-                .init(title: "Coupons")
+                .init(title: "Products", isSelected: isProductsSelected),
+                .init(title: "Coupons", isSelected: !isProductsSelected)
             ]
         ) {
             HStack(spacing: 16) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		01AAD8142D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
 		01ADC1382C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */; };
+		01B3A1F22DB6D48800286B7F /* ItemListType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3A1F12DB6D48800286B7F /* ItemListType.swift */; };
 		01B744E22D2FCA1400AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B744E12D2FCA1300AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift */; };
 		01BB6C072D09DC560094D55B /* CardPresentModalLocationPreAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BB6C062D09DC470094D55B /* CardPresentModalLocationPreAlert.swift */; };
 		01BB6C0A2D09E9630094D55B /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BB6C092D09E9630094D55B /* LocationService.swift */; };
@@ -3322,6 +3323,7 @@
 		01AAD8132D92E37A0081D60B /* PointOfSaleOrderSyncCouponsErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderSyncCouponsErrorMessageView.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift; sourceTree = "<group>"; };
+		01B3A1F12DB6D48800286B7F /* ItemListType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListType.swift; sourceTree = "<group>"; };
 		01B744E12D2FCA1300AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationBackgroundSynchronizerFactory.swift; sourceTree = "<group>"; };
 		01BB6C062D09DC470094D55B /* CardPresentModalLocationPreAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalLocationPreAlert.swift; sourceTree = "<group>"; };
 		01BB6C092D09E9630094D55B /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
@@ -10017,6 +10019,7 @@
 		68F151DF2C0DA7800082AEC8 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				01B3A1F12DB6D48800286B7F /* ItemListType.swift */,
 				20FCBCDC2CE223340082DCA3 /* PointOfSaleAggregateModel.swift */,
 				20C6E7502CDE4AEA00CD124C /* ItemListState.swift */,
 				20F7B12C2D12C7B900C08193 /* ItemsContainerState.swift */,
@@ -15845,6 +15848,7 @@
 				DE8AA0B52BBEBE590084D2CC /* ViewControllerContainer.swift in Sources */,
 				DE7E5E8C2B4E9353002E28D2 /* ErrorStateView.swift in Sources */,
 				20ADE9412C6A02B700C91265 /* POSErrorXMark.swift in Sources */,
+				01B3A1F22DB6D48800286B7F /* ItemListType.swift in Sources */,
 				DE63115B2AF1E13200587641 /* WPComLoginCoordinator.swift in Sources */,
 				EE3B17B62AA03837004D3E0C /* CelebrationView.swift in Sources */,
 				0291497D2D26CB2500F7B3B3 /* ChildItemList.swift in Sources */,


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Update `POSPageHeaderView` to accept the selected state. Keeping the state within `POSPageHeaderView` is a bad approach since it can get out of sync with the `selectedItemType` state.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the coupons feature flag.

1. Open POS
2.Add Product
3. Switch to Coupons
4. Add Coupon
5. Check Out
6. Come Back
7. Confirm Coupons table is shown and Coupons tab is selected

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested with and without the feature flag.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
