### PR TITLE
[Woo POS] Coupons: Keep products and coupons scroll state separate

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -10,7 +10,7 @@ import struct Yosemite.POSVariableParentProduct
 import class Yosemite.Store
 import enum Yosemite.POSItemType
 
-enum ItemListType {
+enum ItemListType: Hashable {
     case products(search: Bool = false)
     case coupons
 

--- a/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 /// A scroll view that supports infinite scrolling by triggering a load more action when the user scrolls near the bottom.
 struct InfiniteScrollView<Content: View>: View {
     @State private var scrollViewHeight: CGFloat = 0
-
+    @Binding var currentPosition: CGFloat
+    
     private let triggerDeterminer: InfiniteScrollTriggerDeterminable
     private let loadMore: () async -> Void
     private let content: Content
@@ -14,10 +15,12 @@ struct InfiniteScrollView<Content: View>: View {
     ///   - content: The main content view to display in the scroll view.
     init(
         triggerDeterminer: InfiniteScrollTriggerDeterminable,
+        currentPosition: Binding<CGFloat>,
         loadMore: @escaping () async -> Void,
         @ViewBuilder content: () -> Content
     ) {
         self.triggerDeterminer = triggerDeterminer
+        self._currentPosition = currentPosition
         self.loadMore = loadMore
         self.content = content()
     }
@@ -31,6 +34,9 @@ struct InfiniteScrollView<Content: View>: View {
                             .onChange(of: proxy.frame(in: .named(Constants.scrollViewNamespace)).maxY) { maxY in
                                 let contentHeight = proxy.size.height
                                 let scrollPosition = contentHeight - maxY
+                                
+                                //
+                                currentPosition = scrollPosition
 
                                 if triggerDeterminer
                                     .shouldTriggerInfiniteScroll(
@@ -74,6 +80,7 @@ private struct PreviewWrapper: View {
     var body: some View {
         InfiniteScrollView(
             triggerDeterminer: ThresholdInfiniteScrollTriggerDeterminer(),
+            currentPosition: .constant(0),
             loadMore: {
                 isLoading = true
                 try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Infinite Scroll/InfiniteScrollView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct InfiniteScrollView<Content: View>: View {
     @State private var scrollViewHeight: CGFloat = 0
     @Binding var currentPosition: CGFloat
-    
+
     private let triggerDeterminer: InfiniteScrollTriggerDeterminable
     private let loadMore: () async -> Void
     private let content: Content
@@ -34,8 +34,7 @@ struct InfiniteScrollView<Content: View>: View {
                             .onChange(of: proxy.frame(in: .named(Constants.scrollViewNamespace)).maxY) { maxY in
                                 let contentHeight = proxy.size.height
                                 let scrollPosition = contentHeight - maxY
-                                
-                                //
+
                                 currentPosition = scrollPosition
 
                                 if triggerDeterminer

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -3,11 +3,6 @@ import enum Yosemite.POSItem
 import protocol WooFoundation.Analytics
 import struct Yosemite.POSVariableParentProduct
 
-enum ScrollPositionKey {
-    case products
-    case coupons
-}
-
 /// Displays a list of POS items or placeholder card based on the given state.
 @available(iOS 17.0, *)
 struct ItemList<HeaderView: View>: View {
@@ -17,7 +12,7 @@ struct ItemList<HeaderView: View>: View {
 
     // Navigation only uses this on iOS 17
     @State private var activeNavigationItem: POSItem? = nil
-    @State private var scrollPositions: [ScrollPositionKey: CGFloat] = [:]
+    @State private var scrollPositions: [ItemListType: CGFloat] = [:]
     @State private var currentPosition: CGFloat = 0
 
     var state: ItemListState? {
@@ -29,10 +24,10 @@ struct ItemList<HeaderView: View>: View {
         }
     }
 
-    private var scrollPositionKey: ScrollPositionKey {
+    private var scrollPositionKey: ItemListType {
         switch itemsController {
         case is PointOfSaleItemsController:
-            return .products
+            return .products()
         default:
             return .coupons
         }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -28,7 +28,7 @@ struct ItemList<HeaderView: View>: View {
             itemsController.itemsViewState.itemsStack.itemStates[posItem]
         }
     }
-    
+
     private var scrollPositionKey: ScrollPositionKey {
         switch itemsController {
         case is PointOfSaleItemsController:
@@ -87,10 +87,10 @@ struct ItemList<HeaderView: View>: View {
                             // Saves old key's position, and restore position for new key, if any:
                             scrollPositions[previousScrollPositionKey] = currentPosition
                             if let savedPosition = scrollPositions[newScrollPositionKey], let state = state {
+                                // Update position, then scroll to saved one
                                 currentPosition = savedPosition
 
-                                // Restore position
-                                let itemHeight: CGFloat = 112
+                                let itemHeight: CGFloat = PointOfSaleItemListCardConstants.productCardSize
                                 let targetIndex = Int(savedPosition / itemHeight)
                                 let safeIndex = min(targetIndex, (state.items.count) - 1)
                                 scrollViewProxy.scrollTo("\(newScrollPositionKey)-\(safeIndex)", anchor: .top)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -86,14 +86,19 @@ struct ItemList<HeaderView: View>: View {
                         .onChange(of: scrollPositionKey) { previousScrollPositionKey, newScrollPositionKey in
                             // Saves old key's position, and restore position for new key, if any:
                             scrollPositions[previousScrollPositionKey] = currentPosition
+
                             if let savedPosition = scrollPositions[newScrollPositionKey], let state = state {
-                                // Update position, then scroll to saved one
+                                // Updates position for this key, then scrolls to saved position
                                 currentPosition = savedPosition
 
                                 let itemHeight: CGFloat = PointOfSaleItemListCardConstants.productCardSize
                                 let targetIndex = Int(savedPosition / itemHeight)
                                 let safeIndex = min(targetIndex, (state.items.count) - 1)
                                 scrollViewProxy.scrollTo("\(newScrollPositionKey)-\(safeIndex)", anchor: .top)
+                            } else {
+                                // First time seeing this key, set to top position
+                                currentPosition = 0
+                                scrollViewProxy.scrollTo("\(newScrollPositionKey)-0", anchor: .top)
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -17,6 +17,7 @@ struct ItemList<HeaderView: View>: View {
 
     // Navigation only uses this on iOS 17
     @State private var activeNavigationItem: POSItem? = nil
+    @State private var scrollPositions: [ScrollPositionKey: CGFloat] = [:]
     @State private var currentPosition: CGFloat = 0
 
     var state: ItemListState? {
@@ -54,37 +55,50 @@ struct ItemList<HeaderView: View>: View {
 
     var body: some View {
         ZStack {
-            InfiniteScrollView(
-                triggerDeterminer: infiniteScrollTriggerDeterminer,
-                currentPosition: $currentPosition,
-                loadMore: {
-                    guard case .loaded(_, let hasMoreItems) = state,
-                          hasMoreItems
-                    else { return }
-                    await itemsController.loadNextItems(base: node)
-                },
-                content: {
-                    LazyVStack(spacing: Constants.itemSpacing) {
-                        headerView
+            ScrollViewReader { scrollViewProxy in
+                InfiniteScrollView(
+                    triggerDeterminer: infiniteScrollTriggerDeterminer,
+                    currentPosition: $currentPosition,
+                    loadMore: {
+                        guard case .loaded(_, let hasMoreItems) = state,
+                              hasMoreItems
+                        else { return }
+                        await itemsController.loadNextItems(base: node)
+                    },
+                    content: {
+                        LazyVStack(spacing: Constants.itemSpacing) {
+                            headerView
 
-                        headerRows
+                            headerRows
 
-                        if let state {
-                            ForEach(state.items) { item in
-                                ItemListRow(item: item, itemActionHandler: itemActionHandler, activeNavigationItem: $activeNavigationItem)
+                            if let state {
+                                ForEach(Array(state.items.enumerated()), id: \.element.id) { index, item in
+                                    ItemListRow(item: item, itemActionHandler: itemActionHandler, activeNavigationItem: $activeNavigationItem)
+                                        .id("\(scrollPositionKey)-\(index)")
+                                }
+                            }
+
+                            footerRows
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, Constants.itemListPadding)
+                        .padding(.bottom, floatingControlAreaSize.height)
+                        .onChange(of: scrollPositionKey) { previousScrollPositionKey, newScrollPositionKey in
+                            // Saves old key's position, and restore position for new key, if any:
+                            scrollPositions[previousScrollPositionKey] = currentPosition
+                            if let savedPosition = scrollPositions[newScrollPositionKey], let state = state {
+                                currentPosition = savedPosition
+
+                                // Restore position
+                                let itemHeight: CGFloat = 112
+                                let targetIndex = Int(savedPosition / itemHeight)
+                                let safeIndex = min(targetIndex, (state.items.count) - 1)
+                                scrollViewProxy.scrollTo("\(newScrollPositionKey)-\(safeIndex)", anchor: .top)
                             }
                         }
-
-                        footerRows
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, Constants.itemListPadding)
-                    .padding(.bottom, floatingControlAreaSize.height)
-                    .onChange(of: scrollPositionKey) { _, newKey in
-                        debugPrint("🍍 scrollposkey: \(newKey) - currentPos: \(currentPosition)" )
-                    }
-                }
-            )
+                )
+            }
 
             // Programmatic navigation overlay for iOS 17
             if #available(iOS 18.0, *) {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -3,6 +3,11 @@ import enum Yosemite.POSItem
 import protocol WooFoundation.Analytics
 import struct Yosemite.POSVariableParentProduct
 
+enum ScrollPositionKey {
+    case products
+    case coupons
+}
+
 /// Displays a list of POS items or placeholder card based on the given state.
 @available(iOS 17.0, *)
 struct ItemList<HeaderView: View>: View {
@@ -12,6 +17,7 @@ struct ItemList<HeaderView: View>: View {
 
     // Navigation only uses this on iOS 17
     @State private var activeNavigationItem: POSItem? = nil
+    @State private var currentPosition: CGFloat = 0
 
     var state: ItemListState? {
         switch node {
@@ -19,6 +25,15 @@ struct ItemList<HeaderView: View>: View {
             itemsController.itemsViewState.itemsStack.root
         case .parent(let posItem):
             itemsController.itemsViewState.itemsStack.itemStates[posItem]
+        }
+    }
+    
+    private var scrollPositionKey: ScrollPositionKey {
+        switch itemsController {
+        case is PointOfSaleItemsController:
+            return .products
+        default:
+            return .coupons
         }
     }
 
@@ -41,6 +56,7 @@ struct ItemList<HeaderView: View>: View {
         ZStack {
             InfiniteScrollView(
                 triggerDeterminer: infiniteScrollTriggerDeterminer,
+                currentPosition: $currentPosition,
                 loadMore: {
                     guard case .loaded(_, let hasMoreItems) = state,
                           hasMoreItems
@@ -64,6 +80,9 @@ struct ItemList<HeaderView: View>: View {
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal, Constants.itemListPadding)
                     .padding(.bottom, floatingControlAreaSize.height)
+                    .onChange(of: scrollPositionKey) { _, newKey in
+                        debugPrint("🍍 scrollposkey: \(newKey) - currentPos: \(currentPosition)" )
+                    }
                 }
             )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-322

## Description

This PR keeps scrolling state separate for Products vs Coupons:

https://github.com/user-attachments/assets/d4829a34-51f7-48d3-b5c9-172cf854a9f0

I've tried different approaches but most of them didn't work very well, I found that binding infinite scroll view and item list, as well as setting unique id to each element has worked best so far (and to be cleaner) but happy to iterate if you think of a better approach.

I wrap the scroll movement into an animation on purpose, as the UI feels pretty wonky if we do so, direct render feels best imho.

## Testing
- Load POS, scroll in Products
- Switch to Coupons, observe that we're at the top of the view, scroll around
- Switch back to Products, observe the previous scrolling state is saved. Same for back and forth.
- Observe that pagination and/or pull-to-refresh doesn't break behaviour.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
