### PR TITLE
Shipping Labels: Fix issue purchasing labels when navigating from a purchased label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -15,7 +15,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     @Published private(set) var hazmatNotice: Notice?
 
     /// The purchased shipping label.
-    @Published private var shippingLabel: ShippingLabel?
+    @Published private(set) var shippingLabel: ShippingLabel?
 
     /// View model for the section displayed after a shipping label is purchased.
     @Published private(set) var postPurchase: WooShippingPostPurchaseViewModel?
@@ -42,7 +42,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     }
 
     /// Address to ship from (store address).
-    @Published private var originAddress: WooShippingOriginAddress?
+    @Published private var originAddress: WooShippingAddress?
 
     /// Address to ship to (customer address),
     @Published private var destinationAddress: WooShippingAddress?
@@ -130,7 +130,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     init(order: Order,
          shipment: Shipment,
          shippingLabel: ShippingLabel?,
-         originAddress: AnyPublisher<WooShippingOriginAddress?, Never>,
+         originAddress: AnyPublisher<WooShippingAddress?, Never>,
          destinationAddress: AnyPublisher<WooShippingAddress?, Never>,
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
@@ -182,7 +182,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         let purchasedLabel = try await withCheckedThrowingContinuation { continuation in
             let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,
                                                                  orderID: order.orderID,
-                                                                 originAddress: originAddress.toWooShippingAddress(),
+                                                                 originAddress: originAddress,
                                                                  destinationAddress: destinationAddress,
                                                                  package: packagePurchase) { result in
                 continuation.resume(with: result)
@@ -196,7 +196,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
 }
 
 private extension WooShippingShipmentDetailsViewModel {
-    func observeAddresses(originAddressPublisher: AnyPublisher<WooShippingOriginAddress?, Never>,
+    func observeAddresses(originAddressPublisher: AnyPublisher<WooShippingAddress?, Never>,
                           destinationAddressPublisher: AnyPublisher<WooShippingAddress?, Never>) {
         originAddressPublisher
             .assign(to: &$originAddress)
@@ -218,7 +218,7 @@ private extension WooShippingShipmentDetailsViewModel {
             .map { [weak self] originAddress, destinationAddress in
                 guard let self else { return nil }
                 return WooShippingServiceViewModel(order: order,
-                                                   originAddress: originAddress?.toWooShippingAddress(),
+                                                   originAddress: originAddress,
                                                    destinationAddress: destinationAddress,
                                                    stores: stores) { [weak self] selectedRate in
                     self?.selectedRate = selectedRate

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -90,7 +90,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Address to ship from (store address), formatted for display and split into separate lines to allow additional formatting.
     var originAddressLines: [String]? {
-        originAddress.components(separatedBy: ", ")
+        if let shippingLabel = currentShipmentDetailsViewModel.shippingLabel {
+            shippingLabel.originAddress.formattedPostalAddress?.components(separatedBy: "\n")
+        } else {
+            originAddress.components(separatedBy: ", ")
+        }
     }
 
     /// This property can be set to display a notice with the provided label about the origin address status.
@@ -98,7 +102,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     var destinationAddressLines: [String]? {
-        (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")
+        if let shippingLabel = currentShipmentDetailsViewModel.shippingLabel {
+            shippingLabel.destinationAddress.formattedPostalAddress?.components(separatedBy: "\n")
+        } else {
+            (destinationAddress.value?.formattedPostalAddress)?.components(separatedBy: ", ")
+        }
     }
 
     /// Possible statuses for a Woo Shipping destination address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -75,14 +75,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private(set) var originAddresses = WooShippingOriginAddressListViewModel(addresses: [])
 
     /// Address to ship from (store address).
-    private let selectedOriginAddress = CurrentValueSubject<WooShippingOriginAddress?, Never>(nil)
+    @Published private var selectedOriginAddress: WooShippingOriginAddress?
 
     /// Address to ship to (customer address),
-    private let destinationAddress = CurrentValueSubject<WooShippingAddress?, Never>(nil)
+    @Published private var destinationAddress: WooShippingAddress?
 
     /// Whether the origin address is unverified.
     var isOriginAddressUnverified: Bool {
-        selectedOriginAddress.value?.isVerified == false
+        selectedOriginAddress?.isVerified == false
     }
 
     /// Address to ship from (store address), formatted for display.
@@ -105,7 +105,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         if let shippingLabel = currentShipmentDetailsViewModel.shippingLabel {
             shippingLabel.destinationAddress.formattedPostalAddress?.components(separatedBy: "\n")
         } else {
-            (destinationAddress.value?.formattedPostalAddress)?.components(separatedBy: ", ")
+            (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")
         }
     }
 
@@ -197,8 +197,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.splitShipmentsViewModel = splitShipmentsViewModel
         self.shipments = splitShipmentsViewModel.shipments
 
-        destinationAddress.send(getDestinationAddress(order: order, address: order.shippingAddress))
-        self.selectedOriginAddress.send(selectedOriginAddress)
+        destinationAddress = getDestinationAddress(order: order, address: order.shippingAddress)
+        self.selectedOriginAddress = selectedOriginAddress
 
         updateShipmentDetailsViewModels()
         loadDestinationAddress()
@@ -235,7 +235,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.splitShipmentsViewModel = splitShipmentsViewModel
         self.shipments = splitShipmentsViewModel.shipments
 
-        destinationAddress.send(selectedShippingLabel.destinationAddress.toWooShippingAddress())
+        destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
 
         updateShipmentDetailsViewModels()
 
@@ -309,7 +309,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     }
 
     func editSelectedOriginAddress() {
-        guard let selectedOriginAddress = selectedOriginAddress.value else {
+        guard let selectedOriginAddress else {
             return
         }
         addressToEdit = WooShippingEditAddressViewModel(address: selectedOriginAddress, onAddressEdited: { [weak self] editedAddress in
@@ -319,11 +319,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             var addresses = originAddresses.addresses
             addresses.remove(at: index)
             addresses.insert(editedAddress, at: index)
-            self.selectedOriginAddress.send(editedAddress)
+            self.selectedOriginAddress = editedAddress
             originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
                                                                     selectedAddressID: editedAddress.id)
             originAddresses.onSelect = { [weak self] selectedAddress in
-                self?.selectedOriginAddress.send(selectedAddress)
+                self?.selectedOriginAddress = selectedAddress
             }
             addressToEdit = nil // Dismisses address edit screen
         })
@@ -332,17 +332,17 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Sets the `addressToEdit` property for editing the destination address.
     /// After the address is edited, the destination address is replaced with the updated address.
     func editDestinationAddress() {
-        addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress.value,
+        addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress,
                                                         orderID: order.orderID,
                                                         email: destinationEmail,
                                                         isVerified: destinationAddressStatus == .verified,
-                                                        originCountryCode: selectedOriginAddress.value?.country,
-                                                        originStateCode: selectedOriginAddress.value?.state,
+                                                        originCountryCode: selectedOriginAddress?.country,
+                                                        originStateCode: selectedOriginAddress?.state,
                                                         onAddressEdited: { [weak self] editedAddress, editedEmail in
             guard let self else {
                 return
             }
-            destinationAddress.send(editedAddress)
+            destinationAddress = editedAddress
             destinationEmail = editedEmail
             destinationAddressStatus = .verified
             addressToEdit = nil // Dismisses address edit screen
@@ -388,11 +388,11 @@ private extension WooShippingCreateLabelsViewModel {
             }
             stores.dispatch(action)
         }
-        selectedOriginAddress.send(addresses.first(where: \.defaultAddress))
+        selectedOriginAddress = addresses.first(where: \.defaultAddress)
         originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
-                                                                selectedAddressID: selectedOriginAddress.value?.id)
+                                                                selectedAddressID: selectedOriginAddress?.id)
         originAddresses.onSelect = { [weak self] selectedAddress in
-            self?.selectedOriginAddress.send(selectedAddress)
+            self?.selectedOriginAddress = selectedAddress
         }
     }
 
@@ -432,13 +432,13 @@ private extension WooShippingCreateLabelsViewModel {
             guard let self else { return }
             switch result {
             case .success(let address):
-                destinationAddress.send(address.normalizedAddress.toWooShippingAddress())
+                destinationAddress = address.normalizedAddress.toWooShippingAddress()
                 destinationAddressStatus = address.isVerified ? .verified : .unverified
             case .failure(let error):
                 DDLogError("⛔️ Error loading destination addresses for Woo Shipping labels: \(error)")
 
                 if let orderShippingAddress = getDestinationAddress(order: order, address: order.shippingAddress) {
-                    destinationAddress.send(orderShippingAddress)
+                    destinationAddress = orderShippingAddress
                     destinationAddressStatus = destinationAddressLines == nil ? .missing : .unverified
                 } else {
                     destinationAddressStatus = .missing
@@ -470,14 +470,14 @@ private extension WooShippingCreateLabelsViewModel {
     func updateShipmentDetailsViewModels() {
         shipmentDetailViewModels = shipments.map { shipment in
             let matchingShippingLabel = shippingLabels.first(where: { $0.shippingLabelID == shipment.purchasedLabelID })
-            let originAddressPublisher = selectedOriginAddress
+            let originAddressPublisher = $selectedOriginAddress
                 .map { $0?.toWooShippingAddress() }
                 .eraseToAnyPublisher()
             return WooShippingShipmentDetailsViewModel(order: order,
                                                        shipment: shipment,
                                                        shippingLabel: matchingShippingLabel,
                                                        originAddress: originAddressPublisher,
-                                                       destinationAddress: destinationAddress.eraseToAnyPublisher(),
+                                                       destinationAddress: $destinationAddress.eraseToAnyPublisher(),
                                                        stores: stores) { [weak self] newLabel in
                 guard let self, let index = shipments.firstIndex(where: { $0.id == shipment.id }) else { return }
                 shippingLabels.append(newLabel)
@@ -496,7 +496,7 @@ private extension WooShippingCreateLabelsViewModel {
 
     /// Observes the selected origin address and updates the displayed origin address and shipping service.
     func observeSelectedOriginAddress() {
-        selectedOriginAddress
+        $selectedOriginAddress
             .sink { [weak self] selectedOriginAddress in
                 guard let self else { return }
                 originAddress = selectedOriginAddress?.formattedPostalAddress ?? ""

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -250,7 +250,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                 }
             }
 
-            if originAddress.isEmpty {
+            if shipments.contains(where: { $0.purchasedLabelID == nil }) {
                 group.addTask {
                     await self.loadOriginAddresses()
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -75,14 +75,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private(set) var originAddresses = WooShippingOriginAddressListViewModel(addresses: [])
 
     /// Address to ship from (store address).
-    @Published private var selectedOriginAddress: WooShippingOriginAddress?
+    private var selectedOriginAddress = CurrentValueSubject<WooShippingOriginAddress?, Never>(nil)
 
     /// Address to ship to (customer address),
-    @Published private var destinationAddress: WooShippingAddress?
+    private var destinationAddress = CurrentValueSubject<WooShippingAddress?, Never>(nil)
 
     /// Whether the origin address is unverified.
     var isOriginAddressUnverified: Bool {
-        selectedOriginAddress?.isVerified == false
+        selectedOriginAddress.value?.isVerified == false
     }
 
     /// Address to ship from (store address), formatted for display.
@@ -185,10 +185,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.onLabelPurchase = onLabelPurchase
         self.currencySettings = currencySettings
-        self.destinationAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress)
         self.destinationEmail = order.shippingAddress?.email ?? order.billingAddress?.email
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
-        self.selectedOriginAddress = selectedOriginAddress
         self.stores = stores
         self.shippingSettingsService = shippingSettingsService
 
@@ -198,6 +196,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                                          stores: stores)
         self.splitShipmentsViewModel = splitShipmentsViewModel
         self.shipments = splitShipmentsViewModel.shipments
+
+        destinationAddress.send(getDestinationAddress(order: order, address: order.shippingAddress))
+        self.selectedOriginAddress.send(selectedOriginAddress)
 
         updateShipmentDetailsViewModels()
         loadDestinationAddress()
@@ -223,7 +224,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.currencySettings = currencySettings
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
-        self.destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
         self.destinationAddressStatus = .verified
         self.onLabelPurchase = nil
         self.stores = stores
@@ -234,6 +234,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                                                          stores: stores)
         self.splitShipmentsViewModel = splitShipmentsViewModel
         self.shipments = splitShipmentsViewModel.shipments
+
+        destinationAddress.send(selectedShippingLabel.destinationAddress.toWooShippingAddress())
 
         updateShipmentDetailsViewModels()
 
@@ -307,7 +309,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     }
 
     func editSelectedOriginAddress() {
-        guard let selectedOriginAddress else {
+        guard let selectedOriginAddress = selectedOriginAddress.value else {
             return
         }
         addressToEdit = WooShippingEditAddressViewModel(address: selectedOriginAddress, onAddressEdited: { [weak self] editedAddress in
@@ -317,11 +319,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             var addresses = originAddresses.addresses
             addresses.remove(at: index)
             addresses.insert(editedAddress, at: index)
-            self.selectedOriginAddress = editedAddress
+            self.selectedOriginAddress.send(editedAddress)
             originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
                                                                     selectedAddressID: editedAddress.id)
             originAddresses.onSelect = { [weak self] selectedAddress in
-                self?.selectedOriginAddress = selectedAddress
+                self?.selectedOriginAddress.send(selectedAddress)
             }
             addressToEdit = nil // Dismisses address edit screen
         })
@@ -330,17 +332,17 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Sets the `addressToEdit` property for editing the destination address.
     /// After the address is edited, the destination address is replaced with the updated address.
     func editDestinationAddress() {
-        addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress,
+        addressToEdit = WooShippingEditAddressViewModel(address: destinationAddress.value,
                                                         orderID: order.orderID,
                                                         email: destinationEmail,
                                                         isVerified: destinationAddressStatus == .verified,
-                                                        originCountryCode: selectedOriginAddress?.country,
-                                                        originStateCode: selectedOriginAddress?.state,
+                                                        originCountryCode: selectedOriginAddress.value?.country,
+                                                        originStateCode: selectedOriginAddress.value?.state,
                                                         onAddressEdited: { [weak self] editedAddress, editedEmail in
             guard let self else {
                 return
             }
-            destinationAddress = editedAddress
+            destinationAddress.send(editedAddress)
             destinationEmail = editedEmail
             destinationAddressStatus = .verified
             addressToEdit = nil // Dismisses address edit screen
@@ -386,11 +388,11 @@ private extension WooShippingCreateLabelsViewModel {
             }
             stores.dispatch(action)
         }
-        selectedOriginAddress = addresses.first(where: \.defaultAddress)
+        selectedOriginAddress.send(addresses.first(where: \.defaultAddress))
         originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
-                                                                selectedAddressID: selectedOriginAddress?.id)
+                                                                selectedAddressID: selectedOriginAddress.value?.id)
         originAddresses.onSelect = { [weak self] selectedAddress in
-            self?.selectedOriginAddress = selectedAddress
+            self?.selectedOriginAddress.send(selectedAddress)
         }
     }
 
@@ -430,13 +432,13 @@ private extension WooShippingCreateLabelsViewModel {
             guard let self else { return }
             switch result {
             case .success(let address):
-                destinationAddress = address.normalizedAddress.toWooShippingAddress()
+                destinationAddress.send(address.normalizedAddress.toWooShippingAddress())
                 destinationAddressStatus = address.isVerified ? .verified : .unverified
             case .failure(let error):
                 DDLogError("⛔️ Error loading destination addresses for Woo Shipping labels: \(error)")
 
-                if let orderShippingAddress = Self.getDestinationAddress(order: order, address: order.shippingAddress) {
-                    destinationAddress = orderShippingAddress
+                if let orderShippingAddress = getDestinationAddress(order: order, address: order.shippingAddress) {
+                    destinationAddress.send(orderShippingAddress)
                     destinationAddressStatus = destinationAddressLines == nil ? .missing : .unverified
                 } else {
                     destinationAddressStatus = .missing
@@ -468,11 +470,14 @@ private extension WooShippingCreateLabelsViewModel {
     func updateShipmentDetailsViewModels() {
         shipmentDetailViewModels = shipments.map { shipment in
             let matchingShippingLabel = shippingLabels.first(where: { $0.shippingLabelID == shipment.purchasedLabelID })
+            let originAddressPublisher = selectedOriginAddress
+                .map { $0?.toWooShippingAddress() }
+                .eraseToAnyPublisher()
             return WooShippingShipmentDetailsViewModel(order: order,
                                                        shipment: shipment,
                                                        shippingLabel: matchingShippingLabel,
-                                                       originAddress: $selectedOriginAddress.eraseToAnyPublisher(),
-                                                       destinationAddress: $destinationAddress.eraseToAnyPublisher(),
+                                                       originAddress: originAddressPublisher,
+                                                       destinationAddress: destinationAddress.eraseToAnyPublisher(),
                                                        stores: stores) { [weak self] newLabel in
                 guard let self, let index = shipments.firstIndex(where: { $0.id == shipment.id }) else { return }
                 shippingLabels.append(newLabel)
@@ -491,7 +496,7 @@ private extension WooShippingCreateLabelsViewModel {
 
     /// Observes the selected origin address and updates the displayed origin address and shipping service.
     func observeSelectedOriginAddress() {
-        $selectedOriginAddress
+        selectedOriginAddress
             .sink { [weak self] selectedOriginAddress in
                 guard let self else { return }
                 originAddress = selectedOriginAddress?.formattedPostalAddress ?? ""
@@ -533,7 +538,7 @@ private extension WooShippingCreateLabelsViewModel {
     /// Gets the destination address as a `ShippingLabelAddress`.
     /// The order's billing phone is used as a fallback if there is no shipping phone.
     ///
-    static func getDestinationAddress(order: Order, address: Address?) -> WooShippingAddress? {
+    func getDestinationAddress(order: Order, address: Address?) -> WooShippingAddress? {
         guard let phone = address?.phone, phone.isNotEmpty else {
             let destinationAddress = address?.copy(phone: order.billingAddress?.phone)
             return destinationAddress?.toWooShippingAddress()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -75,10 +75,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private(set) var originAddresses = WooShippingOriginAddressListViewModel(addresses: [])
 
     /// Address to ship from (store address).
-    private var selectedOriginAddress = CurrentValueSubject<WooShippingOriginAddress?, Never>(nil)
+    private let selectedOriginAddress = CurrentValueSubject<WooShippingOriginAddress?, Never>(nil)
 
     /// Address to ship to (customer address),
-    private var destinationAddress = CurrentValueSubject<WooShippingAddress?, Never>(nil)
+    private let destinationAddress = CurrentValueSubject<WooShippingAddress?, Never>(nil)
 
     /// Whether the origin address is unverified.
     var isOriginAddressUnverified: Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -532,6 +532,108 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             viewModel.hazmatNotice != nil
         }
     }
+
+    func test_originAddressLines_is_correct_for_both_purchased_label_and_unfulfilled_shipment() {
+        // Given
+        let labelOriginAddress = ShippingLabelAddress.fake().copy(address1: "1 E 35th ST")
+        let shippingLabel = ShippingLabel.fake().copy(shippingLabelID: 134,
+                                                      originAddress: labelOriginAddress)
+        let order = Order.fake().copy(shippingLabels: [shippingLabel])
+
+        let originAddress = WooShippingOriginAddress.fake().copy(address1: "123 Main Street",
+                                                                 defaultAddress: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadConfig(_, _, let completion):
+                // There exist 2 shipments, one of which has been fulfilled.
+                let shipments = ["shipment_0": [WooShippingShipmentItem.fake()],
+                                 "shipment_1": [WooShippingShipmentItem.fake()]]
+                let shippingLabelData = WooShippingLabelData(currentOrderLabels: [
+                    ShippingLabelPurchase.fake().copy(shippingLabelID: shippingLabel.shippingLabelID,
+                                                      shipmentID: "shipment_0")
+                ])
+                completion(.success(WooShippingConfig.fake().copy(shipments: shipments,
+                                                                  shippingLabelData: shippingLabelData)))
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores)
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.currentShipment.purchasedLabelID, shippingLabel.shippingLabelID)
+        XCTAssertEqual(viewModel.originAddressLines?.first, labelOriginAddress.address1)
+
+        // When
+        viewModel.selectedShipmentIndex = 1
+
+        // Then
+        XCTAssertNil(viewModel.currentShipment.purchasedLabelID)
+        XCTAssertEqual(viewModel.originAddressLines?.first, originAddress.address1)
+    }
+
+    func test_destinationAddressLines_is_correct_for_both_purchased_label_and_unfulfilled_shipment() {
+        // Given
+        let labelDestinationAddress = ShippingLabelAddress.fake().copy(address1: "1 E 35th ST")
+        let shippingLabel = ShippingLabel.fake().copy(shippingLabelID: 134,
+                                                      destinationAddress: labelDestinationAddress)
+        let order = Order.fake().copy(shippingLabels: [shippingLabel])
+
+        let destinationAddress = WooShippingNormalizedAddress.fake().copy(address1: "123 Main Street")
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([WooShippingOriginAddress.fake().copy(address1: "Test address",
+                                                                          defaultAddress: true)]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadConfig(_, _, let completion):
+                // There exist 2 shipments, one of which has been fulfilled.
+                let shipments = ["shipment_0": [WooShippingShipmentItem.fake()],
+                                 "shipment_1": [WooShippingShipmentItem.fake()]]
+                let shippingLabelData = WooShippingLabelData(currentOrderLabels: [
+                    ShippingLabelPurchase.fake().copy(shippingLabelID: shippingLabel.shippingLabelID,
+                                                      shipmentID: "shipment_0")
+                ])
+                completion(.success(WooShippingConfig.fake().copy(shipments: shipments,
+                                                                  shippingLabelData: shippingLabelData)))
+            case .verifyDestinationAddress(_, _, let completion):
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: destinationAddress,
+                                                                               isTrivialNormalization: nil,
+                                                                               isVerified: true)))
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores)
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.currentShipment.purchasedLabelID, shippingLabel.shippingLabelID)
+        XCTAssertEqual(viewModel.destinationAddressLines?.first, labelDestinationAddress.address1)
+
+        // When
+        viewModel.selectedShipmentIndex = 1
+
+        // Then
+        XCTAssertNil(viewModel.currentShipment.purchasedLabelID)
+        XCTAssertEqual(viewModel.destinationAddressLines?.first, destinationAddress.address1)
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -9,7 +9,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_inits_with_expected_values_for_shipping_label_creation() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -26,7 +26,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_inits_with_expected_values_for_viewing_purchased_label() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -45,7 +45,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_isPurchaseButtonEnabled_true_when_required_fields_are_set() throws {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -66,7 +66,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_selecting_standard_shipping_rate_sets_expected_shippingRates() throws {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -87,7 +87,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_selecting_signature_shipping_rate_sets_expected_shippingRates() throws {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -110,7 +110,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_selecting_adult_signature_shipping_rate_sets_expected_shippingRates() throws {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -136,7 +136,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         // Given
         let expectedShippingLabel = ShippingLabel.fake().copy(carrierID: "usps", trackingNumber: "1234567890")
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -174,7 +174,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         // Given
         var encodedHazmat: [String: Any]?
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
@@ -212,7 +212,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_selectPackage_sets_selectedPackage_with_package_data() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
         let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
                                                             shipment: sampleShipment,
@@ -230,7 +230,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_selectPackage_sets_shipmentWeight_with_items_and_package_weight() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
         let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
                                                             shipment: sampleShipment,
@@ -249,7 +249,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         // Given
         let expectedWeight = 2.5
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
         let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
                                                             shipment: sampleShipment,
@@ -285,7 +285,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_totalCost_has_expected_value_when_shipping_rate_is_set() throws {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -304,7 +304,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_customsFormRequired_when_origin_and_destination_in_US_then_returns_false() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -320,7 +320,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_customsFormRequired_when_origin_address_is_US_military_then_returns_true() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "AA"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "AA"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -336,7 +336,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_customsFormRequired_when_destination_address_is_US_military_then_returns_true() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "AA"))
 
         // When
@@ -352,7 +352,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_customsFormRequired_when_destination_address_is_not_in_US_then_returns_true() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "GB", state: "LD"))
 
         // When
@@ -368,7 +368,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_itnMissingNoticeLabel_when_customs_form_is_not_required() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
 
         // When
@@ -384,7 +384,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_itnMissingNoticeLabel_when_customs_form_is_required() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "GB", state: "LD"))
 
         // When
@@ -416,7 +416,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                             itn: "",
                                             items: [])
 
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "GB", state: "LD"))
 
         // When
@@ -466,21 +466,17 @@ private extension WooShippingShipmentDetailsViewModelTests {
                                packageType: "box")
     }
 
-    func sampleOriginAddress(country: String, state: String) -> WooShippingOriginAddress {
-        WooShippingOriginAddress(id: "default_address",
-                                 company: "HEADQUARTERS",
-                                 address1: "15 ALGONKIN ST",
-                                 address2: "STE 100",
-                                 city: "TICONDEROGA",
-                                 state: state,
-                                 postcode: "12883-1487",
-                                 country: country,
-                                 phone: "223-456-7890",
-                                 firstName: "JANE",
-                                 lastName: "DOE",
-                                 email: "TEST@EXAMPLE.COM",
-                                 defaultAddress: true,
-                                 isVerified: false)
+    func sampleOriginAddress(country: String, state: String) -> WooShippingAddress {
+        WooShippingAddress(company: "HEADQUARTERS",
+                           name: "John Doe",
+                           phone: "",
+                           country: country,
+                           state: state,
+                           address1: "15 ALGONKIN ST",
+                           address2: "STE 100",
+                           city: "TICONDEROGA",
+                           postcode: "12883-1487"
+        )
     }
 
     func sampleDestinationAddress(country: String, state: String) -> WooShippingAddress {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-347
Note: Please review #15528 before this one.

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Currently, there are a few issues regarding origin and destination addresses when multiple shipments exist:
- When navigating to the shipping label creation form from a purchased label on the order details screen, loading shipping rates would fail with an error message indicating a missing destination address. ~~The error is due to both origin and destination addresses are being passed as publishers from a `@Published` property, which doesn't emit the current value upon subscription.~~ The error is due to origin address not being loaded when opening a purchased label.
- When updating the origin and destination addresses of an unfulfilled shipment, the addresses of purchased labels are updated accordingly.

The solution:
- ~~Switch `selectedOriginAddress` and `destinationAddress` in `WooShippingCreateLabelsViewModel` to `CurrentValueSubject` to enable emitting current value upon subscription.~~
- Enable loading origin addresses when there are unfulfilled shipments.
- Updated `originAddressLines` and `destinationAddressLines` to ensure that purchased labels always display correct addresses.
- Refactoring: updated the type of `originAddress` in `WooShippingShipmentDetailsViewModel` to simplify the logic.


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a completed order with several physical products.
3. Select Create shipping labels > Split shipments > Move items to different shipments.
4. Proceed to purchase a label for a shipment.
5. Navigate back to the order details screen after purchase completes.
6. Select View purchased shipping label for the newly purchased label.
7. On the shipping label form, switch to the tab of an unfulfilled shipment.
8. Select a package and confirm that shipping rates can be loaded successfully.
9. Tap on Shipment details sheet of the unfulfilled shipment and update either the origin or destination addresses or both.
10. Switch to the tab of the fulfilled shipment > Tap Shipment details and confirm that the origin and destination addresses are still correct.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Manually tested and confirmed the above cases on simulator iPhone 16 Pro iOS 18.2.
- Added unit tests to verify `originAddressLines` and `destinationAddressLines`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f9fbf784-bccb-4aee-bb45-77610ac5dd0d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
