### PR TITLE
[Woo POS] Replace product restrictions banner with a menu item

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 22.3
 -----
-
+- [internal] POS: Reduced prominence of the simple/variable products only banner [https://github.com/woocommerce/woocommerce-ios/pull/15539]
 
 22.2
 -----

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -36,9 +36,6 @@ struct ItemListView: View {
         itemsController.itemsViewState.itemsStack.root
     }
 
-    @AppStorage(BannerState.isSimpleProductsOnlyBannerDismissedKey)
-    private var isHeaderBannerDismissed: Bool = false
-
     private var shouldShowCoupons: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
     }
@@ -202,19 +199,12 @@ private extension ItemListView {
                             .foregroundStyle(Color.posOnSurface)
                             .padding(Constants.infoIconInset)
                     })
-                    .renderedIf(!shouldShowHeaderBanner && !shouldShowCoupons)
+                    .renderedIf(!shouldShowCoupons)
                     .transition(.opacity.combined(with: .scale))
                 }
             })
-            if !dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
-                bannerCardView
-                    .padding(.horizontal, Constants.bannerCardPadding)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-            }
         }
         .animation(.easeInOut(duration: Constants.animationDuration), value: shouldShowSearchField)
-        .animation(.easeInOut(duration: Constants.animationDuration), value: shouldShowHeaderBanner)
         .animation(.easeInOut(duration: Constants.animationDuration), value: isAddingCouponAllowed)
     }
 
@@ -269,42 +259,13 @@ private extension ItemListView {
         }
     }
 
-    var bannerCardView: some View {
-        POSNoticeView(
-            title: headerBannerTitle,
-            icon: Image(systemName: "info.circle"),
-            onDismiss: {
-                isHeaderBannerDismissed = true
-            },
-            onTap: {
-                showSimpleProductsModal = true
-            }
-        ) {
-            VStack(alignment: .leading, spacing: Constants.bannerTextSpacing) {
-                Text(headerBannerSubtitle)
-                bannerHintAndLearnMoreText
-            }
-        }
-        .padding(.bottom, Constants.bannerCardPadding)
-    }
-
-    private var bannerHintAndLearnMoreText: some View {
-        Text("\(headerBannerHint) \(Localization.headerBannerLearnMoreHint)")
-            .font(.posBodySmallBold)
-            .foregroundColor(Color(.posPrimary))
-    }
-
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
         ItemList(
             itemsController: itemsController,
             node: .root,
             itemActionHandler: actionHandler
-        ) {
-            if dynamicTypeSize.isAccessibilitySize, shouldShowHeaderBanner {
-                bannerCardView
-            }
-        }
+        )
         .refreshable {
             trackPullToRefresh()
             await itemsController.refreshItems(base: .root)
@@ -378,14 +339,6 @@ private extension ItemListView {
 
 @available(iOS 17.0, *)
 private extension ItemListView {
-    var shouldShowHeaderBanner: Bool {
-        guard case .products = selectedItemListType else {
-            return false
-        }
-
-        return itemListState.eligibleToShowSimpleProductsBanner && !isHeaderBannerDismissed
-    }
-
     func displayItemListType(_ itemListType: ItemListType) {
         withAnimation(.easeInOut(duration: Constants.animationDuration)) {
             selectedItemListType = itemListType
@@ -400,44 +353,17 @@ private extension ItemListView {
     }
 }
 
-private extension ItemListState {
-    var eligibleToShowSimpleProductsBanner: Bool {
-        switch self {
-        case .loading,
-                .loaded,
-                .inlineError:
-            return true
-        case .error, .empty:
-            return false
-        }
-    }
-}
-
 /// Constants
 ///
 @available(iOS 17.0, *)
 private extension ItemListView {
     enum Constants {
         static let infoIconInset: EdgeInsets = .init(top: 0, leading: 6, bottom: 0, trailing: 6)
-        static let bannerCardPadding: CGFloat = POSPadding.medium
-        static let bannerTextSpacing: CGFloat = POSSpacing.xSmall
         static let animationDuration: CGFloat = 0.2
     }
 
     enum BannerState {
         static let isSimpleProductsOnlyBannerDismissedKey = "isSimpleProductsOnlyBannerDismissed"
-    }
-
-    var headerBannerTitle: String {
-        Localization.headerBannerTitleSimpleAndVariable
-    }
-
-    var headerBannerSubtitle: String {
-        Localization.headerBannerSubtitleSimpleAndVariable
-    }
-
-    var headerBannerHint: String {
-        Localization.headerBannerHintSimpleAndVariable
     }
 
     enum Localization {
@@ -451,30 +377,6 @@ private extension ItemListView {
             "pos.itemlistview.couponsTitle",
             value: "Coupons",
             comment: "Title of the button at the top of Point of Sale to switch to Coupons list."
-        )
-
-        static let headerBannerTitleSimpleAndVariable = NSLocalizedString(
-            "pos.itemlistview.headerBanner.title.simpleAndVariable",
-            value: "Showing simple and variable products only",
-            comment: "Title of the product selector header banner, which explains current POS limitations"
-        )
-
-        static let headerBannerSubtitleSimpleAndVariable = NSLocalizedString(
-            "pos.itemlistview.headerBanner.subtitle.simpleAndVariable",
-            value: "Only simple and variable non-downloadable products can be used with POS right now.",
-            comment: "Subtitle of the product selector header banner, which explains current POS limitations"
-        )
-
-        static let headerBannerHintSimpleAndVariable = NSLocalizedString(
-            "pos.itemlistview.headerBanner.hint.simpleAndVariable",
-            value: "Other product types will become available in future updates.",
-            comment: "Additional text within the product selector header banner, which explains current POS limitations"
-        )
-
-        static let headerBannerLearnMoreHint = NSLocalizedString(
-            "pos.itemlistview.headerBanner.learnMoreHint",
-            value: "Learn More",
-            comment: "Link to more information within the product selector header banner, which explains current POS limitations"
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -8,8 +8,6 @@ struct ItemListView: View {
 
     @Environment(PointOfSaleAggregateModel.self) private var posModel
 
-    @State private var showSimpleProductsModal: Bool = false
-
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 
@@ -109,9 +107,6 @@ struct ItemListView: View {
         })
         .background(Color.posSurface)
         .accessibilityElement(children: .contain)
-        .posModal(isPresented: $showSimpleProductsModal) {
-            SimpleProductsOnlyInformation(isPresented: $showSimpleProductsModal)
-        }
         .posCouponCreationSheet(isPresented: $showCouponCreationModal, onSuccess: { couponItem in
             Task { @MainActor in
                 posModel.addToCart(couponItem)
@@ -189,18 +184,6 @@ private extension ItemListView {
                         .renderedIf(isAddingCouponAllowed)
                         .transition(.opacity.combined(with: .scale))
                     }
-
-                    Button(action: {
-                        ServiceLocator.analytics.track(.pointOfSaleSimpleProductsExplanationDialogShown)
-                        showSimpleProductsModal = true
-                    }, label: {
-                        Text(Image(systemName: "info.circle"))
-                            .font(.posButtonSymbolLarge)
-                            .foregroundStyle(Color.posOnSurface)
-                            .padding(Constants.infoIconInset)
-                    })
-                    .renderedIf(!shouldShowCoupons)
-                    .transition(.opacity.combined(with: .scale))
                 }
             })
         }
@@ -358,7 +341,6 @@ private extension ItemListView {
 @available(iOS 17.0, *)
 private extension ItemListView {
     enum Constants {
-        static let infoIconInset: EdgeInsets = .init(top: 0, leading: 6, bottom: 0, trailing: 6)
         static let animationDuration: CGFloat = 0.2
     }
 

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -127,20 +127,20 @@ private extension POSFloatingControlView {
         static let exitPointOfSale = NSLocalizedString(
             "pointOfSale.floatingButtons.exit.button.title",
             value: "Exit POS",
-            comment: "The title of the floating button to exit Point of Sale, shown in a popover menu." +
+            comment: "The title of the menu button to exit Point of Sale, shown in a popover menu." +
             "The action is confirmed in a modal."
         )
 
         static let getSupport = NSLocalizedString(
             "pointOfSale.floatingButtons.getSupport.button.title",
             value: "Get Support",
-            comment: "The title of the floating button to get support for Point of Sale, shown in a popover menu."
+            comment: "The title of the menu button to get support for Point of Sale, shown in a popover menu."
         )
 
         static let viewDocumentation = NSLocalizedString(
             "pointOfSale.floatingButtons.viewDocumentation.button.title",
             value: "Documentation",
-            comment: "The title of the floating button to read Point of Sale documentation, shown in a popover menu."
+            comment: "The title of the menu button to read Point of Sale documentation, shown in a popover menu."
         )
 
         static let productRestrictionsInfo = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -8,6 +8,7 @@ struct POSFloatingControlView: View {
     @Binding private var showExitPOSModal: Bool
     @Binding private var showSupport: Bool
     @Binding private var showDocumentation: Bool
+    @State private var showProductRestrictionsModal: Bool = false
 
     init(showExitPOSModal: Binding<Bool>,
          showSupport: Binding<Bool>,
@@ -47,6 +48,14 @@ struct POSFloatingControlView: View {
                         icon: { Image(systemName: "info.circle") }
                     )
                 }
+                Button {
+                    showProductRestrictionsModal = true
+                    ServiceLocator.analytics.track(.pointOfSaleSimpleProductsExplanationDialogShown)
+                } label: {
+                    Label(
+                        title: { Text(Localization.productRestrictionsInfo) },
+                        icon: { Image(systemName: "magnifyingglass") })
+                }
             } label: {
                 VStack {
                     Spacer()
@@ -68,6 +77,9 @@ struct POSFloatingControlView: View {
                 .cornerRadius(Constants.cornerRadius)
                 .disabled(posModel.paymentState.shownFullScreen)
                 .disabled(horizontalSizeClass != .regular)
+        }
+        .posModal(isPresented: $showProductRestrictionsModal) {
+            SimpleProductsOnlyInformation(isPresented: $showProductRestrictionsModal)
         }
         .frame(height: Constants.size)
         .background(Color.clear)
@@ -129,6 +141,13 @@ private extension POSFloatingControlView {
             "pointOfSale.floatingButtons.viewDocumentation.button.title",
             value: "Documentation",
             comment: "The title of the floating button to read Point of Sale documentation, shown in a popover menu."
+        )
+
+        static let productRestrictionsInfo = NSLocalizedString(
+            "pointOfSale.floatingButtons.productRestrictionsInfo.button.title",
+            value: "Where are my products?",
+            comment: "The title of the menu button to view product restrictions info, shown in a popover menu. " +
+            "We only show simple and variable products in POS, this shows a modal to help explain that limitation."
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-357
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes the product restrictions banner and modal (simple/variable products only) less prominent.

 - Removes the banner from the ItemList
 - Removes the `i` button from the header
 - Adds a menu item to show the modal

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Delete the app to ensure you don't have the banner dismissal stored in user defaults
2. Build and run the app, then log in
3. Navigate to POS
4. Observe that the product restrictions banner is not shown, and nor is the `i` button
5. Tap the `...` menu, then `Where are my products?`
6. Observe that the product restrictions modal is shown, and you can interact with it as you'd expect.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Note that this allows the POS to be closed from new parts of the flow, by tapping `Create order in store management`. I've tested that payments are correctly cancelled if you do this while waiting for a customer to tap their card, and it can't be done during a card payment as the menu is inaccessible.

I've tested on an iPad Air running iOS 17.7.3, and a simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/bcff7cb7-0884-43e9-b0a5-564bb88bfa1b


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.