### PR TITLE
[Woo POS] Coupons: Keep products and coupons scroll state separate (Using tab views)

### DIFF
--- a/WooCommerce/Classes/POS/Models/ItemListType.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListType.swift
@@ -1,6 +1,6 @@
 import enum Yosemite.POSItemType
 
-enum ItemListType: Equatable {
+enum ItemListType: Equatable, Hashable {
     case products(search: Bool = false)
     case coupons
 

--- a/WooCommerce/Classes/POS/Models/ItemListType.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListType.swift
@@ -8,7 +8,7 @@ enum ItemListType: Equatable, Hashable {
         switch self {
         case .coupons:
             return .coupon
-        case .products(search: let search):
+        case .products:
             return .product
         }
     }
@@ -28,6 +28,15 @@ enum ItemListType: Equatable, Hashable {
             return false
         case .coupons:
             return true
+        }
+    }
+
+    var isSearch: Bool {
+        switch self {
+        case .coupons:
+            return false
+        case .products(let search):
+            return search
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -84,26 +84,20 @@ struct ItemListView: View {
         VStack(spacing: 0) {
             headerView
 
-            if shouldShowSearchField && searchTerm.isEmpty {
-                POSRecentSearchesView(
-                    savedSearches: posModel.searchHistory(for: selectedItemListType.itemType),
-                    onSearchSelected: { search in
-                        searchTerm = search
-                    }
-                )
-                .background(Color.posSurface)
-            } else {
-                switch itemListState {
-                case .loading(let items),
-                        .loaded(let items, _),
-                        .inlineError(let items, _, _):
-                    listView(items)
-                case .error(let errorState):
-                    errorView(errorState)
-                case .empty:
-                    emptyView
-                }
-            }
+            TabView(selection: $selectedItemListType) {
+                itemListContent
+                    .tag(ItemListType.products(search: false))
+                    .gesture(DragGesture())
+                itemListContent
+                    .tag(ItemListType.products(search: true))
+                    .gesture(DragGesture())
+                itemListContent
+                    .tag(ItemListType.coupons)
+                    .gesture(DragGesture())
+              }
+              .tabViewStyle(.page(indexDisplayMode: .never))
+              .simultaneousGesture(DragGesture())
+              .animation(.none, value: selectedItemListType)
         }
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
         // the navigation is handled in a NavigationLink in ItemList.swift. Avoiding the warning is impractical.
@@ -121,6 +115,30 @@ struct ItemListView: View {
                 await posModel.couponsController.refreshItems(base: .root)
             }
         })
+    }
+
+    @ViewBuilder
+    var itemListContent: some View {
+        if shouldShowSearchField && searchTerm.isEmpty {
+            POSRecentSearchesView(
+                savedSearches: posModel.searchHistory(for: selectedItemListType.itemType),
+                onSearchSelected: { search in
+                    searchTerm = search
+                }
+            )
+            .background(Color.posSurface)
+        } else {
+            switch itemListState {
+            case .loading(let items),
+                    .loaded(let items, _),
+                    .inlineError(let items, _, _):
+                listView(items)
+            case .error(let errorState):
+                errorView(errorState)
+            case .empty:
+                emptyView
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -11,28 +11,10 @@ struct ItemListView: View {
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 
-    private var shouldShowSearchField: Bool {
-        selectedItemListType == .products(search: true)
-    }
     @FocusState private var isSearchFieldFocused: Bool
 
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
-
-    var itemsController: PointOfSaleItemsControllerProtocol {
-        switch selectedItemListType {
-        case .products(search: false):
-            posModel.purchasableItemsController
-        case .products(search: true):
-            posModel.purchasableItemsSearchController
-        case .coupons:
-            posModel.couponsController
-        }
-    }
-
-    private var itemListState: ItemListState {
-        itemsController.itemsViewState.itemsStack.root
-    }
 
     private var shouldShowCoupons: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
@@ -40,6 +22,7 @@ struct ItemListView: View {
 
     private var isAddingCouponAllowed: Bool {
         guard case .coupons = selectedItemListType else { return false }
+        let itemListState = itemListState(selectedItemListType)
         return itemListState.isLoaded || itemListState.isEmpty
     }
 
@@ -56,7 +39,7 @@ struct ItemListView: View {
     }
 
     private var shouldShowHeaderItems: Bool {
-        !shouldShowSearchField
+        !selectedItemListType.isSearch
     }
 
     @State private var showCouponCreationModal: Bool = false
@@ -80,20 +63,14 @@ struct ItemListView: View {
             headerView
 
             TabView(selection: $selectedItemListType) {
-                itemListContent
-                    .tag(ItemListType.products(search: false))
-                    .gesture(DragGesture())
-                itemListContent
-                    .tag(ItemListType.products(search: true))
-                    .gesture(DragGesture())
-                itemListContent
-                    .tag(ItemListType.coupons)
-                    .gesture(DragGesture())
-              }
-              .tabViewStyle(.page(indexDisplayMode: .never))
-              .simultaneousGesture(DragGesture())
-              .animation(.none, value: selectedItemListType)
+                itemListContent(.products(search: false))
+                itemListContent(.products(search: true))
+                itemListContent(.coupons)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .animation(.none, value: selectedItemListType)
         }
+
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
         // the navigation is handled in a NavigationLink in ItemList.swift. Avoiding the warning is impractical.
         .navigationDestination(for: POSItem.self, destination: { item in
@@ -110,27 +87,32 @@ struct ItemListView: View {
     }
 
     @ViewBuilder
-    var itemListContent: some View {
-        if shouldShowSearchField && searchTerm.isEmpty {
-            POSRecentSearchesView(
-                savedSearches: posModel.searchHistory(for: selectedItemListType.itemType),
-                onSearchSelected: { search in
-                    searchTerm = search
+    private func itemListContent(_ itemListType: ItemListType) -> some View {
+        Group {
+            if itemListType.isSearch && searchTerm.isEmpty {
+                POSRecentSearchesView(
+                    savedSearches: posModel.searchHistory(for: itemListType.itemType),
+                    onSearchSelected: { search in
+                        searchTerm = search
+                    }
+                )
+                .background(Color.posSurface)
+            } else {
+                switch itemListState(itemListType) {
+                case .loading(let items),
+                        .loaded(let items, _),
+                        .inlineError(let items, _, _):
+                    listView(items, itemListType: itemListType)
+                case .error(let errorState):
+                    errorView(errorState)
+                    EmptyView()
+                case .empty:
+                    emptyView
                 }
-            )
-            .background(Color.posSurface)
-        } else {
-            switch itemListState {
-            case .loading(let items),
-                    .loaded(let items, _),
-                    .inlineError(let items, _, _):
-                listView(items)
-            case .error(let errorState):
-                errorView(errorState)
-            case .empty:
-                emptyView
             }
         }
+        .tag(itemListType)
+        .gesture(DragGesture()) // Disable a default swipe gesture between the tabs
     }
 }
 
@@ -145,7 +127,7 @@ private extension ItemListView {
                 HStack {
                     if isSearchAllowed {
                         searchField
-                            .renderedIf(shouldShowSearchField)
+                            .renderedIf(selectedItemListType.isSearch)
                             .transition(.opacity.combined(with: .move(edge: .trailing)))
                             .onChange(of: searchTerm) { oldValue, newValue in
                                 // The debouncing logic is a little tricky, because the loading state is held in the controller.
@@ -190,7 +172,7 @@ private extension ItemListView {
                                 isSearchFieldFocused = true
                             }
                         }
-                        .renderedIf(!shouldShowSearchField)
+                        .renderedIf(!selectedItemListType.isSearch)
                         .transition(.opacity.combined(with: .scale))
                     }
 
@@ -205,7 +187,7 @@ private extension ItemListView {
                 }
             })
         }
-        .animation(.easeInOut(duration: Constants.animationDuration), value: shouldShowSearchField)
+        .animation(.easeInOut(duration: Constants.animationDuration), value: selectedItemListType.isSearch)
         .animation(.easeInOut(duration: Constants.animationDuration), value: isAddingCouponAllowed)
         .animation(.easeInOut(duration: Constants.animationDuration), value: searchTerm)
     }
@@ -275,24 +257,24 @@ private extension ItemListView {
     }
 
     @ViewBuilder
-    func listView(_ items: [POSItem]) -> some View {
+    func listView(_ items: [POSItem], itemListType: ItemListType) -> some View {
         ItemList(
-            itemsController: itemsController,
+            itemsController: itemsController(itemListType),
             node: .root,
-            itemActionHandler: actionHandler
+            itemActionHandler: actionHandler(itemListType)
         )
         .refreshable {
             trackPullToRefresh()
-            await itemsController.refreshItems(base: .root)
+            await itemsController(itemListType).refreshItems(base: .root)
         }
     }
 
-    private var actionHandler: POSItemActionHandler {
-        switch selectedItemListType {
+    private func actionHandler(_ itemListType: ItemListType) -> POSItemActionHandler {
+        switch itemListType {
         case .products(search: false), .coupons:
             StandardPOSItemActionHandler(posModel: posModel)
         case .products(search: true):
-            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemListType: selectedItemListType)
+            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemListType: itemListType)
         }
     }
 
@@ -307,7 +289,7 @@ private extension ItemListView {
                 parentItem: parentItem,
                 title: parentProduct.name,
                 itemsController: posModel.purchasableItemsController,
-                itemActionHandler: actionHandler
+                itemActionHandler: actionHandler(selectedItemListType)
             )
         default:
             EmptyView()
@@ -345,7 +327,7 @@ private extension ItemListView {
         default:
             PointOfSaleItemListErrorView(error: errorState, onAction: {
                 Task {
-                    await itemsController.loadItems(base: .root)
+                    await itemsController(selectedItemListType).loadItems(base: .root)
                 }
             })
         }
@@ -357,12 +339,30 @@ private extension ItemListView {
     func displayItemListType(_ itemListType: ItemListType) {
         selectedItemListType = itemListType
         Task { @MainActor in
-            if itemListState.items.isEmpty {
-                await itemsController.loadItems(base: .root)
+            if itemListState(itemListType).items.isEmpty {
+                await itemsController(itemListType).loadItems(base: .root)
             }
         }
 
         trackSelectedItemListTypeTapped(itemListType)
+    }
+}
+
+@available(iOS 17.0, *)
+private extension ItemListView {
+    func itemsController(_ itemType: ItemListType) -> PointOfSaleItemsControllerProtocol {
+        switch itemType {
+        case .products(search: false):
+            posModel.purchasableItemsController
+        case .products(search: true):
+            posModel.purchasableItemsSearchController
+        case .coupons:
+            posModel.couponsController
+        }
+    }
+
+    private func itemListState(_ itemType: ItemListType) -> ItemListState {
+        itemsController(itemType).itemsViewState.itemsStack.root
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -16,8 +16,12 @@ struct ItemListView: View {
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
 
-    private var shouldShowCoupons: Bool {
+    private var isCouponsFeatureEnabled: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
+    }
+
+    private var isSearchProductsFeatureEnabled: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS)
     }
 
     private var isAddingCouponAllowed: Bool {
@@ -27,7 +31,7 @@ struct ItemListView: View {
     }
 
     private var isSearchAllowed: Bool {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS) else {
+        guard isSearchProductsFeatureEnabled else {
             return false
         }
         switch selectedItemListType {
@@ -64,11 +68,16 @@ struct ItemListView: View {
 
             TabView(selection: $selectedItemListType) {
                 itemListContent(.products(search: false))
-                itemListContent(.products(search: true))
-                itemListContent(.coupons)
+                if isSearchProductsFeatureEnabled {
+                    itemListContent(.products(search: true))
+                }
+                if isCouponsFeatureEnabled {
+                    itemListContent(.coupons)
+                }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .animation(.none, value: selectedItemListType)
+            .ignoresSafeArea()
         }
 
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
@@ -176,7 +185,7 @@ private extension ItemListView {
                         .transition(.opacity.combined(with: .scale))
                     }
 
-                    if shouldShowCoupons {
+                    if isCouponsFeatureEnabled {
                         POSPageHeaderActionButton(systemName: "plus") {
                             ServiceLocator.analytics.track(.pointOfSaleCouponsCreateTapped)
                             showCouponCreationModal = true
@@ -206,7 +215,7 @@ private extension ItemListView {
             )
         ]
 
-        if shouldShowCoupons {
+        if isCouponsFeatureEnabled {
             items.append(
                 POSPageHeaderItem(
                     title: Localization.couponsTitle,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Products and Coupons reused a single list, which shared the same scrolling state.

https://github.com/woocommerce/woocommerce-ios/pull/15536 PR attempted to fix this issue by saving the current scroll state for a given item type. However, testing has revealed that the behavior is not entirely stable.

## Solution

I propose an alternative approach of using SwiftUI `TabView` to achieve the same behavior. Passing different lists for different `ItemListType` ensures that their scroll state are independent. 

### Limitations

This solution, however, doesn't preserve the item list state at all times:
- When we switch to checkout and back, the whole `ItemListView` is removed, resulting in lost state
- When we enter search input, `InputListView` is also reloaded, resulting in a reset scroll state for all the "tabs". I tried to investigate that, but I couldn't find a quick solution. My conclusion is that we need to sort out how we handle item and container states between `PointOfSaleDashboardView` and `ItemListView`, since entering `searchText` or changing the `selectedItemListType` also updates the dashboard, which cascades the updates. 
- We also remove and add `ItemList` (and therefore update state) when switching between recent searches and item list, but this is expected behavior for search.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Test with feature flags disabled, confirm that the item list behaves as before
- Enable search and coupons feature flags, confirm that coupons and products preserve their own scroll states

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11 Inch M2 Simulator with various feature flag combinations

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### General Behavior
https://github.com/user-attachments/assets/dab48aa0-f4ee-4f73-a807-aad7c53e0522

### Search-Only

https://github.com/user-attachments/assets/c80532ec-4c66-4e14-9982-7c9fbdb7a38a

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
