### PR TITLE
[Woo POS][Products Search] Analytics for recent searches release

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -149,6 +149,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleCouponRemovedFromCart,
             WooAnalyticsStat.pointOfSaleSearchButtonTapped,
             WooAnalyticsStat.pointOfSalePreSearchRecentTermTapped,
+            WooAnalyticsStat.pointOfSaleKeyboardDismissedInSearch,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -150,6 +150,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleSearchButtonTapped,
             WooAnalyticsStat.pointOfSalePreSearchRecentTermTapped,
             WooAnalyticsStat.pointOfSaleKeyboardDismissedInSearch,
+            WooAnalyticsStat.pointOfSaleItemsNextPageLoaded,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -148,6 +148,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleCouponAddedToCart,
             WooAnalyticsStat.pointOfSaleCouponRemovedFromCart,
             WooAnalyticsStat.pointOfSaleSearchButtonTapped,
+            WooAnalyticsStat.pointOfSalePreSearchRecentTermTapped,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -147,6 +147,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleCouponsPullToRefresh,
             WooAnalyticsStat.pointOfSaleCouponAddedToCart,
             WooAnalyticsStat.pointOfSaleCouponRemovedFromCart,
+            WooAnalyticsStat.pointOfSaleSearchButtonTapped,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1308,6 +1308,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleCouponAddedToCart = "coupon_added_to_cart"
     case pointOfSaleCouponRemovedFromCart = "coupon_removed_from_cart"
     case pointOfSaleSearchButtonTapped = "search_button_tapped"
+    case pointOfSalePreSearchRecentTermTapped = "pre_search_recent_term_tapped"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1307,6 +1307,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleCouponsPullToRefresh = "coupons_pull_to_refresh"
     case pointOfSaleCouponAddedToCart = "coupon_added_to_cart"
     case pointOfSaleCouponRemovedFromCart = "coupon_removed_from_cart"
+    case pointOfSaleSearchButtonTapped = "search_button_tapped"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1309,6 +1309,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleCouponRemovedFromCart = "coupon_removed_from_cart"
     case pointOfSaleSearchButtonTapped = "search_button_tapped"
     case pointOfSalePreSearchRecentTermTapped = "pre_search_recent_term_tapped"
+    case pointOfSaleKeyboardDismissedInSearch = "keyboard_dismissed_in_search"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1310,6 +1310,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleSearchButtonTapped = "search_button_tapped"
     case pointOfSalePreSearchRecentTermTapped = "pre_search_recent_term_tapped"
     case pointOfSaleKeyboardDismissedInSearch = "keyboard_dismissed_in_search"
+    case pointOfSaleItemsNextPageLoaded = "items_next_page_loaded"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -10,6 +10,7 @@ extension WooAnalyticsEvent {
         /// Event property Key.
         private enum Key {
             static let paymentsOnboardingState = "onboarding_state"
+            static let itemListType = "item_list_type"
             static let itemType = "product_type"
             static let itemsInCart = "items_in_cart"
             static let couponsInCart = "coupons_in_cart"
@@ -66,6 +67,13 @@ extension WooAnalyticsEvent {
                 Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
             ])
         }
+
+        static func searchButtonTapped(itemListType: ItemListType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSaleSearchButtonTapped,
+                              properties: [
+                                Key.itemListType: itemListType.analyticsValue
+                              ])
+        }
     }
 }
 
@@ -76,6 +84,17 @@ private extension WooAnalyticsEvent.PointOfSale.CartItemType {
             return "simple"
         case .variation:
             return "variation"
+        }
+    }
+}
+
+private extension ItemListType {
+    var analyticsValue: String {
+        switch self {
+        case .products:
+            return "products"
+        case .coupons:
+            return "coupons"
         }
     }
 }

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -78,6 +78,13 @@ extension WooAnalyticsEvent {
                                 Key.itemListType: itemListType.analyticsValue
                               ])
         }
+
+        static func preSearchRecentTermTapped(itemListType: ItemListType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSalePreSearchRecentTermTapped,
+                              properties: [
+                                Key.itemListType: itemListType.analyticsValue
+                              ])
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -21,6 +21,7 @@ extension WooAnalyticsEvent {
             static let checkoutTapCount = "checkout_tap_count"
             static let waitingTime = "waiting_time"
             static let source = "source"
+            static let search = "search"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -84,6 +85,14 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Key.itemListType: itemListType.analyticsValue
                               ])
+        }
+
+        static func pointOfSaleItemsNextPageLoaded(itemListType: ItemListType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSaleItemsNextPageLoaded,
+                              properties: [
+                                Key.itemListType: itemListType.analyticsValue,
+                                Key.search: itemListType.isSearching
+            ])
         }
     }
 }

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -20,6 +20,7 @@ extension WooAnalyticsEvent {
             static let millisecondsSinceCardTapped = "milliseconds_since_card_tapped"
             static let checkoutTapCount = "checkout_tap_count"
             static let waitingTime = "waiting_time"
+            static let source = "source"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -31,8 +32,11 @@ extension WooAnalyticsEvent {
                               properties: [Key.paymentsOnboardingState: onboardingState.reasonForAnalytics])
         }
 
-        static func addItemToCart(type: CartItemType) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .pointOfSaleAddItemToCart, properties: [Key.itemType: type.analyticsValue])
+        static func addItemToCart(type: CartItemType, itemListType: ItemListType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSaleAddItemToCart, properties: [
+                Key.itemType: type.analyticsValue,
+                Key.source: itemListType.addItemSourceAnalyticsValue
+            ])
         }
 
         static func checkoutTapped(purchasableItemsInCart: Int, couponsInCart: Int) -> WooAnalyticsEvent {
@@ -95,6 +99,16 @@ private extension ItemListType {
             return "products"
         case .coupons:
             return "coupons"
+        }
+    }
+
+    var addItemSourceAnalyticsValue: String {
+        switch self {
+        case .products(search: true):
+            return "search_result"
+        case .products(search: false),
+                .coupons:
+            return "list"
         }
     }
 }

--- a/WooCommerce/Classes/POS/Models/ItemListType.swift
+++ b/WooCommerce/Classes/POS/Models/ItemListType.swift
@@ -8,7 +8,7 @@ enum ItemListType: Equatable {
         switch self {
         case .coupons:
             return .coupon
-        case .products(search: let search):
+        case .products:
             return .product
         }
     }
@@ -28,6 +28,15 @@ enum ItemListType: Equatable {
             return false
         case .coupons:
             return true
+        }
+    }
+
+    var isSearching: Bool {
+        switch self {
+        case .products(search: true):
+            return true
+        case .products(search: false), .coupons:
+            return false
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -70,7 +70,11 @@ private extension ChildItemList {
 
             ItemList(itemsController: itemsController,
                      node: node,
-                     itemActionHandler: itemActionHandler)
+                     itemActionHandler: itemActionHandler,
+                     willLoadMore: {
+                         ServiceLocator.analytics.track(
+                            event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemListType: .products(search: false)))
+                     })
                 .transition(.opacity)
                 .refreshable {
                     ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -26,14 +26,17 @@ struct ItemList<HeaderView: View>: View {
     private let node: ItemListBaseItem
     private let headerView: HeaderView
     private let itemActionHandler: POSItemActionHandler
+    private let willLoadMore: (() -> Void)?
 
     init(itemsController: PointOfSaleItemsControllerProtocol,
          node: ItemListBaseItem,
          itemActionHandler: POSItemActionHandler,
+         willLoadMore: (() -> Void)? = nil,
          @ViewBuilder headerView: () -> HeaderView = { EmptyView() }) {
         self.itemsController = itemsController
         self.node = node
         self.itemActionHandler = itemActionHandler
+        self.willLoadMore = willLoadMore
         self.headerView = headerView()
     }
 
@@ -45,6 +48,7 @@ struct ItemList<HeaderView: View>: View {
                     guard case .loaded(_, let hasMoreItems) = state,
                           hasMoreItems
                     else { return }
+                    willLoadMore?()
                     await itemsController.loadNextItems(base: node)
                 },
                 content: {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
@@ -11,18 +11,18 @@ protocol POSItemActionHandler {
     /// Tracks analytics for a tap on an item
     /// - Parameter for: The item that was tapped
     /// - Parameter using: The analytics service to track to
-    func trackTapAnalytics(for item: POSItem, using analytics: Analytics)
+    func trackTapAnalytics(for item: POSItem, itemListType: ItemListType, using analytics: Analytics)
 }
 
 @available(iOS 17.0, *)
 extension POSItemActionHandler {
     /// Default implementation for analytics tracking – it still needs to be called
-    func trackTapAnalytics(for item: POSItem, using analytics: Analytics) {
+    func trackTapAnalytics(for item: POSItem, itemListType: ItemListType, using analytics: Analytics) {
         switch item {
         case .simpleProduct:
-            analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct))
+            analytics.track(event: .PointOfSale.addItemToCart(type: .simpleProduct, itemListType: itemListType))
         case .variation:
-            analytics.track(event: .PointOfSale.addItemToCart(type: .variation))
+            analytics.track(event: .PointOfSale.addItemToCart(type: .variation, itemListType: itemListType))
         case .coupon:
             analytics.track(.pointOfSaleCouponAddedToCart)
         default:
@@ -36,16 +36,18 @@ extension POSItemActionHandler {
 final class StandardPOSItemActionHandler: POSItemActionHandler {
     private let posModel: PointOfSaleAggregateModelProtocol
     private let analytics: Analytics
+    private let itemListType: ItemListType
 
-    init(posModel: PointOfSaleAggregateModelProtocol, analytics: Analytics = ServiceLocator.analytics) {
+    init(posModel: PointOfSaleAggregateModelProtocol, itemListType: ItemListType, analytics: Analytics = ServiceLocator.analytics) {
         self.posModel = posModel
+        self.itemListType = itemListType
         self.analytics = analytics
     }
 
     func handleTap(_ item: POSItem) {
         posModel.addToCart(item)
 
-        trackTapAnalytics(for: item, using: analytics)
+        trackTapAnalytics(for: item, itemListType: itemListType, using: analytics)
     }
 }
 
@@ -71,6 +73,6 @@ final class SearchResultItemActionHandler: POSItemActionHandler {
         posModel.saveSearchTerm(searchTerm, for: itemListType.itemType)
 
         posModel.addToCart(item)
-        trackTapAnalytics(for: item, using: analytics)
+        trackTapAnalytics(for: item, itemListType: itemListType, using: analytics)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -273,7 +273,11 @@ private extension ItemListView {
         ItemList(
             itemsController: itemsController,
             node: .root,
-            itemActionHandler: actionHandler
+            itemActionHandler: actionHandler,
+            willLoadMore: {
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemListType: selectedItemListType))
+            }
         )
         .refreshable {
             trackPullToRefresh()

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -8,6 +8,8 @@ struct ItemListView: View {
 
     @Environment(PointOfSaleAggregateModel.self) private var posModel
 
+    @Environment(\.keyboardObserver) private var keyboardObserver
+
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 
@@ -257,6 +259,12 @@ private extension ItemListView {
             }
             .transition(.opacity)
             .renderedIf(searchTerm.isNotEmpty)
+        }
+        .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
+            guard isVisible == false else {
+                return
+            }
+            ServiceLocator.analytics.track(.pointOfSaleKeyboardDismissedInSearch)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -84,6 +84,8 @@ struct ItemListView: View {
                     savedSearches: posModel.searchHistory(for: selectedItemListType.itemType),
                     onSearchSelected: { search in
                         searchTerm = search
+                        ServiceLocator.analytics.track(
+                            event: WooAnalyticsEvent.PointOfSale.preSearchRecentTermTapped(itemListType: selectedItemListType))
                     }
                 )
                 .background(Color.posSurface)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -274,7 +274,7 @@ private extension ItemListView {
     private var actionHandler: POSItemActionHandler {
         switch selectedItemListType {
         case .products(search: false), .coupons:
-            StandardPOSItemActionHandler(posModel: posModel)
+            StandardPOSItemActionHandler(posModel: posModel, itemListType: selectedItemListType)
         case .products(search: true):
             SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemListType: selectedItemListType)
         }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -167,6 +167,8 @@ private extension ItemListView {
 
                         POSPageHeaderActionButton(systemName: "magnifyingglass") {
                             withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+                                ServiceLocator.analytics.track(event: WooAnalyticsEvent.PointOfSale.searchButtonTapped(
+                                    itemListType: selectedItemListType))
                                 selectedItemListType = .products(search: true)
                             } completion: {
                                 isSearchFieldFocused = true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-344
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the required analytics for the M1 release of products search. See for details: pdfdoF-6Wm-p2

1. Log `pos_search_button_tapped` with `item_list_type` parameter: `products`
2. Update `pos_item_added_to_cart` to add `source` parameter: `list | search_result`
3. Add `pos_pre_search_recent_term_tapped` event, with `item_list_type` parameter: `products`
4. Add `pos_keyboard_dismissed_in_search` event.
5. Add `pos_items_next_page_loaded` event with `item_list_type` and `search: bool` parameters – log it for all item lists. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Tap the search button and check the analytic event is tracked
4. Type a search term and then dismiss the keyboard: check the analytic event is tracked
5. Tap a product in the search results: check the analytic event is tracked
6. Search something with lots of results (`a` should do it!) then scroll down and check the analytic is logged
7. Clear the search then tap a recent search term: check the analytic event is tracked.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Some of the events can be tracked outside of search – e.g. `item_added_to_cart` has a new `source` parameter, and that should be populated whether the item is added from search results or the normal list. I debated moving the equivalent coupon events to use this same event with an item type property – @staskus wdyt about that?

`items_next_page_loaded` can be tracked on any item list. On variations lists it will always say it's not from a search, which is a little debatable if you opened the variable product in a search context... but it's pretty tricky to add, and there's no search details showing. It's the event I'm least convinced about us adding anyway, if it's a concern, we can just remove it.

I tested on an iPad Air running iOS 17.7.3.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![search_button_tapped console log](https://github.com/user-attachments/assets/e6521b93-aa7b-4e12-977e-d5c09bba3972)

![item_added_to_cart from search console log](https://github.com/user-attachments/assets/e77d5068-f6ef-48c8-b5e4-75bffce9259a)

![item_added_to_cart from list console log](https://github.com/user-attachments/assets/7ce8248a-0b5d-42e2-b66e-be06106bb781)

![recent_search_tapped console log](https://github.com/user-attachments/assets/0d26e2a5-f755-45fe-a2dd-88263557a0df)

![keyboard_dismissed_in_search console log](https://github.com/user-attachments/assets/f9b427b8-d7f7-41cb-8796-fa8ab83411e9)

![next_page_loaded products list console log](https://github.com/user-attachments/assets/3e46aefe-140e-4353-9f62-bccae1ad2909)

![next_page_loaded products search console log](https://github.com/user-attachments/assets/0d7d8eba-e4e7-4d9f-9104-03eafa158fb3)

![next_page_loaded coupons list console log](https://github.com/user-attachments/assets/076f33f5-6639-468e-b4b9-c4558e7405d5)

## Event registration PRs

https://github.com/Automattic/tracks-events-registration/pull/2812

https://github.com/Automattic/tracks-events-registration/pull/2813

https://github.com/Automattic/tracks-events-registration/pull/2814

https://github.com/Automattic/tracks-events-registration/pull/2815

https://github.com/Automattic/tracks-events-registration/pull/2816

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.