### PR TITLE
[Woo POS] Coupons: Display expired coupons with disabled selection

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct CouponCardView: View {
     private let coupon: POSCoupon
+    private let isExpired: Bool
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -11,8 +12,9 @@ struct CouponCardView: View {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
     }
 
-    init(coupon: POSCoupon) {
+    init(coupon: POSCoupon, isExpired: Bool = false) {
         self.coupon = coupon
+        self.isExpired = isExpired
     }
 
     var body: some View {
@@ -21,22 +23,30 @@ struct CouponCardView: View {
 
             VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(coupon.code)
-                    .foregroundStyle(Constants.titleColor)
+                    .foregroundStyle(isExpired ? Constants.disabledTitleColor : Constants.titleColor)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemTitleFont)
 
                 Text(coupon.summary)
-                    .foregroundStyle(Constants.detailColor)
+                    .foregroundStyle(isExpired ? Constants.disabledTitleColor : Constants.detailColor)
                     .font(Constants.itemDetailFont)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
+
+                if isExpired, let expirationDate = coupon.dateExpires {
+                    // TODO: Date needs formatting
+                    Text("Expired . \(expirationDate)")
+                        .foregroundStyle(Constants.disabledTitleColor)
+                        .font(Constants.itemDetailFont)
+                        .lineLimit(1)
+                }
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
             Spacer()
         }
         .frame(maxWidth: .infinity, minHeight: dimension)
-        .background(Constants.backgroundColor)
+        .background(isExpired ? Constants.disabledBackgroundColor : Constants.backgroundColor)
         .posItemCardBorderStyles()
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
@@ -21,20 +21,19 @@ struct CouponCardView: View {
 
             VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(coupon.code)
-                    .foregroundStyle(coupon.isExpired ? Constants.disabledTitleColor : Constants.titleColor)
+                    .foregroundStyle(titleColor)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemTitleFont)
 
                 Text(coupon.summary)
-                    .foregroundStyle(coupon.isExpired ? Constants.disabledTitleColor : Constants.detailColor)
+                    .foregroundStyle(summaryColor)
                     .font(Constants.itemDetailFont)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
 
                 if coupon.isExpired, let expirationDate = coupon.dateExpires {
-                    Text(String(format: Localization.expirationText,
-                              DateFormatter.localizedString(from: expirationDate, dateStyle: .medium, timeStyle: .none)))
-                        .foregroundStyle(Constants.disabledTitleColor)
+                    Text(formattedExpirationText(date: expirationDate))
+                        .foregroundStyle(expirationTextColor)
                         .font(Constants.itemDetailFont)
                         .lineLimit(1)
                 }
@@ -44,22 +43,41 @@ struct CouponCardView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, minHeight: dimension)
-        .background(coupon.isExpired ? Constants.disabledBackgroundColor : Constants.backgroundColor)
+        .background(cardBackgroundColor)
         .posItemCardBorderStyles()
     }
 }
 
 private extension CouponCardView {
     typealias Constants = PointOfSaleItemListCardConstants
-}
 
-private extension CouponCardView {
     enum Localization {
         static let expirationText = NSLocalizedString(
             "couponCardView.expirationText",
             value: "Expired · %@",
-            comment: "Expiration date for a given coupon, displayed in the coupon card. Reads as 'Expired  · 18 April 2025'."
+            comment: "Expiration date for a given coupon, displayed in the coupon card. Reads as 'Expired · 18 April 2025'."
         )
+    }
+
+    func formattedExpirationText(date: Date) -> String {
+        String(format: Localization.expirationText,
+               DateFormatter.localizedString(from: date, dateStyle: .medium, timeStyle: .none))
+    }
+
+    var titleColor: Color {
+        coupon.isExpired ? Constants.disabledTitleColor : Constants.titleColor
+    }
+
+    var summaryColor: Color {
+        coupon.isExpired ? Constants.disabledTitleColor : Constants.detailColor
+    }
+
+    var expirationTextColor: Color {
+        Constants.disabledTitleColor
+    }
+
+    var cardBackgroundColor: Color {
+        coupon.isExpired ? Constants.disabledBackgroundColor : Constants.backgroundColor
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
@@ -55,7 +55,7 @@ private extension CouponCardView {
     enum Localization {
         static let expirationText = NSLocalizedString(
             "couponCardView.expirationText",
-            value: "Expired · %@",
+            value: "Expired on %@",
             comment: "Expiration date for a given coupon, displayed in the coupon card. Reads as 'Expired · 18 April 2025'."
         )
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct CouponCardView: View {
     private let coupon: POSCoupon
-    private let isExpired: Bool
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -12,9 +11,8 @@ struct CouponCardView: View {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
     }
 
-    init(coupon: POSCoupon, isExpired: Bool = false) {
+    init(coupon: POSCoupon) {
         self.coupon = coupon
-        self.isExpired = isExpired
     }
 
     var body: some View {
@@ -23,19 +21,19 @@ struct CouponCardView: View {
 
             VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(coupon.code)
-                    .foregroundStyle(isExpired ? Constants.disabledTitleColor : Constants.titleColor)
+                    .foregroundStyle(coupon.isExpired ? Constants.disabledTitleColor : Constants.titleColor)
                     .multilineTextAlignment(.leading)
                     .font(Constants.itemTitleFont)
 
                 Text(coupon.summary)
-                    .foregroundStyle(isExpired ? Constants.disabledTitleColor : Constants.detailColor)
+                    .foregroundStyle(coupon.isExpired ? Constants.disabledTitleColor : Constants.detailColor)
                     .font(Constants.itemDetailFont)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
 
-                if isExpired, let expirationDate = coupon.dateExpires {
-                    // TODO: Date needs formatting
-                    Text("Expired . \(expirationDate)")
+                if coupon.isExpired, let expirationDate = coupon.dateExpires {
+                    Text(String(format: Localization.expirationText,
+                              DateFormatter.localizedString(from: expirationDate, dateStyle: .medium, timeStyle: .none)))
                         .foregroundStyle(Constants.disabledTitleColor)
                         .font(Constants.itemDetailFont)
                         .lineLimit(1)
@@ -46,13 +44,23 @@ struct CouponCardView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, minHeight: dimension)
-        .background(isExpired ? Constants.disabledBackgroundColor : Constants.backgroundColor)
+        .background(coupon.isExpired ? Constants.disabledBackgroundColor : Constants.backgroundColor)
         .posItemCardBorderStyles()
     }
 }
 
 private extension CouponCardView {
     typealias Constants = PointOfSaleItemListCardConstants
+}
+
+private extension CouponCardView {
+    enum Localization {
+        static let expirationText = NSLocalizedString(
+            "couponCardView.expirationText",
+            value: "Expired · %@",
+            comment: "Expiration date for a given coupon, displayed in the coupon card. Reads as 'Expired  · 18 April 2025'."
+        )
+    }
 }
 
 #if DEBUG

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
@@ -82,9 +82,31 @@ private extension CouponCardView {
 }
 
 #if DEBUG
-#Preview {
-    CouponCardView(coupon: .init(id: .init(),
-                                 code: "Coupon-123",
-                                 summary: "10% off - All Products"))
+#Preview("Coupon states") {
+    VStack(spacing: 16) {
+        VStack(alignment: .leading) {
+            Text("Active Coupon")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            CouponCardView(coupon: .init(
+                id: .init(),
+                code: "Coupon-123",
+                summary: "10% off - All Products"
+            ))
+        }
+
+        VStack(alignment: .leading) {
+            Text("Expired Coupon")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            CouponCardView(coupon: .init(
+                id: .init(),
+                code: "Old-Coupon-123",
+                summary: "10% off - All Products",
+                dateExpires: Calendar.current.date(byAdding: .month, value: -1, to: Date())
+            ))
+        }
+    }
+    .padding()
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/CouponCardView.swift
@@ -17,7 +17,8 @@ struct CouponCardView: View {
 
     var body: some View {
         HStack(spacing: Constants.cardSpacing) {
-            POSCouponImageView(size: dimension)
+            POSCouponImageView(size: dimension,
+                               state: coupon.isExpired ? .expired : .normal)
 
             VStack(alignment: .leading, spacing: Constants.textSpacing) {
                 Text(coupon.code)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -180,10 +180,19 @@ private struct ItemListRow: View {
                 VariationCardView(variation: variation)
             })
         case let .coupon(coupon):
+            let isExpired: Bool = {
+                if let expiryDate = coupon.dateExpires {
+                    return expiryDate < Date()
+                }
+                return false
+            }()
+
             Button(action: {
-                itemActionHandler.handleTap(item)
+                if !isExpired {
+                    itemActionHandler.handleTap(item)
+                }
             }, label: {
-                CouponCardView(coupon: coupon)
+                CouponCardView(coupon: coupon, isExpired: isExpired)
             })
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -180,19 +180,12 @@ private struct ItemListRow: View {
                 VariationCardView(variation: variation)
             })
         case let .coupon(coupon):
-            let isExpired: Bool = {
-                if let expiryDate = coupon.dateExpires {
-                    return expiryDate < Date()
-                }
-                return false
-            }()
-
             Button(action: {
-                if !isExpired {
+                if !coupon.isExpired {
                     itemActionHandler.handleTap(item)
                 }
             }, label: {
-                CouponCardView(coupon: coupon, isExpired: isExpired)
+                CouponCardView(coupon: coupon)
             })
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListCardConstants.swift
@@ -12,6 +12,8 @@ enum PointOfSaleItemListCardConstants {
     static let itemDetailFont: POSFontStyle = .posBodyLargeRegular()
     static let accessoryButtonPadding: CGFloat = POSPadding.medium
     static let backgroundColor: Color = .posSurfaceContainerLowest
+    static let disabledBackgroundColor: Color = .posDisabledContainer
     static let titleColor: Color = .posOnSurface
+    static let disabledTitleColor: Color = .posOnDisabledContainer
     static let detailColor: Color = .posOnSurfaceVariantHighest
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSCouponImageView.swift
@@ -4,6 +4,7 @@ enum POSCouponImageState {
     case success
     case error
     case normal
+    case expired
 }
 
 struct POSCouponImageView: View {
@@ -21,7 +22,7 @@ struct POSCouponImageView: View {
             return .posSuccess
         case .error:
             return .posError
-        case .normal:
+        case .normal, .expired:
             return .posSurfaceDim
         }
     }
@@ -34,6 +35,8 @@ struct POSCouponImageView: View {
             return .posOnError
         case .normal:
             return .posOnSurfaceVariantLowest
+        case .expired:
+            return Constants.disabledTitleColor
         }
     }
 
@@ -51,6 +54,39 @@ struct POSCouponImageView: View {
     }
 }
 
-#Preview {
-    POSCouponImageView(size: 100)
+private extension POSCouponImageView {
+    typealias Constants = PointOfSaleItemListCardConstants
+}
+
+#Preview("ImageView states") {
+    VStack(spacing: 16) {
+        VStack(alignment: .leading) {
+            Text("Normal")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            POSCouponImageView(size: 100)
+        }
+
+        VStack(alignment: .leading) {
+            Text("Success")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            POSCouponImageView(size: 100, state: .success)
+        }
+
+        VStack(alignment: .leading) {
+            Text("Error")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            POSCouponImageView(size: 100, state: .error)
+        }
+
+        VStack(alignment: .leading) {
+            Text("Expired")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            POSCouponImageView(size: 100, state: .expired)
+        }
+    }
+    .padding()
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		68B681182D925B190098D5CD /* PointOfSaleCouponService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B681172D925B170098D5CD /* PointOfSaleCouponService.swift */; };
 		68BD37B528DB2E9800C2A517 /* CustomerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD37B428DB2E9800C2A517 /* CustomerStore.swift */; };
 		68BD37B928DB323D00C2A517 /* CustomerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD37B828DB323D00C2A517 /* CustomerStoreTests.swift */; };
+		68E75F202DB8BFB100A2DA21 /* POSCouponTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E75F1F2DB8BFAC00A2DA21 /* POSCouponTests.swift */; };
 		68EA25342C08734900C49AE2 /* POSSimpleProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */; };
 		68EA25382C0876DF00C49AE2 /* PointOfSaleItemService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
@@ -851,6 +852,7 @@
 		68B681172D925B170098D5CD /* PointOfSaleCouponService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCouponService.swift; sourceTree = "<group>"; };
 		68BD37B428DB2E9800C2A517 /* CustomerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerStore.swift; sourceTree = "<group>"; };
 		68BD37B828DB323D00C2A517 /* CustomerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerStoreTests.swift; sourceTree = "<group>"; };
+		68E75F1F2DB8BFAC00A2DA21 /* POSCouponTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCouponTests.swift; sourceTree = "<group>"; };
 		68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSimpleProduct.swift; sourceTree = "<group>"; };
 		68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemService.swift; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
@@ -1588,6 +1590,7 @@
 		687F83702C0EBF3E00460AB3 /* PointOfSale */ = {
 			isa = PBXGroup;
 			children = (
+				68E75F1F2DB8BFAC00A2DA21 /* POSCouponTests.swift */,
 				016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */,
 				687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */,
 				206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */,
@@ -2915,6 +2918,7 @@
 				DE50296728C7114800551736 /* JetpackConnectionStoreTests.swift in Sources */,
 				0212AC67242C799B00C51F6C /* ResultsController+StorageProductTests.swift in Sources */,
 				D4CBAE6026D440FA00BBE6D1 /* MockAnnouncementsRemote.swift in Sources */,
+				68E75F202DB8BFB100A2DA21 /* POSCouponTests.swift in Sources */,
 				578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */,
 				DE87F40C2D2F839700869522 /* AppSettingsStoreTests+ProductFilterHistory.swift in Sources */,
 				20D210C12B177EEF0099E517 /* WooPaymentsPayoutServiceTests.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
@@ -2,10 +2,12 @@ public struct POSCoupon: Equatable, Hashable {
     public let id: UUID
     public let code: String
     public let summary: String
+    public var dateExpires: Date?
 
-    public init(id: UUID, code: String, summary: String = "") {
+    public init(id: UUID, code: String, summary: String = "", dateExpires: Date? = nil) {
         self.id = id
         self.code = code
         self.summary = summary
+        self.dateExpires = dateExpires
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSCoupon.swift
@@ -10,4 +10,11 @@ public struct POSCoupon: Equatable, Hashable {
         self.summary = summary
         self.dateExpires = dateExpires
     }
+
+    public var isExpired: Bool {
+        guard let dateExpires = dateExpires else {
+            return false
+        }
+        return dateExpires < Date()
+    }
 }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -131,7 +131,8 @@ private extension PointOfSaleCouponService {
                 .coupon(POSCoupon(
                     id: UUID(),
                     code: coupon.code,
-                    summary: coupon.summary(currencySettings: currencySettings)
+                    summary: coupon.summary(currencySettings: currencySettings),
+                    dateExpires: coupon.dateExpires
                 ))
         }
     }

--- a/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
+++ b/Yosemite/Yosemite/PointOfSale/PointOfSaleCouponService.swift
@@ -127,16 +127,12 @@ private extension PointOfSaleCouponService {
     }
 
     func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
-        let now = Date()
-        let nonExpiredCoupons = coupons.filter { coupon in
-            guard let expirationDate = coupon.dateExpires else { return true }
-            return expirationDate >= now
-        }
-
-        return nonExpiredCoupons.compactMap { coupon in
-                .coupon(POSCoupon(id: UUID(),
-                                  code: coupon.code,
-                                  summary: coupon.summary(currencySettings: currencySettings)))
+        coupons.compactMap { coupon in
+                .coupon(POSCoupon(
+                    id: UUID(),
+                    code: coupon.code,
+                    summary: coupon.summary(currencySettings: currencySettings)
+                ))
         }
     }
 

--- a/Yosemite/YosemiteTests/PointOfSale/POSCouponTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSCouponTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import Yosemite
+
+struct POSCouponTests {
+    @Test func test_isExpired_when_no_expiration_date_then_returns_false() {
+        // Given
+        let coupon = POSCoupon(id: UUID(), code: "valid-forever")
+
+        // Then
+        #expect(coupon.isExpired == false)
+    }
+
+    @Test func test_isExpired_when_future_date_then_returns_false() {
+        // Given
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        let coupon = POSCoupon(id: UUID(), code: "will-expire-in-the-future", dateExpires: tomorrow)
+
+        // Then
+        #expect(coupon.isExpired == false)
+    }
+
+    @Test func test_isExpired_when_past_date_then_returns_true() {
+        // Given
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+        let coupon = POSCoupon(id: UUID(), code: "expired-yesterday", dateExpires: yesterday)
+
+        // Then
+        #expect(coupon.isExpired == true)
+    }
+
+    @Test func test_isExpired_when_current_date_then_returns_true() {
+        // Given
+        let now = Date()
+        let coupon = POSCoupon(id: UUID(), code: "expired-now", dateExpires: now)
+
+        // Then
+        #expect(coupon.isExpired == true, "A coupon expiring at the current time should be considered expired")
+    }
+}

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -135,7 +135,7 @@ struct PointOfSaleCouponServiceTests {
         #expect(coupons.items.count == 2)
     }
 
-    @Test func providePointOfSaleCoupons_when_coupons_expired_then_only_provides_non_expired_coupons() async throws {
+    @Test func providePointOfSaleCoupons_when_have_expired_coupons_then_provides_all_coupons() async throws {
         // Given
         let now = Date()
         let noExpiration: Date? = nil
@@ -155,7 +155,7 @@ struct PointOfSaleCouponServiceTests {
         let coupons = try await sut.providePointOfSaleCoupons(pageNumber: 0)
 
         // Then
-        #expect(coupons.items.count == 2)
+        #expect(coupons.items.count == 3)
     }
 
     @Test func providePointOfSaleCoupons_when_no_coupons_then_synchronize_called() async throws {


### PR DESCRIPTION
Closes: WOOMOB-352
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR updates the POSCoupon mapping and list view logic to display expired coupons along normal coupons, so all of them will show in the Coupon List.

Expired coupons use a different style based on Disabled Container/ On Disabled Container, as well as show the expiration date, and are non selectable to add to the cart.

![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-04-23 at 13 49 11](https://github.com/user-attachments/assets/7d13605e-c1a4-4747-8848-657ce98d0591)

## Testing information
* In your store be sure to have: 
  * Coupons with no expiration date
  * Coupons with expiration date but not expired
  * Coupons with expiration date, and expired
* Observe that functionality remains the same, expect for expired coupons cannot be added to the cart.
* Note that we present the localized formatted date to the user (ie: BE 2568 in my calendar), but the underlying expiration logic hasn't changed and we compare with the date that comes from the backend.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
