### PR TITLE
Shipping Labels: Prevent editing fulfilled shipments

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/MoveToShipmentNotice.swift
@@ -8,8 +8,7 @@ struct MoveToShipmentNoticeViewModel {
 
     let allItemsSelected: Bool
     let selectedItemsCount: Int
-    let existingShipmentsCount: Int
-    let currentShipmentIndex: Int?
+    let existingShipmentsIndexesToMove: [Int]
 }
 
 struct MoveToShipmentNotice: View {
@@ -26,7 +25,7 @@ struct MoveToShipmentNotice: View {
 
             Spacer()
 
-            if viewModel.existingShipmentsCount == 1 {
+            if viewModel.existingShipmentsIndexesToMove.isEmpty {
                 moveToNewShipment
             } else {
                 menuWithExistingShipments
@@ -59,12 +58,10 @@ private extension MoveToShipmentNotice {
 
     var menuWithExistingShipments: some View {
         Menu {
-            ForEach(0..<viewModel.existingShipmentsCount, id: \.self) { index in
-                if viewModel.currentShipmentIndex != index {
-                    Button(String.localizedStringWithFormat(Localization.shipment, index + 1), action: {
-                        onMoving(.existingShipment(index: index))
-                    })
-                }
+            ForEach(viewModel.existingShipmentsIndexesToMove, id: \.self) { index in
+                Button(String.localizedStringWithFormat(Localization.shipment, index + 1), action: {
+                    onMoving(.existingShipment(index: index))
+                })
             }
             if !viewModel.allItemsSelected {
                 Button(Localization.newShipment, action: {
@@ -127,7 +124,6 @@ extension MoveToShipmentNotice {
 #Preview {
     MoveToShipmentNotice(viewModel: MoveToShipmentNoticeViewModel(allItemsSelected: false,
                                                                   selectedItemsCount: 4,
-                                                                  existingShipmentsCount: 3,
-                                                                  currentShipmentIndex: 1),
+                                                                  existingShipmentsIndexesToMove: [0, 2, 3]),
                          onMoving: { _ in })
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -382,17 +382,22 @@ private extension WooShippingSplitShipmentsViewModel {
             .reduce(0, +).intValue
 
         let allItemsSelected = selectedItemsCount == totalItemCount
+        let existingShipmentsIndexesToMove = shipments.enumerated()
+            .filter { $0.element.isPurchased == false && $0.offset != currentIndex }
+            .map { $0.offset }
 
         if shipments.count == 1 && allItemsSelected {
             // do not allow moving all items if there is only one shipment at the moment
+            return moveToNoticeViewModel = nil
+        } else if existingShipmentsIndexesToMove.isEmpty && allItemsSelected {
+            // prevent moving all items if all other shipments are fulfilled
             return moveToNoticeViewModel = nil
         }
 
         moveToNoticeViewModel = MoveToShipmentNoticeViewModel(
             allItemsSelected: allItemsSelected,
             selectedItemsCount: selectedItemsCount,
-            existingShipmentsCount: shipments.count,
-            currentShipmentIndex: currentIndex
+            existingShipmentsIndexesToMove: existingShipmentsIndexesToMove
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -150,6 +150,7 @@ private extension WooShippingCreateLabelsView {
                 Image(systemName: "pencil")
                     .padding(.horizontal)
             }
+            .renderedIf(viewModel.hasUnfulfilledShipments)
         }
         .disabled(viewModel.isPurchasingLabel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -51,6 +51,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         shipments[selectedShipmentIndex]
     }
 
+    var hasUnfulfilledShipments: Bool {
+        shipments.contains(where: { $0.purchasedLabelID == nil })
+    }
+
     @Published var labelPurchaseErrorNotice: Notice?
 
     @Published private(set) var state = ContentState.loading

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -183,8 +183,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         let moveToNoticeViewModel = try XCTUnwrap(viewModel.moveToNoticeViewModel)
         XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, false)
         XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 1)
-        XCTAssertEqual(moveToNoticeViewModel.existingShipmentsCount, 1)
-        XCTAssertEqual(moveToNoticeViewModel.currentShipmentIndex, 0)
+        XCTAssertEqual(moveToNoticeViewModel.existingShipmentsIndexesToMove, [])
     }
 
     func test_moveToNoticeViewModel_is_correct_when_there_exists_more_than_one_shipment_and_not_all_items_are_selected() throws {
@@ -207,8 +206,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         let moveToNoticeViewModel = try XCTUnwrap(viewModel.moveToNoticeViewModel)
         XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, false)
         XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 3)
-        XCTAssertEqual(moveToNoticeViewModel.existingShipmentsCount, 2)
-        XCTAssertEqual(moveToNoticeViewModel.currentShipmentIndex, 0)
+        XCTAssertEqual(moveToNoticeViewModel.existingShipmentsIndexesToMove, [1])
     }
 
     func test_moveToNoticeViewModel_is_correct_when_there_exists_more_than_one_shipment_and_all_items_are_selected() throws {
@@ -231,8 +229,40 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         let moveToNoticeViewModel = try XCTUnwrap(viewModel.moveToNoticeViewModel)
         XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, true)
         XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 5)
-        XCTAssertEqual(moveToNoticeViewModel.existingShipmentsCount, 2)
-        XCTAssertEqual(moveToNoticeViewModel.currentShipmentIndex, 0)
+        XCTAssertEqual(moveToNoticeViewModel.existingShipmentsIndexesToMove, [1])
+    }
+
+    func test_moveToNoticeViewModel_is_nil_when_there_exist_no_other_unfulfilled_shipments_and_all_items_are_selected() throws {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+
+        let shippingLabelData = WooShippingLabelData(currentOrderLabels: [ShippingLabelPurchase.fake().copy(shipmentID: "2")])
+        let config = WooShippingConfig(siteID: 123, shipments: [
+            "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+            "2": [WooShippingShipmentItem(id: 2, subItems: [])]
+        ], shippingLabelData: shippingLabelData)
+
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: config,
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        // When
+        viewModel.shipments.first?.contents.first?.childItemRows.first?.handleTap()
+
+        // Then
+        let moveToNoticeViewModel = try XCTUnwrap(viewModel.moveToNoticeViewModel)
+        XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, false)
+        XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 1)
+        XCTAssertEqual(moveToNoticeViewModel.existingShipmentsIndexesToMove, [])
+        
+        // When
+        viewModel.selectAll()
+
+        // Then
+        XCTAssertNil(viewModel.moveToNoticeViewModel)
     }
 
     // MARK: - `moveSelectedItems`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -257,7 +257,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertEqual(moveToNoticeViewModel.allItemsSelected, false)
         XCTAssertEqual(moveToNoticeViewModel.selectedItemsCount, 1)
         XCTAssertEqual(moveToNoticeViewModel.existingShipmentsIndexesToMove, [])
-        
+
         // When
         viewModel.selectAll()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-348
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the Split shipment flow to prevent editing fulfilled shipments. Changes include:
- Hide the edit button for shipments when all shipments are fulfilled.
- Hide the options to move items to fulfilled shipments.
- Hide the move item notice when all items in a shipment is selected and all other shipments are fulfilled.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a completed order with several physical products.
3. Select Create Shipping Label > Split Shipments > Move items to different shipments > tap Done.
4. Proceed to purchase the shipments until there's one left.
5. Tap the edit button on the shipment tab bar to open Split Shipments screen.
6. Select all items in the unfulfilled shipment and confirm that the Move to notice is not displayed.
7. Select only some of the items in the shipment and confirm that the Move to notice is displayed. Notice that there's only one option Move to new shipment. Select that option.
8. Select all items in the current shipment and confirm that the Move to notice is displayed.
9. Tap on Move To and confirm that only the option of the unfulfilled shipment is available. Select that option and tap Done.
10. Proceed to fulfill the last shipment. When done, confirm that the edit button on the shipment tab bar is no longer available.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Manually tested and confirmed the above test cases on simulator iPhone 16 Pro iOS 18.2.
- Updated unit tests for the Move to notice.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/eb77ef65-f48f-4fd8-8e2d-6f369883703a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
