### PR TITLE
[Woo POS][Products Search] Reset item list state to unsearched products on new cart

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -80,7 +80,18 @@ protocol PointOfSaleAggregateModelProtocol {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    let viewStateCoordinator = PointOfSaleViewStateCoordinator()
+    // Private storage of the concrete coordinator
+    private let _viewStateCoordinator = PointOfSaleViewStateCoordinator()
+
+    // Interface that only exposes reset functionality, for use in the aggregate model
+    private var viewStateCoordinator: PointOfSaleViewStateResettable {
+        _viewStateCoordinator
+    }
+
+    // Type-safe accessor specifically for the view
+    var viewStateCoordinatorForView: PointOfSaleViewStateCoordinator {
+        _viewStateCoordinator
+    }
 
     init(itemsController: PointOfSaleItemsControllerProtocol,
          purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol,

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -80,6 +80,8 @@ protocol PointOfSaleAggregateModelProtocol {
 
     private var cancellables: Set<AnyCancellable> = []
 
+    let viewStateCoordinator = PointOfSaleViewStateCoordinator()
+
     init(itemsController: PointOfSaleItemsControllerProtocol,
          purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol,
          couponsController: PointOfSaleCouponsControllerProtocol,
@@ -151,6 +153,7 @@ extension PointOfSaleAggregateModel {
         removeAllItemsFromCart()
         orderController.clearOrder()
         setStateForEditing()
+        viewStateCoordinator.reset()
     }
 
     private func setStateForEditing() {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleViewStateCoordinator.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleViewStateCoordinator.swift
@@ -1,10 +1,17 @@
 import Foundation
 
+@available(iOS 17.0, *)
+protocol PointOfSaleViewStateResettable {
+    /// Resets all view state to its default values.
+    /// This should be called when starting a new cart to ensure the UI returns to its initial state.
+    func reset()
+}
+
 /// Coordinates view-specific state for the Point of Sale interface.
 /// This coordinator manages UI state that needs to persist across the POS experience
 /// but should be reset when starting a new cart/order.
 @available(iOS 17.0, *)
-@Observable final class PointOfSaleViewStateCoordinator {
+@Observable final class PointOfSaleViewStateCoordinator: PointOfSaleViewStateResettable {
     /// The currently selected item list type, shown when building the cart.
     /// When we reset, the non-searched products list is shown for the new cart.
     var selectedItemListType: ItemListType = .products(search: false)

--- a/WooCommerce/Classes/POS/Models/PointOfSaleViewStateCoordinator.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleViewStateCoordinator.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Coordinates view-specific state for the Point of Sale interface.
+/// This coordinator manages UI state that needs to persist across the POS experience
+/// but should be reset when starting a new cart/order.
+@available(iOS 17.0, *)
+@Observable final class PointOfSaleViewStateCoordinator {
+    /// The currently selected item list type, shown when building the cart.
+    /// When we reset, the non-searched products list is shown for the new cart.
+    var selectedItemListType: ItemListType = .products(search: false)
+
+    /// The current search term being used to filter items.
+    /// This is used when `selectedItemListType` is in search mode.
+    /// When we reset, the search term is cleared for the new cart.
+    var searchTerm: String = ""
+
+    /// Resets all view state to its default values.
+    /// This should be called when starting a new cart to ensure the UI returns to its initial state.
+    func reset() {
+        selectedItemListType = .products(search: false)
+        searchTerm = ""
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -11,12 +11,12 @@ struct PointOfSaleDashboardView: View {
 
     @State private var floatingSize: CGSize = .zero
 
-    @State var selectedItemListType: ItemListType = .products(search: false)
-
-    @State var searchTerm: String = ""
+    private var viewStateCoordinator: PointOfSaleViewStateCoordinator {
+        posModel.viewStateCoordinator
+    }
 
     private var itemsViewState: ItemsViewState {
-        switch selectedItemListType {
+        switch viewStateCoordinator.selectedItemListType {
         case .products(let searching):
             if searching {
                 return posModel.purchasableItemsSearchController.itemsViewState
@@ -40,7 +40,7 @@ struct PointOfSaleDashboardView: View {
                 case .error(let error):
                     PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
                         Task {
-                            switch selectedItemListType {
+                            switch viewStateCoordinator.selectedItemListType {
                             case .products(search: false):
                                 await posModel.purchasableItemsController.loadItems(base: .root)
                             case .products(search: true):
@@ -116,11 +116,12 @@ struct PointOfSaleDashboardView: View {
     }
 
     private var contentView: some View {
-        GeometryReader { geometry in
+        @Bindable var viewStateCoordinator = viewStateCoordinator
+        return GeometryReader { geometry in
             HStack {
                 if posModel.orderStage == .building {
-                    ItemListView(selectedItemListType: $selectedItemListType,
-                                 searchTerm: $searchTerm)
+                    ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
+                                 searchTerm: $viewStateCoordinator.searchTerm)
                         .accessibilitySortPriority(2)
                         .transition(.move(edge: .leading))
                 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleDashboardView: View {
     @State private var floatingSize: CGSize = .zero
 
     private var viewStateCoordinator: PointOfSaleViewStateCoordinator {
-        posModel.viewStateCoordinator
+        posModel.viewStateCoordinatorForView
     }
 
     private var itemsViewState: ItemsViewState {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -889,8 +889,9 @@
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		209B7A682CEB6742003BDEF0 /* PointOfSalePaymentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */; };
 		209CA0EE2B50070D0073D1AC /* WooTabContainerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */; };
-		209E96BD2DB681B50089F3D2 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */; };
 		209E8F572DB2AF200089F3D2 /* MockPointOfSalePopularItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E8F562DB2AF200089F3D2 /* MockPointOfSalePopularItemsController.swift */; };
+		209E96BD2DB681B50089F3D2 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */; };
+		209ECA812DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */; };
 		209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EEF8F2C762ED5007969A4 /* POSModalManager.swift */; };
 		20A130EB2C5A27190058022F /* PointOfSaleAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */; };
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
@@ -4158,8 +4159,9 @@
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePaymentState.swift; sourceTree = "<group>"; };
 		209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooTabContainerController.swift; sourceTree = "<group>"; };
-		209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		209E8F562DB2AF200089F3D2 /* MockPointOfSalePopularItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePopularItemsController.swift; sourceTree = "<group>"; };
+		209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
+		209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleViewStateCoordinator.swift; sourceTree = "<group>"; };
 		209EEF8F2C762ED5007969A4 /* POSModalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalManager.swift; sourceTree = "<group>"; };
 		209FC9C42228DA65BD11D65E /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAssetsTests.swift; sourceTree = "<group>"; };
@@ -10032,6 +10034,7 @@
 			children = (
 				01B3A1F12DB6D48800286B7F /* ItemListType.swift */,
 				20FCBCDC2CE223340082DCA3 /* PointOfSaleAggregateModel.swift */,
+				209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */,
 				20C6E7502CDE4AEA00CD124C /* ItemListState.swift */,
 				20F7B12C2D12C7B900C08193 /* ItemsContainerState.swift */,
 				20F7B12E2D12CBE700C08193 /* ItemsViewState.swift */,
@@ -17348,6 +17351,7 @@
 				B53B3F37219C75AC00DF1EB6 /* OrderLoaderViewController.swift in Sources */,
 				03E471BE29388787001A58AD /* TapToPayCardReaderConnectionController.swift in Sources */,
 				DE4D239C29B06642003A4B5D /* WPComMagicLinkView.swift in Sources */,
+				209ECA812DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift in Sources */,
 				02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */,
 				027D4A8D2526FD1800108626 /* SettingsViewController.swift in Sources */,
 				02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-345
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures the item list is correctly reset to the unsearched product list when we make a new cart.

It fixes an issue where some of the view state was retained after an order was completed, with the following symptoms:
- If you had the search open when you tapped `Check out`, when you started a new cart the product list would show the previous search results
- If you had coupons open, coupons would be shown

To achieve this cleanly, I've had to allow the aggregate model to reset view state. I didn't love this, because really it shouldn't need to know about the view state, but I think the solution is actually pretty good. 

We have a `PointOfSaleViewStateCoordinator` which is `@Observable` and made available from the aggregate model.

The aggregate model only has access to reset the view state, not to read or change it. When we start a new cart, the aggregate model calls `reset` and then all the state is cleared correctly.

Perhaps it's a little clunky with the definitions in the aggregate model... but I think it helps keep the intent clear.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `searchProductsInPOS` feature flag, and optionally the `enableCouponsInPointOfSale` flag

1. Launch the app and navigate to POS
2. Search products, and add something to your cart
3. Dismiss the keyboard, but keep the search open
4. Tap `Check out`
5. Tap back
6. Observe that the search is still shown
7. Tap `Check out`, and complete a payment
8. Tap `New order` 
9. Observe that you're shown the unsearched product list. Previously, the search results would still have been shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested on an iPad Air running iOS 17.7.2 (apparently I've been wrong about using the .3 release for a while!)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/425e612b-592b-4e5d-8c6e-8335715a3945


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.