### PR TITLE
[Woo POS][Products Search] Design tweaks for initial search release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -100,7 +100,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .allowMerchantAIAPIKey:
             return false
         case .searchProductsInPOS:
-            return false
+            return true
         case .searchProductsInPOSPt2PopularProducts:
             return false
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.3
 -----
 - [internal] POS: Reduced prominence of the simple/variable products only banner [https://github.com/woocommerce/woocommerce-ios/pull/15539]
+- [**] POS: Product search added [https://github.com/woocommerce/woocommerce-ios/pull/15545]
 
 22.2
 -----

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
@@ -33,8 +33,7 @@ struct POSRecentSearchesView: View {
                     // Grid of saved searches
                     LazyVGrid(
                         columns: gridColumns,
-                        alignment: .leading,
-                        spacing: POSSpacing.medium
+                        alignment: .leading
                     ) {
                         ForEach(savedSearches, id: \.self) { searchTerm in
                             RecentSearchCard(searchTerm: searchTerm, onSearchSelected: onSearchSelected)
@@ -50,12 +49,12 @@ struct POSRecentSearchesView: View {
     private var gridColumns: [GridItem] {
         if dynamicTypeSize.isAccessibilitySize {
             // Single column for accessibility sizes
-            return [GridItem(.flexible(), spacing: POSSpacing.medium)]
+            return [GridItem(.flexible(), spacing: Constants.cardSpacing)]
         } else {
             // Two equal columns for normal sizes
             return [
-                GridItem(.flexible(), spacing: POSSpacing.medium),
-                GridItem(.flexible(), spacing: POSSpacing.medium)
+                GridItem(.flexible(), spacing: Constants.cardSpacing),
+                GridItem(.flexible(), spacing: Constants.cardSpacing)
             ]
         }
     }
@@ -74,6 +73,10 @@ private extension POSRecentSearchesView {
             value: "No recent searches",
             comment: "Text shown when there's nothing to show before a search term is typed in POS")
 
+    }
+
+    enum Constants {
+        static let cardSpacing: CGFloat = POSSpacing.small
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -232,9 +232,7 @@ private extension ItemListView {
             Button {
                 searchTerm = ""
                 isSearchFieldFocused = false
-                withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                    selectedItemListType = .products(search: false)
-                }
+                selectedItemListType = .products(search: false)
             } label: {
                 Image(systemName: "chevron.backward")
                     .foregroundColor(.posOnSurface)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -391,7 +391,7 @@ private extension ItemListView {
 
         static let searchFieldLabel = NSLocalizedString(
             "pos.itemlistview.searchField.label",
-            value: "Search products",
+            value: "Search Products",
             comment: "Label/placeholder text for the product search field in Point of Sale."
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-329
Merge after: #15544 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This fixes a few small design issues:

- Spacing in the recent search grid matches the product list
- The placeholder for the search field is `Search Products` with a capital P
- The animation when going back from search is removed (as it was a bit janky)

The feature flag will also be enabled after this PR, as this is the last thing for release.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Tap the search button; observe that the placeholder text has a capital P
3. Tap back without typing anything; observe that the transition is OK
4. Tap search again and type a search term; observe the transition
5. Tap back again; observe that transition

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested on an iPad Air running iOS 17.7.2, and a simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/e631733c-8f6d-4e0d-a840-ca725f29336a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.