### PR TITLE
Core Data: Prevent crash on the Blaze Dashboard when saving fails

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.3
 -----
 - [internal] POS: Reduced prominence of the simple/variable products only banner [https://github.com/woocommerce/woocommerce-ios/pull/15539]
+- [internal] Attempt fixing (incorrect) crash upon database dropping [https://github.com/woocommerce/woocommerce-ios/pull/15546]
 
 22.2
 -----

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -321,7 +321,7 @@ private extension CoreDataManager {
         var persistentStoreRemovalError: Error?
         do {
             try persistentContainer.persistentStoreCoordinator.destroyPersistentStore(at: storeURL, type: .sqlite, options: nil)
-            NotificationCenter.default.post(name: .StorageManagerDidResetStorage, object: self)
+            NotificationCenter.default.post(name: .StorageManagerDidInvalidateCachedData, object: self)
         } catch {
             persistentStoreRemovalError = error
         }

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -321,7 +321,7 @@ private extension CoreDataManager {
         var persistentStoreRemovalError: Error?
         do {
             try persistentContainer.persistentStoreCoordinator.destroyPersistentStore(at: storeURL, type: .sqlite, options: nil)
-            NotificationCenter.default.post(name: .StorageManagerDidInvalidateCachedData, object: self)
+            NotificationCenter.default.post(name: .StorageManagerDidDropDatabase, object: self)
         } catch {
             persistentStoreRemovalError = error
         }

--- a/Storage/Storage/Protocols/StorageManagerType.swift
+++ b/Storage/Storage/Protocols/StorageManagerType.swift
@@ -5,6 +5,7 @@ import Foundation
 //
 public extension NSNotification.Name {
     static let StorageManagerDidResetStorage = NSNotification.Name(rawValue: "StorageManagerDidResetStorage")
+    static let StorageManagerDidInvalidateCachedData = NSNotification.Name(rawValue: "StorageManagerDidInvalidateCachedData")
 }
 
 

--- a/Storage/Storage/Protocols/StorageManagerType.swift
+++ b/Storage/Storage/Protocols/StorageManagerType.swift
@@ -5,7 +5,7 @@ import Foundation
 //
 public extension NSNotification.Name {
     static let StorageManagerDidResetStorage = NSNotification.Name(rawValue: "StorageManagerDidResetStorage")
-    static let StorageManagerDidInvalidateCachedData = NSNotification.Name(rawValue: "StorageManagerDidInvalidateCachedData")
+    static let StorageManagerDidDropDatabase = NSNotification.Name(rawValue: "StorageManagerDidDropDatabase")
 }
 
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -188,7 +188,7 @@ final class SessionManager: SessionManagerProtocol {
         // Listens when the cached data is invalidated.
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(handleStorageDidInvalidateData),
-                                               name: .StorageManagerDidInvalidateCachedData,
+                                               name: .StorageManagerDidDropDatabase,
                                                object: nil)
     }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -186,12 +186,12 @@ final class SessionManager: SessionManagerProtocol {
         defaultStoreIDSubject = .init(defaults[.defaultStoreID])
 
         // Listens when the core data stack is reset.
-        NotificationCenter.default.addObserver(self, selector: #selector(handleStorageDidInvalidateData), name: .StorageManagerDidResetStorage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(resetTimestampsValues), name: .StorageManagerDidResetStorage, object: nil)
 
 
         // Listens when the cached data is invalidated.
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(handleStorageDidInvalidateData),
+                                               selector: #selector(resetTimestampsValues),
                                                name: .StorageManagerDidDropDatabase,
                                                object: nil)
     }
@@ -293,15 +293,9 @@ private extension SessionManager {
         defaults[.defaultCredentialsType] = nil
     }
 
-    /// Updates the timestamps that control when background data is fetched.
-    ///
-    @objc func handleStorageDidInvalidateData() {
-        resetTimestampsValues()
-    }
-
     /// Removes timestamp values.
     ///
-    func resetTimestampsValues() {
+    @objc func resetTimestampsValues() {
         defaults[.latestBackgroundOrderSyncDate] = nil
         DashboardTimestampStore.resetStore(store: defaults)
     }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -185,6 +185,10 @@ final class SessionManager: SessionManagerProtocol {
 
         defaultStoreIDSubject = .init(defaults[.defaultStoreID])
 
+        // Listens when the core data stack is reset.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleStorageDidInvalidateData), name: .StorageManagerDidResetStorage, object: nil)
+
+
         // Listens when the cached data is invalidated.
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(handleStorageDidInvalidateData),

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -185,8 +185,11 @@ final class SessionManager: SessionManagerProtocol {
 
         defaultStoreIDSubject = .init(defaults[.defaultStoreID])
 
-        // Listens when the core data stack is rest.
-        NotificationCenter.default.addObserver(self, selector: #selector(handleStorageDidInvalidateData), name: .StorageManagerDidInvalidateCachedData, object: nil)
+        // Listens when the cached data is invalidated.
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleStorageDidInvalidateData),
+                                               name: .StorageManagerDidInvalidateCachedData,
+                                               object: nil)
     }
 
     /// Nukes all of the known Session's properties.

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -186,7 +186,7 @@ final class SessionManager: SessionManagerProtocol {
         defaultStoreIDSubject = .init(defaults[.defaultStoreID])
 
         // Listens when the core data stack is rest.
-        NotificationCenter.default.addObserver(self, selector: #selector(handleStorageDidReset), name: .StorageManagerDidResetStorage, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleStorageDidInvalidateData), name: .StorageManagerDidInvalidateCachedData, object: nil)
     }
 
     /// Nukes all of the known Session's properties.
@@ -288,7 +288,7 @@ private extension SessionManager {
 
     /// Updates the timestamps that control when background data is fetched.
     ///
-    @objc func handleStorageDidReset() {
+    @objc func handleStorageDidInvalidateData() {
         resetTimestampsValues()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -311,7 +311,7 @@ private extension BlazeCampaignDashboardViewModel {
             self?.updateResults()
         }
         blazeCampaignResultsController.onDidResetContent = { [weak self] in
-            self?.refetchAllResultsControllers()
+            self?.updateResults()
         }
 
         productResultsController.onDidChangeContent = { [weak self] in
@@ -319,16 +319,10 @@ private extension BlazeCampaignDashboardViewModel {
             self?.updateResults()
         }
         productResultsController.onDidResetContent = { [weak self] in
-            self?.refetchAllResultsControllers()
             self?.updateAvailability()
+            self?.updateResults()
         }
 
-        refetchAllResultsControllers()
-    }
-
-    /// Refetching all the results controllers is necessary after a storage reset in `onDidResetContent`
-    /// callback and before reloading UI that involves more than one results controller.
-    func refetchAllResultsControllers() {
         do {
             try blazeCampaignResultsController.performFetch()
             try productResultsController.performFetch()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -311,7 +311,7 @@ private extension BlazeCampaignDashboardViewModel {
             self?.updateResults()
         }
         blazeCampaignResultsController.onDidResetContent = { [weak self] in
-            self?.updateResults()
+            self?.refetchAllResultsControllers()
         }
 
         productResultsController.onDidChangeContent = { [weak self] in
@@ -319,10 +319,16 @@ private extension BlazeCampaignDashboardViewModel {
             self?.updateResults()
         }
         productResultsController.onDidResetContent = { [weak self] in
+            self?.refetchAllResultsControllers()
             self?.updateAvailability()
-            self?.updateResults()
         }
 
+        refetchAllResultsControllers()
+    }
+
+    /// Refetching all the results controllers is necessary after a storage reset in `onDidResetContent`
+    /// callback and before reloading UI that involves more than one results controller.
+    func refetchAllResultsControllers() {
         do {
             try blazeCampaignResultsController.performFetch()
             try productResultsController.performFetch()

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -483,7 +483,7 @@ final class SessionManagerTests: XCTestCase {
 
         // When
         let sut = SessionManager(defaults: defaults, keychainServiceName: uuid)
-        NotificationCenter.default.post(name: .StorageManagerDidResetStorage, object: nil)
+        NotificationCenter.default.post(name: .StorageManagerDidInvalidateCachedData, object: nil)
 
         // Then
         XCTAssertNil(defaults[UserDefaults.Key.latestBackgroundOrderSyncDate])

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -483,7 +483,7 @@ final class SessionManagerTests: XCTestCase {
 
         // When
         let sut = SessionManager(defaults: defaults, keychainServiceName: uuid)
-        NotificationCenter.default.post(name: .StorageManagerDidInvalidateCachedData, object: nil)
+        NotificationCenter.default.post(name: .StorageManagerDidDropDatabase, object: nil)
 
         // Then
         XCTAssertNil(defaults[UserDefaults.Key.latestBackgroundOrderSyncDate])

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -483,6 +483,33 @@ final class SessionManagerTests: XCTestCase {
 
         // When
         let sut = SessionManager(defaults: defaults, keychainServiceName: uuid)
+        NotificationCenter.default.post(name: .StorageManagerDidResetStorage, object: nil)
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.latestBackgroundOrderSyncDate])
+        for card in DashboardTimestampStore.Card.allCases {
+            for range in DashboardTimestampStore.TimeRange.allCases {
+                XCTAssertNil(DashboardTimestampStore.loadTimestamp(for: card, at: range, store: defaults))
+            }
+        }
+    }
+
+    func test_core_data_database_drop_clears_timestamps_stores() throws {
+
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+
+        // Preload info
+        defaults[UserDefaults.Key.latestBackgroundOrderSyncDate] = Date.now
+        for card in DashboardTimestampStore.Card.allCases {
+            for range in DashboardTimestampStore.TimeRange.allCases {
+                DashboardTimestampStore.saveTimestamp(Date.now, for: card, at: range, store: defaults)
+            }
+        }
+
+        // When
+        let sut = SessionManager(defaults: defaults, keychainServiceName: uuid)
         NotificationCenter.default.post(name: .StorageManagerDidDropDatabase, object: nil)
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-316
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #14961 I added a workaround to drop the database and force crash the app to help users recover from their corrupted database. This caused an unexpected crash on the Blaze dashboard upon resetting the database, causing the app crash earlier without details about the saving failure.

This PR attempts to prevent this by:
- Triggering a different notification that is listented to only by the `SessionManager` to clear the timestamps for cached data.
~~- Adding a future-proof update to prevent crash on the Blaze dashboard when the database is reset.~~

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Smoke test the app with a store that's eligible for Blaze and confirm that the Blaze dashboard is still loaded without issues.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Smoke tested the Blaze dashboard card using simulator iPhone 16 Pro iOS 18.2.
- Added a unit test to confirm the reset of timestamps upon dropping database.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
