### PR TITLE
[Shipping labels] Allow split shipments dismiss without changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -69,6 +69,11 @@ struct WooShippingSplitShipmentsView: View {
                         ActivityIndicator(isAnimating: .constant(true), style: .medium)
                     } else {
                         Button(Localization.done) {
+                            guard viewModel.containsUnsavedChanges else {
+                                dismiss()
+                                return
+                            }
+
                             Task {
                                 do {
                                     try await viewModel.saveShipmentInfo()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -79,7 +79,6 @@ struct WooShippingSplitShipmentsView: View {
                                 }
                             }
                         }
-                        .disabled(!viewModel.enableDoneButton)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -56,9 +56,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         return shipment
     }
 
-    /// Enables "Done" button only if shipments are edited
-    ///
-    var enableDoneButton: Bool {
+    var containsUnsavedChanges: Bool {
         shipmentsSavedInRemote != editedShipmentsInfo
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -696,7 +696,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
     // MARK: - `enableDoneButton`
 
     @MainActor
-    func test_enableDoneButton_is_false_initially() async throws {
+    func test_containsUnsavedChanges_is_false_initially() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 3),
@@ -709,47 +709,11 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
                                                            shippingSettingsService: shippingSettingsService)
 
         // Then
-        XCTAssertFalse(viewModel.enableDoneButton)
+        XCTAssertFalse(viewModel.containsUnsavedChanges)
     }
 
     @MainActor
-    func test_enableDoneButton_turns_true_when_changes_made_to_shipments() async throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 3),
-                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
-        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
-                                                           config: WooShippingConfig.fake(),
-                                                           items: items,
-                                                           stores: stores,
-                                                           currencySettings: currencySettings,
-                                                           shippingSettingsService: shippingSettingsService)
-
-        // When
-        viewModel.shipments.first?.contents.first?.childItemRows.first?.handleTap()
-        viewModel.moveSelectedItems(to: .newShipment)
-
-        // Then
-        XCTAssertTrue(viewModel.enableDoneButton)
-
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            switch action {
-            case let .updateShipment(_, _, _, completion):
-                completion(.success(["0": [WooShippingShipmentItem.fake()]]))
-            default:
-                XCTFail("Received unexpected action: \(action)")
-            }
-        }
-
-        // When
-        try await viewModel.saveShipmentInfo()
-
-        // Then
-        XCTAssertFalse(viewModel.enableDoneButton)
-    }
-
-    @MainActor
-    func test_enableDoneButton_turns_false_when_shipment_changes_are_saved_to_remote() async throws {
+    func test_containsUnsavedChanges_turns_true_when_changes_made_to_shipments() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 3),
@@ -766,7 +730,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         viewModel.moveSelectedItems(to: .newShipment)
 
         // Then
-        XCTAssertTrue(viewModel.enableDoneButton)
+        XCTAssertTrue(viewModel.containsUnsavedChanges)
 
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
@@ -781,11 +745,47 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         try await viewModel.saveShipmentInfo()
 
         // Then
-        XCTAssertFalse(viewModel.enableDoneButton)
+        XCTAssertFalse(viewModel.containsUnsavedChanges)
     }
 
     @MainActor
-    func test_enableDoneButton_turns_false_when_shipment_changes_are_undone() async throws {
+    func test_containsUnsavedChanges_turns_false_when_shipment_changes_are_saved_to_remote() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 3),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: WooShippingConfig.fake(),
+                                                           items: items,
+                                                           stores: stores,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        // When
+        viewModel.shipments.first?.contents.first?.childItemRows.first?.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+
+        // Then
+        XCTAssertTrue(viewModel.containsUnsavedChanges)
+
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .updateShipment(_, _, _, completion):
+                completion(.success(["0": [WooShippingShipmentItem.fake()]]))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+
+        // When
+        try await viewModel.saveShipmentInfo()
+
+        // Then
+        XCTAssertFalse(viewModel.containsUnsavedChanges)
+    }
+
+    @MainActor
+    func test_containsUnsavedChanges_turns_false_when_shipment_changes_are_undone() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 3),
@@ -803,7 +803,7 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         viewModel.undoMovingItems()
 
         // Then
-        XCTAssertFalse(viewModel.enableDoneButton)
+        XCTAssertFalse(viewModel.containsUnsavedChanges)
     }
 }
 


### PR DESCRIPTION
Closes: WOOMOB-338
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description

> Enable the Done button even when there are no changes made, but avoid making shipment update requests in that case.

The change in the PR allows to close the "Split Shipments" screen despite making any changes to shipments configuration. From now on the "Done" button will be always enabled. The API call to save changes will be only executed in case if local changes to shipments are done.

## Testing steps
- Log in to a test store with Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with several physical products.
- Select Create Shipping Label > Split Shipments
- Don't make any changes yet.
- The "Done" button should be enabled and tappable.
- Tap "Done" button.
    - Make sure no progress indication is displayed and the screen is dismissed instantly.
- Open the "Split Shipments" screen again and make a change. For example move an item to a new shipment.
- Tap on "Done" button. 
    - Make sure progress indication is now visible (changes are being saved to server).
    - Make sure the screen is dismissed upon saving is completed.
- ~~Open the "Split Shipments" screen again and make a change. For example move an item to a new shipment.~~
-~~Revert that change manually.~~
- ~~ap "Done" button.~~
    - ~~Make sure no progress indication is displayed and the screen is dismissed instantly.~~

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added