### PR TITLE
Shipping Labels: Update customs form for shipments

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
@@ -23,7 +23,7 @@ struct WooShippingShipmentDetailsView: View {
             WooShippingCustomsRow(informationIsCompleted: viewModel.customsInformationIsCompleted,
                                   customsFormViewModel: viewModel.customsFormViewModel)
                 .padding(.bottom, Layout.contentSpacing)
-                .renderedIf(viewModel.customsFormRequired)
+                .renderedIf(viewModel.shouldShowCustomsForm)
 
             if viewModel.canViewLabel {
                 EmptyView()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -62,15 +62,13 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     private var customsForm: ShippingLabelCustomsForm?
 
     lazy private(set) var customsFormViewModel: WooShippingCustomsFormViewModel = {
-        WooShippingCustomsFormViewModel(order: order, onCompletion: { [weak self] form in
+        WooShippingCustomsFormViewModel(order: order, shipment: shipment, onCompletion: { [weak self] form in
             self?.customsForm = form
         })
     }()
 
     /// Whether the custom information is completed or not.
-    var customsInformationIsCompleted: Bool {
-        customsForm != nil && customsFormViewModel.requiredInformationIsEntered
-    }
+    @Published private(set) var customsInformationIsCompleted = false
 
     /// Check for the need of customs form
     ///
@@ -160,10 +158,6 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     /// Selecting a package also refreshes the available rates for the shipping service.
     func selectPackage(_ packageData: WooShippingPackageDataRepresentable) {
         selectedPackage = packageData
-    }
-
-    func onCustomsFormFilled(form: ShippingLabelCustomsForm) {
-        customsForm = form
     }
 
     /// Purchases a shipping label with the provided label details and settings.
@@ -294,6 +288,12 @@ private extension WooShippingShipmentDetailsViewModel {
                 return nil
             }
             .assign(to: &$itnMissingNoticeLabel)
+
+        customsFormViewModel.$requiredInformationIsEntered.combineLatest($customsFormRequired)
+            .map { (requiredInfoIsEntered, customsFormRequired) -> Bool in
+                requiredInfoIsEntered && customsFormRequired
+            }
+            .assign(to: &$customsInformationIsCompleted)
     }
 
     /// Converts the package data to a `ShippingLabelPackageSelected` object.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -72,7 +72,11 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
 
     /// Check for the need of customs form
     ///
-    @Published private(set) var customsFormRequired: Bool = false
+    @Published private var customsFormRequired = false
+
+    var shouldShowCustomsForm: Bool {
+        customsFormRequired && shippingLabel == nil
+    }
 
     @Published var itnMissingNoticeLabel: String?
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -29,11 +29,9 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published private(set) var destinationCountryCode: String?
 
     private var cancellables = Set<AnyCancellable>()
-    private let shipment: Shipment
     private let onCompletion: (ShippingLabelCustomsForm) -> ()
 
     init(order: Order, shipment: Shipment, onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
-        self.shipment = shipment
         self.onCompletion = onCompletion
 
         itemsViewModels = shipment.items.map {
@@ -51,8 +49,9 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published private(set) var itemsViewModels: [WooShippingCustomsItemViewModel] = []
 
     func onDismiss() {
-        let form = ShippingLabelCustomsForm(packageID: shipment.id,
-                                            packageName: shipment.id,
+        /// Ignoring `packageID` and `packageName` as these are not needed in WooShipping plugin, only in WCS&T
+        let form = ShippingLabelCustomsForm(packageID: "",
+                                            packageName: "",
                                             contentsType: contentType.toFormContentsType(),
                                             contentExplanation: contentType == .other ? contentExplanation : "",
                                             restrictionType: restrictionType.toFormRestrictionType(),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -29,13 +29,18 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published private(set) var destinationCountryCode: String?
 
     private var cancellables = Set<AnyCancellable>()
+    private let shipment: Shipment
     private let onCompletion: (ShippingLabelCustomsForm) -> ()
 
-    init(order: Order, onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
+    init(order: Order, shipment: Shipment, onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
+        self.shipment = shipment
         self.onCompletion = onCompletion
 
-        itemsViewModels = order.items.map {
-            WooShippingCustomsItemViewModel(orderItem: $0, currencySymbol: currencySymbol(from: order))
+        itemsViewModels = shipment.items.map {
+            WooShippingCustomsItemViewModel(itemName: $0.name,
+                                            itemProductID: $0.productOrVariationID,
+                                            itemQuantity: $0.quantity,
+                                            currencySymbol: currencySymbol(from: order))
         }
 
         listenToItemsRequiredInformationValues()
@@ -46,9 +51,8 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     @Published var itemsViewModels: [WooShippingCustomsItemViewModel] = []
 
     func onDismiss() {
-        // TODO: Add package Id and name to support multiple shipments, (where each shipment may have its own customs form)
-        let form = ShippingLabelCustomsForm(packageID: "",
-                                            packageName: "",
+        let form = ShippingLabelCustomsForm(packageID: shipment.id,
+                                            packageName: shipment.id,
                                             contentsType: contentType.toFormContentsType(),
                                             contentExplanation: contentType == .other ? contentExplanation : "",
                                             restrictionType: restrictionType.toFormRestrictionType(),
@@ -57,12 +61,12 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                             itn: internationalTransactionNumber.isValidITN ? internationalTransactionNumber : "",
                                             items: itemsViewModels.map {
             ShippingLabelCustomsForm.Item(description: $0.description,
-                                          quantity: $0.orderItem.quantity,
+                                          quantity: $0.itemQuantity,
                                           value: Double($0.valuePerUnit) ?? 0,
                                           weight: Double($0.weightPerUnit) ?? 0,
                                           hsTariffNumber: $0.isValidTariffNumber ? $0.hsTariffNumber : "",
                                           originCountry: $0.selectedCountry?.code ?? "",
-                                          productID: $0.orderItem.productID)
+                                          productID: $0.itemProductID)
             }
         )
         onCompletion(form)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -48,7 +48,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
         listenForInternationalTransactionNumberIsRequired()
     }
 
-    @Published var itemsViewModels: [WooShippingCustomsItemViewModel] = []
+    @Published private(set) var itemsViewModels: [WooShippingCustomsItemViewModel] = []
 
     func onDismiss() {
         let form = ShippingLabelCustomsForm(packageID: shipment.id,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -16,7 +16,9 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     private let stores: StoresManager
     private let siteID: Int64
     let currencySymbol: String
-    let orderItem: OrderItem
+
+    let itemProductID: Int64
+    let itemQuantity: Decimal
 
     let hsTariffURL = WooConstants.URLs.hsTariffURL.asURL()
 
@@ -36,7 +38,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
               let valuePerUnitDecimal = Decimal(string: valuePerUnit) else {
             return 0
         }
-        return valuePerUnitDecimal * orderItem.quantity
+        return valuePerUnitDecimal * itemQuantity
     }
 
     /// View model for selecting a country from a list.
@@ -66,12 +68,15 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(orderItem: OrderItem,
+    init(itemName: String,
+         itemProductID: Int64,
+         itemQuantity: Decimal,
          currencySymbol: String,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores) {
-        self.title = orderItem.name
-        self.orderItem = orderItem
+        self.title = itemName
+        self.itemProductID = itemProductID
+        self.itemQuantity = itemQuantity
         self.currencySymbol = currencySymbol
         self.storageManager = storageManager
         self.stores = stores
@@ -120,7 +125,7 @@ private extension WooShippingCustomsItemViewModel {
                     return
                 }
 
-                self.hsTariffNumberTotalValue = (hsTariffNumber, valuePerUnitDecimal * orderItem.quantity)
+                self.hsTariffNumberTotalValue = (hsTariffNumber, valuePerUnitDecimal * itemQuantity)
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -4,7 +4,10 @@ struct WooShippingPostPurchaseView: View {
     @ObservedObject private(set) var viewModel: WooShippingPostPurchaseViewModel
 
     @State private var isPrintingLabel = false
-    @State private var showingPrintingError = false
+    @State private var showingLabelPrintingError = false
+
+    @State private var isPrintingCustomsForm = false
+    @State private var showingCustomsFormPrintingError = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -83,6 +86,24 @@ struct WooShippingPostPurchaseView: View {
                             }
                         }
                     }
+                    if let commercialInvoiceURL = viewModel.commercialInvoiceURL {
+                        Button {
+                            Task {
+                                await printCustomsForm(with: commercialInvoiceURL)
+                            }
+                        } label: {
+                            HStack {
+                                Text(Localization.printCustomsFormButton)
+                                    .multilineTextAlignment(.leading)
+                                if isPrintingCustomsForm {
+                                    ProgressView()
+                                        .progressViewStyle(.circular)
+                                } else {
+                                    Image(systemName: "arrow.up.right.square")
+                                }
+                            }
+                        }
+                    }
                     Button {
                         // TODO: Request label refund
                     } label: {
@@ -104,19 +125,33 @@ struct WooShippingPostPurchaseView: View {
                 .footnoteStyle()
         }
         .padding(.vertical)
-        .alert(Localization.PrintingLabelError.title, isPresented: $showingPrintingError, actions: {
+        .alert(Localization.PrintingError.shippingLabel, isPresented: $showingLabelPrintingError, actions: {
             Button(role: .cancel) {} label: {
-                Text(Localization.PrintingLabelError.cancel)
+                Text(Localization.PrintingError.cancel)
             }
             Button {
                 Task { @MainActor in
                     await printLabel()
                 }
             } label: {
-                Text(Localization.PrintingLabelError.retry)
+                Text(Localization.PrintingError.retry)
             }
         }, message: {
-            Text(Localization.PrintingLabelError.message)
+            Text(Localization.PrintingError.message)
+        })
+        .alert(Localization.PrintingError.customsForm, isPresented: $showingCustomsFormPrintingError, actions: {
+            Button(role: .cancel) {} label: {
+                Text(Localization.PrintingError.cancel)
+            }
+            Button {
+                Task { @MainActor in
+                    await printCustomsForm(with: viewModel.commercialInvoiceURL!)
+                }
+            } label: {
+                Text(Localization.PrintingError.retry)
+            }
+        }, message: {
+            Text(Localization.PrintingError.message)
         })
     }
 }
@@ -127,10 +162,21 @@ private extension WooShippingPostPurchaseView {
         do {
             try await viewModel.printLabel()
         } catch {
-            showingPrintingError = true
+            showingLabelPrintingError = true
             DDLogError("Error generating shipping label document for printing: \(error)")
         }
         isPrintingLabel = false
+    }
+
+    func printCustomsForm(with url: URL) async {
+        isPrintingCustomsForm = true
+        do {
+            try await viewModel.printCustomsForm(with: url)
+        } catch {
+            showingCustomsFormPrintingError = true
+            DDLogError("Error downloading customs form for printing: \(error)")
+        }
+        isPrintingCustomsForm = false
     }
 }
 
@@ -172,27 +218,37 @@ private extension WooShippingPostPurchaseView {
         static let note = NSLocalizedString("wooShipping.createLabels.postPurchase.note",
                                             value: "Note: Reusing a printed label is a violation of our terms of service and may result in criminal charges.",
                                             comment: "Note about reusing a purchased shipping label on the shipping label screen")
-        enum PrintingLabelError {
-            static let title = NSLocalizedString(
-                "wooShipping.createLabels.postPurchase.printingLabelError.title",
+        static let printCustomsFormButton = NSLocalizedString(
+            "wooShipping.createLabels.postPurchase.printCustomsFormButton",
+            value: "Print customs form",
+            comment: "Title for button to print a customs form on the shipping label screen"
+        )
+        enum PrintingError {
+            static let shippingLabel = NSLocalizedString(
+                "wooShipping.createLabels.postPurchase.printingError.shippingLabel",
                 value: "Error previewing shipping label",
                 comment: "Title of the error alert when printing a shipping label fails in the post purchase flow."
             )
+            static let customsForm = NSLocalizedString(
+                "wooShipping.createLabels.postPurchase.printingError.customsForm",
+                value: "Error downloading customs form",
+                comment: "Title of the error alert when printing a customs form fails in the post purchase flow."
+            )
             static let message = NSLocalizedString(
-                "wooShipping.createLabels.postPurchase.printingLabelError.message",
+                "wooShipping.createLabels.postPurchase.printingError.message",
                 value: "Do you want to try again?",
-                comment: "Message of the error alert when printing a shipping label fails in the post purchase flow."
+                comment: "Message of the error alert when printing a document fails in the post purchase flow."
             )
             static let cancel = NSLocalizedString(
-                "wooShipping.createLabels.postPurchase.printingLabelError.cancel",
+                "wooShipping.createLabels.postPurchase.printingError.cancel",
                 value: "Cancel",
-                comment: "Button on the error alert when printing a shipping label fails in the post purchase flow." +
+                comment: "Button on the error alert when printing a document fails in the post purchase flow." +
                 "Tapping on this button would cancel the printing."
             )
             static let retry = NSLocalizedString(
-                "wooShipping.createLabels.postPurchase.printingLabelError.retry",
+                "wooShipping.createLabels.postPurchase.printingError.retry",
                 value: "Retry",
-                comment: "Button on the error alert when printing a shipping label fails in the post purchase flow." +
+                comment: "Button on the error alert when printing a document fails in the post purchase flow." +
                 "Tapping on this button would retry printing the shipping label."
             )
         }
@@ -204,7 +260,8 @@ private extension WooShippingPostPurchaseView {
                                                                             labelID: 1,
                                                                             labelSizes: [.label, .legal, .a4],
                                                                             trackingURL: URL(string: "https://woocommerce.com"),
-                                                                            pickupURL: WooShippingCarrier.usps.pickupURL))
+                                                                            pickupURL: WooShippingCarrier.usps.pickupURL,
+                                                                            commercialInvoiceURL: URL(string: "https://example.com")))
         .padding()
 }
 
@@ -213,6 +270,7 @@ private extension WooShippingPostPurchaseView {
                                                                             labelID: 1,
                                                                             labelSizes: [.label, .legal, .a4],
                                                                             trackingURL: nil,
-                                                                            pickupURL: nil))
+                                                                            pickupURL: nil,
+                                                                            commercialInvoiceURL: nil))
         .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -88,7 +88,7 @@ struct WooShippingPostPurchaseView: View {
                     }
                     if let commercialInvoiceURL = viewModel.commercialInvoiceURL {
                         Button {
-                            Task {
+                            Task { @MainActor in
                                 await printCustomsForm(with: commercialInvoiceURL)
                             }
                         } label: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -143,12 +143,14 @@ struct WooShippingPostPurchaseView: View {
             Button(role: .cancel) {} label: {
                 Text(Localization.PrintingError.cancel)
             }
-            Button {
-                Task { @MainActor in
-                    await printCustomsForm(with: viewModel.commercialInvoiceURL!)
+            if let url = viewModel.commercialInvoiceURL {
+                Button {
+                    Task { @MainActor in
+                        await printCustomsForm(with: url)
+                    }
+                } label: {
+                    Text(Localization.PrintingError.retry)
                 }
-            } label: {
-                Text(Localization.PrintingError.retry)
             }
         }, message: {
             Text(Localization.PrintingError.message)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -75,11 +75,7 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
 
     @MainActor
     func printCustomsForm(with url: URL) async throws {
-        let (data, response) = try await URLSession.shared.data(from: url)
-        if let httpResponse = response as? HTTPURLResponse,
-           httpResponse.statusCode != 200 {
-            throw URLError(.badServerResponse)
-        }
+        let (data, _) = try await URLSession.shared.data(from: url)
         presentPrintDialog(with: data)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -18,17 +18,22 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
     /// Shipment pickup URL for the shipping label.
     let pickupURL: URL?
 
+    /// Customs form URL for the shipping label
+    let commercialInvoiceURL: URL?
+
     init(siteID: Int64,
          labelID: Int64,
          labelSizes: [ShippingLabelPaperSize],
          trackingURL: URL?,
          pickupURL: URL?,
+         commercialInvoiceURL: URL?,
          stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.labelID = labelID
         self.labelSizes = labelSizes
         self.trackingURL = trackingURL
         self.pickupURL = pickupURL
+        self.commercialInvoiceURL = commercialInvoiceURL
         self.stores = stores
     }
 
@@ -45,12 +50,19 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
         }()
         let trackingURL = ShippingLabelTrackingURLGenerator.url(for: shippingLabel)
         let pickupURL = WooShippingCarrier(rawValue: shippingLabel.carrierID)?.pickupURL
+        let commercialInvoiceURL: URL? = {
+            guard let urlString = shippingLabel.commercialInvoiceURL else {
+                return nil
+            }
+            return URL(string: urlString)
+        }()
 
         self.init(siteID: shippingLabel.siteID,
                   labelID: shippingLabel.shippingLabelID,
                   labelSizes: labelSizes,
                   trackingURL: trackingURL,
                   pickupURL: pickupURL,
+                  commercialInvoiceURL: commercialInvoiceURL,
                   stores: stores)
     }
 
@@ -58,7 +70,17 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
     @MainActor
     func printLabel() async throws {
         let printData = try await requestPrintData()
-        presentPrintDialog(with: printData)
+        presentPrintDialog(with: printData.data)
+    }
+
+    @MainActor
+    func printCustomsForm(with url: URL) async throws {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode != 200 {
+            throw URLError(.badServerResponse)
+        }
+        presentPrintDialog(with: data)
     }
 }
 
@@ -75,9 +97,9 @@ private extension WooShippingPostPurchaseViewModel {
     }
 
     /// Presents the print dialog with the provided print data.
-    func presentPrintDialog(with printData: ShippingLabelPrintData) {
+    func presentPrintDialog(with data: Data?) {
         let printController = UIPrintInteractionController()
-        printController.printingItem = printData.data
+        printController.printingItem = data
         printController.present(animated: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -2,13 +2,15 @@ import XCTest
 import Yosemite
 @testable import WooCommerce
 
-class WooShippingCustomsFormViewModelTests: XCTestCase {
+final class WooShippingCustomsFormViewModelTests: XCTestCase {
     private var viewModel: WooShippingCustomsFormViewModel!
 
     override func setUp() {
         super.setUp()
 
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
     }
 
     override func tearDown() {
@@ -19,10 +21,11 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_onDismiss_calls_onCompletion_with_right_values() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
+        let shipment = sampleShipment
         var passedForm: ShippingLabelCustomsForm?
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { form in
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: shipment,
+                                                    onCompletion: { form in
             passedForm = form
         })
 
@@ -49,9 +52,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
         XCTAssertEqual(passedForm?.itn, viewModel.internationalTransactionNumber)
         XCTAssertEqual(passedForm?.nonDeliveryOption, .abandon)
 
-        XCTAssertEqual(passedForm?.items.count, orderItems.count)
-        XCTAssertEqual(passedForm?.items.first?.productID, orderItems.first?.productID)
-        XCTAssertEqual(passedForm?.items.first?.quantity, orderItems.first?.quantity)
+        XCTAssertEqual(passedForm?.items.count, shipment.items.count)
+        XCTAssertEqual(passedForm?.items.first?.productID, shipment.items.first?.productOrVariationID)
+        XCTAssertEqual(passedForm?.items.first?.quantity, shipment.items.first?.quantity)
         XCTAssertEqual(passedForm?.items.first?.description, viewModel.itemsViewModels.first?.description)
         XCTAssertEqual(passedForm?.items.first?.value, Double(viewModel.itemsViewModels.first?.valuePerUnit ?? "0"))
         XCTAssertEqual(passedForm?.items.first?.weight, Double(viewModel.itemsViewModels.first?.weightPerUnit ?? "0"))
@@ -60,10 +63,10 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_onDismiss_when_calls_onCompletion_with_invalid_hsTariffNumber_then_returns_empty() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
         var passedForm: ShippingLabelCustomsForm?
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { form in
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { form in
             passedForm = form
         })
 
@@ -78,10 +81,10 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_onDismiss_when_calls_onCompletion_with_content_and_restriction_not_other_then_returns_empty() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
         var passedForm: ShippingLabelCustomsForm?
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { form in
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { form in
             passedForm = form
         })
 
@@ -103,10 +106,10 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_onDismiss_when_calls_onCompletion_with_invalid_itn_then_returns_empty() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
         var passedForm: ShippingLabelCustomsForm?
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { form in
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { form in
             passedForm = form
         })
 
@@ -121,10 +124,10 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_init_passes_right_currency() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
-        // When
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(currency: "USD", items: orderItems), onCompletion: { _ in })
+        let order = Order.fake().copy(currency: "USD")
+        viewModel = WooShippingCustomsFormViewModel(order: order,
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.itemsViewModels.first?.currencySymbol, "$")
@@ -148,8 +151,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_itnValidationError_when_item_view_models_hsTariffNumberTotalValue_is_nil() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(currency: "USD", currencySymbol: "$", items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(currency: "USD"),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.itemsViewModels.forEach { item in
@@ -170,9 +174,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_itnValidationError_when_item_view_models_hsTariffNumberTotalValue_is_less_than_2500() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.itemsViewModels.first?.hsTariffNumberTotalValue = ("123456", 1000)
@@ -183,9 +187,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_itnValidationError_when_item_view_models_hsTariffNumberTotalValue_is_more_than_2500() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.itemsViewModels[0].requiredInformationIsEntered = true
@@ -210,8 +214,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
     func test_itnValidationError_when_destination_country_requires_ITN() {
         // Given
         let requiredDestinations = ["IR", "SY", "KP", "CU", "SD"]
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2)]
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
         viewModel.itemsViewModels.forEach { item in
             item.hsTariffNumber = ""
             item.valuePerUnit = "1000"
@@ -234,9 +239,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_requiredInformationIsEntered_when_itn_is_required_but_invalid_then_returns_false() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
@@ -248,13 +253,13 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_requiredInformationIsEntered_when_itn_is_required_and_valid_then_returns_true() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem()]
-
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.internationalTransactionNumber = "NOEEI 30.37(a)"
-        viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
+        viewModel.itemsViewModels.forEach { $0.requiredInformationIsEntered = true }
 
         // Then
         XCTAssertTrue(viewModel.requiredInformationIsEntered)
@@ -262,9 +267,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_requiredInformationIsEntered_when_content_type_is_other_but_details_are_empty_then_returns_false() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
@@ -278,9 +283,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_requiredInformationIsEntered_when_restriction_type_is_other_but_details_are_empty_then_returns_false() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
@@ -294,9 +299,9 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_requiredInformationIsEntered_when_required_data_is_entered_then_returns_true() {
         // Given
-        let orderItems = [MockOrderItem.sampleItem(productID: 123, quantity: 2), MockOrderItem.sampleItem()]
-
-        viewModel = WooShippingCustomsFormViewModel(order: Order.fake().copy(items: orderItems), onCompletion: { _ in })
+        viewModel = WooShippingCustomsFormViewModel(order: Order.fake(),
+                                                    shipment: sampleShipment,
+                                                    onCompletion: { _ in })
 
         // When
         viewModel.itemsViewModels.first?.requiredInformationIsEntered = true
@@ -309,5 +314,33 @@ class WooShippingCustomsFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.requiredInformationIsEntered)
+    }
+}
+
+private extension WooShippingCustomsFormViewModelTests {
+    var sampleShipment: Shipment {
+        let item1 = ShippingLabelPackageItem(productOrVariationID: 1,
+                                             orderItemID: 123,
+                                             name: "Shirt",
+                                             weight: 0.5,
+                                             quantity: 2,
+                                             value: 9.99,
+                                             dimensions: ProductDimensions.fake(),
+                                             attributes: [],
+                                             imageURL: nil)
+        let item2 = ShippingLabelPackageItem(productOrVariationID: 2,
+                                             orderItemID: 55,
+                                             name: "Pants",
+                                             weight: 0.5,
+                                             quantity: 1,
+                                             value: 11,
+                                             dimensions: ProductDimensions.fake(),
+                                             attributes: [],
+                                             imageURL: nil)
+        return Shipment(contents: [CollapsibleShipmentItemCardViewModel(item: item1, currency: "USD"),
+                                   CollapsibleShipmentItemCardViewModel(item: item2, currency: "USD")],
+                        currency: "USD",
+                        currencySettings: ServiceLocator.currencySettings,
+                        shippingSettingsService: ServiceLocator.shippingSettingsService)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -1,12 +1,15 @@
 import XCTest
 @testable import WooCommerce
 
-class WooShippingCustomsItemViewModelTests: XCTestCase {
+final class WooShippingCustomsItemViewModelTests: XCTestCase {
     private var viewModel: WooShippingCustomsItemViewModel!
 
     override func setUp() {
         super.setUp()
-        viewModel = WooShippingCustomsItemViewModel(orderItem: MockOrderItem.sampleItem(), currencySymbol: "$")
+        viewModel = WooShippingCustomsItemViewModel(itemName: "Test",
+                                                    itemProductID: 22,
+                                                    itemQuantity: 1,
+                                                    currencySymbol: "$")
     }
 
     func test_when_tariff_number_is_empty_then_it_is_valid() {
@@ -45,9 +48,11 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
     }
 
     func test_hsTariffNumberTotalValue_when_currency_symbol_is_not_$_returns_nil() {
-        // When
-        let orderItem = MockOrderItem.sampleItem(quantity: 2)
-        viewModel = WooShippingCustomsItemViewModel(orderItem: orderItem, currencySymbol: "$")
+        // Given
+        viewModel = WooShippingCustomsItemViewModel(itemName: "Test",
+                                                    itemProductID: 22,
+                                                    itemQuantity: 1,
+                                                    currencySymbol: "$")
 
         // Then
         XCTAssertNil(viewModel.hsTariffNumberTotalValue)
@@ -55,9 +60,13 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
     }
 
     func test_hsTariffNumberTotalValue_when_currency_symbol_is_$_but_hsTariffNumber_is_empty_returns_nil() {
+        //Given
+        viewModel = WooShippingCustomsItemViewModel(itemName: "Test",
+                                                    itemProductID: 22,
+                                                    itemQuantity: 1,
+                                                    currencySymbol: "$")
+
         // When
-        let orderItem = MockOrderItem.sampleItem(quantity: 2)
-        viewModel = WooShippingCustomsItemViewModel(orderItem: orderItem, currencySymbol: "$")
         viewModel.valuePerUnit = "1000"
         viewModel.hsTariffNumber = ""
 
@@ -67,9 +76,11 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
     }
 
     func test_hsTariffNumberTotalValue_when_currency_symbol_is_$_but_invalid_hs_tariff_number_returns_nil() {
-        // When
-        let orderItem = MockOrderItem.sampleItem(quantity: 2)
-        viewModel = WooShippingCustomsItemViewModel(orderItem: orderItem, currencySymbol: "$")
+        // Given
+        viewModel = WooShippingCustomsItemViewModel(itemName: "Test",
+                                                    itemProductID: 22,
+                                                    itemQuantity: 1,
+                                                    currencySymbol: "$")
         viewModel.hsTariffNumber = "123"
         viewModel.valuePerUnit = "1000"
 
@@ -79,14 +90,16 @@ class WooShippingCustomsItemViewModelTests: XCTestCase {
     }
 
     func test_hsTariffNumberTotalValue_when_currency_symbol_is_$_and_value_is_more_than_2500_and_valid_hs_tariff_number_returns_values() {
-        // When
-        let orderItem = MockOrderItem.sampleItem(quantity: 2)
-        viewModel = WooShippingCustomsItemViewModel(orderItem: orderItem, currencySymbol: "$")
+        // Given
+        viewModel = WooShippingCustomsItemViewModel(itemName: "Test",
+                                                    itemProductID: 22,
+                                                    itemQuantity: 2,
+                                                    currencySymbol: "$")
         viewModel.valuePerUnit = "3000"
         viewModel.hsTariffNumber = "123456"
 
         // Then
         XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.0, viewModel.hsTariffNumber)
-        XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.1, Decimal(string: viewModel.valuePerUnit)! * orderItem.quantity)
+        XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.1, Decimal(string: viewModel.valuePerUnit)! * 2)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
@@ -9,14 +9,21 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
         let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .a4]
         let trackingURL = URL(string: "https://woocommerce.com")
         let pickupURL = WooShippingCarrier.usps.pickupURL
+        let customsFormURL = URL(string: "https://example.com")
 
         // When
-        let viewModel = WooShippingPostPurchaseViewModel(siteID: 123, labelID: 1, labelSizes: labelSizes, trackingURL: trackingURL, pickupURL: pickupURL)
+        let viewModel = WooShippingPostPurchaseViewModel(siteID: 123,
+                                                         labelID: 1,
+                                                         labelSizes: labelSizes,
+                                                         trackingURL: trackingURL,
+                                                         pickupURL: pickupURL,
+                                                         commercialInvoiceURL: customsFormURL)
 
         // Then
         XCTAssertEqual(viewModel.labelSizes, labelSizes)
         XCTAssertEqual(viewModel.trackingURL, trackingURL)
         XCTAssertEqual(viewModel.pickupURL, pickupURL)
+        XCTAssertEqual(viewModel.commercialInvoiceURL, customsFormURL)
     }
 
     func test_labelSizes_includes_expected_default_values() {
@@ -66,6 +73,18 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.pickupURL, WooShippingCarrier.usps.pickupURL)
+    }
+
+    func test_commercialInvoiceURL_parsed_from_shipping_label() {
+        // Given
+        let customsFormURL = "https://example.com"
+        let shippingLabel = ShippingLabel.fake().copy(commercialInvoiceURL: customsFormURL)
+
+        // When
+        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
+
+        // Then
+        XCTAssertEqual(viewModel.commercialInvoiceURL, URL(string: customsFormURL))
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -368,7 +368,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_shouldShowCustomsForm_when_shipping_label_is_purchased_then_returns_false() {
         // Given
-        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "GB", state: "LD"))
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -302,7 +302,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.totalCost, "$40.06")
     }
 
-    func test_customsFormRequired_when_origin_and_destination_in_US_then_returns_false() {
+    func test_shouldShowCustomsForm_when_origin_and_destination_in_US_then_returns_false() {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
@@ -315,10 +315,10 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                             destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
 
         // Then
-        XCTAssertFalse(viewModel.customsFormRequired)
+        XCTAssertFalse(viewModel.shouldShowCustomsForm)
     }
 
-    func test_customsFormRequired_when_origin_address_is_US_military_then_returns_true() {
+    func test_shouldShowCustomsForm_when_origin_address_is_US_military_then_returns_true() {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "AA"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
@@ -331,10 +331,10 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                             destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
 
         // Then
-        XCTAssertTrue(viewModel.customsFormRequired)
+        XCTAssertTrue(viewModel.shouldShowCustomsForm)
     }
 
-    func test_customsFormRequired_when_destination_address_is_US_military_then_returns_true() {
+    func test_shouldShowCustomsForm_when_destination_address_is_US_military_then_returns_true() {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "AA"))
@@ -347,10 +347,10 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                             destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
 
         // Then
-        XCTAssertTrue(viewModel.customsFormRequired)
+        XCTAssertTrue(viewModel.shouldShowCustomsForm)
     }
 
-    func test_customsFormRequired_when_destination_address_is_not_in_US_then_returns_true() {
+    func test_shouldShowCustomsForm_when_destination_address_is_not_in_US_then_returns_true() {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "GB", state: "LD"))
@@ -363,7 +363,23 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                             destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
 
         // Then
-        XCTAssertTrue(viewModel.customsFormRequired)
+        XCTAssertTrue(viewModel.shouldShowCustomsForm)
+    }
+
+    func test_shouldShowCustomsForm_when_shipping_label_is_purchased_then_returns_false() {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "GB", state: "LD"))
+
+        // When
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: ShippingLabel.fake(),
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowCustomsForm)
     }
 
     func test_itnMissingNoticeLabel_when_customs_form_is_not_required() {
@@ -406,16 +422,6 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
     func test_customsInformationIsCompleted_when_custom_form_is_filled() {
         // Given
-        let form = ShippingLabelCustomsForm(packageID: "",
-                                            packageName: "",
-                                            contentsType: .documents,
-                                            contentExplanation: "",
-                                            restrictionType: .quarantine,
-                                            restrictionComments: "",
-                                            nonDeliveryOption: .abandon,
-                                            itn: "",
-                                            items: [])
-
         let originAddressSubject = CurrentValueSubject<WooShippingOriginAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "GB", state: "LD"))
 
@@ -425,7 +431,9 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                             shippingLabel: nil,
                                                             originAddress: originAddressSubject.eraseToAnyPublisher(),
                                                             destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
-        viewModel.onCustomsFormFilled(form: form)
+        viewModel.customsFormViewModel.itemsViewModels.first?.requiredInformationIsEntered = true
+        viewModel.customsFormViewModel.contentType = .documents
+        viewModel.customsFormViewModel.restrictionType = .quarantine
 
         // Then
         XCTAssertTrue(viewModel.customsInformationIsCompleted)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-336
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates customs form to support multiple shipments. Changes include:
- Update customs form to display only items in the related shipment.
- Hide customs form after purchasing a label
- Add entry point to print customs form for a purchased label.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a completed order with several phsical products.
3. Select Create shipping label > Split shipment > move items to different shipment > tap Done.
4. Update the origin country to an address in the US and destination to another country to enable customs form.
5. Select the customs form row and confirm that the form includes only items in the shipment.
6. Enter required details and tap Done. Confirm that the customs form is then marked as complete.
7. Proceed to purchase a label by selecting a package and shipping rate.
8. After purchasing, confirm that the customs form is hidden from the shipping label form.
9. Confirm that there's an entry point to print customs form on the purchased label details view.
10. Tap on the button and confirm that a print view is presented with the correct form.
11. Disable the internet connection and try printing the customs form again. Confirm that an error alert is displayed with the option to retry printing.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Manually tested the flow following the steps above and confirmed everything works on simulator iPhone 16 Pro iOS 18.2.
- Added unit tests to verify changes on the `WooShippingPostPurchaseViewModel`.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/78e105e7-ca03-45e4-a204-b3572cdf7a48

Error alert:


https://github.com/user-attachments/assets/41fa01b2-b94f-4aa7-869a-7932a61d996c


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
