### PR TITLE
Shipping Labels: Update integration with delete package endpoint

### DIFF
--- a/Networking/Networking/Remote/WooShippingRemote.swift
+++ b/Networking/Networking/Remote/WooShippingRemote.swift
@@ -1,3 +1,10 @@
+/// Enum for package types supported by WooShipping
+///
+public enum WooShippingPackageType: String {
+    case custom
+    case predefined
+}
+
 /// Protocol for `WooShippingRemote` mainly used for mocking.
 ///
 public protocol WooShippingRemoteProtocol {
@@ -7,6 +14,7 @@ public protocol WooShippingRemoteProtocol {
                        completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void)
     func deletePackage(siteID: Int64,
                        packageID: String,
+                       packageType: WooShippingPackageType,
                        completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void)
     func loadLabelRates(siteID: Int64,
                         orderID: Int64,
@@ -107,8 +115,9 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
 
     public func deletePackage(siteID: Int64,
                               packageID: String,
+                              packageType: WooShippingPackageType,
                               completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void) {
-        let path = "\(Path.packages)/\(packageID)"
+        let path = [Path.packages, packageType.rawValue, packageID].joined(separator: "/")
 
         let request = JetpackRequest(wooApiVersion: .wooShipping,
                                      method: .delete,

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -90,12 +90,13 @@ final class WooShippingRemoteTests: XCTestCase {
         // Given
         let remote = WooShippingRemote(network: network)
         let package = WooShippingCustomPackage.fake()
-        network.simulateResponse(requestUrlSuffix: "packages/\(package.id)", filename: "wooshipping-delete-package-success")
+        network.simulateResponse(requestUrlSuffix: "packages/custom/\(package.id)", filename: "wooshipping-delete-package-success")
 
         // When
         let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             remote.deletePackage(siteID: self.sampleSiteID,
-                                 packageID: package.id) { result in
+                                 packageID: package.id,
+                                 packageType: .custom) { result in
                 promise(result)
             }
         }
@@ -110,12 +111,13 @@ final class WooShippingRemoteTests: XCTestCase {
         // Given
         let remote = WooShippingRemote(network: network)
         let package = WooShippingCustomPackage.fake()
-        network.simulateResponse(requestUrlSuffix: "packages/\(package.id)", filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "packages/custom/\(package.id)", filename: "generic_error")
 
         // When
         let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             remote.deletePackage(siteID: self.sampleSiteID,
-                                 packageID: package.id) { result in
+                                 packageID: package.id,
+                                 packageType: .custom) { result in
                 promise(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -19,6 +19,13 @@ enum WooShippingPackageSource {
         }
         return sourceID
     }
+
+    var isCustomPackage: Bool {
+        switch self {
+        case .custom: true
+        case .predefined: false
+        }
+    }
 }
 
 protocol WooShippingPackageDataRepresentable {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -262,7 +262,9 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         }
 
         // delete on backend
-        let deleteAction = WooShippingAction.deletePackage(siteID: siteID, packageID: packageToRemove.id) { result in
+        let deleteAction = WooShippingAction.deletePackage(siteID: siteID,
+                                                           packageID: packageToRemove.id,
+                                                           packageType: .custom) { result in
             if case .failure(let error) = result {
                 DDLogError("⛔️ Error removing saved Woo Shipping package: \(error)")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -264,7 +264,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         // delete on backend
         let deleteAction = WooShippingAction.deletePackage(siteID: siteID,
                                                            packageID: packageToRemove.id,
-                                                           packageType: .custom) { result in
+                                                           packageType: packageToRemove.source.isCustomPackage ? .custom : .predefined) { result in
             if case .failure(let error) = result {
                 DDLogError("⛔️ Error removing saved Woo Shipping package: \(error)")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -215,7 +215,22 @@ final class WooShippingAddPackageViewModel: ObservableObject {
             _ = withAnimation(starAnimation) {
                 starredCarriersPackages.remove(packageID)
             }
-            // TODO: use delete action when it is ready (https://github.com/woocommerce/woocommerce-ios/issues/14679)
+            let action = WooShippingAction.deletePackage(siteID: siteID,
+                                                         packageID: packageID,
+                                                         packageType: .predefined,
+                                                         completion: { [weak self] result in
+                if case .failure(let error) = result {
+                    DDLogError("⛔️ Error saving Woo Shipping package: \(error)")
+                    self?.starredCarriersPackages.insert(packageID)
+                    self?.notice = Notice(title: Localization.removingPackageFailure,
+                                          feedbackType: .error,
+                                          actionTitle: Localization.retry,
+                                          actionHandler: {
+                        self?.starUnstarPackage(packageID, carrierID: carrierID)
+                    })
+                }
+            })
+            stores.dispatch(action)
         }
         else {
             _ = withAnimation(starAnimation) {
@@ -229,7 +244,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
                     self?.starredCarriersPackages.remove(packageID)
                     self?.notice = Notice(title: Localization.savingPackageFailure,
                                           feedbackType: .error,
-                                          actionTitle: Localization.savingPackageRetry,
+                                          actionTitle: Localization.retry,
                                           actionHandler: {
                         self?.starUnstarPackage(packageID, carrierID: carrierID)
                     })
@@ -240,7 +255,6 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     }
 
     // delete saved packages
-    @MainActor
     func removeSavedPackage(_ packageToRemove: WooShippingPackageDataRepresentable) {
         // delete the package locally and on backend
 
@@ -257,30 +271,38 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 
         let removedStarredCarrierID = starredCarriersPackages.remove(packageToRemove.id)
 
-        if self.selectedSavedPackageId == packageToRemove.id {
-            self.selectedSavedPackageId = nil
+        if selectedSavedPackageId == packageToRemove.id {
+            selectedSavedPackageId = nil
         }
 
         // delete on backend
         let deleteAction = WooShippingAction.deletePackage(siteID: siteID,
                                                            packageID: packageToRemove.id,
-                                                           packageType: packageToRemove.source.isCustomPackage ? .custom : .predefined) { result in
+                                                           packageType: packageToRemove.source.isCustomPackage ? .custom : .predefined) { [weak self] result in
+            guard let self else { return }
             if case .failure(let error) = result {
                 DDLogError("⛔️ Error removing saved Woo Shipping package: \(error)")
 
                 // undo removing of the package
                 // first: undo starring
                 if let carrierID = removedStarredCarrierID {
-                    self.starredCarriersPackages.insert(carrierID)
+                    starredCarriersPackages.insert(carrierID)
                 }
                 // second: undo removing from custom saved
                 if let customPackagesIndex {
-                    self.customSavedPackages.insert(packageToRemove, at: customPackagesIndex)
+                    customSavedPackages.insert(packageToRemove, at: customPackagesIndex)
                 }
                 // third: undo removing from predefined saved
                 if let predefinedPackagesIndex {
-                    self.predefinedSavedPackages.insert(packageToRemove, at: predefinedPackagesIndex)
+                    predefinedSavedPackages.insert(packageToRemove, at: predefinedPackagesIndex)
                 }
+
+                notice = Notice(title: Localization.removingPackageFailure,
+                                      feedbackType: .error,
+                                      actionTitle: Localization.retry,
+                                      actionHandler: { [weak self] in
+                    self?.removeSavedPackage(packageToRemove)
+                })
             }
         }
 
@@ -290,15 +312,20 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 
 extension WooShippingAddPackageViewModel {
     enum Localization {
+        static let removingPackageFailure = NSLocalizedString(
+            "wooShippingAddPackageViewModel.removingPackageFailure",
+            value: "Unable to remove package",
+            comment: "Message on a notice when removing a package fails in the shipping creation flow"
+        )
         static let savingPackageFailure = NSLocalizedString(
             "wooShippingAddPackageViewModel.savingPackageFailure",
             value: "Unable to save package",
             comment: "Message on a notice when saving a package fails in the shipping creation flow"
         )
-        static let savingPackageRetry = NSLocalizedString(
-            "wooShippingAddPackageViewModel.savingPackageRetry",
+        static let retry = NSLocalizedString(
+            "wooShippingAddPackageViewModel.retry",
             value: "Retry",
-            comment: "Button to retry saving a package fails in the shipping creation flow"
+            comment: "Button to retry saving/removing a package in the shipping creation flow"
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -152,7 +152,7 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
 
         mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
-            case let .deletePackage(receivedSiteID, packageID, completion):
+            case let .deletePackage(receivedSiteID, packageID, _, completion):
                 XCTAssertEqual(receivedSiteID, siteID)
                 XCTAssert(packageID == customPackage.id || packageID == predefinedSavedPackage.id)
                 completion(.success(.fake()))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import TestKit
 @testable import WooCommerce
 import Yosemite
+import enum Networking.WooShippingPackageType
 
 final class WooShippingAddPackageViewModelTests: XCTestCase {
     @MainActor
@@ -53,7 +54,7 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.starredCarriersPackages.count, 0)
     }
 
-    func test_starUnstarPackage_creates_notice_when_fails() {
+    func test_staring_package_creates_notice_when_fails() {
         // Given
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
@@ -61,6 +62,8 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
             switch action {
             case let .createPackage(_, _, _, completion):
                 completion(.failure(.duplicateCustomPackageNames))
+            case .deletePackage:
+                XCTFail("Delete package should not be triggered!")
             default:
                 break
             }
@@ -71,6 +74,72 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
 
         // When
         viewModel.starUnstarPackage("1", carrierID: "usps")
+
+        // Then
+        waitUntil {
+            viewModel.notice != nil
+        }
+        XCTAssertEqual(viewModel.notice?.feedbackType, .error)
+    }
+
+    func test_unstaring_package_triggers_removing_package_correctly() {
+        // Given
+        let testSiteID: Int64 = 1234
+        let testPackageID = "1"
+
+        var triggeredSiteID: Int64?
+        var triggeredPackageID: String?
+        var triggeredPackageType: Networking.WooShippingPackageType?
+
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .createPackage:
+                XCTFail("Create package should not be triggered!")
+            case let .deletePackage(siteID, packageID, packageType, completion):
+                triggeredSiteID = siteID
+                triggeredPackageID = packageID
+                triggeredPackageType = packageType
+                completion(.success(.fake()))
+            default:
+                break
+            }
+        }
+        let viewModel = WooShippingAddPackageViewModel(siteID: testSiteID,
+                                                       stores: mockStores)
+        viewModel.starredCarriersPackages.insert(testPackageID)
+
+        // When
+        viewModel.starUnstarPackage(testPackageID, carrierID: "usps")
+
+        // Then
+        XCTAssertEqual(triggeredSiteID, testSiteID)
+        XCTAssertEqual(triggeredPackageID, testPackageID)
+        XCTAssertEqual(triggeredPackageType, .predefined)
+    }
+
+    func test_unstaring_package_creates_notice_when_fails() {
+        // Given
+        let testSiteID: Int64 = 1234
+        let testPackageID = "1"
+
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .createPackage:
+                XCTFail("Create package should not be triggered!")
+            case let .deletePackage(_, _, _, completion):
+                completion(.failure(NSError(domain: "Test", code: 400)))
+            default:
+                break
+            }
+        }
+        let viewModel = WooShippingAddPackageViewModel(siteID: testSiteID,
+                                                       stores: mockStores)
+        viewModel.starredCarriersPackages.insert(testPackageID)
+
+        // When
+        viewModel.starUnstarPackage(testPackageID, carrierID: "usps")
 
         // Then
         waitUntil {
@@ -116,7 +185,7 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         let expectedError = NSError(domain: "test", code: 400)
         mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
-            case let .loadPackages(receivedSiteID, completion):
+            case let .loadPackages(_, completion):
                 completion(.failure(expectedError))
             default:
                 XCTFail("Received unexpected action: \(action)")
@@ -131,15 +200,17 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.packageLoadingError as? NSError, expectedError)
     }
 
-    @MainActor
-    func test_remove_saved_package_dispatches_deletePackage_action() {
+    func test_remove_saved_package_dispatches_deletePackage_action_correctly_for_predefined_package() {
         // Given
         let siteID: Int64 = 1234
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = WooShippingAddPackageViewModel(siteID: siteID,
                                                        stores: mockStores)
 
-        let customPackage = WooShippingCustomPackage.fake().copy(id: "custom")
+        var triggeredSiteID: Int64?
+        var triggeredPackagedID: String?
+        var triggeredPackageType: Networking.WooShippingPackageType?
+
         let predefinedPackage = WooShippingPredefinedPackage(id: "predefined",
                                                              name: "name",
                                                              isLetter: false,
@@ -152,24 +223,85 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
 
         mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
-            case let .deletePackage(receivedSiteID, packageID, _, completion):
-                XCTAssertEqual(receivedSiteID, siteID)
-                XCTAssert(packageID == customPackage.id || packageID == predefinedSavedPackage.id)
+            case let .deletePackage(receivedSiteID, packageID, packageType, completion):
+                triggeredSiteID = siteID
+                triggeredPackagedID = packageID
+                triggeredPackageType = packageType
                 completion(.success(.fake()))
             default:
                 XCTFail("Received unexpected action: \(action)")
             }
         }
 
-        // When/Then
-        viewModel.removeSavedPackage(customPackage.toPackageData())
-        XCTAssertEqual(mockStores.receivedActions.count, 1)
-        assertThat(mockStores.receivedActions.first, isAnInstanceOf: WooShippingAction.self)
-
-        // When/Then
+        // When
         viewModel.removeSavedPackage(predefinedSavedPackage.toPackageData())
-        XCTAssertEqual(mockStores.receivedActions.count, 2)
-        assertThat(mockStores.receivedActions.first, isAnInstanceOf: WooShippingAction.self)
+
+        // Then
+        XCTAssertEqual(triggeredSiteID, siteID)
+        XCTAssertEqual(triggeredPackagedID, predefinedSavedPackage.id)
+        XCTAssertEqual(triggeredPackageType, .predefined)
+    }
+
+    func test_remove_saved_package_dispatches_deletePackage_action_correctly_for_custom_package() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddPackageViewModel(siteID: siteID,
+                                                       stores: mockStores)
+
+        let customPackage = WooShippingCustomPackage.fake().copy(id: "custom")
+
+        var triggeredSiteID: Int64?
+        var triggeredPackagedID: String?
+        var triggeredPackageType: Networking.WooShippingPackageType?
+
+        mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .deletePackage(receivedSiteID, packageID, packageType, completion):
+                triggeredSiteID = receivedSiteID
+                triggeredPackagedID = packageID
+                triggeredPackageType = packageType
+                completion(.success(.fake()))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.removeSavedPackage(customPackage.toPackageData())
+
+        // Then
+        XCTAssertEqual(triggeredSiteID, siteID)
+        XCTAssertEqual(triggeredPackagedID, customPackage.id)
+        XCTAssertEqual(triggeredPackageType, .custom)
+    }
+
+    func test_remove_saved_package_creates_notice_when_fails() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddPackageViewModel(siteID: siteID,
+                                                       stores: mockStores)
+
+        let customPackage = WooShippingCustomPackage.fake().copy(id: "custom")
+
+        mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .deletePackage(_, _, _, completion):
+                completion(.failure(NSError(domain: "Test", code: 400)))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.removeSavedPackage(customPackage.toPackageData())
+
+        // Then
+        waitUntil {
+            viewModel.notice != nil
+        }
+        XCTAssertEqual(viewModel.notice?.feedbackType, .error)
     }
 
     func test_it_fetches_and_transforms_packages_from_storage() throws {

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -8,10 +8,11 @@ public enum WooShippingAction: Action {
                        predefinedOption: WooShippingPredefinedSavedOption? = nil,
                        completion: (Result<WooShippingCreatePackageResponse, PackageCreationError>) -> Void)
 
-    /// Deletes a custom package or deactivates a carrier package with provided package ID.
+    /// Deletes a package or deactivates a carrier package with provided package ID and type.
     ///
     case deletePackage(siteID: Int64,
                        packageID: String,
+                       packageType: WooShippingPackageType,
                        completion: (Result<WooShippingCreatePackageResponse, Error>) -> Void)
 
     /// Fetch list of shipping label rates for the order.

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -32,8 +32,11 @@ public final class WooShippingStore: Store {
         switch action {
         case .createPackage(let siteID, let customPackage, let predefinedOption, let completion):
             createPackage(siteID: siteID, customPackage: customPackage, predefinedOption: predefinedOption, completion: completion)
-        case .deletePackage(let siteID, let packageID, let completion):
-            deletePackage(siteID: siteID, packageID: packageID, completion: completion)
+        case let .deletePackage(siteID, packageID, packageType, completion):
+            deletePackage(siteID: siteID,
+                          packageID: packageID,
+                          packageType: packageType,
+                          completion: completion)
         case .loadLabelRates(let siteID, let orderID, let originAddress, let destinationAddress, let packages, let completion):
             loadLabelRates(siteID: siteID,
                            orderID: orderID,
@@ -105,8 +108,9 @@ private extension WooShippingStore {
 
     func deletePackage(siteID: Int64,
                        packageID: String,
+                       packageType: WooShippingPackageType,
                        completion: @escaping (Result<WooShippingCreatePackageResponse, Error>) -> Void) {
-        remote.deletePackage(siteID: siteID, packageID: packageID) { [weak self] result in
+        remote.deletePackage(siteID: siteID, packageID: packageID, packageType: packageType) { [weak self] result in
             switch result {
             case .success(let packages):
                 self?.upsertCreatePackagesResponseInBackground(readOnlyPackages: packages, siteID: siteID, onCompletion: {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -181,7 +181,10 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
         }
     }
 
-    func deletePackage(siteID: Int64, packageID: String, completion: @escaping (Result<Networking.WooShippingCreatePackageResponse, any Error>) -> Void) {
+    func deletePackage(siteID: Int64,
+                       packageID: String,
+                       packageType: WooShippingPackageType,
+                       completion: @escaping (Result<Networking.WooShippingCreatePackageResponse, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -122,7 +122,8 @@ final class WooShippingStoreTests: XCTestCase {
         // When
         let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             let action = WooShippingAction.deletePackage(siteID: self.sampleSiteID,
-                                                         packageID: WooShippingCustomPackage.fake().id) { result in
+                                                         packageID: WooShippingCustomPackage.fake().id,
+                                                         packageType: .custom) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -144,7 +145,8 @@ final class WooShippingStoreTests: XCTestCase {
         // When
         let result: Result<WooShippingCreatePackageResponse, Error> = waitFor { promise in
             let action = WooShippingAction.deletePackage(siteID: self.sampleSiteID,
-                                                         packageID: WooShippingCustomPackage.fake().id) { result in
+                                                         packageID: WooShippingCustomPackage.fake().id,
+                                                         packageType: .custom) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -185,7 +187,8 @@ final class WooShippingStoreTests: XCTestCase {
         // When
         let onSuccess: Bool = waitFor { promise in
             let action = WooShippingAction.deletePackage(siteID: self.sampleSiteID,
-                                                         packageID: WooShippingCustomPackage.fake().id) { result in
+                                                         packageID: WooShippingCustomPackage.fake().id,
+                                                         packageType: .custom) { result in
                 promise(result.isSuccess)
             }
             store.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-60
Also closes WOOMOB-66

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the integration of the delete packages endpoint following the [latest doc update](https://github.com/woocommerce/woocommerce-shipping/blob/trunk/docs/api/packages.md#delete-package).

Changes include:
- Updates to the Networking and Yosemite layers to include package type in delete package requests.
- Updates to `WooShippingAddPackageViewModel` to handle removing packages and unstaring predefined packages.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a test store with the WooShipping plugin set up.
2. Navigate to the Orders tab and select a completed order with physical products.
3. Select Create shipping label > Select a Package.
4. Switch to Carrier tab and tap on the Star button of any package. 
5. Tap on the same button again and confirm that this is successful (you can check the request on ProxyMan to be sure as the UI is updated optimistically).
6. Tap on another star button and switch to the Saved tab.
7. Swipe to delete the predefined package that you just saved. Confirm that this is successful.
8. Switch to the Custom tab to create a custom package if you haven't done already.
9. Switch to the Saved tab, and swipe to delete the custom package that you just saved. Confirm that this is successful.
10. Repeat steps 6-9 but with the Internet disconnected before removing the packages. Confirm that the UI is reverted and a notice is displayed when the requests fail.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Manually tested and confirmed the above test cases on simulator iPhone 16 Pro iOS 18.2.
- Added unit tests to confirm the changes.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Error cases:

Predefined tab | Saved tab
--- | ---
<img src="https://github.com/user-attachments/assets/c17413f8-83d2-434b-bf90-a549276b4190" width=320 /> | <img src="https://github.com/user-attachments/assets/f70c263a-1e30-4ecc-94a8-c67733997e2d" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
