### PR TITLE
[Woo POS][Products Search] Extract search component

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -73,7 +73,7 @@ protocol PointOfSaleAggregateModelProtocol {
     private let orderController: PointOfSaleOrderControllerProtocol
     private let analytics: Analytics
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
-    private let searchHistoryService: POSSearchHistoryProviding
+    let searchHistoryService: POSSearchHistoryProviding
 
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -33,7 +33,7 @@ struct PointOfSaleItemListEmptyView: View {
         ScrollableVStack {
             Spacer()
             VStack(alignment: .center, spacing: POSSpacing.none) {
-                let shouldShowIcon: Bool = !dynamicTypeSize.isAccessibilitySize && keyboard.keyboardHeight <= 0
+                let shouldShowIcon: Bool = !dynamicTypeSize.isAccessibilitySize && !keyboard.isFullSizeKeyboardVisible
 
                 if shouldShowIcon {
                     icon
@@ -77,7 +77,7 @@ struct PointOfSaleItemListEmptyView: View {
             Spacer()
         }
         .multilineTextAlignment(.center)
-        .padding(.bottom, keyboard.keyboardHeight <= 0 ? floatingControlAreaSize.height : 0)
+        .padding(.bottom, !keyboard.isFullSizeKeyboardVisible ? floatingControlAreaSize.height : 0)
         .animation(.default, value: keyboard.keyboardHeight)
         .measureWidth { width in
             viewWidth = width

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
@@ -1,0 +1,34 @@
+import Foundation
+import enum Yosemite.POSItemType
+import protocol Yosemite.POSSearchHistoryProviding
+
+@available(iOS 17.0, *)
+final class POSProductSearchable: POSSearchable {
+    private let itemsController: PointOfSaleSearchingItemsControllerProtocol
+    private let searchHistoryProvider: POSSearchHistoryProviding
+
+    init(itemsController: PointOfSaleSearchingItemsControllerProtocol,
+         searchHistoryProvider: POSSearchHistoryProviding) {
+        self.itemsController = itemsController
+        self.searchHistoryProvider = searchHistoryProvider
+    }
+
+    var itemType: POSItemType {
+        .product
+    }
+
+    var searchHistory: [String] {
+        searchHistoryProvider.searchHistory(for: itemType)
+    }
+
+    func performSearch(term: String) {
+        Task { @MainActor in
+            await itemsController.searchItems(searchTerm: term, baseItem: .root)
+        }
+    }
+
+    func selectRecentSearch(term: String) {
+        searchHistoryProvider.saveSuccessfulSearch(term: term, for: itemType)
+        performSearch(term: term)
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
@@ -13,12 +13,10 @@ final class POSProductSearchable: POSSearchable {
         self.searchHistoryProvider = searchHistoryProvider
     }
 
-    var itemType: POSItemType {
-        .product
-    }
+    let itemListType: ItemListType = .products(search: false)
 
     var searchHistory: [String] {
-        searchHistoryProvider.searchHistory(for: itemType)
+        searchHistoryProvider.searchHistory(for: itemListType.itemType)
     }
 
     func performSearch(term: String) async {

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
@@ -21,14 +21,7 @@ final class POSProductSearchable: POSSearchable {
         searchHistoryProvider.searchHistory(for: itemType)
     }
 
-    func performSearch(term: String) {
-        Task { @MainActor in
-            await itemsController.searchItems(searchTerm: term, baseItem: .root)
-        }
-    }
-
-    func selectRecentSearch(term: String) {
-        searchHistoryProvider.saveSuccessfulSearch(term: term, for: itemType)
-        performSearch(term: term)
+    func performSearch(term: String) async {
+        await itemsController.searchItems(searchTerm: term, baseItem: .root)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -17,7 +17,7 @@ protocol POSSearchable {
 
 /// A reusable search field view for POS items
 @available(iOS 17.0, *)
-struct POSSearchFieldView: View {
+struct POSSearchField: View {
     @Environment(\.keyboardObserver) private var keyboardObserver
 
     @Binding var searchTerm: String
@@ -152,7 +152,7 @@ struct POSSearchContentView<Content: View>: View {
 
 // MARK: - Localization
 @available(iOS 17.0, *)
-private extension POSSearchFieldView {
+private extension POSSearchField {
     enum Localization {
         static let searchFieldLabel = NSLocalizedString(
             "pos.searchview.searchField.label",

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -20,13 +20,13 @@ protocol POSSearchable {
 struct POSSearchField: View {
     @Environment(\.keyboardObserver) private var keyboardObserver
 
-    @Binding var searchTerm: String
+    @Binding private var searchTerm: String
     @FocusState private var isSearchFieldFocused: Bool
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
 
     private let searchable: any POSSearchable
-    let onBack: () -> Void
+    private let onBack: () -> Void
 
     init(searchTerm: Binding<String>,
          searchable: any POSSearchable,

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -4,8 +4,8 @@ import enum Yosemite.POSItemType
 /// Protocol defining search capabilities for POS items
 @available(iOS 17.0, *)
 protocol POSSearchable {
-    /// The type of items being searched
-    var itemType: POSItemType { get }
+    /// The type of item lists being searched
+    var itemListType: ItemListType { get }
 
     /// Recent search history for the current item type
     var searchHistory: [String] { get }
@@ -134,6 +134,8 @@ struct POSSearchContentView<Content: View>: View {
                 savedSearches: searchable.searchHistory,
                 onSearchSelected: { selectedSearchTerm in
                     searchTerm = selectedSearchTerm
+                    ServiceLocator.analytics.track(
+                        event: .PointOfSale.preSearchRecentTermTapped(itemListType: searchable.itemListType))
                 }
             )
             .background(Color.posSurface)

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -117,17 +117,14 @@ struct POSSearchContentView<Content: View>: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private let searchable: any POSSearchable
-    private let searchTerm: String
-    private let onSearchTermChange: (String) -> Void
+    @Binding private var searchTerm: String
     private let content: (Bool) -> Content
 
     init(searchable: any POSSearchable,
-         searchTerm: String,
-         onSearchTermChange: @escaping (String) -> Void,
+         searchTerm: Binding<String>,
          @ViewBuilder content: @escaping (Bool) -> Content) {
         self.searchable = searchable
-        self.searchTerm = searchTerm
-        self.onSearchTermChange = onSearchTermChange
+        self._searchTerm = searchTerm
         self.content = content
     }
 
@@ -135,11 +132,8 @@ struct POSSearchContentView<Content: View>: View {
         if searchTerm.isEmpty {
             POSRecentSearchesView(
                 savedSearches: searchable.searchHistory,
-                onSearchSelected: { search in
-                    onSearchTermChange(search)
-                    Task { @MainActor in
-                        await searchable.performSearch(term: search)
-                    }
+                onSearchSelected: { selectedSearchTerm in
+                    searchTerm = selectedSearchTerm
                 }
             )
             .background(Color.posSurface)

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -12,107 +12,36 @@ protocol POSSearchable {
 
     /// Called when a search should be performed
     /// - Parameter term: The search term to use
-    func performSearch(term: String)
-
-    /// Called when a recent search is selected
-    /// - Parameter term: The search term that was selected
-    func selectRecentSearch(term: String)
+    func performSearch(term: String) async
 }
 
-/// A reusable search view component for POS items
+/// A reusable search field view for POS items
 @available(iOS 17.0, *)
-struct POSSearchView<Content: View>: View {
+struct POSSearchFieldView: View {
     @Environment(\.keyboardObserver) private var keyboardObserver
 
     @Binding var searchTerm: String
-    @Binding var isSearching: Bool
+    @FocusState private var isSearchFieldFocused: Bool
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
 
-    @FocusState private var isSearchFieldFocused: Bool
-
     private let searchable: any POSSearchable
-    private let content: () -> Content
+    let onBack: () -> Void
 
-    private typealias Localization = POSSearchViewLocalization
-
-    init(isSearching: Binding<Bool>,
-         searchTerm: Binding<String>,
+    init(searchTerm: Binding<String>,
          searchable: any POSSearchable,
-         @ViewBuilder content: @escaping () -> Content) {
-        self._isSearching = isSearching
+         onBack: @escaping () -> Void) {
         self._searchTerm = searchTerm
         self.searchable = searchable
-        self.content = content
+        self.onBack = onBack
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            searchField
-                .transition(.opacity.combined(with: .move(edge: .trailing)))
-
-            if searchTerm.isEmpty {
-                POSRecentSearchesView(
-                    savedSearches: searchable.searchHistory,
-                    onSearchSelected: { search in
-                        searchTerm = search
-                        searchable.selectRecentSearch(term: search)
-                    }
-                )
-                .background(Color.posSurface)
-            } else {
-                content()
-            }
-        }
-        .background(Color.posSurface)
-        .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
-            guard isVisible == false else { return }
-            ServiceLocator.analytics.track(.pointOfSaleKeyboardDismissedInSearch)
-        }
-        .onChange(of: searchTerm) { oldValue, newValue in
-            // The debouncing logic is a little tricky, because the loading state is held in the controller.
-            // Arguably, we should use view state `isSearching` for this, so the UI is independent of the request timing.
-
-            // As the user types, we don't want to send every keystroke to the remote, so we debounce the requests.
-            // However, we don't want to debounce the first keystroke of a new search, so that the loading
-            // state shows immediately and the UI feels responsive.
-
-            // So, if the last search was finished, we don't debounce the first character. If it didn't
-            // finish i.e. it is still ongoing, we debounce the next keystrokes by 300ms. In either case,
-            // the ongoing search is redundant now there's a new search term, so we cancel it.
-            let shouldDebounceNextSearchRequest = !didFinishSearch
-            searchTask?.cancel()
-
-            searchTask = Task {
-                if shouldDebounceNextSearchRequest {
-                    try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
-                }
-
-                guard !Task.isCancelled else { return }
-
-                guard newValue.isNotEmpty else {
-                    didFinishSearch = true
-                    return
-                }
-
-                didFinishSearch = false
-                searchable.performSearch(term: newValue)
-
-                if !Task.isCancelled {
-                    didFinishSearch = true
-                }
-            }
-        }
-    }
-
-    private var searchField: some View {
         HStack(spacing: POSSpacing.small) {
             Button {
-                withAnimation {
-                    clearSearch()
-                    isSearchFieldFocused = false
-                    isSearching = false
-                }
+                searchTerm = ""
+                onBack()
+                isSearchFieldFocused = false
             } label: {
                 Image(systemName: "chevron.backward")
                     .foregroundColor(.posOnSurface)
@@ -120,15 +49,49 @@ struct POSSearchView<Content: View>: View {
             }
 
             TextField(text: $searchTerm) {
-                Text(searchable.itemType.searchFieldLabel)
+                Text(Localization.searchFieldLabel)
             }
             .font(POSFontStyle.posBodyLargeRegular())
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
             .focused($isSearchFieldFocused)
+            .onChange(of: searchTerm) { oldValue, newValue in
+                // The debouncing logic is a little tricky, because the loading state is held in the controller.
+                // Arguably, we should use view state `isSearching` for this, so the UI is independent of the request timing.
+
+                // As the user types, we don't want to send every keystroke to the remote, so we debounce the requests.
+                // However, we don't want to debounce the first keystroke of a new search, so that the loading
+                // state shows immediately and the UI feels responsive.
+
+                // So, if the last search was finished, we don't debounce the first character. If it didn't
+                // finish i.e. it is still ongoing, we debounce the next keystrokes by 300ms. In either case,
+                // the ongoing search is redundant now there's a new search term, so we cancel it.
+                let shouldDebounceNextSearchRequest = !didFinishSearch
+                searchTask?.cancel()
+
+                searchTask = Task {
+                    if shouldDebounceNextSearchRequest {
+                        try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
+                    }
+
+                    guard !Task.isCancelled else { return }
+
+                    guard newValue.isNotEmpty else {
+                        didFinishSearch = true
+                        return
+                    }
+
+                    didFinishSearch = false
+                    await searchable.performSearch(term: newValue)
+
+                    if !Task.isCancelled {
+                        didFinishSearch = true
+                    }
+                }
+            }
 
             Button {
-                clearSearch()
+                searchTerm = ""
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .accessibilityLabel(Localization.searchFieldClearButtonAccessibilityLabel)
@@ -138,21 +101,71 @@ struct POSSearchView<Content: View>: View {
             .transition(.opacity)
             .renderedIf(searchTerm.isNotEmpty)
         }
+        .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
+            guard isVisible == false else { return }
+            ServiceLocator.analytics.track(.pointOfSaleKeyboardDismissedInSearch)
+        }
+        .onAppear {
+            isSearchFieldFocused = true
+        }
+    }
+}
+
+/// A reusable search content view for POS items
+@available(iOS 17.0, *)
+struct POSSearchContentView<Content: View>: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private let searchable: any POSSearchable
+    private let searchTerm: String
+    private let onSearchTermChange: (String) -> Void
+    private let content: (Bool) -> Content
+
+    init(searchable: any POSSearchable,
+         searchTerm: String,
+         onSearchTermChange: @escaping (String) -> Void,
+         @ViewBuilder content: @escaping (Bool) -> Content) {
+        self.searchable = searchable
+        self.searchTerm = searchTerm
+        self.onSearchTermChange = onSearchTermChange
+        self.content = content
     }
 
-    private func clearSearch() {
-        searchTerm = ""
+    var body: some View {
+        if searchTerm.isEmpty {
+            POSRecentSearchesView(
+                savedSearches: searchable.searchHistory,
+                onSearchSelected: { search in
+                    onSearchTermChange(search)
+                    Task { @MainActor in
+                        await searchable.performSearch(term: search)
+                    }
+                }
+            )
+            .background(Color.posSurface)
+        } else {
+            content(true)
+                .background(Color.posSurface)
+        }
     }
 }
 
 // MARK: - Localization
 @available(iOS 17.0, *)
-private enum POSSearchViewLocalization {
-    static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
-        "pos.searchview.searchField.clearButton.accessibilityLabel",
-        value: "Clear Search",
-        comment: "Accessibility label for the clear button in the Point of Sale search screen."
-    )
+private extension POSSearchFieldView {
+    enum Localization {
+        static let searchFieldLabel = NSLocalizedString(
+            "pos.searchview.searchField.label",
+            value: "Search",
+            comment: "Label/placeholder text for the search field in Point of Sale."
+        )
+
+        static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
+            "pos.searchview.searchField.clearButton.accessibilityLabel",
+            value: "Clear Search",
+            comment: "Accessibility label for the clear button in the Point of Sale search screen."
+        )
+    }
 }
 
 private extension POSItemType {

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -51,6 +51,7 @@ struct POSSearchField: View {
             TextField(text: $searchTerm) {
                 Text(Localization.searchFieldLabel)
             }
+            .textFieldStyle(.roundedBorder)
             .font(POSFontStyle.posBodyLargeRegular())
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+import enum Yosemite.POSItemType
+
+/// Protocol defining search capabilities for POS items
+@available(iOS 17.0, *)
+protocol POSSearchable {
+    /// The type of items being searched
+    var itemType: POSItemType { get }
+
+    /// Recent search history for the current item type
+    var searchHistory: [String] { get }
+
+    /// Called when a search should be performed
+    /// - Parameter term: The search term to use
+    func performSearch(term: String)
+
+    /// Called when a recent search is selected
+    /// - Parameter term: The search term that was selected
+    func selectRecentSearch(term: String)
+}
+
+/// A reusable search view component for POS items
+@available(iOS 17.0, *)
+struct POSSearchView<Content: View>: View {
+    @Environment(\.keyboardObserver) private var keyboardObserver
+
+    @Binding var searchTerm: String
+    @Binding var isSearching: Bool
+    @State private var searchTask: Task<Void, Never>?
+    @State private var didFinishSearch = true
+
+    @FocusState private var isSearchFieldFocused: Bool
+
+    private let searchable: any POSSearchable
+    private let content: () -> Content
+
+    private typealias Localization = POSSearchViewLocalization
+
+    init(isSearching: Binding<Bool>,
+         searchTerm: Binding<String>,
+         searchable: any POSSearchable,
+         @ViewBuilder content: @escaping () -> Content) {
+        self._isSearching = isSearching
+        self._searchTerm = searchTerm
+        self.searchable = searchable
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+                .transition(.opacity.combined(with: .move(edge: .trailing)))
+
+            if searchTerm.isEmpty {
+                POSRecentSearchesView(
+                    savedSearches: searchable.searchHistory,
+                    onSearchSelected: { search in
+                        searchTerm = search
+                        searchable.selectRecentSearch(term: search)
+                    }
+                )
+                .background(Color.posSurface)
+            } else {
+                content()
+            }
+        }
+        .background(Color.posSurface)
+        .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
+            guard isVisible == false else { return }
+            ServiceLocator.analytics.track(.pointOfSaleKeyboardDismissedInSearch)
+        }
+        .onChange(of: searchTerm) { oldValue, newValue in
+            // The debouncing logic is a little tricky, because the loading state is held in the controller.
+            // Arguably, we should use view state `isSearching` for this, so the UI is independent of the request timing.
+
+            // As the user types, we don't want to send every keystroke to the remote, so we debounce the requests.
+            // However, we don't want to debounce the first keystroke of a new search, so that the loading
+            // state shows immediately and the UI feels responsive.
+
+            // So, if the last search was finished, we don't debounce the first character. If it didn't
+            // finish i.e. it is still ongoing, we debounce the next keystrokes by 300ms. In either case,
+            // the ongoing search is redundant now there's a new search term, so we cancel it.
+            let shouldDebounceNextSearchRequest = !didFinishSearch
+            searchTask?.cancel()
+
+            searchTask = Task {
+                if shouldDebounceNextSearchRequest {
+                    try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
+                }
+
+                guard !Task.isCancelled else { return }
+
+                guard newValue.isNotEmpty else {
+                    didFinishSearch = true
+                    return
+                }
+
+                didFinishSearch = false
+                searchable.performSearch(term: newValue)
+
+                if !Task.isCancelled {
+                    didFinishSearch = true
+                }
+            }
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: POSSpacing.small) {
+            Button {
+                withAnimation {
+                    clearSearch()
+                    isSearchFieldFocused = false
+                    isSearching = false
+                }
+            } label: {
+                Image(systemName: "chevron.backward")
+                    .foregroundColor(.posOnSurface)
+                    .font(.posButtonSymbolLarge)
+            }
+
+            TextField(text: $searchTerm) {
+                Text(searchable.itemType.searchFieldLabel)
+            }
+            .font(POSFontStyle.posBodyLargeRegular())
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+            .focused($isSearchFieldFocused)
+
+            Button {
+                clearSearch()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .accessibilityLabel(Localization.searchFieldClearButtonAccessibilityLabel)
+                    .foregroundColor(.posOnSurfaceVariantHighest)
+                    .font(.posButtonSymbolSmall)
+            }
+            .transition(.opacity)
+            .renderedIf(searchTerm.isNotEmpty)
+        }
+    }
+
+    private func clearSearch() {
+        searchTerm = ""
+    }
+}
+
+// MARK: - Localization
+@available(iOS 17.0, *)
+private enum POSSearchViewLocalization {
+    static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
+        "pos.searchview.searchField.clearButton.accessibilityLabel",
+        value: "Clear Search",
+        comment: "Accessibility label for the clear button in the Point of Sale search screen."
+    )
+}
+
+private extension POSItemType {
+    var searchFieldLabel: String {
+        switch self {
+        case .product:
+            return Localization.productsSearchFieldLabel
+        default:
+            return Localization.defaultSearchFieldLabel
+        }
+    }
+
+    enum Localization {
+        static let productsSearchFieldLabel = NSLocalizedString(
+            "pos.itemListView.products.searchField.label",
+            value: "Search Products",
+            comment: "Label/placeholder text for the search field for Products in Point of Sale."
+        )
+
+        static let defaultSearchFieldLabel = NSLocalizedString(
+            "pos.itemListView.searchField.label",
+            value: "Search",
+            comment: "Fallback label/placeholder text for the search field in Point of Sale."
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -8,6 +8,7 @@ import struct Yosemite.POSVariableParentProduct
 struct ItemList<HeaderView: View>: View {
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     @Environment(PointOfSaleAggregateModel.self) private var posModel
+    @Environment(\.keyboardObserver) private var keyboardObserver
     @StateObject private var infiniteScrollTriggerDeterminer = ThresholdInfiniteScrollTriggerDeterminer()
 
     // Navigation only uses this on iOS 17
@@ -67,7 +68,7 @@ struct ItemList<HeaderView: View>: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal, Constants.itemListPadding)
-                    .padding(.bottom, floatingControlAreaSize.height)
+                    .padding(.bottom, keyboardObserver.isFullSizeKeyboardVisible ? Constants.itemListPadding : floatingControlAreaSize.height)
                 }
             )
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -8,8 +8,6 @@ struct ItemListView: View {
 
     @Environment(PointOfSaleAggregateModel.self) private var posModel
 
-    @Environment(\.keyboardObserver) private var keyboardObserver
-
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -209,7 +209,7 @@ private extension ItemListView {
                 HStack {
                     if isSearchAllowed {
                         if selectedItemListType.isSearching {
-                            POSSearchFieldView(
+                            POSSearchField(
                                 searchTerm: $searchTerm,
                                 searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
                                                                searchHistoryProvider: posModel.searchHistoryService),

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -102,10 +102,7 @@ struct ItemListView: View {
                     POSSearchContentView(
                         searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
                                                          searchHistoryProvider: posModel.searchHistoryService),
-                        searchTerm: searchTerm,
-                        onSearchTermChange: { newTerm in
-                            searchTerm = newTerm
-                        }
+                        searchTerm: $searchTerm
                     ) { _ in
                         itemListContent(selectedItemListType)
                     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -13,7 +13,7 @@ struct ItemListView: View {
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 
-    private var isSearching: Binding<Bool> {
+    private var _isSearching: Binding<Bool> {
         Binding(
             get: {
                 switch selectedItemListType {
@@ -32,6 +32,10 @@ struct ItemListView: View {
                 }
             }
         )
+    }
+
+    private var isSearching: Bool {
+        _isSearching.wrappedValue
     }
 
     @State private var searchTask: Task<Void, Never>?
@@ -64,7 +68,7 @@ struct ItemListView: View {
     }
 
     private var shouldShowHeaderItems: Bool {
-        !selectedItemListType.isSearching
+        !isSearching
     }
 
     @State private var showCouponCreationModal: Bool = false
@@ -117,7 +121,7 @@ struct ItemListView: View {
         ZStack {
             itemListContent(itemListType)
 
-            if selectedItemListType.isSearching && itemListType.isProducts {
+            if isSearching {
                 POSSearchContentView(
                     searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
                                                      searchHistoryProvider: posModel.searchHistoryService),
@@ -203,7 +207,7 @@ private extension ItemListView {
             POSPageHeaderView(items: headerViewItems, trailingContent: {
                 HStack {
                     if isSearchAllowed {
-                        if selectedItemListType.isSearching {
+                        if isSearching {
                             POSSearchField(
                                 searchTerm: $searchTerm,
                                 searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
@@ -238,7 +242,7 @@ private extension ItemListView {
                 }
             })
         }
-        .animation(.easeInOut(duration: Constants.animationDuration), value: selectedItemListType.isSearching)
+        .animation(.easeInOut(duration: Constants.animationDuration), value: isSearching)
         .animation(.easeInOut(duration: Constants.animationDuration), value: isAddingCouponAllowed)
         .animation(.easeInOut(duration: Constants.animationDuration), value: searchTerm)
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -97,7 +97,7 @@ struct ItemListView: View {
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .animation(.none, value: selectedItemListType)
-            .ignoresSafeArea()
+            .ignoresSafeArea(.container) // Respect the keyboard safe area
         }
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
         // the navigation is handled in a NavigationLink in ItemList.swift. Avoiding the warning is impractical.

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -181,12 +181,10 @@ struct ItemListView: View {
         // Note that navigation is handled by the ItemList in iOS 17, so any changes to this should be reflected in ItemListRow.
         switch parentItem {
         case let .variableParentProduct(parentProduct):
-            // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
-            // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
             ChildItemList(
                 parentItem: parentItem,
                 title: parentProduct.name,
-                itemsController: posModel.purchasableItemsController,
+                itemsController: itemsController(selectedItemListType),
                 itemActionHandler: actionHandler(selectedItemListType)
             )
         default:

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -99,12 +99,14 @@ struct ItemListView: View {
                 .ignoresSafeArea()
 
                 if selectedItemListType.isSearching {
-                    POSSearchView(
-                        isSearching: isSearching,
-                        searchTerm: $searchTerm,
+                    POSSearchContentView(
                         searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
-                                                         searchHistoryProvider: posModel.searchHistoryService)
-                    ) {
+                                                         searchHistoryProvider: posModel.searchHistoryService),
+                        searchTerm: searchTerm,
+                        onSearchTermChange: { newTerm in
+                            searchTerm = newTerm
+                        }
+                    ) { _ in
                         itemListContent(selectedItemListType)
                     }
                     .transition(.opacity.combined(with: .move(edge: .trailing)))
@@ -206,15 +208,28 @@ private extension ItemListView {
             POSPageHeaderView(items: headerViewItems, trailingContent: {
                 HStack {
                     if isSearchAllowed {
-                        POSPageHeaderActionButton(systemName: "magnifyingglass") {
-                            withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                                ServiceLocator.analytics.track(event: WooAnalyticsEvent.PointOfSale.searchButtonTapped(
-                                    itemListType: selectedItemListType))
-                                selectedItemListType = .products(search: true)
+                        if selectedItemListType.isSearching {
+                            POSSearchFieldView(
+                                searchTerm: $searchTerm,
+                                searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
+                                                               searchHistoryProvider: posModel.searchHistoryService),
+                                onBack: {
+                                    withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+                                        selectedItemListType = .products(search: false)
+                                    }
+                                }
+                            )
+                            .transition(.opacity.combined(with: .move(edge: .trailing)))
+                        } else {
+                            POSPageHeaderActionButton(systemName: "magnifyingglass") {
+                                withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+                                    ServiceLocator.analytics.track(event: WooAnalyticsEvent.PointOfSale.searchButtonTapped(
+                                        itemListType: selectedItemListType))
+                                    selectedItemListType = .products(search: true)
+                                }
                             }
+                            .transition(.opacity.combined(with: .scale))
                         }
-                        .renderedIf(!selectedItemListType.isSearching)
-                        .transition(.opacity.combined(with: .scale))
                     }
 
                     if isCouponsFeatureEnabled {
@@ -308,6 +323,8 @@ private extension ItemListView {
 @available(iOS 17.0, *)
 private extension ItemListView {
     func displayItemListType(_ itemListType: ItemListType) {
+        // Clear search term when switching tabs
+        searchTerm = ""
         selectedItemListType = itemListType
         Task { @MainActor in
             if itemListState(itemListType).items.isEmpty {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -8,6 +8,8 @@ struct ItemListView: View {
 
     @Environment(PointOfSaleAggregateModel.self) private var posModel
 
+    @Environment(\.keyboardObserver) private var keyboardObserver
+
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 
@@ -97,7 +99,8 @@ struct ItemListView: View {
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .animation(.none, value: selectedItemListType)
-            .ignoresSafeArea(.container) // Respect the keyboard safe area
+            // Respect the keyboard safe area when a full keyboard is shown, but not the external keyboard shortcut bar.
+            .ignoresSafeArea(keyboardObserver.isFullSizeKeyboardVisible ? .container : [.keyboard, .container])
         }
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
         // the navigation is handled in a NavigationLink in ItemList.swift. Avoiding the warning is impractical.

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -89,9 +89,9 @@ struct ItemListView: View {
 
             ZStack {
                 TabView(selection: $selectedItemListType) {
-                    itemListContent(.products(search: false))
+                    itemListTabContent(.products(search: false))
                     if isCouponsFeatureEnabled {
-                        itemListContent(.coupons)
+                        itemListTabContent(.coupons)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -13,7 +13,26 @@ struct ItemListView: View {
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 
-    @FocusState private var isSearchFieldFocused: Bool
+    private var isSearching: Binding<Bool> {
+        Binding(
+            get: {
+                switch selectedItemListType {
+                case .products(search: let searching):
+                    return searching
+                case .coupons:
+                    return false
+                }
+            },
+            set: { newValue in
+                switch selectedItemListType {
+                case .products:
+                    selectedItemListType = .products(search: newValue)
+                case .coupons:
+                    break // No-op since coupons don't support search
+                }
+            }
+        )
+    }
 
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
@@ -80,8 +99,16 @@ struct ItemListView: View {
                 .ignoresSafeArea()
 
                 if selectedItemListType.isSearching {
-                    searchOverlay(itemListType: selectedItemListType)
-                        .transition(.opacity.combined(with: .move(edge: .trailing)))
+                    POSSearchView(
+                        isSearching: isSearching,
+                        searchTerm: $searchTerm,
+                        searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
+                                                         searchHistoryProvider: posModel.searchHistoryService)
+                    ) {
+                        itemListContent(selectedItemListType)
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+                    .zIndex(1)
                 }
             }
         }
@@ -101,6 +128,13 @@ struct ItemListView: View {
     }
 
     @ViewBuilder
+    private func itemListTabContent(_ itemListType: ItemListType) -> some View {
+        itemListContent(itemListType)
+            .tag(itemListType)
+            .gesture(DragGesture()) // Disable a default swipe gesture between the tabs
+    }
+
+    @ViewBuilder
     private func itemListContent(_ itemListType: ItemListType) -> some View {
         Group {
             switch itemListState(itemListType) {
@@ -115,42 +149,54 @@ struct ItemListView: View {
                 emptyView
             }
         }
-        .tag(itemListType)
-        .gesture(DragGesture()) // Disable a default swipe gesture between the tabs
     }
 
     @ViewBuilder
-    private func searchOverlay(itemListType: ItemListType) -> some View {
-        VStack(spacing: 0) {
-            if searchTerm.isEmpty {
-                POSRecentSearchesView(
-                    savedSearches: posModel.searchHistory(for: itemListType.itemType),
-                    onSearchSelected: { search in
-                        searchTerm = search
-                        ServiceLocator.analytics.track(
-                            event: WooAnalyticsEvent.PointOfSale.preSearchRecentTermTapped(itemListType: itemListType))
-                    }
-                )
-                .background(Color.posSurface)
-            } else {
-                switch itemListState(itemListType) {
-                case .loading(let items),
-                        .loaded(let items, _),
-                        .inlineError(let items, _, _):
-                    listView(items, itemListType: itemListType)
-                case .error(let errorState):
-                    errorView(errorState)
-                    EmptyView()
-                case .empty:
-                    emptyView
-                }
+    private func listView(_ items: [POSItem], itemListType: ItemListType) -> some View {
+        ItemList(
+            itemsController: itemsController(itemListType),
+            node: .root,
+            itemActionHandler: actionHandler(itemListType),
+            willLoadMore: {
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemListType: selectedItemListType))
             }
+        )
+        .refreshable {
+            trackPullToRefresh()
+            await itemsController(itemListType).refreshItems(base: .root)
         }
-        .background(Color.posSurface)
+    }
+
+    private func actionHandler(_ itemListType: ItemListType) -> POSItemActionHandler {
+        switch itemListType {
+        case .products(search: false), .coupons:
+            StandardPOSItemActionHandler(posModel: posModel, itemListType: selectedItemListType)
+        case .products(search: true):
+            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemListType: itemListType)
+        }
+    }
+
+    @ViewBuilder
+    func childListView(parentItem: POSItem) -> some View {
+        // Note that navigation is handled by the ItemList in iOS 17, so any changes to this should be reflected in ItemListRow.
+        switch parentItem {
+        case let .variableParentProduct(parentProduct):
+            // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
+            // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
+            ChildItemList(
+                parentItem: parentItem,
+                title: parentProduct.name,
+                itemsController: posModel.purchasableItemsController,
+                itemActionHandler: actionHandler(selectedItemListType)
+            )
+        default:
+            EmptyView()
+        }
     }
 }
 
-/// View Helpers
+/// Header view
 ///
 @available(iOS 17.0, *)
 private extension ItemListView {
@@ -160,52 +206,11 @@ private extension ItemListView {
             POSPageHeaderView(items: headerViewItems, trailingContent: {
                 HStack {
                     if isSearchAllowed {
-                        searchField
-                            .renderedIf(selectedItemListType.isSearching)
-                            .transition(.opacity.combined(with: .move(edge: .trailing)))
-                            .onChange(of: searchTerm) { oldValue, newValue in
-                                // The debouncing logic is a little tricky, because the loading state is held in the controller.
-                                // Arguably, we should use view state `isSearching` for this, so the UI is independent of the request timing.
-
-                                // As the user types, we don't want to send every keystroke to the remote, so we debounce the requests.
-                                // However, we don't want to debounce the first keystroke of a new search, so that the loading
-                                // state shows immediately and the UI feels responsive.
-
-                                // So, if the last search was finished, we don't debounce the first character. If it didn't
-                                // finish i.e. it is still ongoing, we debounce the next keystrokes by 300ms. In either case,
-                                // the ongoing search is redundant now there's a new search term, so we cancel it.
-                                let shouldDebounceNextSearchRequest = !didFinishSearch
-                                searchTask?.cancel()
-
-                                searchTask = Task {
-                                    if shouldDebounceNextSearchRequest {
-                                        try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
-                                    }
-
-                                    guard !Task.isCancelled else { return }
-
-                                    guard searchTerm.isNotEmpty else {
-                                        didFinishSearch = true
-                                        return
-                                    }
-
-                                    didFinishSearch = false
-
-                                    await posModel.purchasableItemsSearchController.searchItems(searchTerm: newValue, baseItem: .root)
-
-                                    if !Task.isCancelled {
-                                        didFinishSearch = true
-                                    }
-                                }
-                            }
-
                         POSPageHeaderActionButton(systemName: "magnifyingglass") {
                             withAnimation(.easeInOut(duration: Constants.animationDuration)) {
                                 ServiceLocator.analytics.track(event: WooAnalyticsEvent.PointOfSale.searchButtonTapped(
                                     itemListType: selectedItemListType))
                                 selectedItemListType = .products(search: true)
-                            } completion: {
-                                isSearchFieldFocused = true
                             }
                         }
                         .renderedIf(!selectedItemListType.isSearching)
@@ -256,90 +261,12 @@ private extension ItemListView {
 
         return items
     }
+}
 
-    var searchField: some View {
-        HStack(spacing: POSSpacing.small) {
-            Button {
-                searchTerm = ""
-                isSearchFieldFocused = false
-                selectedItemListType = .products(search: false)
-            } label: {
-                Image(systemName: "chevron.backward")
-                    .foregroundColor(.posOnSurface)
-                    .font(.posButtonSymbolLarge)
-            }
-
-            TextField(text: $searchTerm) {
-                Text(Localization.searchFieldLabel)
-            }
-            .font(POSFontStyle.posBodyLargeRegular())
-            .autocorrectionDisabled()
-            .textInputAutocapitalization(.never)
-            .focused($isSearchFieldFocused)
-
-            Button {
-                searchTerm = ""
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .accessibilityLabel(Localization.searchFieldClearButtonAccessibilityLabel)
-                    .foregroundColor(.posOnSurfaceVariantHighest)
-                    .font(.posButtonSymbolSmall)
-            }
-            .transition(.opacity)
-            .renderedIf(searchTerm.isNotEmpty)
-        }
-        .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
-            guard isVisible == false else {
-                return
-            }
-            ServiceLocator.analytics.track(.pointOfSaleKeyboardDismissedInSearch)
-        }
-    }
-
-    @ViewBuilder
-    func listView(_ items: [POSItem], itemListType: ItemListType) -> some View {
-        ItemList(
-            itemsController: itemsController(itemListType),
-            node: .root,
-            itemActionHandler: actionHandler(itemListType),
-            willLoadMore: {
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemListType: selectedItemListType))
-            }
-        )
-        .refreshable {
-            trackPullToRefresh()
-            await itemsController(itemListType).refreshItems(base: .root)
-        }
-    }
-
-    private func actionHandler(_ itemListType: ItemListType) -> POSItemActionHandler {
-        switch itemListType {
-        case .products(search: false), .coupons:
-            StandardPOSItemActionHandler(posModel: posModel, itemListType: selectedItemListType)
-        case .products(search: true):
-            SearchResultItemActionHandler(posModel: posModel, searchTerm: searchTerm, itemListType: itemListType)
-        }
-    }
-
-    @ViewBuilder
-    func childListView(parentItem: POSItem) -> some View {
-        // Note that navigation is handled by the ItemList in iOS 17, so any changes to this should be reflected in ItemListRow.
-        switch parentItem {
-        case let .variableParentProduct(parentProduct):
-            // This always uses the non-search itemsController, otherwise it will have the search term and not work properly
-            // This is a temporary fix until we tidy up the stack selection, as it means non-products child lists won't work.
-            ChildItemList(
-                parentItem: parentItem,
-                title: parentProduct.name,
-                itemsController: posModel.purchasableItemsController,
-                itemActionHandler: actionHandler(selectedItemListType)
-            )
-        default:
-            EmptyView()
-        }
-    }
-
+/// View Helpers
+///
+@available(iOS 17.0, *)
+private extension ItemListView {
     @ViewBuilder
     var emptyView: some View {
         switch selectedItemListType {
@@ -433,18 +360,6 @@ private extension ItemListView {
             "pos.itemlistview.couponsTitle",
             value: "Coupons",
             comment: "Title of the button at the top of Point of Sale to switch to Coupons list."
-        )
-
-        static let searchFieldLabel = NSLocalizedString(
-            "pos.itemlistview.searchField.label",
-            value: "Search Products",
-            comment: "Label/placeholder text for the product search field in Point of Sale."
-        )
-
-        static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
-            "pos.itemlistview.searchField.clearButton.accessibilityLabel",
-            value: "Clear Search",
-            comment: "Accessibility label for the clear button in the Point of Sale product search screen."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -237,7 +237,7 @@ private extension ItemListView {
                 title: Localization.productsTitle,
                 isSelected: selectedItemListType.isProducts,
                 action: {
-                    displayItemListType(.products(search: searchTerm.isNotEmpty))
+                    displayItemListType(.products(search: false))
                 }
             )
         ]

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -137,18 +137,15 @@ struct ItemListView: View {
 
     @ViewBuilder
     private func itemListContent(_ itemListType: ItemListType) -> some View {
-        Group {
-            switch itemListState(itemListType) {
-            case .loading(let items),
-                    .loaded(let items, _),
-                    .inlineError(let items, _, _):
-                listView(items, itemListType: itemListType)
-            case .error(let errorState):
-                errorView(errorState)
-                EmptyView()
-            case .empty:
-                emptyView
-            }
+        switch itemListState(itemListType) {
+        case .loading(let items),
+                .loaded(let items, _),
+                .inlineError(let items, _, _):
+            listView(items, itemListType: itemListType)
+        case .error(let errorState):
+            errorView(errorState)
+        case .empty:
+            emptyView
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -68,20 +68,23 @@ struct ItemListView: View {
         VStack(spacing: 0) {
             headerView
 
-            TabView(selection: $selectedItemListType) {
-                itemListContent(.products(search: false))
-                if isSearchProductsFeatureEnabled {
-                    itemListContent(.products(search: true))
+            ZStack {
+                TabView(selection: $selectedItemListType) {
+                    itemListContent(.products(search: false))
+                    if isCouponsFeatureEnabled {
+                        itemListContent(.coupons)
+                    }
                 }
-                if isCouponsFeatureEnabled {
-                    itemListContent(.coupons)
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.none, value: selectedItemListType)
+                .ignoresSafeArea()
+
+                if selectedItemListType.isSearching {
+                    searchOverlay(itemListType: selectedItemListType)
+                        .transition(.opacity.combined(with: .move(edge: .trailing)))
                 }
             }
-            .tabViewStyle(.page(indexDisplayMode: .never))
-            .animation(.none, value: selectedItemListType)
-            .ignoresSafeArea()
         }
-
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
         // the navigation is handled in a NavigationLink in ItemList.swift. Avoiding the warning is impractical.
         .navigationDestination(for: POSItem.self, destination: { item in
@@ -100,7 +103,26 @@ struct ItemListView: View {
     @ViewBuilder
     private func itemListContent(_ itemListType: ItemListType) -> some View {
         Group {
-            if itemListType.isSearching && searchTerm.isEmpty {
+            switch itemListState(itemListType) {
+            case .loading(let items),
+                    .loaded(let items, _),
+                    .inlineError(let items, _, _):
+                listView(items, itemListType: itemListType)
+            case .error(let errorState):
+                errorView(errorState)
+                EmptyView()
+            case .empty:
+                emptyView
+            }
+        }
+        .tag(itemListType)
+        .gesture(DragGesture()) // Disable a default swipe gesture between the tabs
+    }
+
+    @ViewBuilder
+    private func searchOverlay(itemListType: ItemListType) -> some View {
+        VStack(spacing: 0) {
+            if searchTerm.isEmpty {
                 POSRecentSearchesView(
                     savedSearches: posModel.searchHistory(for: itemListType.itemType),
                     onSearchSelected: { search in
@@ -124,8 +146,7 @@ struct ItemListView: View {
                 }
             }
         }
-        .tag(itemListType)
-        .gesture(DragGesture()) // Disable a default swipe gesture between the tabs
+        .background(Color.posSurface)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -87,29 +87,15 @@ struct ItemListView: View {
         VStack(spacing: 0) {
             headerView
 
-            ZStack {
-                TabView(selection: $selectedItemListType) {
-                    itemListTabContent(.products(search: false))
-                    if isCouponsFeatureEnabled {
-                        itemListTabContent(.coupons)
-                    }
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.none, value: selectedItemListType)
-                .ignoresSafeArea()
-
-                if selectedItemListType.isSearching {
-                    POSSearchContentView(
-                        searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
-                                                         searchHistoryProvider: posModel.searchHistoryService),
-                        searchTerm: $searchTerm
-                    ) { _ in
-                        itemListContent(selectedItemListType)
-                    }
-                    .transition(.opacity.combined(with: .move(edge: .trailing)))
-                    .zIndex(1)
+            TabView(selection: $selectedItemListType) {
+                itemListTabContent(.products(search: false))
+                if isCouponsFeatureEnabled {
+                    itemListTabContent(.coupons)
                 }
             }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .animation(.none, value: selectedItemListType)
+            .ignoresSafeArea()
         }
         // N.B. This navigationDestination causes a runtime warning in iOS 17, and is ignored. On iOS 17,
         // the navigation is handled in a NavigationLink in ItemList.swift. Avoiding the warning is impractical.
@@ -128,9 +114,23 @@ struct ItemListView: View {
 
     @ViewBuilder
     private func itemListTabContent(_ itemListType: ItemListType) -> some View {
-        itemListContent(itemListType)
-            .tag(itemListType)
-            .gesture(DragGesture()) // Disable a default swipe gesture between the tabs
+        ZStack {
+            itemListContent(itemListType)
+
+            if selectedItemListType.isSearching && itemListType.isProducts {
+                POSSearchContentView(
+                    searchable: POSProductSearchable(itemsController: posModel.purchasableItemsSearchController,
+                                                     searchHistoryProvider: posModel.searchHistoryService),
+                    searchTerm: $searchTerm
+                ) { _ in
+                    itemListContent(selectedItemListType)
+                }
+                .transition(.opacity.combined(with: .move(edge: .trailing)))
+                .zIndex(1)
+            }
+        }
+        .tag(itemListType)
+        .gesture(DragGesture()) // Disable a default swipe gesture between the tabs
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/KeyboardObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/KeyboardObserver.swift
@@ -7,6 +7,15 @@ final class KeyboardObserver {
     private(set) var isKeyboardVisible: Bool = false
     private(set) var keyboardHeight: CGFloat = 0
 
+    /// When an external keyboard is in use, iPadOS shows a quicktype bar at the bottom of the screen.
+    /// This is reported as a keyboard with height, so `isKeyboardVisible` will be true and
+    /// keyboard height will be > 0.
+    /// However, it's much less of an impingement on the view, so there may be no modification to the view required.
+    /// `isFullSizeKeyboardVisible` is true when the full software keyboard is shown.
+    var isFullSizeKeyboardVisible: Bool {
+        return keyboardHeight > Constants.hardwareKeyboardHelperBarHeightThreshold
+    }
+
     private var cancellables = Set<AnyCancellable>()
 
     init() {
@@ -36,6 +45,13 @@ final class KeyboardObserver {
         let keyboardFrame = frameValue.cgRectValue
         self.keyboardHeight = keyboardFrame.height
         self.isKeyboardVisible = true
+    }
+}
+
+@available(iOS 17.0, *)
+private extension KeyboardObserver {
+    enum Constants {
+        static let hardwareKeyboardHelperBarHeightThreshold: CGFloat = 90
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 		209E96BD2DB681B50089F3D2 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */; };
 		209ECA812DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */; };
 		209EE8132DBA95BA0089F3D2 /* POSSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EE8122DBA95BA0089F3D2 /* POSSearchView.swift */; };
+		209EE8152DBA96D00089F3D2 /* POSProductSearchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EE8142DBA96D00089F3D2 /* POSProductSearchable.swift */; };
 		209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EEF8F2C762ED5007969A4 /* POSModalManager.swift */; };
 		20A130EB2C5A27190058022F /* PointOfSaleAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */; };
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
@@ -4164,6 +4165,7 @@
 		209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleViewStateCoordinator.swift; sourceTree = "<group>"; };
 		209EE8122DBA95BA0089F3D2 /* POSSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchView.swift; sourceTree = "<group>"; };
+		209EE8142DBA96D00089F3D2 /* POSProductSearchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductSearchable.swift; sourceTree = "<group>"; };
 		209EEF8F2C762ED5007969A4 /* POSModalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalManager.swift; sourceTree = "<group>"; };
 		209FC9C42228DA65BD11D65E /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAssetsTests.swift; sourceTree = "<group>"; };
@@ -8466,6 +8468,7 @@
 		20B9EC682DAFFB3800512EF5 /* Item Search */ = {
 			isa = PBXGroup;
 			children = (
+				209EE8142DBA96D00089F3D2 /* POSProductSearchable.swift */,
 				209EE8122DBA95BA0089F3D2 /* POSSearchView.swift */,
 				20B9EC692DAFFB7A00512EF5 /* POSRecentSearchesView.swift */,
 			);
@@ -17394,6 +17397,7 @@
 				B5D1AFC020BC67C200DB0E8C /* WooConstants.swift in Sources */,
 				45C8B26123155CBC0002FA77 /* BillingInformationViewController.swift in Sources */,
 				E12FB786266E0CAE0039E9C2 /* ApllicationLogDetailView.swift in Sources */,
+				209EE8152DBA96D00089F3D2 /* POSProductSearchable.swift in Sources */,
 				74EC34A5225FE21F004BBC2E /* ProductLoaderViewController.swift in Sources */,
 				CE8CCD43239AC06E009DBD22 /* RefundDetailsViewController.swift in Sources */,
 				869C2AA42C91791B00DDEE13 /* AztecEditorView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -892,6 +892,7 @@
 		209E8F572DB2AF200089F3D2 /* MockPointOfSalePopularItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E8F562DB2AF200089F3D2 /* MockPointOfSalePopularItemsController.swift */; };
 		209E96BD2DB681B50089F3D2 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */; };
 		209ECA812DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */; };
+		209EE8132DBA95BA0089F3D2 /* POSSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EE8122DBA95BA0089F3D2 /* POSSearchView.swift */; };
 		209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EEF8F2C762ED5007969A4 /* POSModalManager.swift */; };
 		20A130EB2C5A27190058022F /* PointOfSaleAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */; };
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
@@ -4162,6 +4163,7 @@
 		209E8F562DB2AF200089F3D2 /* MockPointOfSalePopularItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePopularItemsController.swift; sourceTree = "<group>"; };
 		209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleViewStateCoordinator.swift; sourceTree = "<group>"; };
+		209EE8122DBA95BA0089F3D2 /* POSSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchView.swift; sourceTree = "<group>"; };
 		209EEF8F2C762ED5007969A4 /* POSModalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalManager.swift; sourceTree = "<group>"; };
 		209FC9C42228DA65BD11D65E /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAssetsTests.swift; sourceTree = "<group>"; };
@@ -8464,6 +8466,7 @@
 		20B9EC682DAFFB3800512EF5 /* Item Search */ = {
 			isa = PBXGroup;
 			children = (
+				209EE8122DBA95BA0089F3D2 /* POSSearchView.swift */,
 				20B9EC692DAFFB7A00512EF5 /* POSRecentSearchesView.swift */,
 			);
 			path = "Item Search";
@@ -17161,6 +17164,7 @@
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,
 				02BBD6E929A3024400243BE2 /* StoreOnboardingTaskView.swift in Sources */,
 				028203CF297662A200217369 /* DomainSelectorDataProvider.swift in Sources */,
+				209EE8132DBA95BA0089F3D2 /* POSSearchView.swift in Sources */,
 				DE74F2A327E41D650002FE59 /* EnableAnalyticsViewModel.swift in Sources */,
 				AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */,
 				EE5B5BB32AB30C0A009BCBD6 /* ProductCreationAIEligibilityChecker.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-146
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes various changes to our search UI heirarchy, with the end result of extracting it and making it ready for use for the coupons list.

1. Show search results as an overlay in a ZStack inside their relevant tab
2. Extract the search field view to POSSearchField
3. Extract the search content to POSSearchContentView – N.B. we still pass in the itemlist. Perhaps this could be more opinionated and have its own itemlist definition, but I like that it can be identical to the view using it
4. Combine the search dependencies into POSSearchable implementations (maybe the protocol could do with a better name...)

The change in the heirarchy means that scroll state for the main list is now retained during searches, so if you scroll, then search something, then come back to the main list, it'll be where you left it. Scroll state is still not retained when checking out.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Tap search
3. Search for items
4. Add them to your cart
6. Experiment with clearing search, and going back to the main list

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This requires thorough testing of the search and tab switching interactions on both iOS 17 and iOS 18. 

One known issue; on iOS 17, the navigation workaround for child lists doesn't like being in a ZStack. That means when you tap a variable parent product, the child list is shown immediately, with no animation. I've spent some time trying to track it down and will do more later, but I think the tradeoff of having a properly reusable and properly structured view is worth it. Note that if we just use NavigationStack on iOS 17, it works properly, but I don't want to reintroduce the leaks that we fixed with the workaround, it's too risky.

Another known issue; when moving to checkout from a variation list, then coming back, you'll be at the root of whichever view you were on last (product list or product search.) This is just how it is in trunk as well; we'll need to keep the navigation path/activeNavigationItem in our view state coordinator to fix it.

I've tested iOS 17.7.2 on an iPad Air, and iOS 18.4 on a simulator. I tested with, and without, the coupons flag enabled.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d6f3a62d-ecb4-4cb8-a5a0-0b0e48ae57f3


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added