### PR TITLE
[Shipping Labels] Disable last unfulfilled shipment removal item

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -131,10 +131,14 @@ private extension WooShippingSplitShipmentsView {
     var removeShipmentMenu: some View {
         Menu {
             ForEach(viewModel.shipments) { shipment in
-                Button(String.localizedStringWithFormat(Localization.removeShipmentFormat,
-                                                        viewModel.retrieveName(for: shipment).lowercased())) {
+                Button(
+                    String.localizedStringWithFormat(
+                        Localization.removeShipmentFormat,
+                        viewModel.retrieveName(for: shipment).lowercased()
+                    )
+                ) {
                     shipmentToRemove = shipment
-                }.disabled(shipment.isPurchased)
+                }.disabled(viewModel.isShipmentDeleteOptionDisabled(for: shipment))
             }
             Divider()
             Button(Localization.mergeAll) {
@@ -268,7 +272,7 @@ private extension WooShippingSplitShipmentsView {
                                        lineColor: otherShipment == shipmentToMergeInto ? .accentColor : Color(.separator),
                                        lineWidth: otherShipment == shipmentToMergeInto ? 2 : 1)
                     }
-                    .disabled(otherShipment.isPurchased)
+                    .disabled(viewModel.isShipmentDeleteOptionDisabled(for: otherShipment))
                 }
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -304,9 +304,12 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     /// 2. The view model is currently saving shipment info
     /// 3. The shipment is the last unfulfilled shipment
     func isShipmentDeleteOptionDisabled(for shipment: Shipment) -> Bool {
+        if shipment.isPurchased || isSavingShipmentInfo {
+            return true
+        }
+
         let unfulfilledShipments = shipments.filter { !$0.isPurchased }
-        let isLastUnfulfilled = unfulfilledShipments.count == 1 && unfulfilledShipments.first == shipment
-        return shipment.isPurchased || isSavingShipmentInfo || isLastUnfulfilled
+        return unfulfilledShipments.count == 1 && unfulfilledShipments.first == shipment
     }
 
     func shipmentsToMerge(for shipment: Shipment) -> [Shipment] {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -298,6 +298,17 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         return String.localizedStringWithFormat(Localization.shipmentFormat, index + 1)
     }
 
+    /// Determines if a shipment's delete option should be disabled.
+    /// A shipment's delete option should be disabled if:
+    /// 1. The shipment is already purchased
+    /// 2. The view model is currently saving shipment info
+    /// 3. The shipment is the last unfulfilled shipment
+    func isShipmentDeleteOptionDisabled(for shipment: Shipment) -> Bool {
+        let unfulfilledShipments = shipments.filter { !$0.isPurchased }
+        let isLastUnfulfilled = unfulfilledShipments.count == 1 && unfulfilledShipments.first == shipment
+        return shipment.isPurchased || isSavingShipmentInfo || isLastUnfulfilled
+    }
+
     func shipmentsToMerge(for shipment: Shipment) -> [Shipment] {
         shipments.filter { $0 != shipment }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -850,9 +850,9 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
                 ShippingLabelPurchase.fake().copy(shipmentID: "1")
             ]
         )
-        
+
         let config = WooShippingConfig(
-            siteID: 123, 
+            siteID: 123,
             shipments: [
                 "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
                 "2": [WooShippingShipmentItem(id: 2, subItems: [])]
@@ -911,13 +911,13 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
                 ShippingLabelPurchase.fake().copy(shipmentID: "2")
             ]
         )
-        
+
         let config = WooShippingConfig(
-            siteID: 123, 
+            siteID: 123,
             shipments: [
                 "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
                 "2": [WooShippingShipmentItem(id: 2, subItems: [])]
-            ], 
+            ],
             shippingLabelData: shippingLabelData
         )
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -835,6 +835,106 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.containsUnsavedChanges)
     }
+
+    // MARK: - `isShipmentDeleteOptionDisabled`
+
+    func test_isShipmentDeleteOptionDisabled_returns_true_for_purchased_shipment() throws {
+        // Given
+        let items = [
+            sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+            sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)
+        ]
+
+        let shippingLabelData = WooShippingLabelData(
+            currentOrderLabels: [
+                ShippingLabelPurchase.fake().copy(shipmentID: "1")
+            ]
+        )
+        
+        let config = WooShippingConfig(
+            siteID: 123, 
+            shipments: [
+                "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+                "2": [WooShippingShipmentItem(id: 2, subItems: [])]
+            ], shippingLabelData: shippingLabelData
+        )
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: config,
+            items: items,
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // When
+        let purchasedShipment = viewModel.shipments[0]  // First shipment is purchased
+
+        // Then
+        XCTAssertTrue(viewModel.isShipmentDeleteOptionDisabled(for: purchasedShipment))
+    }
+
+    func test_isShipmentDeleteOptionDisabled_returns_false_for_unfulfilled_shipment_when_there_are_multiple() throws {
+        // Given
+        let items = [
+            sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+            sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)
+        ]
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: WooShippingConfig.fake(),
+            items: items,
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // When
+        viewModel.shipments.first?.contents.first?.childItemRows.first?.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+
+        // Then
+        XCTAssertEqual(viewModel.shipments.count, 2)
+        XCTAssertFalse(viewModel.isShipmentDeleteOptionDisabled(for: viewModel.shipments[0]))
+        XCTAssertFalse(viewModel.isShipmentDeleteOptionDisabled(for: viewModel.shipments[1]))
+    }
+
+    func test_isShipmentDeleteOptionDisabled_returns_true_for_last_unfulfilled_shipment() throws {
+        // Given
+        let items = [
+            sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+            sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)
+        ]
+
+        let shippingLabelData = WooShippingLabelData(
+            currentOrderLabels: [
+                ShippingLabelPurchase.fake().copy(shipmentID: "2")
+            ]
+        )
+        
+        let config = WooShippingConfig(
+            siteID: 123, 
+            shipments: [
+                "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+                "2": [WooShippingShipmentItem(id: 2, subItems: [])]
+            ], 
+            shippingLabelData: shippingLabelData
+        )
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: config,
+            items: items,
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // When
+        let unfulfilledShipment = viewModel.shipments[0]  // First shipment is unfulfilled
+
+        // Then
+        XCTAssertTrue(viewModel.isShipmentDeleteOptionDisabled(for: unfulfilledShipment))
+    }
 }
 
 private extension WooShippingSplitShipmentsViewModelTests {


### PR DESCRIPTION
Part of: WOOMOB-369
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
The PR change addresses the issue where it was possible to delete the last unfulfilled shipment. The "Remove shipment" option for such shipment will be disabled.

Adds `isShipmentDeleteOptionDisabled` method that determines the `disabled` state of such option.

## Known issues.

It's still possible to merge shipments when there is only 1 unfulfilled shipment left. The "Select all" is also active for fulfilled shipments which shouldn't be the case. That's gonna be addressed in separate PRs.

## Testing steps
- Log in to a test store with Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with several physical products.
- Setup order in the way that it has N of fulfilled shipments (with labels purchased) and 1 unfulfilled shipment.
- Enter "Split Shipments" screen.
- Tap on "..." meatballs option to edit shipments.
- Make sure that the "Remove shipment" option for the only unfulfilled shipment is disabled.

## Testing information
- Corresponding view model tests added
- Tested on iPhone 16 (18.2) simulator

## Screenshots

Before | After
--- | ---
<img width="371" alt="Снимок экрана 2025-04-25 в 16 04 21" src="https://github.com/user-attachments/assets/1669235b-ef29-48eb-ab71-928662b86bad" /> | <img width="372" alt="Снимок экрана 2025-04-25 в 16 01 34" src="https://github.com/user-attachments/assets/8a76f100-695b-490f-a652-2c66fa528003" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.