### PR TITLE
[Mobile Payments] Prevent sleep during TTP configuration steps.

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -988,6 +988,7 @@ extension StripeCardReaderService: TapToPayReaderDelegate {
     // TODO: use a specific `deviceSetup` in these three functions instead of reusing the softwareUpdateSubject
     // https://github.com/woocommerce/woocommerce-ios/issues/8088
     public func tapToPayReader(_ reader: Reader, didStartInstallingUpdate update: ReaderSoftwareUpdate, cancelable: Cancelable?) {
+        UIApplication.shared.isIdleTimerDisabled = true
         softwareUpdateSubject.send(.started(cancelable: cancelable.map(StripeCancelable.init(cancelable:))))
     }
 
@@ -996,6 +997,7 @@ extension StripeCardReaderService: TapToPayReaderDelegate {
     }
 
     public func tapToPayReader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
+        UIApplication.shared.isIdleTimerDisabled = false
         if let error = error {
             let underlyingError = Self.logAndDecodeError(error)
             softwareUpdateSubject.send(.failed(

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [internal] POS: Reduced prominence of the simple/variable products only banner [https://github.com/woocommerce/woocommerce-ios/pull/15539]
 - [**] POS: Product search added [https://github.com/woocommerce/woocommerce-ios/pull/15545]
+- [*] Payments: Prevent sleep during Tap to Pay on iPhone configuration step [https://github.com/woocommerce/woocommerce-ios/pull/15555]
 
 22.2
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-285
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When using Tap to Pay on iPhone for the first time (or the first time in a while) on a device, it has a configuration step. We use our software update flow to communicate this.

This PR prevents sleep during the configuration step, in the same way as we do for Bluetooth readers.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

**Take care – you only get one shot per device because you can't simulate it.**

Delete the app, then install from Xcode, but don't do anything in the app. Stop the app from Xcode.

Ensure you're running the app on a physical device, without being connected to the debugger/Xcode. Devices never sleep when connected to Xcode, so you can't simulate this.

Set your device's sleep time to 30s

1. Launch the app from the springboard and log in
2. Go to Menu > Payments
3. Tap Set up Tap to Pay on iPhone and go through the flow
4. Observe that you're shown the Updating step – don't touch the screen during this, and run a timer
5. Observe that the display dims after a few seconds, and locks after 30s since your last interaction

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested and confirmed this on an iPhone 13 Pro running iOS 17

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/6a22bbcf-3414-460d-bd01-839d79b6fbc1


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.