### PR TITLE
[Mobile Payments] Use plugin-specific Pending Requirements learn more link

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [internal] POS: Reduced prominence of the simple/variable products only banner [https://github.com/woocommerce/woocommerce-ios/pull/15539]
 - [**] POS: Product search added [https://github.com/woocommerce/woocommerce-ios/pull/15545]
 - [*] Payments: Prevent sleep during Tap to Pay on iPhone configuration step [https://github.com/woocommerce/woocommerce-ios/pull/15555]
+- [*] Payments: Use correct documentation link for pending requirements onboarding step [https://github.com/woocommerce/woocommerce-ios/pull/15556]
 
 22.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
@@ -70,10 +70,11 @@ struct CardPresentPaymentsOnboardingView: View {
                 InPersonPaymentsStripeAccountOverdue(analyticReason: viewModel.state.reasonForAnalytics,
                                                      onRefresh: viewModel.refresh,
                                                      plugin: plugin)
-            case .stripeAccountPendingRequirement(_, let deadline):
+            case .stripeAccountPendingRequirement(let plugin, let deadline):
                 InPersonPaymentsStripeAccountPending(
                     deadline: deadline,
                     analyticReason: viewModel.state.reasonForAnalytics,
+                    plugin: plugin,
                     onSkip: viewModel.skipPendingRequirements)
             case .stripeAccountUnderReview:
                 InPersonPaymentsStripeAccountReview(analyticReason: viewModel.state.reasonForAnalytics)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -4,9 +4,8 @@ import enum Yosemite.CardPresentPaymentsPlugin
 struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
     let analyticReason: String
+    let plugin: CardPresentPaymentsPlugin
     let onSkip: () -> ()
-
-    private let plugin: CardPresentPaymentsPlugin = .stripe
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -72,7 +71,7 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountPending_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountPending(deadline: Date(), analyticReason: "", onSkip: {})
+        InPersonPaymentsStripeAccountPending(deadline: Date(), analyticReason: "", plugin: .wcPay, onSkip: {})
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-113
Merge after: #15555 
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures we specify a plugin when we get the pending requirements error, which results in us getting a platform specific link for the Learn more button.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Change the code to always return `true` in `CardPresentPaymentsOnboardingUseCase.isStripeAccountPendingRequirements(account:)`
2. Launch the app and use a WooPayments site
3. Go to Menu > Payments
4. Tap the `Continue setup` button in the banner at the bottom
5. Wait for the pending requirements screen to show
6. Tap `Learn More`
7. Observe that the WooPayments documentation is shown

Switch to a Stripe site and repeat; observe that the Stripe docs are shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested on iOS 18.4 on an iPhone 15 Pro Max

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/578e2503-c6a2-4d0b-a50b-66e86b5ec2f9


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.