### PR TITLE
[Woo POS] [Receipts] Set `created_via` parameter in POS order creation request to identify POS orders

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -379,6 +379,7 @@ internal extension Order {
         case metadata           = "meta_data"
         case giftCards          = "gift_cards"
         case shippingLabels     = "shipping_labels"
+        case createdVia         = "created_via"
     }
 }
 

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Order: Remote Endpoints
 ///
 public class OrdersRemote: Remote {
+    /// The source of the order creation.
+    public enum OrderCreationSource {
+        case storeManagement
+        case pointOfSale
+    }
 
     /// Retrieves all of the `Orders` available.
     ///
@@ -161,9 +166,15 @@ public class OrdersRemote: Remote {
     ///     - order: Order to be created.
     ///     - giftCard: Optional gift card to apply to the order.
     ///     - fields: Fields of the order to be created.
+    ///     - source: Source of the order creation.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func createOrder(siteID: Int64, order: Order, giftCard: String?, fields: [CreateOrderField], completion: @escaping (Result<Order, Error>) -> Void) {
+    public func createOrder(siteID: Int64,
+                            order: Order,
+                            giftCard: String?,
+                            fields: [CreateOrderField],
+                            source: OrderCreationSource = .storeManagement,
+                            completion: @escaping (Result<Order, Error>) -> Void) {
         do {
             let path = Constants.ordersPath
             let mapper = OrderMapper(siteID: siteID)
@@ -206,6 +217,10 @@ public class OrdersRemote: Remote {
                 params[Order.CodingKeys.metadata.rawValue] = try [MetaData(metadataID: 0,
                                                                                 key: OrderAttributionInfo.Keys.sourceType.rawValue,
                                                                                 value: OrderAttributionInfo.Values.mobileAppSourceType).toDictionary()]
+
+                if let createdViaValue = source.createdViaValue {
+                    params[Order.CodingKeys.createdVia.rawValue] = createdViaValue
+                }
 
                 return params
             }()
@@ -390,7 +405,7 @@ public class OrdersRemote: Remote {
 extension OrdersRemote: POSOrdersRemoteProtocol {
     public func createPOSOrder(siteID: Int64, order: Order, fields: [CreateOrderField]) async throws -> Order {
         return try await withCheckedThrowingContinuation { continuation in
-            createOrder(siteID: siteID, order: order, giftCard: nil, fields: fields) { result in
+            createOrder(siteID: siteID, order: order, giftCard: nil, fields: fields, source: .pointOfSale) { result in
                 switch result {
                 case let .success(order):
                     continuation.resume(returning: order)
@@ -493,5 +508,16 @@ public extension OrdersRemote {
         case customerNote
         case customerID
         case currency
+    }
+}
+
+private extension OrdersRemote.OrderCreationSource {
+    var createdViaValue: String? {
+        switch self {
+        case .storeManagement:
+            return nil
+        case .pointOfSale:
+            return "pos-rest-api"
+        }
     }
 }

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -739,6 +739,33 @@ final class OrdersRemoteTests: XCTestCase {
         assertEqual(received, expected)
     }
 
+    func test_createPOSOrder_sets_created_via_for_point_of_sale() async throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let order = Order.fake()
+
+        // When
+        _ = try? await remote.createPOSOrder(siteID: 123, order: order, fields: [])
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["created_via"] as? String)
+        assertEqual(received, "pos-rest-api")
+    }
+
+    func test_createOrder_without_source_parameter_does_not_set_created_via() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let order = Order.fake()
+
+        // When
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        XCTAssertNil(request.parameters["created_via"])
+    }
+
     // MARK: - Delete order tests
 
     func test_delete_order_properly_returns_parsed_order() throws {

--- a/Yosemite/Yosemite/Stores/SystemStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/SystemStatusStore.swift
@@ -134,7 +134,8 @@ private extension SystemStatusStore {
     func fetchSystemPlugin(siteID: Int64, systemPluginNameList: [String], completionHandler: @escaping (SystemPlugin?) -> Void) {
         let matchingPlugins = storageManager.viewStorage.loadSystemPlugins(siteID: siteID, matching: systemPluginNameList)
             .map { $0.toReadOnly() }
-        completionHandler(matchingPlugins.first)
+        let matchingPlugin = matchingPlugins.first { $0.active } ?? matchingPlugins.first
+        completionHandler(matchingPlugin)
     }
 
     func fetchSystemPluginWithPath(siteID: Int64, pluginPath: String, onCompletion: @escaping (SystemPlugin?) -> Void) {

--- a/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift
@@ -126,6 +126,74 @@ final class SystemStatusStoreTests: XCTestCase {
         XCTAssertEqual(systemPluginResult?.name, "Plugin 3") // number of systemPlugins in storage
     }
 
+    func test_fetchSystemPlugin_prefers_active_plugin_when_multiple_plugins_exist() throws {
+        // Given
+        let pluginName = "Plugin 1"
+        let inactivePlugin = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        inactivePlugin.name = pluginName
+        inactivePlugin.active = false
+        inactivePlugin.siteID = sampleSiteID
+
+        let activePlugin = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.name = pluginName
+        activePlugin.active = true
+        activePlugin.siteID = sampleSiteID
+
+        let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let fetchedPlugin = waitFor { promise in
+            store.onAction(SystemStatusAction.fetchSystemPlugin(siteID: self.sampleSiteID,
+                                                                systemPluginName: pluginName) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        let plugin = try XCTUnwrap(fetchedPlugin)
+        XCTAssertTrue(plugin.active)
+        XCTAssertEqual(plugin.name, pluginName)
+    }
+
+    func test_fetchSystemPlugin_returns_inactive_plugin_when_no_active_plugin_exists() throws {
+        // Given
+        let inactivePlugin = viewStorage.insertNewObject(ofType: SystemPlugin.self)
+        inactivePlugin.name = "Plugin 1"
+        inactivePlugin.active = false
+        inactivePlugin.siteID = sampleSiteID
+
+        let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let fetchedPlugin = waitFor { promise in
+            store.onAction(SystemStatusAction.fetchSystemPlugin(siteID: self.sampleSiteID,
+                                                                systemPluginName: "Plugin 1") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        let plugin = try XCTUnwrap(fetchedPlugin)
+        XCTAssertFalse(plugin.active)
+        XCTAssertEqual(plugin.name, "Plugin 1")
+    }
+
+    func test_fetchSystemPlugin_returns_nil_when_no_plugin_exists() {
+        // Given
+        let store = SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let fetchedPlugin = waitFor { promise in
+            store.onAction(SystemStatusAction.fetchSystemPlugin(siteID: self.sampleSiteID,
+                                                                systemPluginName: "NonExistentPlugin") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertNil(fetchedPlugin)
+    }
+
     func test_fetchSystemPluginsList_return_systemPlugins_correctly() {
         // Given
         let systemPlugin1 = viewStorage.insertNewObject(ofType: SystemPlugin.self)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-214
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Just one reviewer is needed for this PR.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request sets `created_via` parameter to `pos-rest-api` for POS orders in `OrdersRemote` to differentiate from non-POS orders, now that the API support is available in WC version 9.9.0 https://github.com/woocommerce/woocommerce/pull/57225. Additionally, it addresses an issue in `SystemStatusStore` when multiple plugins of the same name exist in the installed plugins like when using WC beta tester plugin with JN (as in the testing steps for this PR) and maybe other beta testing tool. Below are the most important changes:

### Changes to `OrdersRemote`:

* Added a new `OrderCreationSource` enum to represent the source of order creation, with cases for `storeManagement` and `pointOfSale` (`Networking/Networking/Remote/OrdersRemote.swift`).
* Updated the `createOrder` method to include an optional `source` parameter, defaulting to `.storeManagement`. This parameter is used to set the `created_via` field in the request parameters (`Networking/Networking/Remote/OrdersRemote.swift`). [[1]](diffhunk://#diff-5f592324134171a4e989878341b34bccb460d45913ba26acd2a0a4b671de1373R169-R177) [[2]](diffhunk://#diff-5f592324134171a4e989878341b34bccb460d45913ba26acd2a0a4b671de1373R221-R224)
* Modified the `createPOSOrder` method to automatically set the `source` parameter to `.pointOfSale` when creating orders through the POS system (`Networking/Networking/Remote/OrdersRemote.swift`).
* Introduced a private extension to map `OrderCreationSource` to the appropriate `created_via` value (`Networking/Networking/Remote/OrdersRemote.swift`).

### Enhancements to `SystemStatusStore`:

* Updated the `fetchSystemPlugin` method to prioritize active plugins when multiple plugins match the criteria. If no active plugin exists, it falls back to the first matching inactive plugin (`Yosemite/Yosemite/Stores/SystemStatusStore.swift`). This addresses the issue when POS isn't considered eligible using WC beta tester plugin, as beta testing tools often add another WC plugin in parallel with a different version.

### Test Coverage:

* Added tests for `OrdersRemote` to verify the correct behavior of the `created_via` field when creating orders with and without the `source` parameter (`Networking/NetworkingTests/Remote/OrdersRemoteTests.swift`).
* Added tests for `SystemStatusStore` to ensure it correctly prioritizes active plugins, falls back to inactive plugins when no active ones exist, and returns `nil` when no plugins are found (`Yosemite/YosemiteTests/Stores/SystemStatusStoreTests.swift`).

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Create a JN site with `WooCommerce` and `WooCommerce Beta Tester` (select `trunk`) plugins. Create and publish a product
- In the app, go to Orders tab and create an order. This order will be referred to as "order from store management"
- Go to Menu tab --> POS entry point should be visible
- Tap to enter POS
- Proceed to create an order and pay with cash. This order will be referred to as "order from POS"
- In API testing tool (I personally use Postman), check the response for `{{site_url}}/wp-json/wc/v3/orders/{{order_id}}` for 2 orders created above with the API credentials generated in WC Settings > Advanced > REST API. In the API request, I used Basic Auth with Username & Password from the generated API key and secret --> "order from store management" response should have `created_via` parameter set to `rest-api` (default behavior in core for orders created via API), and "order from POS" response should have `created_via` parameter set to `pos-rest-api` (new in WC version 9.9.0 https://github.com/woocommerce/woocommerce/pull/57225)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I tested with a local wp-env site and a JN site.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
