### PR TITLE
Shipping Labels: Fix UI issues after purchasing labels

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/WooShippingAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/WooShippingAddress.swift
@@ -119,3 +119,17 @@ extension WooShippingAddress {
         self.init(company: "", name: "", phone: "", country: "", state: "", address1: "", address2: "", city: "", postcode: "")
     }
 }
+
+public extension WooShippingAddress {
+    func toShippingLabelAddress() -> ShippingLabelAddress {
+        ShippingLabelAddress(company: company,
+                             name: name,
+                             phone: phone,
+                             country: country,
+                             state: state,
+                             address1: address1,
+                             address2: address2,
+                             city: city,
+                             postcode: postcode)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -189,9 +189,13 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
             }
             stores.dispatch(action)
         }
-        shippingLabel = purchasedLabel
-        postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: purchasedLabel)
-        onLabelPurchase?(purchasedLabel)
+        /// Addresses are not included in purchased shipping label details
+        /// so we have to manually populate the details.
+        let updatedLabel = purchasedLabel.copy(originAddress: originAddress.toShippingLabelAddress(),
+                                               destinationAddress: destinationAddress.toShippingLabelAddress())
+        shippingLabel = updatedLabel
+        postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: updatedLabel)
+        onLabelPurchase?(updatedLabel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -138,7 +138,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         dismissedInstructions = true
     }
 
-    func didPurchaseShipment(shipmentID: String, purchasedLabelID: Int64) {
+    func didPurchaseLabel(for shipmentID: String, purchasedLabelID: Int64) {
         guard let index = shipments.firstIndex(where: { $0.id == shipmentID }) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -138,6 +138,21 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         dismissedInstructions = true
     }
 
+    func didPurchaseShipment(shipmentID: String, purchasedLabelID: Int64) {
+        guard let index = shipments.firstIndex(where: { $0.id == shipmentID }) else {
+            return
+        }
+        let currentShipment = shipments[index]
+        let updatedContents = currentShipment.contents.map {
+            CollapsibleShipmentItemCardViewModel(item: $0.packageItem, isSelectable: false, currency: order.currency)
+        }
+        shipments[index] = Shipment(contents: updatedContents,
+                                    purchasedLabelID: purchasedLabelID,
+                                    currency: order.currency,
+                                    currencySettings: currencySettings,
+                                    shippingSettingsService: shippingSettingsService)
+    }
+
     func moveSelectedItems(to destination: MoveToShipmentNoticeViewModel.Destination) {
         moveToNoticeViewModel = nil
         instructions = nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -490,6 +490,8 @@ private extension WooShippingCreateLabelsViewModel {
                                             currency: order.currency,
                                             currencySettings: currencySettings,
                                             shippingSettingsService: shippingSettingsService)
+                splitShipmentsViewModel.didPurchaseShipment(shipmentID: shipment.id,
+                                                            purchasedLabelID: newLabel.shippingLabelID)
                 onLabelPurchase?(markOrderComplete)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -490,8 +490,8 @@ private extension WooShippingCreateLabelsViewModel {
                                             currency: order.currency,
                                             currencySettings: currencySettings,
                                             shippingSettingsService: shippingSettingsService)
-                splitShipmentsViewModel.didPurchaseShipment(shipmentID: shipment.id,
-                                                            purchasedLabelID: newLabel.shippingLabelID)
+                splitShipmentsViewModel.didPurchaseLabel(for: shipment.id,
+                                                         purchasedLabelID: newLabel.shippingLabelID)
                 onLabelPurchase?(markOrderComplete)
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -723,6 +723,44 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shipments[1].contents[0].packageItem.quantity, 1)
     }
 
+    // MARK: - `didPurchaseLabel`
+    func test_didPurchaseLabel_updates_fulfilled_shipment_correctly() throws {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1),
+                     sampleItem(id: 3, weight: 4, value: 5, quantity: 3)]
+
+        let shippingLabelData = WooShippingLabelData(currentOrderLabels: []) // none purchased yet
+        let config = WooShippingConfig(siteID: 123, shipments: [
+            "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+            "2": [WooShippingShipmentItem(id: 2, subItems: [])]
+        ], shippingLabelData: shippingLabelData)
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: config,
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        // Confidence check
+        XCTAssertTrue(viewModel.shipments[0].contents.allSatisfy({ $0.mainItemRow.isSelectable }))
+
+        // When
+        let shipmentID = viewModel.shipments[0].id
+        let purchasedLabelID: Int64 = 325
+        viewModel.didPurchaseLabel(for: shipmentID, purchasedLabelID: purchasedLabelID)
+
+        // Then
+        XCTAssertEqual(viewModel.shipments.count, 2)
+        XCTAssertEqual(viewModel.shipments[0].purchasedLabelID, purchasedLabelID)
+        XCTAssertFalse(viewModel.shipments[0].contents[0].mainItemRow.isSelectable)
+        XCTAssertTrue(viewModel.shipments[0].contents[0].childItemRows.allSatisfy({ !$0.isSelectable }))
+
+
+        XCTAssertEqual(viewModel.shipments[1].contents.count, 1)
+        XCTAssertTrue(viewModel.shipments[1].contents[0].mainItemRow.isSelectable)
+        XCTAssertNil(viewModel.shipments[1].purchasedLabelID)
+    }
+
     // MARK: - `enableDoneButton`
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -210,6 +210,46 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(shipmentDetails?["category"] as? String, ShippingLabelHazmatCategory.class3.rawValue)
     }
 
+    @MainActor
+    func test_purchaseLabel_triggers_onLabelPurchase_with_correct_purchased_shipping_label() async throws {
+        // Given
+        let expectedShippingLabel = ShippingLabel.fake().copy(carrierID: "usps", trackingNumber: "1234567890")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+
+        // When
+        var purchasedLabel: ShippingLabel?
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
+                                                            stores: stores,
+                                                            onLabelPurchase: { purchasedLabel = $0 })
+
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, completion):
+                completion(.success(expectedShippingLabel))
+            case .loadPackages, .loadOriginAddresses, .verifyDestinationAddress, .loadConfig:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.selectPackage(samplePackageData())
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+        try await viewModel.purchaseLabel()
+
+        // Then
+        XCTAssertNotNil(purchasedLabel)
+        XCTAssertEqual(purchasedLabel?.originAddress, originAddressSubject.value?.toShippingLabelAddress())
+        XCTAssertEqual(purchasedLabel?.destinationAddress, destinationAddressSubject.value?.toShippingLabelAddress())
+    }
+
     func test_selectPackage_sets_selectedPackage_with_package_data() {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-386
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After purchasing a label, there are a few issues:
- The origin and destination addresses of the label are not displayed correctly. This is due to the details are missing from the response of shipping label purchases and need to be populated manually.
- When opening the Split shipments screen after purchasing a label, the fulfilled shipment is not displayed as completed.

This PR fixes the above issues by:
- Manually populate the origin and destination addresses to the purchased label.
- Update the Split Shipments screen after purchasing a label.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a completed order with several physical products.
3. Select Create shipping label > Split shipment > Move items to different shipments > tap Done.
4. Proceed to purchase a label.
5. After the purchase completes, open the bottom sheet and confirm that the origin and destination address are displayed correctly and not editable.
6. Tap on the pencil button on the shipment tab bar to open the Split shipments screen. 
7. Confirm that the fulfilled shipment is marked as complete and cannot be updated.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Manually tested and confirmed the above test cases on simulator iPhone 16 Pro iOS 18.2.
- Added unit tests to confirm the changes in split shipments and label purchase.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/b73f98fd-cc95-4bbf-ab82-d208f496a082



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
