### PR TITLE
[Payments] Update `CardPresentPaymentsPlugin`'s plugin name to WooPayments

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -64,7 +64,7 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
 
     /// Returns true if In Person Payments allows sending failed payment email receipts via the API.
     /// WooCommerce 9.5 allows to attach a customer email after payment is made and send email receipt via the API.
-    /// WooCommerc 9.5 automatically sends failure receipt after the order fails if the customer email is attached to the order.
+    /// WooCommerce 9.5 automatically sends failure receipt after the order fails if the customer email is attached to the order.
     /// WooPayments 8.6 aligns the app with the web and automatically sets the order as failed when the payment processing fails.
     /// WooCommerce Stripe Gateway 9.1.0 aligns the app with the web and automatically sets the order as failed when the payment processing fails.
     ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -1216,6 +1216,16 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(eventProperties["country"] as? String, "US")
         XCTAssertEqual(eventProperties["error_description"] as? String, expectedError.description)
     }
+
+    func test_CardPresentPaymentsPlugin_has_expected_name_and_fileNames() {
+        XCTAssertEqual(CardPresentPaymentsPlugin.wcPay.pluginName, "WooPayments")
+        XCTAssertEqual(CardPresentPaymentsPlugin.wcPay.fileNameWithoutExtension, "woocommerce-payments")
+        XCTAssertEqual(CardPresentPaymentsPlugin.wcPay.fileNameWithPathExtension, "woocommerce-payments/woocommerce-payments")
+
+        XCTAssertEqual(CardPresentPaymentsPlugin.stripe.pluginName, "WooCommerce Stripe Gateway")
+        XCTAssertEqual(CardPresentPaymentsPlugin.stripe.fileNameWithoutExtension, "woocommerce-gateway-stripe")
+        XCTAssertEqual(CardPresentPaymentsPlugin.stripe.fileNameWithPathExtension, "woocommerce-gateway-stripe/woocommerce-gateway-stripe")
+    }
 }
 
 // MARK: - Settings helpers
@@ -1257,8 +1267,8 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
             .fake()
             .copy(
                 siteID: sampleSiteID,
-                plugin: "woocommerce-payments/woocommerce-payments.php",
-                name: "WooCommerce Payments",
+                plugin: CardPresentPaymentsPlugin.wcPay.fileNameWithPathExtension,
+                name: CardPresentPaymentsPlugin.wcPay.pluginName,
                 version: version.rawValue,
                 networkActivated: networkActivated,
                 active: active
@@ -1273,8 +1283,8 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
             .fake()
             .copy(
                 siteID: sampleSiteID,
-                plugin: "woocommerce-gateway-stripe/woocommerce-gateway-stripe.php",
-                name: "WooCommerce Stripe Gateway",
+                plugin: CardPresentPaymentsPlugin.stripe.fileNameWithPathExtension,
+                name: CardPresentPaymentsPlugin.stripe.pluginName,
                 version: version.rawValue,
                 networkActivated: networkActivated,
                 active: active

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
@@ -7,7 +7,7 @@ public enum CardPresentPaymentsPlugin: Equatable, CaseIterable {
     public var pluginName: String {
         switch self {
         case .wcPay:
-            return "WooCommerce Payments"
+            return "WooPayments"
         case .stripe:
             return "WooCommerce Stripe Gateway"
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Ref: p1745828121665009-slack-CGPNUU63E

## Description

In this PR we update `CardPresentPaymentsPlugin` `pluginName` variable to be `"WooPayments"`, this is used for certain [eligibility checks](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewModels/Order%20Details/Receipts/ReceiptEligibilityUseCase.swift#L99) in receipts, where we reach to system plugins with the plugin name to confirm if the plugin is installed. 

In this case, we were passing `"WooCommerce Payments"`, which would fail the check as its saved in storage by the rebranded plugin name, returning falsely `nil` (plugin not installed/not active):

``` 
▿ 18 : SystemPlugin
    - siteID : -1
    - plugin : "woocommerce-payments/woocommerce-payments.php"
    - name : "WooPayments"
    - version : "9.2.1"
    - versionLatest : "9.2.1"
    - url : "https://woocommerce.com/payments/"
    - authorName : "WooCommerce"
    - authorUrl : "https://woocommerce.com/"
    - networkActivated : false
    - active : true
```

## Testing information
- CI should pass
- Process and pay for an order using WooCommerce Payments and card payment. Upon completion, the "See Receipts" row should load normally:

![simulator_screenshot_325A7E2A-56D3-4B0F-8270-5E12168F6920](https://github.com/user-attachments/assets/5b031d44-fe50-4c1f-9e3a-7d1941273465)

Ideally we should use the plugin path for these sort of checks, but this is out of the scope of this PR. There's also ~300 references to "WooCommerce Payments" in the codebase that we should update. Will log issues separately for these two.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
