### PR TITLE
[Shipping Labels] Conditionally disable merge shipments option

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -144,6 +144,7 @@ private extension WooShippingSplitShipmentsView {
             Button(Localization.mergeAll) {
                 showingMergeAllSheet = true
             }
+            .disabled(viewModel.isMergeAllUnfulfilledDisabled())
         } label: {
             Image(systemName: "ellipsis")
                 .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -312,6 +312,20 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         return unfulfilledShipments.count == 1 && unfulfilledShipments.first == shipment
     }
 
+    /// Determines if the "merge all unfulfilled" option should be disabled.
+    /// The option should be disabled if:
+    /// 1. The view model is currently saving shipment info
+    /// 2. There are no unfulfilled shipments
+    /// 3. There is only one unfulfilled shipment
+    func isMergeAllUnfulfilledDisabled() -> Bool {
+        if isSavingShipmentInfo {
+            return true
+        }
+
+        let unfulfilledShipments = shipments.filter { !$0.isPurchased }
+        return unfulfilledShipments.count <= 1
+    }
+
     func shipmentsToMerge(for shipment: Shipment) -> [Shipment] {
         shipments.filter { $0 != shipment }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -935,6 +935,73 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.isShipmentDeleteOptionDisabled(for: unfulfilledShipment))
     }
+
+    // MARK: - `isMergeAllUnfulfilledDisabled`
+
+    func test_isMergeAllUnfulfilledDisabled_returns_true_when_no_unfulfilled_shipments() throws {
+        // Given
+        let shippingLabelData = WooShippingLabelData(
+            currentOrderLabels: [
+                ShippingLabelPurchase.fake().copy(shipmentID: "1")
+            ]
+        )
+
+        let config = WooShippingConfig(
+            siteID: 123,
+            shipments: [
+                "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])]
+            ],
+            shippingLabelData: shippingLabelData
+        )
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: config,
+            items: [sampleItem(id: 1, weight: 5, value: 10, quantity: 2)],
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // Then
+        XCTAssertTrue(viewModel.isMergeAllUnfulfilledDisabled())
+    }
+
+    func test_isMergeAllUnfulfilledDisabled_returns_true_when_only_one_unfulfilled_shipment() {
+        // Given
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: WooShippingConfig.fake(),
+            items: [sampleItem(id: 1, weight: 5, value: 10, quantity: 2)],
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // Then
+        XCTAssertTrue(viewModel.isMergeAllUnfulfilledDisabled())
+    }
+
+    func test_isMergeAllUnfulfilledDisabled_returns_false_when_multiple_unfulfilled_shipments() {
+        // Given
+        let items = [
+            sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+            sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)
+        ]
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: WooShippingConfig.fake(),
+            items: items,
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // When
+        viewModel.shipments.first?.contents.last?.childItemRows.first?.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+
+        // Then
+        XCTAssertFalse(viewModel.isMergeAllUnfulfilledDisabled())
+    }
 }
 
 private extension WooShippingSplitShipmentsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-369

## Description
This PR disables the "Merge all unfulfilled" option in the split shipments view. The option is now disabled when:
- There are no unfulfilled shipments
- There is only one unfulfilled shipment

This change ensures that the merge option is only available when it makes sense to use it (i.e., when there are multiple unfulfilled shipments to merge), preventing breaking behaviour.

## Testing steps
- Log in to a test store with Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with several physical products.
- Setup order in the way that it has N of fulfilled shipments (with labels purchased) and 1 unfulfilled shipment.
- Enter "Split Shipments" screen.
- Tap on "..." meatballs option to edit shipments.
- Make sure that the "Merge all unfulfilled" option is disabled.

## Steps to repro

- Run tests from above in latest `trunk`
- The "Merge all unfulfilled" will be available.
- Tapping on it and accepting merge in bottom sheet will result in merging with the fulfilled shipment and breaking behaviour.

## Screenshots

Before | After
--- | ---
<img width="370" alt="Снимок экрана 2025-04-28 в 13 33 07" src="https://github.com/user-attachments/assets/3d1ce289-f37b-43ed-836a-bd273c3dcc1e" /> | <img width="371" alt="Снимок экрана 2025-04-28 в 13 23 38" src="https://github.com/user-attachments/assets/fe0a51bc-6129-4a7c-ab51-54758819b599" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.