### PR TITLE
[Woo POS] Display an underlying error for Alamofire errors when loading POS order

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -15,6 +15,7 @@ import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 import enum WooFoundation.CurrencyCode
 import protocol WooFoundation.Analytics
+import enum Alamofire.AFError
 
 enum SyncOrderState {
     case newOrder
@@ -92,19 +93,11 @@ protocol PointOfSaleOrderControllerProtocol {
 
     private func setOrderStateToError(_ error: Error,
                                       retryHandler: @escaping () async -> Void) {
-        if let couponsError = CouponsError(underlyingError: error) {
-            orderState = .error(.invalidCoupon(couponsError.message), {
-                Task {
-                    await retryHandler()
-                }
-            })
-        } else {
-            orderState = .error(.other(error.localizedDescription), {
-                Task {
-                    await retryHandler()
-                }
-            })
-        }
+        orderState = .error(orderStateError(from: error), {
+            Task {
+                await retryHandler()
+            }
+        })
     }
 
     func sendReceipt(recipientEmail: String) async throws {
@@ -200,6 +193,22 @@ private extension PointOfSaleOrderController {
         }
 
         return formattedDiscount
+    }
+}
+
+
+// MARK: - Error Handling
+
+@available(iOS 17.0, *)
+private extension PointOfSaleOrderController {
+    func orderStateError(from error: Error) -> PointOfSaleOrderState.OrderStateError {
+        if let couponsError = CouponsError(underlyingError: error) {
+            return .invalidCoupon(couponsError.message)
+        } else if let afErrorDescription = (error as? AFError)?.underlyingError?.localizedDescription {
+            return .other(afErrorDescription)
+        } else {
+            return .other(error.localizedDescription)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Based on feedback pdfdoF-6WZ-p2#comment-8069.  

`Alamofire` wraps errors with internal details, which is not user-friendly. Most usually, we see these errors when the network connection fails. A quick fix to show an underlying localized error for `Alamofire` errors.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Turn off the internet connection
3. Tap 'Check out'
4. Confirm that a user-friendly error message is shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air M2 18.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/90e6dbbb-59d8-4e60-bb06-b0886791266e

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.