### PR TITLE
[Shipping Labels] Fix product icon color

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1345,11 +1345,11 @@ extension UIImage {
     }
 
     static var shippingIcon: UIImage {
-        UIImage(imageLiteralResourceName: "icon-shipping")
+        UIImage(imageLiteralResourceName: "icon-shipping").withRenderingMode(.alwaysTemplate)
     }
 
     static var productIcon: UIImage {
-        UIImage(imageLiteralResourceName: "icon-product")
+        UIImage(imageLiteralResourceName: "icon-product").withRenderingMode(.alwaysTemplate)
     }
 
     static var appPasswordTutorialImage: UIImage {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-81
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description

Applies template rendering mode for product and shipment icons to follow the color scheme.

## Steps to reproduce
- Enable dark mode
- Log in to a test store with Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with several physical products.
- Tap on "Create shipping labels".
- Open the "Shipment details" bottom sheet.
- The "product" icon on "N items" row must contrast with the background and be readable.

## Screenshots

Before | After
--- | ---
![Снимок экрана 2025-04-30 в 15 34 18](https://github.com/user-attachments/assets/58704e11-6783-4a71-9356-29d850deb7bb) | ![Снимок экрана 2025-04-30 в 15 31 55](https://github.com/user-attachments/assets/f637ee78-7883-4d13-b83a-1ce1608ce5d8)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.