### PR TITLE
[Shipping Labels] Fix padding for shipments items box

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -22,13 +22,13 @@ struct WooShippingCustomsRow: View {
                 .captionStyle()
                 .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
                 .padding(.vertical, Layout.statusBadgeVerticalPadding)
+                .frame(height: Layout.statusBadgeHeight * scale)
                 .background(
                     RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
                         .fill(informationIsCompleted ?
                               Color.withColorStudio(name: .green, shade: .shade5) :
                                 Color.withColorStudio(name: .red, shade: .shade10))
                 )
-                .padding(.horizontal, 10)
 
             PencilEditButton {
                 showCustomsForm.toggle()
@@ -47,12 +47,12 @@ private extension WooShippingCustomsRow {
     enum Layout {
         static let borderCornerRadius: CGFloat = 8
         static let borderWidth: CGFloat = 0.5
-        static let pencilButtonSizeDimensions: CGFloat = 22
         static let customsTitleFontSize: CGFloat = 17
         static let statusBadgeFontSize: CGFloat = 14
         static let statusBadgeCornerRadius: CGFloat = 6
         static let statusBadgeHorizontalPadding: CGFloat = 12
-        static let statusBadgeVerticalPadding: CGFloat = 6
+        static let statusBadgeVerticalPadding: CGFloat = 4
+        static let statusBadgeHeight: CGFloat = 24
         static let borderPadding: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
@@ -36,7 +36,7 @@ struct WooShippingItems: View {
                 }
             }
         })
-        .padding()
+        .padding(.vertical, Layout.totalVerticalPadding - CollapsibleViewConstants.verticalPadding)
         .frame(maxWidth: .infinity, alignment: .center)
         .if(isCollapsed) { view in
             view
@@ -49,6 +49,9 @@ private extension WooShippingItems {
     enum Layout {
         static let borderCornerRadius: CGFloat = 8
         static let borderWidth: CGFloat = 0.5
+
+        /// Total vertical padding between content and outer border
+        static let totalVerticalPadding: CGFloat = 16
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
@@ -36,7 +36,7 @@ struct WooShippingItems: View {
                 }
             }
         })
-        .padding(.vertical, Layout.totalVerticalPadding - CollapsibleViewConstants.verticalPadding)
+        .padding(.vertical, Layout.verticalPadding)
         .frame(maxWidth: .infinity, alignment: .center)
         .if(isCollapsed) { view in
             view
@@ -51,7 +51,7 @@ private extension WooShippingItems {
         static let borderWidth: CGFloat = 0.5
 
         /// Total vertical padding between content and outer border
-        static let totalVerticalPadding: CGFloat = 16
+        static let verticalPadding: CGFloat = 6
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
@@ -26,6 +26,7 @@ struct WooShippingItems: View {
                 Text(itemsDetailLabel)
                     .foregroundStyle(Color(.textSubtle))
             }
+            .padding(.vertical, Layout.textContainerAdditionalVerticalPadding)
         },
                         content: {
             VStack {
@@ -51,7 +52,9 @@ private extension WooShippingItems {
         static let borderWidth: CGFloat = 0.5
 
         /// Total vertical padding between content and outer border
-        static let verticalPadding: CGFloat = 6
+        static let verticalPadding: CGFloat = 8
+
+        static let textContainerAdditionalVerticalPadding: CGFloat = 2
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleView.swift
@@ -13,6 +13,9 @@ struct CollapsibleView<Label: View, Content: View>: View {
     private let backgroundColor: UIColor
     private let hasSubtleChevron: Bool
 
+    private let horizontalPadding: CGFloat = 16
+    private let verticalPadding: CGFloat = 8
+
     init(isCollapsible: Bool = true,
          isCollapsed: Binding<Bool> = .constant(false),
          safeAreaInsets: EdgeInsets = .zero,
@@ -51,9 +54,9 @@ struct CollapsibleView<Label: View, Content: View>: View {
                 }
             })
             .buttonStyle(PlainButtonStyle())
-            .padding(.horizontal, CollapsibleViewConstants.horizontalPadding)
+            .padding(.horizontal, horizontalPadding)
             .padding(.horizontal, insets: safeAreaInsets)
-            .padding(.vertical, CollapsibleViewConstants.verticalPadding)
+            .padding(.vertical, verticalPadding)
             .background(Color(backgroundColor))
 
             Divider()
@@ -64,13 +67,6 @@ struct CollapsibleView<Label: View, Content: View>: View {
             }
         }
     }
-}
-
-enum CollapsibleViewConstants {
-    /// Internal horizontal padding of the view
-    fileprivate static let horizontalPadding: CGFloat = 16
-    /// Internal vertical padding of the view
-    static let verticalPadding: CGFloat = 8
 }
 
 struct CollapsibleView_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleView.swift
@@ -13,9 +13,6 @@ struct CollapsibleView<Label: View, Content: View>: View {
     private let backgroundColor: UIColor
     private let hasSubtleChevron: Bool
 
-    private let horizontalPadding: CGFloat = 16
-    private let verticalPadding: CGFloat = 8
-
     init(isCollapsible: Bool = true,
          isCollapsed: Binding<Bool> = .constant(false),
          safeAreaInsets: EdgeInsets = .zero,
@@ -54,9 +51,9 @@ struct CollapsibleView<Label: View, Content: View>: View {
                 }
             })
             .buttonStyle(PlainButtonStyle())
-            .padding(.horizontal, horizontalPadding)
+            .padding(.horizontal, CollapsibleViewConstants.horizontalPadding)
             .padding(.horizontal, insets: safeAreaInsets)
-            .padding(.vertical, verticalPadding)
+            .padding(.vertical, CollapsibleViewConstants.verticalPadding)
             .background(Color(backgroundColor))
 
             Divider()
@@ -67,6 +64,13 @@ struct CollapsibleView<Label: View, Content: View>: View {
             }
         }
     }
+}
+
+enum CollapsibleViewConstants {
+    /// Internal horizontal padding of the view
+    fileprivate static let horizontalPadding: CGFloat = 16
+    /// Internal vertical padding of the view
+    static let verticalPadding: CGFloat = 8
 }
 
 struct CollapsibleView_Previews: PreviewProvider {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-79
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description

Fixes the paddings for product items and customs settings box in "Shipment" options. Updates `WooShippingItems` and `WooShippingCustomsRow` internal content paddings to conform to designs.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your - - Log in to a test store with Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with several physical products.
- Tap on "Create shipping labels".
- Add a foreign destination address to reveal a customs settings box.
- Make sure the product items box and customs settings box have same paddings and heights.
- Side paddings of internal content should also be similar. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After 
--- | ---
![Снимок экрана 2025-04-30 в 13 52 39](https://github.com/user-attachments/assets/86eef511-92ff-48f3-9350-76dd20bb1142) | ![Снимок экрана 2025-04-30 в 13 54 14](https://github.com/user-attachments/assets/7547fadf-877c-41e1-9911-74c797f3662e)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.