### PR TITLE
[Woo POS] Coupons: Search - Create search strategy

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		012848DE2D9EDAC100A9C69B /* MockCouponStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */; };
 		012848E22D9EDF2D00A9C69B /* MockSettingStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012848E12D9EDF2D00A9C69B /* MockSettingStoreMethods.swift */; };
 		0133302B2DBFB47B000B1D8D /* PointOfSaleDefaultCouponFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0133302A2DBFB478000B1D8D /* PointOfSaleDefaultCouponFetchStrategyTests.swift */; };
+		013337912DBFE97D000B1D8D /* PointOfSaleSearchCouponFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013337902DBFE970000B1D8D /* PointOfSaleSearchCouponFetchStrategyTests.swift */; };
 		0139C2B02D91D1C600C78FDE /* POSCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0139C2AF2D91D1C400C78FDE /* POSCart.swift */; };
 		0149547D2DBBA5A400C8870D /* PointOfSaleCouponFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0149547C2DBBA59E00C8870D /* PointOfSaleCouponFetchStrategy.swift */; };
 		016A776B2D9D30C90004FCD6 /* PointOfSaleCouponServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */; };
@@ -576,6 +577,7 @@
 		012848DD2D9EDAC100A9C69B /* MockCouponStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponStoreMethods.swift; sourceTree = "<group>"; };
 		012848E12D9EDF2D00A9C69B /* MockSettingStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingStoreMethods.swift; sourceTree = "<group>"; };
 		0133302A2DBFB478000B1D8D /* PointOfSaleDefaultCouponFetchStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDefaultCouponFetchStrategyTests.swift; sourceTree = "<group>"; };
+		013337902DBFE970000B1D8D /* PointOfSaleSearchCouponFetchStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleSearchCouponFetchStrategyTests.swift; sourceTree = "<group>"; };
 		0139C2AF2D91D1C400C78FDE /* POSCart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCart.swift; sourceTree = "<group>"; };
 		0149547C2DBBA59E00C8870D /* PointOfSaleCouponFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCouponFetchStrategy.swift; sourceTree = "<group>"; };
 		016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCouponServiceTests.swift; sourceTree = "<group>"; };
@@ -1618,6 +1620,7 @@
 		687F83702C0EBF3E00460AB3 /* PointOfSale */ = {
 			isa = PBXGroup;
 			children = (
+				013337902DBFE970000B1D8D /* PointOfSaleSearchCouponFetchStrategyTests.swift */,
 				0133302A2DBFB478000B1D8D /* PointOfSaleDefaultCouponFetchStrategyTests.swift */,
 				68E75F1F2DB8BFAC00A2DA21 /* POSCouponTests.swift */,
 				016A776A2D9D30C10004FCD6 /* PointOfSaleCouponServiceTests.swift */,
@@ -2899,6 +2902,7 @@
 				DEB387862C2C09A70025256E /* GoogleAdsStoreTests.swift in Sources */,
 				B5C9DE242087FF20006B910A /* StoreTests.swift in Sources */,
 				455A931D2747C19300259C7F /* AppSettingsStoreTests+OrdersSettings.swift in Sources */,
+				013337912DBFE97D000B1D8D /* PointOfSaleSearchCouponFetchStrategyTests.swift in Sources */,
 				D88303E925E459DC00C877F9 /* CardPresentPaymentStoreTests.swift in Sources */,
 				02FF055C23D9846A0058E6E7 /* MediaFileManagerTests.swift in Sources */,
 				0248B36B2459127200A271A4 /* MockNetwork+Path.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
+++ b/Yosemite/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
@@ -109,7 +109,7 @@ public struct PointOfSaleSearchCouponFetchStrategy: PointOfSaleCouponFetchStrate
                     case .success:
                         let results = getSearchResults()
                         let hasMorePages = results.count == PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize * pageNumber
-                        continuation.resume(returning: .init(items: getSearchResults(), hasMorePages: hasMorePages))
+                        continuation.resume(returning: .init(items: results, hasMorePages: hasMorePages))
                     case .failure:
                         continuation.resume(throwing: PointOfSaleCouponServiceError.couponsLoadingError)
                     }

--- a/Yosemite/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
+++ b/Yosemite/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
@@ -65,9 +65,85 @@ private extension PointOfSaleDefaultCouponFetchStrategy {
     @MainActor
     func fetchLocalCoupons(limit: Int? = nil) -> [POSItem] {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated,
-                                          ascending: false)
+        let resultsController = CouponResultsControllerAdapter(storage: storage, currencySettings: currencySettings)
+        return resultsController.fetchCoupons(predicate: predicate, limit: limit)
+    }
+}
 
+extension PointOfSaleDefaultCouponFetchStrategy {
+    enum Constants {
+        static let defaultPageSize: Int = 25
+    }
+}
+
+// MARK: - Search Coupon Strategy
+
+public struct PointOfSaleSearchCouponFetchStrategy: PointOfSaleCouponFetchStrategy {
+    private let siteID: Int64
+    private let couponStoreMethods: CouponStoreMethodsProtocol
+    private let storage: StorageManagerType
+    private let currencySettings: CurrencySettings
+    private let searchTerm: String
+
+    init(siteID: Int64,
+         currencySettings: CurrencySettings,
+         storage: StorageManagerType,
+         couponStoreMethods: CouponStoreMethodsProtocol,
+         searchTerm: String
+    ) {
+        self.siteID = siteID
+        self.couponStoreMethods = couponStoreMethods
+        self.storage = storage
+        self.currencySettings = currencySettings
+        self.searchTerm = searchTerm
+    }
+
+    public func fetchCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {
+        return try await withCheckedThrowingContinuation { continuation in
+            couponStoreMethods.searchCoupons(
+                siteID: siteID,
+                keyword: searchTerm,
+                pageNumber: pageNumber,
+                pageSize: PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize) { result in
+                    switch result {
+                    case .success:
+                        let results = getSearchResults()
+                        let hasMorePages = results.count == PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize * pageNumber
+                        continuation.resume(returning: .init(items: getSearchResults(), hasMorePages: hasMorePages))
+                    case .failure:
+                        continuation.resume(throwing: PointOfSaleCouponServiceError.couponsLoadingError)
+                    }
+                }
+        }
+    }
+
+    private func getSearchResults() -> [POSItem] {
+        let sitePredicate = NSPredicate(format: "siteID == %lld", siteID)
+        let searchPredicate = NSPredicate(format: "ANY searchResults.keyword = %@", searchTerm)
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sitePredicate] + [searchPredicate])
+        let resultsController = CouponResultsControllerAdapter(storage: storage, currencySettings: currencySettings)
+        return resultsController.fetchCoupons(predicate: predicate)
+    }
+
+    public func fetchLocalCoupons() async throws -> [POSItem] {
+        // No support for returning local search results
+        return []
+    }
+}
+
+// MARK: - Results Controller
+
+private struct CouponResultsControllerAdapter {
+    private let storage: StorageManagerType
+    private let currencySettings: CurrencySettings
+
+    init(storage: StorageManagerType, currencySettings: CurrencySettings) {
+        self.storage = storage
+        self.currencySettings = currencySettings
+    }
+
+    func fetchCoupons(predicate: NSPredicate, limit: Int? = nil) -> [POSItem] {
+        let descriptor = NSSortDescriptor(keyPath: \StorageCoupon.dateCreated, ascending: false)
         let resultsController = ResultsController<StorageCoupon>(storageManager: storage,
                                                                  matching: predicate,
                                                                  fetchLimit: limit,
@@ -83,7 +159,7 @@ private extension PointOfSaleDefaultCouponFetchStrategy {
         }
     }
 
-    func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
+    private func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
         coupons.compactMap { coupon in
                 .coupon(POSCoupon(
                     id: UUID(),
@@ -92,11 +168,5 @@ private extension PointOfSaleDefaultCouponFetchStrategy {
                     dateExpires: coupon.dateExpires
                 ))
         }
-    }
-}
-
-private extension PointOfSaleDefaultCouponFetchStrategy {
-    enum Constants {
-        static let defaultPageSize: Int = 25
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -159,6 +159,19 @@ extension MockStorageManager {
         return newCoupon
     }
 
+    /// Inserts a sample coupon search result with associated coupons
+    ///
+    func insertSampleCouponSearchResult(keyword: String, coupons: [Coupon]) {
+        let searchResult = viewStorage.insertNewObject(ofType: StorageCouponSearchResult.self)
+        searchResult.keyword = keyword
+
+        for coupon in coupons {
+            let storageCoupon = viewStorage.insertNewObject(ofType: StorageCoupon.self)
+            storageCoupon.update(with: coupon)
+            storageCoupon.addToSearchResults(searchResult)
+        }
+    }
+
     /// Inserts a new (Sample) Customer into the specified context.
     ///
     @discardableResult

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleSearchCouponFetchStrategyTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleSearchCouponFetchStrategyTests.swift
@@ -1,0 +1,112 @@
+import Testing
+@testable import Yosemite
+import class WooFoundation.CurrencySettings
+
+struct PointOfSaleSearchCouponFetchStrategyTests {
+    private let sut: PointOfSaleSearchCouponFetchStrategy
+    private let couponStoreMethods: MockCouponStoreMethods
+    private let storage: MockStorageManager
+    private let sampleSiteID: Int64 = 123
+    private let searchTerm = "test"
+
+    init() {
+        self.couponStoreMethods = MockCouponStoreMethods()
+        self.storage = MockStorageManager()
+        self.sut = .init(
+            siteID: sampleSiteID,
+            currencySettings: CurrencySettings(),
+            storage: storage,
+            couponStoreMethods: couponStoreMethods,
+            searchTerm: searchTerm
+        )
+    }
+
+    @Test func fetchLocalCoupons_always_returns_empty_array() async throws {
+        // Given
+        let coupon = Coupon.fake().copy(siteID: sampleSiteID, code: "coupon")
+        storage.insertSampleCoupon(readOnlyCoupon: coupon)
+
+        // When
+        let coupons = try await sut.fetchLocalCoupons()
+
+        // Then
+        #expect(coupons.isEmpty)
+    }
+
+    @Test func fetchCoupons_when_no_results_then_returns_empty_array() async throws {
+        // When
+        let result = try await sut.fetchCoupons(pageNumber: 1)
+
+        // Then
+        #expect(result.items.isEmpty)
+        #expect(!result.hasMorePages)
+    }
+
+    @Test func fetchCoupons_when_search_succeeds_then_returns_results() async throws {
+        // Given
+        let coupon1 = Coupon.fake().copy(siteID: sampleSiteID, code: "test_coupon_1")
+        let coupon2 = Coupon.fake().copy(siteID: sampleSiteID, code: "test_coupon_2")
+        storage.insertSampleCoupon(readOnlyCoupon: coupon1)
+        storage.insertSampleCoupon(readOnlyCoupon: coupon2)
+        storage.insertSampleCouponSearchResult(keyword: searchTerm, coupons: [coupon1, coupon2])
+
+        // When
+        let result = try await sut.fetchCoupons(pageNumber: 1)
+
+        // Then
+        #expect(result.items.count == 2)
+        #expect(!result.hasMorePages)
+    }
+
+    @Test func fetchCoupons_when_search_fails_then_throws_couponsLoadingError() async throws {
+        // Given
+        couponStoreMethods.shouldFailSync = true
+
+        // When
+        do {
+            _ = try await sut.fetchCoupons(pageNumber: 1)
+        } catch {
+            // Then
+            let expectedError = error as? PointOfSaleCouponServiceError
+            #expect(expectedError == .couponsLoadingError)
+        }
+    }
+
+    @Test func fetchCoupons_when_full_page_then_hasMorePages_is_true() async throws {
+        // Given
+        // Insert enough coupons to fill a page
+        var coupons: [Coupon] = []
+        for i in 0..<PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize {
+            let coupon = Coupon.fake().copy(siteID: sampleSiteID, code: "test_coupon_\(i)")
+            storage.insertSampleCoupon(readOnlyCoupon: coupon)
+            coupons.append(coupon)
+        }
+        storage.insertSampleCouponSearchResult(keyword: searchTerm, coupons: coupons)
+
+        // When
+        let result = try await sut.fetchCoupons(pageNumber: 1)
+
+        // Then
+        #expect(result.items.count == PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize)
+        #expect(result.hasMorePages)
+    }
+
+    @Test func fetchCoupons_when_not_full_page_then_hasMorePages_is_false() async throws {
+        // Given
+        // Insert less coupons than page size
+        var coupons: [Coupon] = []
+        for i in 0..<PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize - 1 {
+            let coupon = Coupon.fake().copy(siteID: sampleSiteID, code: "test_coupon_\(i)")
+            storage.insertSampleCoupon(readOnlyCoupon: coupon)
+            coupons.append(coupon)
+        }
+        storage.insertSampleCouponSearchResult(keyword: searchTerm, coupons: coupons)
+
+        // When
+        let result = try await sut.fetchCoupons(pageNumber: 1)
+
+        // Then
+        #expect(result.items.count == PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize - 1)
+        #expect(!result.hasMorePages)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Continuation of https://github.com/woocommerce/woocommerce-ios/pull/15565

Created `PointOfSaleSearchCouponFetchStrategy`.

`PointOfSaleSearchCouponFetchStrategy` reuses the existing functionality developed for the Coupons search within IPP. It combines remote fetching and search results saving within` ResultsController`.

Since we don't support local search, this approach could be considered a bit too complex. However, using this approach allows it to fit in better with the existing Default Strategy, which also combines remote sync with local fetch. We also reuse existing code and methods, which allows us to get the required functionality quicker.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

There's no UI for search, however, the functionality can be tested by hardcoding the search term. Go to `PointOfSaleCouponService` and replace the strategy initializer with:

```swift
        self.strategy = strategy ?? PointOfSaleSearchCouponFetchStrategy(
            siteID: siteID,
            currencySettings: currencySettings,
            storage: storage,
            couponStoreMethods: couponStoreMethods,
            searchTerm: "hardcoded search term"
        )
```

Try a couple of search terms and confirm that the expected results are shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Further testing I want to do:
- [x]  Test and compare results with pure-remote search to see if any differences are found using this approach.
- [x] Regression-test existing functionality

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
