### PR TITLE
Shipping Labels: Update keyboard types for email and phone number fields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -66,9 +66,11 @@ struct WooShippingEditAddressView: View {
                 }
                 .padding(.bottom, Constants.extraPadding)
                 AddressTextField(field: viewModel.email,
-                                 focused: $focusedField)
+                                 focused: $focusedField,
+                                 keyboardType: .emailAddress)
                 AddressTextField(field: viewModel.phone,
-                                 focused: $focusedField)
+                                 focused: $focusedField,
+                                 keyboardType: .phonePad)
                 .padding(.bottom, Constants.extraPadding)
                 if viewModel.showSaveAsDefault {
                     Toggle(Localization.defaultAddress, isOn: $viewModel.isDefaultAddress)
@@ -186,6 +188,8 @@ struct WooShippingEditAddressView: View {
         /// The focused state of the field.
         @FocusState.Binding var focused: WooShippingAddressFieldType?
 
+        var keyboardType = UIKeyboardType.default
+
         var body: some View {
             VStack(spacing: Constants.innerSpacing) {
                 HStack(spacing: Constants.requiredLabelSpacing) {
@@ -198,6 +202,7 @@ struct WooShippingEditAddressView: View {
                 .font(.subheadline)
                 .foregroundStyle(Color(.text))
                 TextField(Localization.title(for: field.type), text: $field.value, prompt: Text(field.required ? "" : Localization.optional))
+                    .keyboardType(keyboardType)
                     .focused($focused, equals: field.type)
                     .onChange(of: field.value) { _ in
                         field.clearError()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-82
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR improves the UX for the address editing screen by setting the correct keyboard types for email and phone number fields.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a completed order with physical products.
3. Select Create shipping label, then open the bottom sheet and select the destination address.
4. On the Edit address screen,  switch between different text fields and confirm that the keyboard is updated correctly for each field.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Manually tested and confirmed the fix on simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Field | Before | After 
--- | --- | ---
Email | <img src="https://github.com/user-attachments/assets/d219ce5b-391b-49a4-8cd1-34b9520275d8" width=320 /> | <img src="https://github.com/user-attachments/assets/4b15c00c-0e49-4867-81a2-a299bb4e01f2" width=320 />
Phone | <img src="https://github.com/user-attachments/assets/7a32f9d3-e353-4ac6-aaae-03b6a7eee6c9" width=320 /> | <img src="https://github.com/user-attachments/assets/32b51204-a014-49a3-b48d-394e6f6eeaa6" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
