### PR TITLE
Shipping Labels: Reload label rates upon updating customs form and HAZMAT category

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -59,7 +59,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     /// Selected shipping rate when creating a shipping label.
     @Published private(set) var selectedRate: WooShippingSelectedRate?
 
-    private var customsForm: ShippingLabelCustomsForm?
+    @Published private var customsForm: ShippingLabelCustomsForm?
 
     lazy private(set) var customsFormViewModel: WooShippingCustomsFormViewModel = {
         WooShippingCustomsFormViewModel(order: order, shipment: shipment, onCompletion: { [weak self] form in
@@ -124,7 +124,9 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         }
         return buildSelectedPackage(selectedPackage,
                                     weight: Double(shipmentWeight) ?? 0,
-                                    shipmentID: shipment.id)
+                                    shipmentID: shipment.id,
+                                    hazmatCategory: hazmatCategory,
+                                    customsForm: customsForm)
     }
 
     private var debounceDuration: Double
@@ -260,11 +262,15 @@ private extension WooShippingShipmentDetailsViewModel {
             .debounce(for: .seconds(debounceDuration), scheduler: DispatchQueue.main)
             .removeDuplicates()
             .combineLatest($selectedPackage, $shippingService)
-            .sink { [weak self] weight, selectedPackage, shippingService in
+            .combineLatest($customsForm, $hazmatCategory)
+            .sink { [weak self] input in
+                let ((weight, selectedPackage, shippingService), customsForm, hazmatCategory) = input
                 guard let self, let selectedPackage, let shippingService else { return }
                 let package = buildSelectedPackage(selectedPackage,
                                                    weight: Double(weight) ?? 0,
-                                                   shipmentID: shipment.id)
+                                                   shipmentID: shipment.id,
+                                                   hazmatCategory: hazmatCategory,
+                                                   customsForm: customsForm)
                 shippingService.loadLabelRates(for: package)
             }
             .store(in: &subscriptions)
@@ -305,7 +311,11 @@ private extension WooShippingShipmentDetailsViewModel {
     }
 
     /// Converts the package data to a `ShippingLabelPackageSelected` object.
-    func buildSelectedPackage(_ packageData: WooShippingPackageDataRepresentable, weight: Double, shipmentID: String) -> ShippingLabelPackageSelected {
+    func buildSelectedPackage(_ packageData: WooShippingPackageDataRepresentable,
+                              weight: Double,
+                              shipmentID: String,
+                              hazmatCategory: ShippingLabelHazmatCategory?,
+                              customsForm: ShippingLabelCustomsForm?) -> ShippingLabelPackageSelected {
         ShippingLabelPackageSelected(id: shipmentID,
                                      boxID: packageData.id,
                                      length: Double(packageData.length) ?? 0,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -38,8 +38,10 @@ struct WooShippingServiceView: View {
                             viewModel.loadLabelRates(for: package)
                         }
                     }
-                case .noRatesAvailable:
-                    ErrorState(message: Localization.noRatesAvailable)
+                case .noRatesAvailable(let isHAZMAT):
+                    ErrorState(message: isHAZMAT ?
+                               Localization.noRatesAvailableWithHAZMAT :
+                               Localization.noRatesAvailableNoHAZMAT)
                 }
             }
         }
@@ -206,11 +208,20 @@ private extension WooShippingServiceView {
                                                               value: "We are unable to load shipping rates",
                                                               comment: "Error message when loading shipping label rates "
                                                               + "failed on the shipping label creation screen")
-        static let noRatesAvailable = NSLocalizedString("wooShipping.createLabels.rates.noRatesAvailable",
-                                                        value: "We couldn't find a shipping service for the combination of the selected package "
-                                                        + "and the total shipment weight. Please adjust your input and try again.",
-                                                        comment: "Error message when no shipping rates were found "
-                                                        + "based on the combination of the selected package and the total shipment weight.")
+        static let noRatesAvailableNoHAZMAT = NSLocalizedString(
+            "wooShipping.createLabels.rates.noRatesAvailableNoHAZMAT",
+            value: "We couldn't find a shipping service for the combination of the selected package "
+            + "and the total shipment weight. Please adjust your input and try again.",
+            comment: "Error message when no shipping rates were found "
+            + "based on the combination of the selected package and the total shipment weight."
+        )
+        static let noRatesAvailableWithHAZMAT = NSLocalizedString(
+            "wooShipping.createLabels.rates.noRatesAvailableWithHAZMAT",
+            value: "We couldn't find a shipping service for the combination of the selected HAZMAT category, "
+            + "the selected package, and the total shipment weight. Please adjust your input and try again.",
+            comment: "Error message when no shipping rates were found "
+            + "based on the combination of the selected HAZMAT category, package and the total shipment weight."
+        )
         static let retryCTA = NSLocalizedString("wooShipping.createLabels.rates.retryCTA",
                                                 value: "Retry",
                                                 comment: "Button to retry loading data on the shipping label creation screen")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -97,7 +97,8 @@ final class WooShippingServiceViewModel: ObservableObject {
                 guard let rates = rates.first(where: { $0.packageID == selectedPackage.id }),
                       rates.defaultRates.isNotEmpty else {
                     DDLogError("⛔️ Fetched shipping label rates for Woo Shipping do not include rates for selected package: \(selectedPackage)")
-                    updateLoadingState(to: .error(Error.noRatesAvailable))
+                    let isHAZMAT = selectedPackage.hazmatCategory != nil
+                    updateLoadingState(to: .error(Error.noRatesAvailable(isHAZMAT: isHAZMAT)))
                     return
                 }
 
@@ -144,11 +145,11 @@ extension WooShippingServiceViewModel {
         case error(_ error: Error)
     }
 
-    enum Error: Swift.Error {
+    enum Error: Swift.Error, Equatable {
         case missingDestinationAddress
         case missingShipmentWeight
         case failedLoadingLabelRates
-        case noRatesAvailable
+        case noRatesAvailable(isHAZMAT: Bool)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -286,7 +286,14 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         viewModel.loadLabelRates(for: samplePackage)
 
         // Then
-        XCTAssertEqual(viewModel.loadingState, .error(.noRatesAvailable))
+        XCTAssertEqual(viewModel.loadingState, .error(.noRatesAvailable(isHAZMAT: false)))
+
+        // When
+        let updatedPackage = samplePackage.copy(hazmatCategory: "Test")
+        viewModel.loadLabelRates(for: updatedPackage)
+
+        // Then
+        XCTAssertEqual(viewModel.loadingState, .error(.noRatesAvailable(isHAZMAT: true)))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -323,6 +323,92 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(packageWeightForLabelRates, expectedWeight)
     }
 
+    func test_changing_customs_form_loads_new_label_rates_with_updated_customs_form() {
+        // Given
+        let expectedItem = ShippingLabelCustomsForm.Item.fake().copy(quantity: 2, productID: 1)
+        let expectedCustomsForm = ShippingLabelCustomsForm.fake().copy(contentsType: .gift,
+                                                                       restrictionType: .quarantine,
+                                                                       nonDeliveryOption: .abandon,
+                                                                       items: [expectedItem])
+        var sentCustomsForm: ShippingLabelCustomsForm?
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, packages, _):
+                sentCustomsForm = packages.first?.customsForm
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([]))
+            case .loadConfig:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
+                                                            stores: stores,
+                                                            debounceDuration: 0)
+
+
+        // When
+        viewModel.selectPackage(samplePackageData())
+        viewModel.customsFormViewModel.contentType = .gift
+        viewModel.customsFormViewModel.restrictionType = .quarantine
+        viewModel.customsFormViewModel.onDismiss()
+
+        // Then
+        waitUntil {
+            sentCustomsForm != nil
+        }
+        XCTAssertEqual(sentCustomsForm, expectedCustomsForm)
+    }
+
+    func test_changing_HAZMAT_category_loads_new_label_rates_with_updated_HAZMAT_category() {
+        // Given
+        let expectedHAZMATCategory = "CLASS_1"
+        var sentHAZMATCategory: String?
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, packages, _):
+                sentHAZMATCategory = packages.first?.hazmatCategory
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([]))
+            case .loadConfig:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
+                                                            stores: stores,
+                                                            debounceDuration: 0)
+
+
+        // When
+        viewModel.selectPackage(samplePackageData())
+        viewModel.hazmatCategory = .class1
+
+        // Then
+        waitUntil {
+            sentHAZMATCategory != nil
+        }
+        XCTAssertEqual(sentHAZMATCategory, expectedHAZMATCategory)
+    }
+
     func test_totalCost_has_expected_value_when_shipping_rate_is_set() throws {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-77
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the logic for loading label rates by always considering any changes to the selected customs form and HAZMAT category.

Additionally, the error message when no label rates are available has also been updated to include HAZMAT category (following the error message on the web).

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a completed order.
3. Select Create shipping label.
4. Update the destination address to a non-US address to require a customs form.
5. Fill the customs form and select a package. Confirm with Proxyman the request to `/wcshipping/v1/label/rate&_method=post`.
6. Update the customs form and confirm that label rates are reloaded with the updated customs form details.
7. Update the HAZMAT category and confirm that label rates are reloaded with the updated category. 
8. When a HAZMAT category is selected for an international shipment, label rates seem to be unavailable. Confirm that in this case, the error message includes the selected HAZMAT category as one of the factors.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Manually tested and confirmed the above tests on simulator iPhone 16 Pro iOS 18.2.
- Added unit tests to verify the new changes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/7cd72a1f-bb9a-4b9f-ad0b-24f450e2daa1


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
