### PR TITLE
[Woo POS] Consistency between error and empty states for Products and Coupons

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -87,9 +87,14 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
                 return try await fetchItems(pageNumber: pageNumber, appendToExistingItems: false)
             }
         } catch {
-            itemsViewState.containerState = .error(PointOfSaleErrorState.errorOnLoadingProducts)
-            itemsViewState.itemsStack = ItemsStackState(root: .loaded([], hasMoreItems: false),
-                                                       itemStates: [:])
+            let items = itemsViewState.itemsStack.root.items
+            let stackState: ItemsStackState
+            if items.isEmpty {
+                stackState = ItemsStackState(root: .error(.errorOnLoadingProducts), itemStates: [:])
+            } else {
+                stackState = ItemsStackState(root: .inlineError(items, error: .errorOnLoadingProducts, context: .refresh), itemStates: [:])
+            }
+            itemsViewState = ItemsViewState(containerState: .content, itemsStack: stackState)
         }
     }
 
@@ -200,9 +205,9 @@ private extension PointOfSaleItemsController {
 
     func setRootLoadingState() {
         let items = itemsViewState.itemsStack.root.items
-        if items.isEmpty {
-            itemsViewState.containerState = .loading
-        } else {
+
+        let isInitialState = itemsViewState.containerState == .loading
+        if !isInitialState {
             itemsViewState.itemsStack.root = .loading(items)
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -12,18 +12,6 @@ struct PointOfSaleItemListEmptyView: View {
 
     @Environment(\.keyboardObserver) private var keyboard
 
-    private var shouldShowErrorIcon: Bool {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale) else {
-            return false
-        }
-        switch viewModel.itemListType {
-        case .coupons, .products(search: false):
-            return true
-        case .products(search: true):
-            return false
-        }
-    }
-
     init(viewModel: PointOfSaleItemListEmptyViewModel, onAction: (() -> Void)? = nil) {
         self.viewModel = viewModel
         self.onAction = onAction
@@ -86,16 +74,11 @@ struct PointOfSaleItemListEmptyView: View {
 
     @ViewBuilder
     private var icon: some View {
-        if shouldShowErrorIcon {
-            POSErrorExclamationMark(size: .large)
-                .accessibilityHidden(true)
-        } else {
-            Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: Constants.iconSize, height: Constants.iconSize)
-                .foregroundColor(.posOnSurfaceVariantHighest)
-        }
+        Image(decorative: PointOfSaleAssets.magnifierNotFound.imageName)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: Constants.iconSize, height: Constants.iconSize)
+            .foregroundColor(.posOnSurfaceVariantHighest)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -324,17 +324,14 @@ final class PointOfSaleItemsControllerTests {
         )
 
         itemProvider.errorToThrow = MockError.requestFailed
-        let expectedError = PointOfSaleErrorState(errorType: .productsLoadError,
-                                                  title: "Error loading products",
-                                                  subtitle: "Give it another go?",
-                                                  buttonText: "Retry")
         try #require(sut.itemsViewState.containerState == .loading)
 
         // When
         await sut.loadItems(base: .root)
 
         // Then
-        #expect(sut.itemsViewState.containerState == .error(expectedError))
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .error(.errorOnLoadingProducts))
     }
 
     @available(iOS 17.0, *)
@@ -491,34 +488,6 @@ final class PointOfSaleItemsControllerTests {
     }
 
     @available(iOS 17.0, *)
-    @Test func loadItems_sets_container_state_to_loading_and_root_state_to_loading_state_when_no_existing_items() async throws {
-        // Given
-        let itemProvider = MockPointOfSaleItemService()
-        let sut = PointOfSaleItemsController(
-            itemProvider: itemProvider,
-            itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory(siteID: 1, credentials: nil)
-        )
-
-        itemProvider.shouldReturnZeroItems = true
-
-        await confirmation() { confirmation in
-            withObservationTracking {
-                _ = sut.itemsViewState.containerState
-            } onChange: {
-                // Then
-                Task { @MainActor in
-                    #expect(sut.itemsViewState.containerState == .loading)
-                    #expect(sut.itemsViewState.itemsStack.root == .loading([]))
-                    confirmation()
-                }
-            }
-
-            // When
-            await sut.loadItems(base: .root)
-        }
-    }
-
-    @available(iOS 17.0, *)
     @Test func loadItems_preserves_itemStates() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -598,6 +567,38 @@ final class PointOfSaleItemsControllerTests {
         // Then
         let fetchStrategy = try #require(itemProvider.spyItemsFetchStrategy as? PointOfSaleSearchPurchasableItemFetchStrategy)
         #expect(fetchStrategy.searchTerm == "green mug")
+    }
+
+    @available(iOS 17.0, *)
+    @Test func setRootLoadingState_when_not_initial_state_then_sets_loading_state() async throws {
+        // Given
+        let itemProvider = MockPointOfSaleItemService()
+        let sut = PointOfSaleItemsController(
+            itemProvider: itemProvider,
+            itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory(siteID: 1, credentials: nil)
+        )
+
+        let initialItems = MockPointOfSaleItemService.makeInitialItems()
+        itemProvider.itemPages = [initialItems]
+        await sut.loadItems(base: .root)
+        try #require(sut.itemsViewState.containerState == .content)
+
+        // When
+
+        await confirmation() { confirmation in
+            withObservationTracking {
+                _ = sut.itemsViewState.itemsStack.root
+            } onChange: {
+                // Then
+                Task { @MainActor in
+                    #expect(sut.itemsViewState.itemsStack.root == .loading(initialItems))
+                    confirmation()
+                }
+            }
+
+            // When
+            await sut.loadItems(base: .root)
+        }
     }
 
     enum MockError: Error {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Making a few changes to align Products and Coupons, and iOS with Android:

- Only show a full-screen loading state during initial launch (aligning with Android)
- Show magnifier for empty states for both Products and Coupons (aligning with Android, and waiting for further design improvements)
- Show in-line message when refresh fails for both Products and Coupons

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Empty View

1. Load a site with no products and coupons
2. Open POS
3. Confirm a full-screen loading is shown
4. Confirm POS loads showing empty products view with a magnifier glass
5. Confirm coupons show empty view with a magnifier glass

### Error View

1. Turn off the network before opening the POS
2. Open POS
3. Confirm a full screen loading is shown
4. Confirm POS loads showing error products view
5. Confirm coupons tab shows a similar view
6. Come back to Products, turn on internet, and retry
7. Confirm loading is showing within the table and items load

### Inline error view

1. Open POS
2. Confirm products are loaded
3. Turn off the network
4. Pull to refresh
5. Confirm an inline error is shown

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### iOS

#### Empty View

https://github.com/user-attachments/assets/17fb726d-7d33-4683-a180-378ceff11526

#### Error View

https://github.com/user-attachments/assets/329a9a60-f867-4bd0-bae1-c2e9d36e43db

#### Inline error view

https://github.com/user-attachments/assets/edb0cbb2-cbc5-4477-b3c3-989f000192e3

### Android 
<img width="500" alt="Android Coupons" src="https://github.com/user-attachments/assets/0ac9dcb0-ec69-4efa-b5fd-bee3e3ae3e77" />
<img width="500" alt="Android Products" src="https://github.com/user-attachments/assets/ef03a5c8-9165-4e46-93db-a9da0c5cbf78" />
<img width="500" alt="Android Loading" src="https://github.com/user-attachments/assets/26e38cc7-2126-4b16-a0f3-ef2f9a98ba4a" />
<img width="500" alt="Android Loading Products" src="https://github.com/user-attachments/assets/ccafc3d2-e281-4451-92ac-7df6c56e808f" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
