### PR TITLE
[Woo POS] Track variation parent list search state

### DIFF
--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -1,4 +1,5 @@
 import enum Yosemite.CardPresentPaymentOnboardingState
+import enum Yosemite.POSItemType
 
 extension WooAnalyticsEvent {
     enum PointOfSale {
@@ -87,11 +88,11 @@ extension WooAnalyticsEvent {
                               ])
         }
 
-        static func pointOfSaleItemsNextPageLoaded(itemListType: ItemListType) -> WooAnalyticsEvent {
+        static func pointOfSaleItemsNextPageLoaded(itemType: POSItemType, searching: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSaleItemsNextPageLoaded,
                               properties: [
-                                Key.itemListType: itemListType.analyticsValue,
-                                Key.search: itemListType.isSearching
+                                Key.itemListType: itemType.analyticsValue,
+                                Key.search: searching
             ])
         }
     }
@@ -125,6 +126,19 @@ private extension ItemListType {
         case .products(search: false),
                 .coupons:
             return "list"
+        }
+    }
+}
+
+private extension POSItemType {
+    var analyticsValue: String {
+        switch self {
+        case .product:
+            return "product"
+        case .variation:
+            return "variation"
+        case .coupon:
+            return "coupon"
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -8,7 +8,7 @@ struct ChildItemList: View {
     private let title: String
     private var itemsController: PointOfSaleItemsControllerProtocol
     private let itemActionHandler: POSItemActionHandler
-    private let parentListIsSearching: Bool
+    private let analyticsTracker: PointOfSaleItemListAnalyticsTracker
     @Environment(\.dismiss) private var dismiss
 
     private var node: ItemListBaseItem {
@@ -24,12 +24,12 @@ struct ChildItemList: View {
          title: String,
          itemsController: PointOfSaleItemsControllerProtocol,
          itemActionHandler: POSItemActionHandler,
-         parentListIsSearching: Bool) {
+         analyticsTracker: PointOfSaleItemListAnalyticsTracker) {
         self.parentItem = parentItem
         self.title = title
         self.itemsController = itemsController
         self.itemActionHandler = itemActionHandler
-        self.parentListIsSearching = parentListIsSearching
+        self.analyticsTracker = analyticsTracker
     }
 
     var body: some View {
@@ -75,15 +75,13 @@ private extension ChildItemList {
                      node: node,
                      itemActionHandler: itemActionHandler,
                      willLoadMore: {
-                         ServiceLocator.analytics.track(
-                            event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemType: .variation,
-                                                                                                searching: parentListIsSearching))
-                     })
-                .transition(.opacity)
-                .refreshable {
-                    ServiceLocator.analytics.track(.pointOfSaleVariationsPullToRefresh)
-                    await itemsController.refreshItems(base: node)
-                }
+                analyticsTracker.trackNextPageWillLoad()
+            })
+            .transition(.opacity)
+            .refreshable {
+                analyticsTracker.trackRefresh()
+                await itemsController.refreshItems(base: node)
+            }
         }
     }
 
@@ -173,7 +171,7 @@ private extension ChildItemList {
                          title: parentProduct.name,
                          itemsController: itemsController,
                          itemActionHandler: PointOfSalePreviewItemActionHandler(),
-                         parentListIsSearching: false)
+                         analyticsTracker: PointOfSaleItemListAnalyticsTracker(itemType: .variation, isSearching: false))
 }
 
 @available(iOS 17.0, *)
@@ -196,7 +194,7 @@ private extension ChildItemList {
                          title: parentProduct.name,
                          itemsController: itemsController,
                          itemActionHandler: PointOfSalePreviewItemActionHandler(),
-                         parentListIsSearching: false)
+                         analyticsTracker: PointOfSaleItemListAnalyticsTracker(itemType: .variation, isSearching: false))
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -8,6 +8,7 @@ struct ChildItemList: View {
     private let title: String
     private var itemsController: PointOfSaleItemsControllerProtocol
     private let itemActionHandler: POSItemActionHandler
+    private let parentListIsSearching: Bool
     @Environment(\.dismiss) private var dismiss
 
     private var node: ItemListBaseItem {
@@ -22,11 +23,13 @@ struct ChildItemList: View {
     init(parentItem: POSItem,
          title: String,
          itemsController: PointOfSaleItemsControllerProtocol,
-         itemActionHandler: POSItemActionHandler) {
+         itemActionHandler: POSItemActionHandler,
+         parentListIsSearching: Bool) {
         self.parentItem = parentItem
         self.title = title
         self.itemsController = itemsController
         self.itemActionHandler = itemActionHandler
+        self.parentListIsSearching = parentListIsSearching
     }
 
     var body: some View {
@@ -73,7 +76,8 @@ private extension ChildItemList {
                      itemActionHandler: itemActionHandler,
                      willLoadMore: {
                          ServiceLocator.analytics.track(
-                            event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemListType: .products(search: false)))
+                            event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemType: .variation,
+                                                                                                searching: parentListIsSearching))
                      })
                 .transition(.opacity)
                 .refreshable {
@@ -168,7 +172,8 @@ private extension ChildItemList {
     return ChildItemList(parentItem: parentItem,
                          title: parentProduct.name,
                          itemsController: itemsController,
-                         itemActionHandler: PointOfSalePreviewItemActionHandler())
+                         itemActionHandler: PointOfSalePreviewItemActionHandler(),
+                         parentListIsSearching: false)
 }
 
 @available(iOS 17.0, *)
@@ -190,7 +195,8 @@ private extension ChildItemList {
     return ChildItemList(parentItem: parentItem,
                          title: parentProduct.name,
                          itemsController: itemsController,
-                         itemActionHandler: PointOfSalePreviewItemActionHandler())
+                         itemActionHandler: PointOfSalePreviewItemActionHandler(),
+                         parentListIsSearching: false)
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -83,7 +83,8 @@ struct ItemList<HeaderView: View>: View {
                     destination: ChildItemList(parentItem: activeItem,
                                                title: parentProduct.name,
                                                itemsController: posModel.purchasableItemsController,
-                                               itemActionHandler: itemActionHandler),
+                                               itemActionHandler: itemActionHandler,
+                                               parentListIsSearching: posModel.viewStateCoordinatorForView.selectedItemListType.isSearching),
                     isActive: Binding(
                         get: { activeNavigationItem != nil },
                         set: { if !$0 { activeNavigationItem = nil } }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import enum Yosemite.POSItem
-import protocol WooFoundation.Analytics
 import struct Yosemite.POSVariableParentProduct
 
 /// Displays a list of POS items or placeholder card based on the given state.
@@ -84,7 +83,9 @@ struct ItemList<HeaderView: View>: View {
                                                title: parentProduct.name,
                                                itemsController: posModel.purchasableItemsController,
                                                itemActionHandler: itemActionHandler,
-                                               parentListIsSearching: posModel.viewStateCoordinatorForView.selectedItemListType.isSearching),
+                                               analyticsTracker: PointOfSaleItemListAnalyticsTracker(
+                                                itemType: .variation,
+                                                isSearching: posModel.viewStateCoordinatorForView.selectedItemListType.isSearching)),
                     isActive: Binding(
                         get: { activeNavigationItem != nil },
                         set: { if !$0 { activeNavigationItem = nil } }
@@ -144,7 +145,6 @@ private struct ItemListRow: View {
     let itemActionHandler: POSItemActionHandler
     @Binding var activeNavigationItem: POSItem?
     @Environment(PointOfSaleAggregateModel.self) private var posModel
-    let analytics: Analytics = ServiceLocator.analytics
 
     var body: some View {
         switch item {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListAnalyticsTracker.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListAnalyticsTracker.swift
@@ -1,0 +1,39 @@
+import Foundation
+import WooFoundation
+import enum Yosemite.POSItemType
+
+struct PointOfSaleItemListAnalyticsTracker {
+    private let itemType: POSItemType
+    private let isSearching: Bool
+
+    init(itemType: POSItemType, isSearching: Bool) {
+        self.itemType = itemType
+        self.isSearching = isSearching
+    }
+
+    init(itemListType: ItemListType) {
+        self.itemType = itemListType.itemType
+        self.isSearching = itemListType.isSearching
+    }
+
+    func trackNextPageWillLoad() {
+        ServiceLocator.analytics.track(
+            event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemType: itemType,
+                                                                                searching: isSearching))
+    }
+
+    func trackRefresh() {
+        ServiceLocator.analytics.track(refreshEvent)
+    }
+
+    private var refreshEvent: WooAnalyticsStat {
+        switch itemType {
+        case .product:
+                .pointOfSaleProductsPullToRefresh
+        case .coupon:
+                .pointOfSaleCouponsPullToRefresh
+        case .variation:
+                .pointOfSaleVariationsPullToRefresh
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListAnalyticsTracker.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/PointOfSaleItemListAnalyticsTracker.swift
@@ -5,15 +5,30 @@ import enum Yosemite.POSItemType
 struct PointOfSaleItemListAnalyticsTracker {
     private let itemType: POSItemType
     private let isSearching: Bool
+    private let itemListType: ItemListType?
 
     init(itemType: POSItemType, isSearching: Bool) {
         self.itemType = itemType
         self.isSearching = isSearching
+        self.itemListType = nil
     }
 
     init(itemListType: ItemListType) {
         self.itemType = itemListType.itemType
         self.isSearching = itemListType.isSearching
+        self.itemListType = itemListType
+    }
+
+    func trackItemListSelected() {
+        guard let itemListType else {
+            return
+        }
+        switch itemListType {
+        case .products:
+            ServiceLocator.analytics.track(.pointOfSaleProductsTapped)
+        case .coupons:
+            ServiceLocator.analytics.track(.pointOfSaleCouponsTapped)
+        }
     }
 
     func trackNextPageWillLoad() {
@@ -35,5 +50,12 @@ struct PointOfSaleItemListAnalyticsTracker {
         case .variation:
                 .pointOfSaleVariationsPullToRefresh
         }
+    }
+
+    func trackSearchTapped() {
+        guard let itemListType else {
+            return
+        }
+        ServiceLocator.analytics.track(event: .PointOfSale.searchButtonTapped(itemListType: itemListType))
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -225,8 +225,7 @@ private extension ItemListView {
                         } else {
                             POSPageHeaderActionButton(systemName: "magnifyingglass") {
                                 withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                                    ServiceLocator.analytics.track(event: WooAnalyticsEvent.PointOfSale.searchButtonTapped(
-                                        itemListType: selectedItemListType))
+                                    analyticsTracker.trackSearchTapped()
                                     selectedItemListType = .products(search: true)
                                 }
                             }
@@ -334,7 +333,7 @@ private extension ItemListView {
             }
         }
 
-        trackSelectedItemListTypeTapped(itemListType)
+        analyticsTracker.trackItemListSelected()
     }
 }
 
@@ -380,18 +379,6 @@ private extension ItemListView {
             value: "Coupons",
             comment: "Title of the button at the top of Point of Sale to switch to Coupons list."
         )
-    }
-}
-
-@available(iOS 17.0, *)
-private extension ItemListView {
-    func trackSelectedItemListTypeTapped(_ type: ItemListType) {
-        switch type {
-        case .products:
-            ServiceLocator.analytics.track(.pointOfSaleProductsTapped)
-        case .coupons:
-            ServiceLocator.analytics.track(.pointOfSaleCouponsTapped)
-        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -160,7 +160,8 @@ struct ItemListView: View {
             itemActionHandler: actionHandler(itemListType),
             willLoadMore: {
                 ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemListType: selectedItemListType))
+                    event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemType: itemListType.itemType,
+                                                                                        searching: itemListType.isSearching))
             }
         )
         .refreshable {
@@ -187,7 +188,8 @@ struct ItemListView: View {
                 parentItem: parentItem,
                 title: parentProduct.name,
                 itemsController: itemsController(selectedItemListType),
-                itemActionHandler: actionHandler(selectedItemListType)
+                itemActionHandler: actionHandler(selectedItemListType),
+                parentListIsSearching: selectedItemListType.isSearching
             )
         default:
             EmptyView()

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -13,6 +13,10 @@ struct ItemListView: View {
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
 
+    private var analyticsTracker: PointOfSaleItemListAnalyticsTracker {
+        PointOfSaleItemListAnalyticsTracker(itemListType: selectedItemListType)
+    }
+
     private var _isSearching: Binding<Bool> {
         Binding(
             get: {
@@ -159,13 +163,11 @@ struct ItemListView: View {
             node: .root,
             itemActionHandler: actionHandler(itemListType),
             willLoadMore: {
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.PointOfSale.pointOfSaleItemsNextPageLoaded(itemType: itemListType.itemType,
-                                                                                        searching: itemListType.isSearching))
+                analyticsTracker.trackNextPageWillLoad()
             }
         )
         .refreshable {
-            trackPullToRefresh()
+            analyticsTracker.trackRefresh()
             await itemsController(itemListType).refreshItems(base: .root)
         }
     }
@@ -189,7 +191,8 @@ struct ItemListView: View {
                 title: parentProduct.name,
                 itemsController: itemsController(selectedItemListType),
                 itemActionHandler: actionHandler(selectedItemListType),
-                parentListIsSearching: selectedItemListType.isSearching
+                analyticsTracker: PointOfSaleItemListAnalyticsTracker(itemType: .variation,
+                                                                      isSearching: selectedItemListType.isSearching)
             )
         default:
             EmptyView()
@@ -388,15 +391,6 @@ private extension ItemListView {
             ServiceLocator.analytics.track(.pointOfSaleProductsTapped)
         case .coupons:
             ServiceLocator.analytics.track(.pointOfSaleCouponsTapped)
-        }
-    }
-
-    func trackPullToRefresh() {
-        switch selectedItemListType {
-        case .products:
-            ServiceLocator.analytics.track(.pointOfSaleProductsPullToRefresh)
-        case .coupons:
-            ServiceLocator.analytics.track(.pointOfSaleCouponsPullToRefresh)
         }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -799,6 +799,7 @@
 		2004E2E92C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E82C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift */; };
 		2004E2EB2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2EA2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift */; };
 		2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */; };
+		2005D3F32DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005D3F22DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift */; };
 		200798F02DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200798EF2DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift */; };
 		200BA1592CF092280006DC5B /* PointOfSaleItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BA1582CF092280006DC5B /* PointOfSaleItemsController.swift */; };
 		200BA15B2CF0A2130006DC5B /* MockPointOfSaleItemsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BA15A2CF0A2130006DC5B /* MockPointOfSaleItemsService.swift */; };
@@ -4070,6 +4071,7 @@
 		2004E2E82C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentAlert.swift; sourceTree = "<group>"; };
 		2004E2EA2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentPreflightAdaptor.swift; sourceTree = "<group>"; };
 		2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift; sourceTree = "<group>"; };
+		2005D3F22DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListAnalyticsTracker.swift; sourceTree = "<group>"; };
 		200798EF2DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemsSearchController.swift; sourceTree = "<group>"; };
 		200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		200BA1582CF092280006DC5B /* PointOfSaleItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemsController.swift; sourceTree = "<group>"; };
@@ -7635,6 +7637,7 @@
 				0196FF932DA806720063CEF1 /* CouponCardView.swift */,
 				0291497C2D26CB2500F7B3B3 /* ChildItemList.swift */,
 				020556502D5DA45500E51059 /* GhostItemCardView.swift */,
+				2005D3F22DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift */,
 			);
 			path = "Item Selector";
 			sourceTree = "<group>";
@@ -16761,6 +16764,7 @@
 				CE4ECA582BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift in Sources */,
 				01FB19582C6E901800A44FF0 /* DynamicHStack.swift in Sources */,
 				AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */,
+				2005D3F32DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift in Sources */,
 				D8752EF7265E60F4008ACC80 /* PaymentCaptureCelebration.swift in Sources */,
 				B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */,
 				205B7EC72C19FCA700D14A36 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the `pos_items_next_page_loaded` event to add variation as an option for the `item_list_type` property, with `search` based on its parent list.

I also moved the various multiple-list events to a new `PointOfSaleItemListAnalyticsTracker` which (I think) declutters the view.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and go to POS
2. Search for a variable product that has more than 25 variations
3. Tap the product to open it
4. Scroll down
5. Observe that the analytic is tracked as expected

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on an iPad Air running iOS 17.7.2. I tested all the combinations of events I moved, even though the screenshot only shows the ones I changed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![CleanShot 2025-04-29 at 17 53 21@2x](https://github.com/user-attachments/assets/4430a097-93f7-4123-ad60-972833af7bc7)

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.