### PR TITLE
[Woo POS] VoiceOver improvements for itemlist and search

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -129,6 +129,7 @@ struct ItemListView: View {
     private func itemListTabContent(_ itemListType: ItemListType) -> some View {
         ZStack {
             itemListContent(itemListType)
+                .accessibilityElement(children: isSearching ? .ignore : .contain)
 
             if isSearching {
                 POSSearchContentView(

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
@@ -10,7 +10,8 @@ struct POSItemImageView: View {
         Rectangle()
             .foregroundColor(Constants.placeholderBackgroundColor)
             .overlay {
-                Text(Image(systemName: "archivebox"))
+                Image(systemName: "archivebox")
+                    .accessibilityHidden(true)
                     .font(.posButtonSymbolLarge)
                     .foregroundColor(Constants.placeholderIconColor)
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-390
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR prevents items from the main ItemList behind an active search from being focusable and announced by VoiceOver. Additionally, it removes an announcement for the placeholder item list image.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Start a search, type a search term
3. Activate VoiceOver
4. Swipe to the cart (use title swiping if you like)
5. Swipe back to the item list - observe that only the search results are focused and announced – previously, the underlying list would also be selectable,

Focus a product row with a placeholder image – observe that it doesn't say "archive" at the beginning.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested with an iPad Air running iOS 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

🔉 Sound on!

### Before


https://github.com/user-attachments/assets/6c030810-8d76-4ff7-a2aa-380ae75f17c3


### After

https://github.com/user-attachments/assets/21900f1a-ac80-4bdd-92f1-9baa8629d75d


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.