### PR TITLE
[Woo POS][Products Search] Make search field match designs

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
@@ -18,6 +18,7 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
             focusedBorderColor: .posPrimary,
             unfocusedBorderColor: .posSurfaceBright,
             backgroundColor: .posSurfaceBright,
+            cornerRadius: POSCornerRadiusStyle.medium.value,
             height: searchFieldHeight,
             content: { configuration in
                 AnyView(

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Text field style for search fields that includes a magnifier icon and clear button
+struct POSSearchTextFieldStyle: TextFieldStyle {
+    private let focused: Bool
+    @Binding private var searchTerm: String
+    @ScaledMetric private var searchFieldHeight: CGFloat = 56.0
+
+    init(focused: Bool, searchTerm: Binding<String>) {
+        self.focused = focused
+        self._searchTerm = searchTerm
+    }
+
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+        .textFieldStyle(WooRoundedBorderTextFieldStyle(
+            focused: focused,
+            focusedBorderColor: .posPrimary,
+            unfocusedBorderColor: .posSurfaceBright,
+            backgroundColor: .posSurfaceBright,
+            height: searchFieldHeight,
+            content: { configuration in
+                AnyView(
+                    HStack(spacing: POSSpacing.small) {
+                        Image(systemName: "magnifyingglass")
+                            .accessibilityHidden(true)
+                            .foregroundColor(.posOnSurface)
+                            .font(.posButtonSymbolMedium)
+                            .padding(.leading, Defaults.horizontalPadding)
+
+                        configuration
+
+                        if searchTerm.isNotEmpty {
+                            Button {
+                                searchTerm = ""
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .accessibilityLabel(Localization.searchFieldClearButtonAccessibilityLabel)
+                                    .foregroundColor(.posOnSurfaceVariantHighest)
+                                    .font(.posButtonSymbolMedium)
+                            }
+                            .padding(.trailing, Defaults.horizontalPadding)
+                        }
+                    }
+                )
+            }
+        ))
+    }
+}
+
+private extension POSSearchTextFieldStyle {
+    enum Defaults {
+        static let horizontalPadding: CGFloat = POSSpacing.medium
+    }
+
+    enum Localization {
+        static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
+            "pos.searchview.searchField.clearButton.accessibilityLabel",
+            value: "Clear Search",
+            comment: "Accessibility label for the clear button in the Point of Sale search screen."
+        )
+    }
+}
+

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
@@ -61,4 +61,3 @@ private extension POSSearchTextFieldStyle {
         )
     }
 }
-

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
@@ -33,7 +33,7 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
                             Button {
                                 searchTerm = ""
                             } label: {
-                                Image(systemName: "xmark.circle.fill")
+                                Image(systemName: "xmark.circle")
                                     .accessibilityLabel(Localization.searchFieldClearButtonAccessibilityLabel)
                                     .foregroundColor(.posOnSurfaceVariantHighest)
                                     .font(.posButtonSymbolMedium)

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
@@ -26,7 +26,6 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
                             .accessibilityHidden(true)
                             .foregroundColor(.posOnSurface)
                             .font(.posButtonSymbolMedium)
-                            .padding(.leading, Defaults.horizontalPadding)
 
                         configuration
 
@@ -39,7 +38,6 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
                                     .foregroundColor(.posOnSurfaceVariantHighest)
                                     .font(.posButtonSymbolMedium)
                             }
-                            .padding(.trailing, Defaults.horizontalPadding)
                         }
                     }
                 )
@@ -49,10 +47,6 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
 }
 
 private extension POSSearchTextFieldStyle {
-    enum Defaults {
-        static let horizontalPadding: CGFloat = POSSpacing.medium
-    }
-
     enum Localization {
         static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
             "pos.searchview.searchField.clearButton.accessibilityLabel",

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchTextFieldStyle.swift
@@ -19,6 +19,7 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
             unfocusedBorderColor: .posSurfaceBright,
             backgroundColor: .posSurfaceBright,
             cornerRadius: POSCornerRadiusStyle.medium.value,
+            insets: EdgeInsets(top: POSPadding.small, leading: POSPadding.medium, bottom: POSPadding.small, trailing: POSPadding.medium),
             height: searchFieldHeight,
             content: { configuration in
                 AnyView(
@@ -26,7 +27,7 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
                         Image(systemName: "magnifyingglass")
                             .accessibilityHidden(true)
                             .foregroundColor(.posOnSurface)
-                            .font(.posButtonSymbolMedium)
+                            .font(.posBodyMediumBold)
 
                         configuration
 
@@ -37,7 +38,7 @@ struct POSSearchTextFieldStyle: TextFieldStyle {
                                 Image(systemName: "xmark.circle")
                                     .accessibilityLabel(Localization.searchFieldClearButtonAccessibilityLabel)
                                     .foregroundColor(.posOnSurfaceVariantHighest)
-                                    .font(.posButtonSymbolMedium)
+                                    .font(.posBodyMediumBold)
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -58,7 +58,7 @@ struct POSSearchField: View {
                 backgroundColor: .posSurfaceBright,
                 height: Constants.textFieldHeight
             ))
-            .font(POSFontStyle.posBodyLargeRegular())
+            .font(.posBodyLargeBold)
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
             .focused($isSearchFieldFocused)

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -52,7 +52,7 @@ struct POSSearchField: View {
             TextField(text: $searchTerm) {
                 Text(searchable.itemListType.itemType.searchFieldLabel)
             }
-            .textFieldStyle(RoundedBorderTextFieldStyle(
+            .textFieldStyle(WooRoundedBorderTextFieldStyle(
                 focused: isSearchFieldFocused,
                 focusedBorderColor: .posPrimary,
                 unfocusedBorderColor: .posSurfaceBright,

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -25,6 +25,7 @@ struct POSSearchField: View {
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
     @ScaledMetric private var searchFieldHeight: CGFloat = 56.0
+    @ScaledMetric private var backButtonWidth: CGFloat = 48.0
 
     private let searchable: any POSSearchable
     private let onBack: () -> Void
@@ -48,6 +49,7 @@ struct POSSearchField: View {
                     .foregroundColor(.posOnSurface)
                     .font(.posButtonSymbolLarge)
             }
+            .frame(minWidth: backButtonWidth)
 
             TextField(text: $searchTerm) {
                 Text(searchable.itemListType.itemType.searchFieldLabel)

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -52,13 +52,8 @@ struct POSSearchField: View {
             TextField(text: $searchTerm) {
                 Text(searchable.itemListType.itemType.searchFieldLabel)
             }
-            .textFieldStyle(WooRoundedBorderTextFieldStyle(
-                focused: isSearchFieldFocused,
-                focusedBorderColor: .posPrimary,
-                unfocusedBorderColor: .posSurfaceBright,
-                backgroundColor: .posSurfaceBright,
-                height: searchFieldHeight
-            ))
+            .textFieldStyle(POSSearchTextFieldStyle(focused: isSearchFieldFocused,
+                                                    searchTerm: $searchTerm))
             .font(.posBodyLargeBold)
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
@@ -97,17 +92,6 @@ struct POSSearchField: View {
                     }
                 }
             }
-
-            Button {
-                searchTerm = ""
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .accessibilityLabel(Localization.searchFieldClearButtonAccessibilityLabel)
-                    .foregroundColor(.posOnSurfaceVariantHighest)
-                    .font(.posButtonSymbolSmall)
-            }
-            .transition(.opacity)
-            .renderedIf(searchTerm.isNotEmpty)
         }
         .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
             guard isVisible == false else { return }
@@ -155,17 +139,6 @@ struct POSSearchContentView<Content: View>: View {
 }
 
 // MARK: - Localization
-@available(iOS 17.0, *)
-private extension POSSearchField {
-    enum Localization {
-        static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
-            "pos.searchview.searchField.clearButton.accessibilityLabel",
-            value: "Clear Search",
-            comment: "Accessibility label for the clear button in the Point of Sale search screen."
-        )
-    }
-}
-
 private extension POSItemType {
     var searchFieldLabel: String {
         switch self {

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -51,7 +51,13 @@ struct POSSearchField: View {
             TextField(text: $searchTerm) {
                 Text(Localization.searchFieldLabel)
             }
-            .textFieldStyle(.roundedBorder)
+            .textFieldStyle(RoundedBorderTextFieldStyle(
+                focused: isSearchFieldFocused,
+                focusedBorderColor: .posPrimary,
+                unfocusedBorderColor: .posSurfaceBright,
+                backgroundColor: .posSurfaceBright,
+                height: Constants.textFieldHeight
+            ))
             .font(POSFontStyle.posBodyLargeRegular())
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
@@ -109,6 +115,13 @@ struct POSSearchField: View {
         .onAppear {
             isSearchFieldFocused = true
         }
+    }
+}
+
+@available(iOS 17.0, *)
+private extension POSSearchField {
+    enum Constants {
+        static let textFieldHeight: CGFloat = 56.0
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -24,6 +24,7 @@ struct POSSearchField: View {
     @FocusState private var isSearchFieldFocused: Bool
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
+    @ScaledMetric private var searchFieldHeight: CGFloat = 56.0
 
     private let searchable: any POSSearchable
     private let onBack: () -> Void
@@ -56,7 +57,7 @@ struct POSSearchField: View {
                 focusedBorderColor: .posPrimary,
                 unfocusedBorderColor: .posSurfaceBright,
                 backgroundColor: .posSurfaceBright,
-                height: Constants.textFieldHeight
+                height: searchFieldHeight
             ))
             .font(.posBodyLargeBold)
             .autocorrectionDisabled()
@@ -115,13 +116,6 @@ struct POSSearchField: View {
         .onAppear {
             isSearchFieldFocused = true
         }
-    }
-}
-
-@available(iOS 17.0, *)
-private extension POSSearchField {
-    enum Constants {
-        static let textFieldHeight: CGFloat = 56.0
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -25,7 +25,6 @@ struct POSSearchField: View {
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
     @ScaledMetric private var searchFieldHeight: CGFloat = 56.0
-    @ScaledMetric private var backButtonWidth: CGFloat = 48.0
 
     private let searchable: any POSSearchable
     private let onBack: () -> Void
@@ -40,16 +39,11 @@ struct POSSearchField: View {
 
     var body: some View {
         HStack(spacing: POSSpacing.small) {
-            Button {
+            POSPageHeaderBackButton(configuration: .init(state: .enabled, action: {
                 searchTerm = ""
                 onBack()
                 isSearchFieldFocused = false
-            } label: {
-                Image(systemName: "chevron.backward")
-                    .foregroundColor(.posOnSurface)
-                    .font(.posButtonSymbolLarge)
-            }
-            .frame(minWidth: backButtonWidth)
+            }))
 
             TextField(text: $searchTerm) {
                 Text(searchable.itemListType.itemType.searchFieldLabel)

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -49,7 +49,7 @@ struct POSSearchField: View {
             }
 
             TextField(text: $searchTerm) {
-                Text(Localization.searchFieldLabel)
+                Text(searchable.itemListType.itemType.searchFieldLabel)
             }
             .textFieldStyle(RoundedBorderTextFieldStyle(
                 focused: isSearchFieldFocused,
@@ -164,12 +164,6 @@ struct POSSearchContentView<Content: View>: View {
 @available(iOS 17.0, *)
 private extension POSSearchField {
     enum Localization {
-        static let searchFieldLabel = NSLocalizedString(
-            "pos.searchview.searchField.label",
-            value: "Search",
-            comment: "Label/placeholder text for the search field in Point of Sale."
-        )
-
         static let searchFieldClearButtonAccessibilityLabel = NSLocalizedString(
             "pos.searchview.searchField.clearButton.accessibilityLabel",
             value: "Clear Search",
@@ -183,6 +177,8 @@ private extension POSItemType {
         switch self {
         case .product:
             return Localization.productsSearchFieldLabel
+        case .coupon:
+            return Localization.couponsSearchFieldLabel
         default:
             return Localization.defaultSearchFieldLabel
         }
@@ -190,9 +186,15 @@ private extension POSItemType {
 
     enum Localization {
         static let productsSearchFieldLabel = NSLocalizedString(
-            "pos.itemListView.products.searchField.label",
-            value: "Search Products",
+            "pos.itemListView.products.searchField.label.1",
+            value: "Search products",
             comment: "Label/placeholder text for the search field for Products in Point of Sale."
+        )
+
+        static let couponsSearchFieldLabel = NSLocalizedString(
+            "pos.itemListView.coupons.searchField.label",
+            value: "Search coupons",
+            comment: "Label/placeholder text for the search field for Coupons in Point of Sale."
         )
 
         static let defaultSearchFieldLabel = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderBackButton.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderBackButton.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct POSPageHeaderBackButton: View {
+    private let configuration: POSPageHeaderBackButtonConfiguration
+
+    init(configuration: POSPageHeaderBackButtonConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        Button(action: configuration.action) {
+            Text(Image(systemName: Constants.backButtonIcon))
+                .font(.posButtonSymbolLarge)
+                .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
+                .foregroundColor(configuration.state == .disabled ? .posOnSurfaceVariantLowest : .posOnSurface)
+                .padding(.horizontal, Constants.backButtonHorizontalPadding)
+        }
+        .disabled(configuration.state == .disabled || configuration.state == .shimmering)
+        .if(configuration.state == .shimmering) { view in
+            view.shimmering()
+        }
+    }
+}
+
+private extension POSPageHeaderBackButton {
+    enum Constants {
+        static let backButtonIcon = "chevron.backward"
+        /// Icon container is 48x48, chevron icon width is 24px. Therefore, adding a horizontal padding (48-24)/2 = 12.
+        static let backButtonHorizontalPadding: CGFloat = 12
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -116,28 +116,17 @@ struct POSPageHeaderView<TrailingContent: View>: View {
     @ViewBuilder
     private var backButton: some View {
         if let configuration = backButtonConfiguration {
-            Button(action: configuration.action) {
-                Text(Image(systemName: Constants.backButtonIcon))
-                    .font(.posButtonSymbolLarge)
-                    .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
-                    .foregroundColor(configuration.state == .disabled ? .posOnSurfaceVariantLowest : .posOnSurface)
-                    .padding(.horizontal, Constants.backButtonHorizontalPadding)
-            }
-            .disabled(configuration.state == .disabled || configuration.state == .shimmering)
-            .if(configuration.state == .shimmering) { view in
-                view.shimmering()
-            }
+            POSPageHeaderBackButton(configuration: configuration)
         }
     }
 }
 
 private enum Constants {
-    static let backButtonIcon = "chevron.backward"
-    /// Icon container is 48x48, chevron icon width is 24px. Therefore, adding a horizontal padding (48-24)/2 = 12.
-    static let backButtonHorizontalPadding: CGFloat = 12
     static let horizontalSpacing: CGFloat = POSSpacing.medium
     static let titleSubtitleSpacing: CGFloat = POSSpacing.xSmall
 }
+
+
 
 @available(iOS 17.0, *)
 #Preview {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -109,8 +109,13 @@ struct POSPageHeaderView<TrailingContent: View>: View {
             }
         }
         .frame(minHeight: POSHeaderLayoutConstants.minHeight)
-        .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
+        .padding(.leading, shouldHaveLeadingPaddingForItems ? POSHeaderLayoutConstants.sectionHorizontalPadding : POSPadding.none)
+        .padding(.trailing, POSHeaderLayoutConstants.sectionHorizontalPadding)
         .padding(.vertical, POSHeaderLayoutConstants.sectionVerticalPadding)
+    }
+
+    private var shouldHaveLeadingPaddingForItems: Bool {
+        items.isNotEmpty  || showsBackButton
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Authentication/AuthenticationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AuthenticationFormFieldView.swift
@@ -56,12 +56,12 @@ struct AuthenticationFormFieldView: View {
                         }
                     }
                     .font(.body)
-                    .textFieldStyle(RoundedBorderTextFieldStyle(
+                    .textFieldStyle(WooRoundedBorderTextFieldStyle(
                         focused: viewModel.isFocused,
                         // Custom insets to leave trailing space for the reveal button.
-                        insets: .init(top: RoundedBorderTextFieldStyle.Defaults.insets.top,
-                                      leading: RoundedBorderTextFieldStyle.Defaults.insets.leading,
-                                      bottom: RoundedBorderTextFieldStyle.Defaults.insets.bottom,
+                        insets: .init(top: WooRoundedBorderTextFieldStyle.Defaults.insets.top,
+                                      leading: WooRoundedBorderTextFieldStyle.Defaults.insets.leading,
+                                      bottom: WooRoundedBorderTextFieldStyle.Defaults.insets.bottom,
                                       trailing: Layout.secureFieldRevealButtonHorizontalPadding * 2 + Layout.secureFieldRevealButtonDimension * scale),
                         height: 44 * scale
                     ))
@@ -81,7 +81,7 @@ struct AuthenticationFormFieldView: View {
                 }
             } else {
                 TextField(viewModel.placeholder, text: viewModel.text)
-                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isFocused))
+                    .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: viewModel.isFocused))
                     .keyboardType(viewModel.keyboardType)
                     .autocapitalization(viewModel.autocapitalization)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
@@ -25,7 +25,7 @@ struct CollapsibleCustomerCard: View {
                 VStack(alignment: .leading) {
                     Text(Localization.emailAddressTitle)
                     TextField(Localization.emailAddressPlaceholder, text: $viewModel.email)
-                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                        .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true))
                 }
 
                 Text("Create new customer toggle")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
@@ -23,7 +23,7 @@ struct GiftCardInputView: View {
                         HStack {
                             TextField(Localization.placeholder, text: $viewModel.code)
                                 .focused()
-                                .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                                .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true))
                             Spacer()
                             Button {
                                 showsScanner = true

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -6,6 +6,7 @@ struct WooRoundedBorderTextFieldStyle: TextFieldStyle {
     private let focusedBorderColor: Color
     private let unfocusedBorderColor: Color
     private let backgroundColor: Color
+    private let cornerRadius: CGFloat
     private let insets: EdgeInsets
     private let height: CGFloat?
     private let content: ((TextField<Self._Label>) -> AnyView)?
@@ -22,12 +23,14 @@ struct WooRoundedBorderTextFieldStyle: TextFieldStyle {
          focusedBorderColor: Color = Defaults.focusedBorderColor,
          unfocusedBorderColor: Color = Defaults.unfocusedBorderColor,
          backgroundColor: Color = .clear,
+         cornerRadius: CGFloat = 8,
          insets: EdgeInsets = Defaults.insets,
          height: CGFloat? = nil,
          content: ((TextField<Self._Label>) -> AnyView)? = nil) {
         self.focused = focused
         self.focusedBorderColor = focusedBorderColor
         self.unfocusedBorderColor = unfocusedBorderColor
+        self.cornerRadius = cornerRadius
         self.backgroundColor = backgroundColor
         self.insets = insets
         self.height = height
@@ -41,7 +44,7 @@ struct WooRoundedBorderTextFieldStyle: TextFieldStyle {
             .padding(insets)
             .background(
                 backgroundColor
-                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                     .roundedBorder(cornerRadius: 8, lineColor: focused ? focusedBorderColor: unfocusedBorderColor,
                                    lineWidth: focused ? 2: 1)
                     .frame(height: height)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -5,6 +5,7 @@ struct RoundedBorderTextFieldStyle: TextFieldStyle {
     private let focused: Bool
     private let focusedBorderColor: Color
     private let unfocusedBorderColor: Color
+    private let backgroundColor: Color
     private let insets: EdgeInsets
     private let height: CGFloat?
 
@@ -17,11 +18,13 @@ struct RoundedBorderTextFieldStyle: TextFieldStyle {
     init(focused: Bool,
          focusedBorderColor: Color = Defaults.focusedBorderColor,
          unfocusedBorderColor: Color = Defaults.unfocusedBorderColor,
+         backgroundColor: Color = .clear,
          insets: EdgeInsets = Defaults.insets,
          height: CGFloat? = nil) {
         self.focused = focused
         self.focusedBorderColor = focusedBorderColor
         self.unfocusedBorderColor = unfocusedBorderColor
+        self.backgroundColor = backgroundColor
         self.insets = insets
         self.height = height
     }
@@ -30,9 +33,10 @@ struct RoundedBorderTextFieldStyle: TextFieldStyle {
         configuration
             .padding(insets)
             .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(focused ? focusedBorderColor: unfocusedBorderColor,
-                            lineWidth: focused ? 2: 1)
+                backgroundColor
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .roundedBorder(cornerRadius: 8, lineColor: focused ? focusedBorderColor: unfocusedBorderColor,
+                                   lineWidth: focused ? 2: 1)
                     .frame(height: height)
             )
             .frame(height: height)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -8,29 +8,36 @@ struct WooRoundedBorderTextFieldStyle: TextFieldStyle {
     private let backgroundColor: Color
     private let insets: EdgeInsets
     private let height: CGFloat?
+    private let content: ((TextField<Self._Label>) -> AnyView)?
 
     /// - Parameters:
     ///   - focused: Whether the field is focused or not.
     ///   - focusedBorderColor: The border color when the field is focused.
     ///   - unfocusedBorderColor: The border color when the field is not focused.
+    ///   - backgroundColor: The background color of the textfield
     ///   - insets: The insets between the background border and the text input.
     ///   - height: An optional fixed height for the field.
+    ///   - content: Optional closure to wrap the text field content.
     init(focused: Bool,
          focusedBorderColor: Color = Defaults.focusedBorderColor,
          unfocusedBorderColor: Color = Defaults.unfocusedBorderColor,
          backgroundColor: Color = .clear,
          insets: EdgeInsets = Defaults.insets,
-         height: CGFloat? = nil) {
+         height: CGFloat? = nil,
+         content: ((TextField<Self._Label>) -> AnyView)? = nil) {
         self.focused = focused
         self.focusedBorderColor = focusedBorderColor
         self.unfocusedBorderColor = unfocusedBorderColor
         self.backgroundColor = backgroundColor
         self.insets = insets
         self.height = height
+        self.content = content
     }
 
     func _body(configuration: TextField<Self._Label>) -> some View {
-        configuration
+        let styledContent = content?(configuration) ?? AnyView(configuration)
+
+        styledContent
             .padding(insets)
             .background(
                 backgroundColor

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Text field has a rounded border that has a thicker border and brighter border color when the field is focused.
-struct RoundedBorderTextFieldStyle: TextFieldStyle {
+struct WooRoundedBorderTextFieldStyle: TextFieldStyle {
     private let focused: Bool
     private let focusedBorderColor: Color
     private let unfocusedBorderColor: Color
@@ -43,7 +43,7 @@ struct RoundedBorderTextFieldStyle: TextFieldStyle {
     }
 }
 
-extension RoundedBorderTextFieldStyle {
+extension WooRoundedBorderTextFieldStyle {
     enum Defaults {
         static let focusedBorderColor: Color = .init(uiColor: .brand)
         static let unfocusedBorderColor: Color = .gray
@@ -55,29 +55,29 @@ struct TextFieldStyles_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             TextField("placeholder", text: .constant("focused"))
-                .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true))
             TextField("placeholder", text: .constant("unfocused"))
-                .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
+                .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: false))
             TextField("placeholder", text: .constant("focused with a different color"))
-                .textFieldStyle(RoundedBorderTextFieldStyle(focused: true, focusedBorderColor: .orange))
+                .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true, focusedBorderColor: .orange))
                 .environment(\.sizeCategory, .extraExtraExtraLarge)
             TextField("placeholder", text: .constant("unfocused with a different color"))
-                .textFieldStyle(RoundedBorderTextFieldStyle(focused: false, unfocusedBorderColor: .cyan))
+                .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: false, unfocusedBorderColor: .cyan))
             TextField("placeholder", text: .constant("custom insets"))
-                .textFieldStyle(RoundedBorderTextFieldStyle(focused: false, insets: .init(top: 20, leading: 0, bottom: 10, trailing: 50)))
+                .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: false, insets: .init(top: 20, leading: 0, bottom: 10, trailing: 50)))
                 .frame(width: 150)
             HStack {
                 TextField("placeholder", text: .constant("text field"))
-                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                    .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true))
                 SecureField("placeholder", text: .constant("secure"))
-                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                    .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true))
             }
             .environment(\.sizeCategory, .extraExtraExtraLarge)
             HStack {
                 TextField("placeholder", text: .constant("text field"))
-                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true, height: 100))
+                    .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true, height: 100))
                 SecureField("placeholder", text: .constant("secure"))
-                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                    .textFieldStyle(WooRoundedBorderTextFieldStyle(focused: true))
             }
             .environment(\.sizeCategory, .extraExtraExtraLarge)
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -799,6 +799,7 @@
 		2004E2E92C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E82C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift */; };
 		2004E2EB2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2EA2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift */; };
 		2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */; };
+		2005D7A72DC240CB00E12021 /* POSSearchTextFieldStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005D7A62DC240CB00E12021 /* POSSearchTextFieldStyle.swift */; };
 		200798F02DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200798EF2DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift */; };
 		200BA1592CF092280006DC5B /* PointOfSaleItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BA1582CF092280006DC5B /* PointOfSaleItemsController.swift */; };
 		200BA15B2CF0A2130006DC5B /* MockPointOfSaleItemsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BA15A2CF0A2130006DC5B /* MockPointOfSaleItemsService.swift */; };
@@ -4070,6 +4071,7 @@
 		2004E2E82C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentAlert.swift; sourceTree = "<group>"; };
 		2004E2EA2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentPreflightAdaptor.swift; sourceTree = "<group>"; };
 		2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift; sourceTree = "<group>"; };
+		2005D7A62DC240CB00E12021 /* POSSearchTextFieldStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchTextFieldStyle.swift; sourceTree = "<group>"; };
 		200798EF2DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemsSearchController.swift; sourceTree = "<group>"; };
 		200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		200BA1582CF092280006DC5B /* PointOfSaleItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemsController.swift; sourceTree = "<group>"; };
@@ -8471,6 +8473,7 @@
 				209EE8142DBA96D00089F3D2 /* POSProductSearchable.swift */,
 				209EE8122DBA95BA0089F3D2 /* POSSearchView.swift */,
 				20B9EC692DAFFB7A00512EF5 /* POSRecentSearchesView.swift */,
+				2005D7A62DC240CB00E12021 /* POSSearchTextFieldStyle.swift */,
 			);
 			path = "Item Search";
 			sourceTree = "<group>";
@@ -16834,6 +16837,7 @@
 				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,
 				DE74F2A527E41D740002FE59 /* EnableAnalyticsView.swift in Sources */,
 				B90DACC02A30AEF000365897 /* BarcodeScannerItemFinder.swift in Sources */,
+				2005D7A72DC240CB00E12021 /* POSSearchTextFieldStyle.swift in Sources */,
 				D85A3C5626C1911600C0E026 /* InPersonPaymentsPluginNotInstalledView.swift in Sources */,
 				EE505DE32B3D36F0006E3323 /* BlazeCreateCampaignIntroViewModel.swift in Sources */,
 				2004E2CE2C077B0B00D62521 /* CardPresentPaymentCardReader.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -801,6 +801,7 @@
 		2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */; };
 		2005D3F32DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005D3F22DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift */; };
 		2005D7A72DC240CB00E12021 /* POSSearchTextFieldStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005D7A62DC240CB00E12021 /* POSSearchTextFieldStyle.swift */; };
+		2005FC9D2DC37E4D00E12021 /* POSPageHeaderBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005FC9C2DC37E4D00E12021 /* POSPageHeaderBackButton.swift */; };
 		200798F02DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200798EF2DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift */; };
 		200BA1592CF092280006DC5B /* PointOfSaleItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BA1582CF092280006DC5B /* PointOfSaleItemsController.swift */; };
 		200BA15B2CF0A2130006DC5B /* MockPointOfSaleItemsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BA15A2CF0A2130006DC5B /* MockPointOfSaleItemsService.swift */; };
@@ -4074,6 +4075,7 @@
 		2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift; sourceTree = "<group>"; };
 		2005D3F22DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListAnalyticsTracker.swift; sourceTree = "<group>"; };
 		2005D7A62DC240CB00E12021 /* POSSearchTextFieldStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchTextFieldStyle.swift; sourceTree = "<group>"; };
+		2005FC9C2DC37E4D00E12021 /* POSPageHeaderBackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPageHeaderBackButton.swift; sourceTree = "<group>"; };
 		200798EF2DA804200037C505 /* MockPointOfSalePurchasableItemsSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemsSearchController.swift; sourceTree = "<group>"; };
 		200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		200BA1582CF092280006DC5B /* PointOfSaleItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemsController.swift; sourceTree = "<group>"; };
@@ -6619,6 +6621,7 @@
 				027ADB742D218A8D009608DB /* POSItemCardBorderStylesModifier.swift */,
 				0295736A2D62B93300865E27 /* POSPageHeaderView.swift */,
 				015456CD2DB033FF0071C3C4 /* POSPageHeaderActionButton.swift */,
+				2005FC9C2DC37E4D00E12021 /* POSPageHeaderBackButton.swift */,
 				0295CDBF2D6477C400865E27 /* POSNoticeView.swift */,
 				021A17202D7036AF006DF7C0 /* DynamicFrameScaler.swift */,
 			);
@@ -16781,6 +16784,7 @@
 				DE7E5E812B4BCC06002E28D2 /* BlazeTargetLanguagePickerViewModel.swift in Sources */,
 				0230B4D22C333E0800F2F660 /* PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel.swift in Sources */,
 				0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */,
+				2005FC9D2DC37E4D00E12021 /* POSPageHeaderBackButton.swift in Sources */,
 				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,
 				021DD44D286A3A8D004F0468 /* UIViewController+Navigation.swift in Sources */,
 				B958A7CB28B3D4A100823EEF /* RouteMatcher.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-404
Closes: WOOMOB-400

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the search field to match the designs

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Tap search
3. Observe that the search field matches designs:

- Highlighted purple when focused
- Magnifier and clear button inside text field
- `Search products` or `Search coupons` placeholder text
- Bold text

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested on an iPad Air running iOS 17.7.2, and a simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/0e2ece65-acd7-4095-8cc0-188485a9f15d


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.