### PR TITLE
[Woo POS][Products Search] Update search request debounce to match Android

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -72,7 +72,7 @@ struct POSSearchField: View {
 
                 searchTask = Task {
                     if shouldDebounceNextSearchRequest {
-                        try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
+                        try? await Task.sleep(nanoseconds: 500 * NSEC_PER_MSEC)
                     }
 
                     guard !Task.isCancelled else { return }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-418
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR increases the debounce interval from 300ms to 500ms, to take account of slower software keyboard typing speeds and match Android.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Set up a proxy tool to monitor the network

1. Launch the POS and navigate to Search
2. Type two characters
3. Observe that the first character is sent immediately, and the second about 500ms later (it's not exact at the network layer though)

Repeat the test with a longer search term, typing at more than 1 character every 500ms
Observe that the second request is sent 500ms after you finish typing.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air running iOS 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### 2 keystrokes:


https://github.com/user-attachments/assets/6b79a3ac-f590-4f0f-a550-22f303affa65


### 6 keystrokes:
https://github.com/user-attachments/assets/c8e9deaf-7d91-42eb-a06e-2c13cd01140b

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.