### PR TITLE
[Woo POS][Products Search] Let recent searches scroll over floating buttons

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSRecentSearchesView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 @available(iOS 17.0, *)
 struct POSRecentSearchesView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
+    @Environment(\.keyboardObserver) private var keyboardObserver
 
     let savedSearches: [String]
     let onSearchSelected: (String) -> Void
@@ -43,7 +45,7 @@ struct POSRecentSearchesView: View {
                     .padding(.horizontal, POSPadding.medium)
                 }
             }
-            .padding(.bottom, POSPadding.medium)
+            .padding(.bottom, keyboardObserver.isFullSizeKeyboardVisible ? POSPadding.medium : floatingControlAreaSize.height + POSPadding.medium)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-389
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds padding when required to allow all recent searches to be visible over floating buttons.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and go to POS
2. Open search
3. Add 9+ search history items (search for a term, then tap an item in the results)
4. Clear the last search if needed to see the search history
5. Dismiss the keyboard
6. Scroll the recent searches – observe that you can see all the search history.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested on an iPad Air running iOS 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/70c45761-4c15-4a05-9fde-57004566b37c


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.