### PR TITLE
[Woo POS] Coupons: Fix an issue where search list momentarily appears with previous search results

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -49,6 +49,10 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleSearchingItemsControll
         await loadFirstPage()
     }
 
+    func clearSearchItems(baseItem: ItemListBaseItem) {
+        setSearchingState()
+    }
+
     @MainActor
     func loadNextItems(base: ItemListBaseItem) async {
         guard paginationTracker.hasNextPage else {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -27,6 +27,7 @@ protocol PointOfSaleItemsControllerProtocol {
 protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsControllerProtocol {
     /// Searches for items
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async
+    func clearSearchItems(baseItem: ItemListBaseItem)
 }
 
 
@@ -67,6 +68,10 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
         fetchStrategy = itemFetchStrategyFactory.searchStrategy(searchTerm: searchTerm)
         setSearchingState(base: baseItem)
         await loadFirstPage(base: baseItem)
+    }
+
+    func clearSearchItems(baseItem: ItemListBaseItem) {
+        setSearchingState(base: baseItem)
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
@@ -23,4 +23,8 @@ final class POSProductSearchable: POSSearchable {
     func performSearch(term: String) async {
         await itemsController.searchItems(searchTerm: term, baseItem: .root)
     }
+
+    func clearSearchResults() {
+        itemsController.clearSearchItems(baseItem: .root)
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -13,6 +13,8 @@ protocol POSSearchable {
     /// Called when a search should be performed
     /// - Parameter term: The search term to use
     func performSearch(term: String) async
+
+    func clearSearchResults()
 }
 
 /// A reusable search field view for POS items
@@ -71,6 +73,8 @@ struct POSSearchField: View {
                 searchTask = Task {
                     if shouldDebounceNextSearchRequest {
                         try? await Task.sleep(nanoseconds: 500 * NSEC_PER_MSEC)
+                    } else {
+                        searchable.clearSearchResults()
                     }
 
                     guard !Task.isCancelled else { return }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -143,6 +143,9 @@ struct ItemListView: View {
                     searchTerm: $searchTerm
                 ) { _ in
                     itemListContent(selectedItemListType)
+                        .onDisappear() {
+                            searchItemsController.clearSearchItems(baseItem: .root)
+                        }
                 }
                 .transition(.opacity.combined(with: .move(edge: .trailing)))
                 .zIndex(1)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -143,9 +143,6 @@ struct ItemListView: View {
                     searchTerm: $searchTerm
                 ) { _ in
                     itemListContent(selectedItemListType)
-                        .onDisappear() {
-                            searchItemsController.clearSearchItems(baseItem: .root)
-                        }
                 }
                 .transition(.opacity.combined(with: .move(edge: .trailing)))
                 .zIndex(1)

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -89,6 +89,7 @@ final class PointOfSalePreviewCouponsController: PointOfSaleCouponsControllerPro
     func refreshItems(base: ItemListBaseItem) async { }
     func loadNextItems(base: ItemListBaseItem) async { }
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async { }
+    func clearSearchItems(baseItem: ItemListBaseItem) { }
 }
 
 @available(iOS 17.0, *)
@@ -109,6 +110,8 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
     }
 
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async {}
+
+    func clearSearchItems(baseItem: ItemListBaseItem) { }
 
     func refreshItems(base: ItemListBaseItem) async {
         await loadItems(base: base)

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponsController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponsController.swift
@@ -17,4 +17,5 @@ final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtoc
     func loadNextItems(base: ItemListBaseItem) async { }
     func enableCoupons() async { }
     func searchItems(searchTerm: String, baseItem: WooCommerce.ItemListBaseItem) async { }
+    func clearSearchItems(baseItem: WooCommerce.ItemListBaseItem) { }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
@@ -15,4 +15,6 @@ final class MockPointOfSalePurchasableItemsSearchController: PointOfSaleSearchin
     func refreshItems(base: ItemListBaseItem) async { }
 
     func loadNextItems(base: ItemListBaseItem) async { }
+
+    func clearSearchItems(baseItem: WooCommerce.ItemListBaseItem) { }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-407 <!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The search list appears when the search term is not empty. However, there's a slight delay between the search term getting a value and making the first request.

If searchController holds item list values from the previous search, then the previous list momentarily appears before a new search is initiated.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Select Products / Coupons
3. Search and select items to generate recent searches
4. Select a recent search
5. Confirm that loading is immediately shown, followed by results.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11-inch M2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/5933c405-191a-4f23-89d4-b1733fabe5a6

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
