### PR TITLE
[Woo POS] Coupons Fix coupon sheet losing its state

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
+++ b/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
@@ -18,7 +18,7 @@ private struct POSCouponCreationSheetModifier: ViewModifier {
 
     @State private var selectedType: POSCouponDiscountType?
     @State private var showCouponSelectionSheet: Bool = false
-    @State var addedCouponItem: POSItem?
+    @State private var addedCouponItem: POSItem?
 
     func body(content: Content) -> some View {
         content

--- a/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
+++ b/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
@@ -18,41 +18,68 @@ private struct POSCouponCreationSheetModifier: ViewModifier {
 
     @State private var selectedType: POSCouponDiscountType?
     @State private var showCouponSelectionSheet: Bool = false
+    @State var addedCouponItem: POSItem?
 
     func body(content: Content) -> some View {
         content
             .sheet(item: $selectedType) { (posDiscountType: POSCouponDiscountType) in
-                var addedCouponItem: POSItem?
-                let viewModel = AddEditCouponViewModel(discountType: posDiscountType.discountType, onSuccess: { coupon in
-                    addedCouponItem = .coupon(.init(id: UUID(), code: coupon.code, summary: coupon.summary()))
-                })
-                var view = AddEditCoupon(viewModel)
-
-                view.dismissHandler = {
-                    selectedType = nil
-                }
-
-                view.onDisappear = {
-                    if let couponItem = addedCouponItem {
+                POSCouponCreationView(
+                    discountType: posDiscountType.discountType,
+                    showTypeSelection: $showCouponSelectionSheet,
+                    onSuccess: { coupon in
+                        addedCouponItem = .coupon(.init(id: UUID(), code: coupon.code, summary: coupon.summary()))
+                    },
+                    dismissHandler: {
                         selectedType = nil
-                        onSuccess(couponItem)
-                        addedCouponItem = nil
+                    },
+                    onDisappear: {
+                        if let couponItem = addedCouponItem {
+                            selectedType = nil
+                            onSuccess(couponItem)
+                            addedCouponItem = nil
+                        }
                     }
-                }
-
-                view.discountTypeHandler = { _ in
-                    showCouponSelectionSheet = true
-                }
-
-                return view
-                    .interactiveDismissDisabled()
-                    .discountTypeSelectionSheet(isPresented: $showCouponSelectionSheet) { type in
-                        showCouponSelectionSheet = false
-                        viewModel.discountType = type.discountType
-                    }
+                )
             }
             .discountTypeSelectionSheet(isPresented: $isPresented) { type in
                 selectedType = type
+            }
+    }
+}
+
+private struct POSCouponCreationView: View {
+    @StateObject private var viewModel: AddEditCouponViewModel
+    @Binding var showTypeSelection: Bool
+    let dismissHandler: () -> Void
+    let onDisappear: () -> Void
+
+    init(discountType: Coupon.DiscountType,
+         showTypeSelection: Binding<Bool>,
+         onSuccess: @escaping (Coupon) -> Void,
+         dismissHandler: @escaping () -> Void,
+         onDisappear: @escaping () -> Void) {
+        _showTypeSelection = showTypeSelection
+        self.dismissHandler = dismissHandler
+        self.onDisappear = onDisappear
+        _viewModel = StateObject(wrappedValue: AddEditCouponViewModel(
+            discountType: discountType,
+            onSuccess: onSuccess
+        ))
+    }
+
+    var body: some View {
+        var view = AddEditCoupon(viewModel)
+        view.dismissHandler = dismissHandler
+        view.onDisappear = onDisappear
+        view.discountTypeHandler = { _ in
+            showTypeSelection = true
+        }
+
+        return view
+            .interactiveDismissDisabled()
+            .discountTypeSelectionSheet(isPresented: $showTypeSelection) { type in
+                showTypeSelection = false
+                viewModel.discountType = type.discountType
             }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The coupon creation sheet keeps being redrawn, making it unusable. It happens due to `keyboardObserver` causing the whole `ItemListView` to update, including the `sheet`. I also found other cases, for example, putting POS to and from the background.

The issue lies within the `POSCouponCreationSheet` itself. It creates `ViewModel` which is `ObservableObject` within the view body. By declaring `AddEditCouponViewModel` as `@StateObject`, we maintain the view state throughout the updates.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Switch to coupons
3. Select "+" to create a coupon
4. Select any of the coupon type
5. Interact with the form, update the amount, select a specific product, put POS to the background and back
6. Confirm that the sheet does not get redrawn and doesn't lose its state

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11 18.2

## Screenshot
 
https://github.com/user-attachments/assets/dd7d9792-2dd6-4848-a7e8-c8fe21af63a5

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
