### PR TITLE
[Order Details] Refactor order detail rows to account for async operations

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1342,166 +1342,177 @@ extension OrderDetailsDataSource {
             return Section(category: .customerInformation, title: Title.information, rows: rows)
         }()
 
-        let payment: Section = {
-            var rows: [Row] = [.payment]
+        createPaymentSection { [weak self] paymentSection in
+            guard let self else { return }
 
-            rows.append(.customerPaid)
-
-            if condensedRefunds.isNotEmpty {
-                let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
-                rows.append(contentsOf: refunds)
-                rows.append(.netAmount)
-            }
-
-            if isEligibleForPayment {
-                rows.append(.collectCardPaymentButton)
-            }
-
-            switch orderHasLocalReceipt {
-            case true:
-                rows.append(.seeLegacyReceipt)
-            case false:
-                isEligibleForBackendReceipt { isEligible in
-                    if isEligible {
-                        rows.append(.seeReceipt)
-                    }
+            let subscriptions: Section? = {
+                // Subscriptions section is hidden if there are no subscriptions for the order.
+                guard self.orderSubscriptions.isNotEmpty else {
+                    return nil
                 }
-            }
 
+                let rows: [Row] = Array(repeating: .subscriptions, count: self.orderSubscriptions.count)
+                return Section(category: .subscriptions, title: Title.subscriptions, rows: rows)
+            }()
+
+            let giftCards: Section? = {
+                guard self.shouldShowGiftCards else {
+                    return nil
+                }
+
+                let rows: [Row] = Array(repeating: .giftCards, count: self.appliedGiftCards.count)
+                return Section(category: .giftCards, title: Title.giftCards, rows: rows)
+            }()
+
+            let tracking: Section? = {
+                // Tracking section is hidden if there are non-empty non-refunded shipping labels.
+                guard self.shippingLabels.nonRefunded.isEmpty else {
+                    return nil
+                }
+
+                guard self.orderTracking.count > 0 else {
+                    return nil
+                }
+
+                let rows: [Row] = Array(repeating: .tracking, count: self.orderTracking.count)
+                return Section(category: .tracking, title: Title.tracking, rows: rows)
+            }()
+
+            let addTracking: Section? = {
+                // Add tracking section is hidden if there are non-empty non-refunded shipping labels.
+                guard self.shippingLabels.nonRefunded.isEmpty else {
+                    return nil
+                }
+
+                // Hide the section if the shipment
+                // tracking plugin is not installed
+                guard self.trackingIsReachable else {
+                    return nil
+                }
+
+                let title: String?
+                if self.orderTracking.count == 0 {
+                    title = NSLocalizedString(
+                        "orderDetails.addTrackingRow.title",
+                        value: "Optional Tracking Information",
+                        comment: "Title for the row to add tracking information."
+                    )
+                } else {
+                    title = nil
+                }
+                let row = Row.trackingAdd
+
+                return Section(category: .addTracking, title: title, rightTitle: nil, rows: [row])
+            }()
+
+            let notes: Section = {
+                let rows = [.addOrderNote] + self.orderNotesSections.map {$0.row}
+                return Section(category: .notes, title: Title.notes, rows: rows)
+            }()
+
+            let attribution: Section? = {
+                let rows: [Row] = {
+                    var rows: [Row] = [.attributionOrigin]
+
+                    guard let orderAttributionInfo = self.order.attributionInfo else {
+                        return rows
+                    }
+
+                    if let _ = orderAttributionInfo.sourceType {
+                        rows.append(.attributionSourceType)
+                    }
+
+                    if let _ = orderAttributionInfo.campaign {
+                        rows.append(.attributionCampaign)
+                    }
+
+                    if let _ = orderAttributionInfo.source {
+                        rows.append(.attributionSource)
+                    }
+
+                    if let _ = orderAttributionInfo.medium {
+                        rows.append(.attributionMedium)
+                    }
+
+                    if let _ = orderAttributionInfo.deviceType {
+                        rows.append(.attributionDeviceType)
+                    }
+
+                    if let _ = orderAttributionInfo.sessionPageViews {
+                        rows.append(.attributionSessionPageViews)
+                    }
+
+                    return rows
+                }()
+
+                return Section(category: .attribution, title: Title.orderAttribution, rows: rows)
+            }()
+
+            let trashOrderSection: Section? = {
+                return Section(category: .trashOrder, rows: [.trashOrder])
+            }()
+
+            self.sections = ([summary,
+                              products,
+                              customAmountsSection,
+                              customFields,
+                              installWCShipSection,
+                              refundedProducts] +
+                             shippingLabelSections +
+                             [subscriptions,
+                              shippingLinesSection,
+                              paymentSection,
+                              customerInformation,
+                              attribution,
+                              giftCards,
+                              tracking,
+                              addTracking,
+                              notes,
+                              trashOrderSection]).compactMap { $0 }
+
+            self.updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
+            self.onUIReloadRequired?()
+        }
+    }
+
+    private func createPaymentSection(completion: @escaping (Section) -> Void) {
+        var rows: [Row] = [.payment]
+        rows.append(.customerPaid)
+
+        if condensedRefunds.isNotEmpty {
+            let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
+            rows.append(contentsOf: refunds)
+            rows.append(.netAmount)
+        }
+
+        if isEligibleForPayment {
+            rows.append(.collectCardPaymentButton)
+        }
+
+        switch orderHasLocalReceipt {
+        case true:
+            rows.append(.seeLegacyReceipt)
+            finishSection()
+        case false:
+            isEligibleForBackendReceipt { [weak self] isEligible in
+                guard let self = self else { return }
+                if isEligible {
+                    rows.append(.seeReceipt)
+                }
+                finishSection()
+            }
+        }
+
+        func finishSection() {
             if isEligibleForRefund {
                 rows.append(.issueRefundButton)
             }
 
-            return Section(category: .payment, title: Title.payment, rows: rows)
-        }()
-
-        let subscriptions: Section? = {
-            // Subscriptions section is hidden if there are no subscriptions for the order.
-            guard orderSubscriptions.isNotEmpty else {
-                return nil
-            }
-
-            let rows: [Row] = Array(repeating: .subscriptions, count: orderSubscriptions.count)
-            return Section(category: .subscriptions, title: Title.subscriptions, rows: rows)
-        }()
-
-        let giftCards: Section? = {
-            guard shouldShowGiftCards else {
-                return nil
-            }
-
-            let rows: [Row] = Array(repeating: .giftCards, count: appliedGiftCards.count)
-            return Section(category: .giftCards, title: Title.giftCards, rows: rows)
-        }()
-
-        let tracking: Section? = {
-            // Tracking section is hidden if there are non-empty non-refunded shipping labels.
-            guard shippingLabels.nonRefunded.isEmpty else {
-                return nil
-            }
-
-            guard orderTracking.count > 0 else {
-                return nil
-            }
-
-            let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
-            return Section(category: .tracking, title: Title.tracking, rows: rows)
-        }()
-
-        let addTracking: Section? = {
-            // Add tracking section is hidden if there are non-empty non-refunded shipping labels.
-            guard shippingLabels.nonRefunded.isEmpty else {
-                return nil
-            }
-
-            // Hide the section if the shipment
-            // tracking plugin is not installed
-            guard trackingIsReachable else {
-                return nil
-            }
-
-            let title: String?
-            if orderTracking.count == 0 {
-                title = NSLocalizedString(
-                    "orderDetails.addTrackingRow.title",
-                    value: "Optional Tracking Information",
-                    comment: "Title for the row to add tracking information."
-                )
-            } else {
-                title = nil
-            }
-            let row = Row.trackingAdd
-
-            return Section(category: .addTracking, title: title, rightTitle: nil, rows: [row])
-        }()
-
-        let notes: Section = {
-            let rows = [.addOrderNote] + orderNotesSections.map {$0.row}
-            return Section(category: .notes, title: Title.notes, rows: rows)
-        }()
-
-        let attribution: Section? = {
-
-            let rows: [Row] = {
-                var rows: [Row] = [.attributionOrigin]
-
-                guard let orderAttributionInfo = order.attributionInfo else {
-                    return rows
-                }
-
-                if let _ = orderAttributionInfo.sourceType {
-                    rows.append(.attributionSourceType)
-                }
-
-                if let _ = orderAttributionInfo.campaign {
-                    rows.append(.attributionCampaign)
-                }
-
-                if let _ = orderAttributionInfo.source {
-                    rows.append(.attributionSource)
-                }
-
-                if let _ = orderAttributionInfo.medium {
-                    rows.append(.attributionMedium)
-                }
-
-                if let _ = orderAttributionInfo.deviceType {
-                    rows.append(.attributionDeviceType)
-                }
-
-                if let _ = orderAttributionInfo.sessionPageViews {
-                    rows.append(.attributionSessionPageViews)
-                }
-
-                return rows
-            }()
-
-            return Section(category: .attribution, title: Title.orderAttribution, rows: rows)
-        }()
-
-        let trashOrderSection: Section? = {
-            return Section(category: .trashOrder, rows: [.trashOrder])
-        }()
-
-        sections = ([summary,
-                     products,
-                     customAmountsSection,
-                     customFields,
-                     installWCShipSection,
-                     refundedProducts] +
-                    shippingLabelSections +
-                    [subscriptions,
-                     shippingLinesSection,
-                     payment,
-                     customerInformation,
-                     attribution,
-                     giftCards,
-                     tracking,
-                     addTracking,
-                     notes,
-                     trashOrderSection]).compactMap { $0 }
-
-        updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
+            let section = Section(category: .payment,
+                                  title: Title.payment,
+                                  rows: rows)
+            completion(section)
+        }
     }
 
     func refund(at indexPath: IndexPath) -> Refund? {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1475,46 +1475,6 @@ extension OrderDetailsDataSource {
         }
     }
 
-    private func createPaymentSection(completion: @escaping (Section) -> Void) {
-        var rows: [Row] = [.payment]
-        rows.append(.customerPaid)
-
-        if condensedRefunds.isNotEmpty {
-            let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
-            rows.append(contentsOf: refunds)
-            rows.append(.netAmount)
-        }
-
-        if isEligibleForPayment {
-            rows.append(.collectCardPaymentButton)
-        }
-
-        switch orderHasLocalReceipt {
-        case true:
-            rows.append(.seeLegacyReceipt)
-            finishSection()
-        case false:
-            isEligibleForBackendReceipt { [weak self] isEligible in
-                guard let self = self else { return }
-                if isEligible {
-                    rows.append(.seeReceipt)
-                }
-                finishSection()
-            }
-        }
-
-        func finishSection() {
-            if isEligibleForRefund {
-                rows.append(.issueRefundButton)
-            }
-
-            let section = Section(category: .payment,
-                                  title: Title.payment,
-                                  rows: rows)
-            completion(section)
-        }
-    }
-
     func refund(at indexPath: IndexPath) -> Refund? {
         let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell
         let condensedRefund = condensedRefunds[index]
@@ -2042,5 +2002,49 @@ extension OrderDetailsDataSource {
         static let paymentCell = 1
         static let paidByCustomerCell = 1
         static let cellDefaultMargin: CGFloat = 16
+    }
+}
+
+private extension OrderDetailsDataSource {
+    private func createPaymentSection(completion: @escaping (Section) -> Void) {
+        var rows: [Row] = [.payment, .customerPaid]
+
+        if condensedRefunds.isNotEmpty {
+            let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
+            rows.append(contentsOf: refunds)
+            rows.append(.netAmount)
+        }
+
+        if isEligibleForPayment {
+            rows.append(.collectCardPaymentButton)
+        }
+
+        switch orderHasLocalReceipt {
+        case true:
+            rows.append(.seeLegacyReceipt)
+            let section = buildPaymentSection(from: rows)
+            completion(section)
+        case false:
+            isEligibleForBackendReceipt { [weak self] isEligible in
+                guard let self else { return }
+                var updatedRows = rows
+                if isEligible {
+                    updatedRows.append(.seeReceipt)
+                }
+                let section = self.buildPaymentSection(from: updatedRows)
+                completion(section)
+            }
+        }
+    }
+
+    private func buildPaymentSection(from rows: [Row]) -> Section {
+        var updatedRows = rows
+        if isEligibleForRefund {
+            updatedRows.append(.issueRefundButton)
+        }
+
+        return Section(category: .payment,
+                       title: Title.payment,
+                       rows: updatedRows)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -74,8 +74,9 @@ final class OrderDetailsDataSource: NSObject {
     /// Whether the option to re-create shipping labels should be visible.
     ///
     var shouldAllowRecreatingShippingLabels: Bool {
-        return isEligibleForShippingLabelCreation && shippingLabels.isNotEmpty &&
-            !isEligibleForPayment
+        isEligibleForShippingLabelCreation &&
+        shippingLabels.isNotEmpty &&
+        !isEligibleForPayment
     }
 
     /// Whether the option to install the WCShip extension should be visible.
@@ -404,10 +405,10 @@ extension OrderDetailsDataSource {
     func viewForHeaderInSection(_ section: Int, tableView: UITableView) -> UIView? {
         guard section >= 0 && section < sections.count else {
             ServiceLocator.crashLogging.logMessage(
-                            "Invalid section in viewForHeaderInSection in OrderDetailsDataSource",
-                            properties: ["section": section],
-                            level: .error
-                        )
+                "Invalid section in viewForHeaderInSection in OrderDetailsDataSource",
+                properties: ["section": section],
+                level: .error
+            )
             return nil
         }
         let section = sections[section]
@@ -548,8 +549,8 @@ private extension OrderDetailsDataSource {
 
         cell.accessibilityTraits = .button
         cell.accessibilityLabel = NSLocalizedString(
-                "View Custom Fields",
-                comment: "Accessibility label for the 'View Custom Fields' button"
+            "View Custom Fields",
+            comment: "Accessibility label for the 'View Custom Fields' button"
         )
         cell.accessibilityHint = NSLocalizedString(
             "Show the custom fields for this order.",

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1203,9 +1203,17 @@ extension OrderDetailsDataSource {
             productVariations: resultsControllers.productVariations
         )
 
-        let staticSections = buildStaticSections()
+        var sections = buildStaticSections().compactMap { $0 }
         let paymentSection = await createPaymentSection()
-        self.sections = (staticSections + [paymentSection]).compactMap { $0 }
+
+        // Finds the position between shippingLines and customerInformation to inject the payment section,
+        // otherwise will always appear last because of being async
+        let insertIndex = sections.firstIndex { $0.category == .customerInformation }
+            ?? sections.count
+
+        sections.insert(paymentSection, at: insertIndex)
+        self.sections = sections
+
         self.updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
         self.onUIReloadRequired?()
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -273,6 +273,8 @@ final class OrderDetailsDataSource: NSObject {
 
     private let refundableOrderItemsDeterminer: OrderRefundsOptionsDeterminerProtocol
 
+    private let receiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol
+
     private let currencySettings: CurrencySettings
 
     private let userIsAdmin: Bool
@@ -285,6 +287,7 @@ final class OrderDetailsDataSource: NSObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration,
          refundableOrderItemsDeterminer: OrderRefundsOptionsDeterminerProtocol = OrderRefundsOptionsDeterminer(),
+         receiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol = ReceiptEligibilityUseCase(),
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          siteSettings: [SiteSetting] = ServiceLocator.selectedSiteSettings.siteSettings,
          userIsAdmin: Bool = ServiceLocator.stores.sessionManager.defaultRoles.contains(.administrator),
@@ -294,6 +297,7 @@ final class OrderDetailsDataSource: NSObject {
         self.cardPresentPaymentsConfiguration = cardPresentPaymentsConfiguration
         self.couponLines = order.coupons
         self.refundableOrderItemsDeterminer = refundableOrderItemsDeterminer
+        self.receiptEligibilityUseCase = receiptEligibilityUseCase
         self.currencySettings = currencySettings
         self.siteSettings = siteSettings
         self.userIsAdmin = userIsAdmin
@@ -1501,12 +1505,9 @@ extension OrderDetailsDataSource {
 
     @MainActor
     private func isEligibleForBackendReceipt() async -> Bool {
-        // Temporary: By returning earlier we stop leaking continuation and go down from 44 to 3 failed tests
-        return true
-
         guard !isEligibleForPayment else { return false }
         return await withCheckedContinuation { continuation in
-            ReceiptEligibilityUseCase().isEligibleForBackendReceipts { isEligible in
+            receiptEligibilityUseCase.isEligibleForBackendReceipts { isEligible in
                 continuation.resume(returning: isEligible)
             }
         }
@@ -1528,7 +1529,7 @@ extension OrderDetailsDataSource {
         guard !isEligibleForPayment else {
             return completion(false)
         }
-        ReceiptEligibilityUseCase().isEligibleForBackendReceipts { isEligibleForReceipt in
+        receiptEligibilityUseCase.isEligibleForBackendReceipts { isEligibleForReceipt in
             completion(isEligibleForReceipt)
         }
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1508,7 +1508,14 @@ extension OrderDetailsDataSource {
         } else if await isEligibleForBackendReceipt() {
             rows.append(.seeReceipt)
         }
-        return buildPaymentSection(from: rows)
+        if isEligibleForRefund {
+            rows.append(.issueRefundButton)
+        }
+        return Section(
+            category: .payment,
+            title: Title.payment,
+            rows: rows
+        )
     }
 
     @MainActor
@@ -2048,17 +2055,5 @@ extension OrderDetailsDataSource {
         static let paymentCell = 1
         static let paidByCustomerCell = 1
         static let cellDefaultMargin: CGFloat = 16
-    }
-}
-
-private extension OrderDetailsDataSource {
-    private func buildPaymentSection(from rows: [Row]) -> Section {
-        var updatedRows = rows
-        if isEligibleForRefund {
-            updatedRows.append(.issueRefundButton)
-        }
-        return Section(category: .payment,
-                       title: Title.payment,
-                       rows: updatedRows)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1209,11 +1209,15 @@ extension OrderDetailsDataSource {
         let summary = Section(category: .summary, row: .summary)
 
         let products: Section? = {
-            if items.isEmpty { return nil }
+            if items.isEmpty {
+                return nil
+            }
+
             let aggregateOrderItemCount = aggregateOrderItems.count
             guard aggregateOrderItemCount > 0 else {
                 return nil
             }
+
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
             switch (shouldShowShippingLabelCreation, isProcessingStatus, isRefundedStatus, isEligibleForPayment) {
@@ -1263,7 +1267,7 @@ extension OrderDetailsDataSource {
         }()
 
         let customFields: Section? = {
-            Section(category: .customFields, row: .customFields)
+            return Section(category: .customFields, row: .customFields)
         }()
 
         let refundedProducts: Section? = {
@@ -1281,6 +1285,7 @@ extension OrderDetailsDataSource {
             guard shouldAllowWCShipInstallation else {
                 return nil
             }
+
             let rows: [Row] = [.installWCShip]
             return Section(category: .installWCShip, title: nil, rows: rows)
         }()
@@ -1289,6 +1294,7 @@ extension OrderDetailsDataSource {
             guard shippingLabels.isNotEmpty else {
                 return []
             }
+
             let sections = shippingLabels.enumerated().map { index, shippingLabel -> Section in
                 let title = String.localizedStringWithFormat(Title.shippingLabelPackageFormat, index + 1)
                 let isRefunded = shippingLabel.refund != nil
@@ -1313,6 +1319,7 @@ extension OrderDetailsDataSource {
             guard shippingLines.count > 0 else {
                 return nil
             }
+
             return Section(category: .shippingLines, title: Title.shippingLines, rows: Array(repeating: .shippingLine, count: shippingLines.count))
         }()
 
@@ -1321,6 +1328,7 @@ extension OrderDetailsDataSource {
             guard orderSubscriptions.isNotEmpty else {
                 return nil
             }
+
             let rows: [Row] = Array(repeating: .subscriptions, count: orderSubscriptions.count)
             return Section(category: .subscriptions, title: Title.subscriptions, rows: rows)
         }()
@@ -1329,6 +1337,7 @@ extension OrderDetailsDataSource {
             guard shouldShowGiftCards else {
                 return nil
             }
+
             let rows: [Row] = Array(repeating: .giftCards, count: appliedGiftCards.count)
             return Section(category: .giftCards, title: Title.giftCards, rows: rows)
         }()
@@ -1342,6 +1351,7 @@ extension OrderDetailsDataSource {
             guard orderTracking.count > 0 else {
                 return nil
             }
+
             let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
             return Section(category: .tracking, title: Title.tracking, rows: rows)
         }()
@@ -1369,11 +1379,12 @@ extension OrderDetailsDataSource {
                 title = nil
             }
             let row = Row.trackingAdd
+
             return Section(category: .addTracking, title: title, rightTitle: nil, rows: [row])
         }()
 
         let notes: Section = {
-            let rows = [.addOrderNote] + orderNotesSections.map { $0.row }
+            let rows = [.addOrderNote] + orderNotesSections.map {$0.row}
             return Section(category: .notes, title: Title.notes, rows: rows)
         }()
 
@@ -1420,14 +1431,32 @@ extension OrderDetailsDataSource {
         }()
 
         let customerInformation: Section? = {
-            var rows: [Row] = [.customerNote, .billingDetail]
-            let orderContainsOnlyVirtualProducts = self.products.filter { product in
-                items.first(where: { $0.productID == product.productID }) != nil
-            }.allSatisfy { $0.virtual }
-            if order.shippingAddress != nil && !orderContainsOnlyVirtualProducts {
+            var rows: [Row] = []
+
+            /// Customer Note
+            /// Always visible to allow adding & editing.
+            rows.append(.customerNote)
+
+            /// Shipping Address
+            /// Almost always visible to allow editing.
+            let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
+                return items.first(where: { $0.productID == product.productID}) != nil
+            }.allSatisfy { $0.virtual == true }
+
+
+            if order.shippingAddress != nil && orderContainsOnlyVirtualProducts == false {
                 rows.append(.shippingAddress)
             }
-            guard rows.isNotEmpty else { return nil }
+
+            /// Billing Address
+            /// Always visible to allow editing.
+            rows.append(.billingDetail)
+
+            /// Return `nil` if there is no rows to display.
+            guard rows.isNotEmpty else {
+                return nil
+            }
+
             return Section(category: .customerInformation, title: Title.information, rows: rows)
         }()
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -248,7 +248,9 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var orderSubscriptions: [Subscription] = [] {
         didSet {
-            reloadSections()
+            Task { @MainActor in
+                await reloadSections()
+            }
         }
     }
 
@@ -1186,23 +1188,22 @@ extension OrderDetailsDataSource {
     /// When: Customer Note == nil          >>> Hide Customer Note
     /// When: Shipping == nil               >>> Display: Shipping = "No address specified"
     ///
-    func reloadSections() {
-        Task { @MainActor in
-            // Freezes any data that require lookup after the sections are reloaded, in case the data from a ResultsController changes before the next reload.
-            shippingLabels = resultsControllers.shippingLabels
-            shippingLabelOrderItemsAggregator = AggregatedShippingLabelOrderItems(
-                shippingLabels: shippingLabels,
-                orderItems: items,
-                products: products,
-                productVariations: resultsControllers.productVariations
-            )
+    @MainActor
+    func reloadSections() async {
+        // Freezes any data that require lookup after the sections are reloaded, in case the data from a ResultsController changes before the next reload.
+        shippingLabels = resultsControllers.shippingLabels
+        shippingLabelOrderItemsAggregator = AggregatedShippingLabelOrderItems(
+            shippingLabels: shippingLabels,
+            orderItems: items,
+            products: products,
+            productVariations: resultsControllers.productVariations
+        )
 
-            let staticSections = buildStaticSections()
-            let paymentSection = await createPaymentSection()
-            self.sections = (staticSections + [paymentSection]).compactMap { $0 }
-            self.updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
-            self.onUIReloadRequired?()
-        }
+        let staticSections = buildStaticSections()
+        let paymentSection = await createPaymentSection()
+        self.sections = (staticSections + [paymentSection]).compactMap { $0 }
+        self.updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
+        self.onUIReloadRequired?()
     }
 
     private func buildStaticSections() -> [Section?] {
@@ -1500,6 +1501,9 @@ extension OrderDetailsDataSource {
 
     @MainActor
     private func isEligibleForBackendReceipt() async -> Bool {
+        // Temporary: By returning earlier we stop leaking continuation and go down from 44 to 3 failed tests
+        return true
+
         guard !isEligibleForPayment else { return false }
         return await withCheckedContinuation { continuation in
             ReceiptEligibilityUseCase().isEligibleForBackendReceipts { isEligible in

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1211,55 +1211,84 @@ extension OrderDetailsDataSource {
         let products: Section? = {
             if items.isEmpty { return nil }
             let aggregateOrderItemCount = aggregateOrderItems.count
-            guard aggregateOrderItemCount > 0 else { return nil }
+            guard aggregateOrderItemCount > 0 else {
+                return nil
+            }
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
             switch (shouldShowShippingLabelCreation, isProcessingStatus, isRefundedStatus, isEligibleForPayment) {
             case (true, false, false, false):
+                // Order completed and eligible for shipping label creation:
                 rows.append(.shippingLabelCreateButton)
                 rows.append(.shippingLabelCreationInfo(showsSeparator: false))
             case (true, true, false, false):
+                // Order processing shippable:
                 rows.append(.shippingLabelCreateButton)
                 rows.append(.markCompleteButton(style: .secondary, showsBottomSpacing: false))
                 rows.append(.shippingLabelCreationInfo(showsSeparator: false))
             case (false, true, false, false):
+                // Order processing digital:
                 rows.append(.markCompleteButton(style: .primary, showsBottomSpacing: true))
             default:
                 break
             }
 
-            guard rows.isNotEmpty else { return nil }
+            if rows.count == 0 {
+                return nil
+            }
 
-            let headerStyle: Section.HeaderStyle = shouldAllowRecreatingShippingLabels
-                ? .actionablePrimary(actionConfig: PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
+            let headerStyle: Section.HeaderStyle
+            if shouldAllowRecreatingShippingLabels {
+                let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
                     self?.onProductsMoreMenuTapped?(sourceView)
-                  })
-                : .twoColumn
-
-            return Section(category: .products, title: Title.products, rows: rows, headerStyle: headerStyle)
+                }
+                headerStyle = .actionablePrimary(actionConfig: headerActionConfig)
+            } else {
+                headerStyle = .twoColumn
+            }
+            return Section(category: .products,
+                           title: Title.products,
+                           rows: rows,
+                           headerStyle: headerStyle)
         }()
 
         let customAmountsSection: Section? = {
-            guard customAmounts.isNotEmpty else { return nil }
-            return Section(category: .customAmounts, title: Title.customAmounts, rows: Array(repeating: .customAmount, count: customAmounts.count))
+            guard customAmounts.isNotEmpty else {
+                return nil
+            }
+
+            return Section(category: .customAmounts,
+                          title: Title.customAmounts,
+                          rows: Array(repeating: .customAmount, count: customAmounts.count))
         }()
 
         let customFields: Section? = {
             Section(category: .customFields, row: .customFields)
         }()
 
-        let refundedProducts: Section? = refundedProductsCount > 0
-            ? Section(category: .refundedProducts, title: Title.refundedProducts, row: .refundedProducts)
-            : nil
+        let refundedProducts: Section? = {
+            // Refunds on
+            guard refundedProductsCount > 0 else {
+                return nil
+            }
+
+            let row: Row = .refundedProducts
+
+            return Section(category: .refundedProducts, title: Title.refundedProducts, row: row)
+        }()
 
         let installWCShipSection: Section? = {
-            guard shouldAllowWCShipInstallation else { return nil }
+            guard shouldAllowWCShipInstallation else {
+                return nil
+            }
             let rows: [Row] = [.installWCShip]
             return Section(category: .installWCShip, title: nil, rows: rows)
         }()
 
         let shippingLabelSections: [Section] = {
-            guard shippingLabels.isNotEmpty else { return [] }
+            guard shippingLabels.isNotEmpty else {
+                return []
+            }
             let sections = shippingLabels.enumerated().map { index, shippingLabel -> Section in
                 let title = String.localizedStringWithFormat(Title.shippingLabelPackageFormat, index + 1)
                 let isRefunded = shippingLabel.refund != nil
@@ -1281,39 +1310,64 @@ extension OrderDetailsDataSource {
         }()
 
         let shippingLinesSection: Section? = {
-            guard shippingLines.count > 0 else { return nil }
+            guard shippingLines.count > 0 else {
+                return nil
+            }
             return Section(category: .shippingLines, title: Title.shippingLines, rows: Array(repeating: .shippingLine, count: shippingLines.count))
         }()
 
         let subscriptions: Section? = {
-            guard orderSubscriptions.isNotEmpty else { return nil }
+            // Subscriptions section is hidden if there are no subscriptions for the order.
+            guard orderSubscriptions.isNotEmpty else {
+                return nil
+            }
             let rows: [Row] = Array(repeating: .subscriptions, count: orderSubscriptions.count)
             return Section(category: .subscriptions, title: Title.subscriptions, rows: rows)
         }()
 
         let giftCards: Section? = {
-            guard shouldShowGiftCards else { return nil }
+            guard shouldShowGiftCards else {
+                return nil
+            }
             let rows: [Row] = Array(repeating: .giftCards, count: appliedGiftCards.count)
             return Section(category: .giftCards, title: Title.giftCards, rows: rows)
         }()
 
         let tracking: Section? = {
-            guard shippingLabels.nonRefunded.isEmpty else { return nil }
-            guard orderTracking.count > 0 else { return nil }
+            // Tracking section is hidden if there are non-empty non-refunded shipping labels.
+            guard shippingLabels.nonRefunded.isEmpty else {
+                return nil
+            }
+
+            guard orderTracking.count > 0 else {
+                return nil
+            }
             let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
             return Section(category: .tracking, title: Title.tracking, rows: rows)
         }()
 
         let addTracking: Section? = {
-            guard shippingLabels.nonRefunded.isEmpty else { return nil }
-            guard trackingIsReachable else { return nil }
-            let title: String? = orderTracking.count == 0
-                ? NSLocalizedString(
+            // Add tracking section is hidden if there are non-empty non-refunded shipping labels.
+            guard shippingLabels.nonRefunded.isEmpty else {
+                return nil
+            }
+
+            // Hide the section if the shipment
+            // tracking plugin is not installed
+            guard trackingIsReachable else {
+                return nil
+            }
+
+            let title: String?
+            if orderTracking.count == 0 {
+                title = NSLocalizedString(
                     "orderDetails.addTrackingRow.title",
                     value: "Optional Tracking Information",
                     comment: "Title for the row to add tracking information."
                 )
-                : nil
+            } else {
+                title = nil
+            }
             let row = Row.trackingAdd
             return Section(category: .addTracking, title: title, rightTitle: nil, rows: [row])
         }()
@@ -1326,15 +1380,38 @@ extension OrderDetailsDataSource {
         let attribution: Section? = {
             let rows: [Row] = {
                 var rows: [Row] = [.attributionOrigin]
-                guard let orderAttributionInfo = order.attributionInfo else { return rows }
-                if let _ = orderAttributionInfo.sourceType { rows.append(.attributionSourceType) }
-                if let _ = orderAttributionInfo.campaign { rows.append(.attributionCampaign) }
-                if let _ = orderAttributionInfo.source { rows.append(.attributionSource) }
-                if let _ = orderAttributionInfo.medium { rows.append(.attributionMedium) }
-                if let _ = orderAttributionInfo.deviceType { rows.append(.attributionDeviceType) }
-                if let _ = orderAttributionInfo.sessionPageViews { rows.append(.attributionSessionPageViews) }
+
+                guard let orderAttributionInfo = order.attributionInfo else {
+                    return rows
+                }
+
+                if let _ = orderAttributionInfo.sourceType {
+                    rows.append(.attributionSourceType)
+                }
+
+                if let _ = orderAttributionInfo.campaign {
+                    rows.append(.attributionCampaign)
+                }
+
+                if let _ = orderAttributionInfo.source {
+                    rows.append(.attributionSource)
+                }
+
+                if let _ = orderAttributionInfo.medium {
+                    rows.append(.attributionMedium)
+                }
+
+                if let _ = orderAttributionInfo.deviceType {
+                    rows.append(.attributionDeviceType)
+                }
+
+                if let _ = orderAttributionInfo.sessionPageViews {
+                    rows.append(.attributionSessionPageViews)
+                }
+
                 return rows
             }()
+
             return Section(category: .attribution, title: Title.orderAttribution, rows: rows)
         }()
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1186,104 +1186,79 @@ extension OrderDetailsDataSource {
     /// When: Shipping == nil               >>> Display: Shipping = "No address specified"
     ///
     func reloadSections() {
-        // Freezes any data that require lookup after the sections are reloaded, in case the data from a ResultsController changes before the next reload.
-        shippingLabels = resultsControllers.shippingLabels
-        shippingLabelOrderItemsAggregator = AggregatedShippingLabelOrderItems(shippingLabels: shippingLabels,
-                                                                                   orderItems: items,
-                                                                                   products: products,
-                                                                                   productVariations: resultsControllers.productVariations)
+        Task { @MainActor in
+            // Freezes any data that require lookup after the sections are reloaded, in case the data from a ResultsController changes before the next reload.
+            shippingLabels = resultsControllers.shippingLabels
+            shippingLabelOrderItemsAggregator = AggregatedShippingLabelOrderItems(
+                shippingLabels: shippingLabels,
+                orderItems: items,
+                products: products,
+                productVariations: resultsControllers.productVariations
+            )
 
+            let staticSections = buildStaticSections()
+            let paymentSection = await createPaymentSection()
+            self.sections = (staticSections + [paymentSection]).compactMap { $0 }
+            self.updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
+            self.onUIReloadRequired?()
+        }
+    }
+
+    private func buildStaticSections() -> [Section?] {
         let summary = Section(category: .summary, row: .summary)
 
         let products: Section? = {
-            if items.isEmpty {
-                return nil
-            }
-
+            if items.isEmpty { return nil }
             let aggregateOrderItemCount = aggregateOrderItems.count
-            guard aggregateOrderItemCount > 0 else {
-                return nil
-            }
-
+            guard aggregateOrderItemCount > 0 else { return nil }
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
             switch (shouldShowShippingLabelCreation, isProcessingStatus, isRefundedStatus, isEligibleForPayment) {
             case (true, false, false, false):
-                // Order completed and eligible for shipping label creation:
                 rows.append(.shippingLabelCreateButton)
                 rows.append(.shippingLabelCreationInfo(showsSeparator: false))
             case (true, true, false, false):
-                // Order processing shippable:
                 rows.append(.shippingLabelCreateButton)
                 rows.append(.markCompleteButton(style: .secondary, showsBottomSpacing: false))
                 rows.append(.shippingLabelCreationInfo(showsSeparator: false))
             case (false, true, false, false):
-                // Order processing digital:
                 rows.append(.markCompleteButton(style: .primary, showsBottomSpacing: true))
             default:
-                // Other cases
                 break
             }
 
-            if rows.count == 0 {
-                return nil
-            }
+            guard rows.isNotEmpty else { return nil }
 
-            let headerStyle: Section.HeaderStyle
-            if shouldAllowRecreatingShippingLabels {
-                let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
+            let headerStyle: Section.HeaderStyle = shouldAllowRecreatingShippingLabels
+                ? .actionablePrimary(actionConfig: PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
                     self?.onProductsMoreMenuTapped?(sourceView)
-                }
-                headerStyle = .actionablePrimary(actionConfig: headerActionConfig)
-            } else {
-                headerStyle = .twoColumn
-            }
+                  })
+                : .twoColumn
 
-            return Section(category: .products,
-                           title: Title.products,
-                           rows: rows,
-                           headerStyle: headerStyle)
+            return Section(category: .products, title: Title.products, rows: rows, headerStyle: headerStyle)
         }()
 
         let customAmountsSection: Section? = {
-            guard customAmounts.isNotEmpty else {
-                return nil
-            }
-
-            return Section(category: .customAmounts,
-                          title: Title.customAmounts,
-                          rows: Array(repeating: .customAmount, count: customAmounts.count))
+            guard customAmounts.isNotEmpty else { return nil }
+            return Section(category: .customAmounts, title: Title.customAmounts, rows: Array(repeating: .customAmount, count: customAmounts.count))
         }()
 
         let customFields: Section? = {
-            return Section(category: .customFields, row: .customFields)
+            Section(category: .customFields, row: .customFields)
         }()
 
-        let refundedProducts: Section? = {
-            // Refunds on
-            guard refundedProductsCount > 0 else {
-                return nil
-            }
-
-            let row: Row = .refundedProducts
-
-            return Section(category: .refundedProducts, title: Title.refundedProducts, row: row)
-        }()
+        let refundedProducts: Section? = refundedProductsCount > 0
+            ? Section(category: .refundedProducts, title: Title.refundedProducts, row: .refundedProducts)
+            : nil
 
         let installWCShipSection: Section? = {
-            guard shouldAllowWCShipInstallation else {
-                return nil
-            }
-
+            guard shouldAllowWCShipInstallation else { return nil }
             let rows: [Row] = [.installWCShip]
             return Section(category: .installWCShip, title: nil, rows: rows)
         }()
 
         let shippingLabelSections: [Section] = {
-            guard shippingLabels.isNotEmpty else {
-                return []
-            }
-
+            guard shippingLabels.isNotEmpty else { return [] }
             let sections = shippingLabels.enumerated().map { index, shippingLabel -> Section in
                 let title = String.localizedStringWithFormat(Title.shippingLabelPackageFormat, index + 1)
                 let isRefunded = shippingLabel.refund != nil
@@ -1305,173 +1280,124 @@ extension OrderDetailsDataSource {
         }()
 
         let shippingLinesSection: Section? = {
-            guard shippingLines.count > 0 else {
-                return nil
-            }
-
+            guard shippingLines.count > 0 else { return nil }
             return Section(category: .shippingLines, title: Title.shippingLines, rows: Array(repeating: .shippingLine, count: shippingLines.count))
         }()
 
+        let subscriptions: Section? = {
+            guard orderSubscriptions.isNotEmpty else { return nil }
+            let rows: [Row] = Array(repeating: .subscriptions, count: orderSubscriptions.count)
+            return Section(category: .subscriptions, title: Title.subscriptions, rows: rows)
+        }()
+
+        let giftCards: Section? = {
+            guard shouldShowGiftCards else { return nil }
+            let rows: [Row] = Array(repeating: .giftCards, count: appliedGiftCards.count)
+            return Section(category: .giftCards, title: Title.giftCards, rows: rows)
+        }()
+
+        let tracking: Section? = {
+            guard shippingLabels.nonRefunded.isEmpty else { return nil }
+            guard orderTracking.count > 0 else { return nil }
+            let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
+            return Section(category: .tracking, title: Title.tracking, rows: rows)
+        }()
+
+        let addTracking: Section? = {
+            guard shippingLabels.nonRefunded.isEmpty else { return nil }
+            guard trackingIsReachable else { return nil }
+            let title: String? = orderTracking.count == 0
+                ? NSLocalizedString(
+                    "orderDetails.addTrackingRow.title",
+                    value: "Optional Tracking Information",
+                    comment: "Title for the row to add tracking information."
+                )
+                : nil
+            let row = Row.trackingAdd
+            return Section(category: .addTracking, title: title, rightTitle: nil, rows: [row])
+        }()
+
+        let notes: Section = {
+            let rows = [.addOrderNote] + orderNotesSections.map { $0.row }
+            return Section(category: .notes, title: Title.notes, rows: rows)
+        }()
+
+        let attribution: Section? = {
+            let rows: [Row] = {
+                var rows: [Row] = [.attributionOrigin]
+                guard let orderAttributionInfo = order.attributionInfo else { return rows }
+                if let _ = orderAttributionInfo.sourceType { rows.append(.attributionSourceType) }
+                if let _ = orderAttributionInfo.campaign { rows.append(.attributionCampaign) }
+                if let _ = orderAttributionInfo.source { rows.append(.attributionSource) }
+                if let _ = orderAttributionInfo.medium { rows.append(.attributionMedium) }
+                if let _ = orderAttributionInfo.deviceType { rows.append(.attributionDeviceType) }
+                if let _ = orderAttributionInfo.sessionPageViews { rows.append(.attributionSessionPageViews) }
+                return rows
+            }()
+            return Section(category: .attribution, title: Title.orderAttribution, rows: rows)
+        }()
+
+        let trashOrderSection: Section? = {
+            Section(category: .trashOrder, rows: [.trashOrder])
+        }()
+
         let customerInformation: Section? = {
-            var rows: [Row] = []
-
-            /// Customer Note
-            /// Always visible to allow adding & editing.
-            rows.append(.customerNote)
-
-            /// Shipping Address
-            /// Almost always visible to allow editing.
-            let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
-                return items.first(where: { $0.productID == product.productID}) != nil
-            }.allSatisfy { $0.virtual == true }
-
-
-            if order.shippingAddress != nil && orderContainsOnlyVirtualProducts == false {
+            var rows: [Row] = [.customerNote, .billingDetail]
+            let orderContainsOnlyVirtualProducts = self.products.filter { product in
+                items.first(where: { $0.productID == product.productID }) != nil
+            }.allSatisfy { $0.virtual }
+            if order.shippingAddress != nil && !orderContainsOnlyVirtualProducts {
                 rows.append(.shippingAddress)
             }
-
-            /// Billing Address
-            /// Always visible to allow editing.
-            rows.append(.billingDetail)
-
-            /// Return `nil` if there is no rows to display.
-            guard rows.isNotEmpty else {
-                return nil
-            }
-
+            guard rows.isNotEmpty else { return nil }
             return Section(category: .customerInformation, title: Title.information, rows: rows)
         }()
 
-        createPaymentSection { [weak self] paymentSection in
-            guard let self else { return }
+        return [
+            summary,
+            products,
+            customAmountsSection,
+            customFields,
+            installWCShipSection,
+            refundedProducts
+        ] + shippingLabelSections + [
+            subscriptions,
+            shippingLinesSection,
+            customerInformation,
+            attribution,
+            giftCards,
+            tracking,
+            addTracking,
+            notes,
+            trashOrderSection
+        ]
+    }
 
-            let subscriptions: Section? = {
-                // Subscriptions section is hidden if there are no subscriptions for the order.
-                guard self.orderSubscriptions.isNotEmpty else {
-                    return nil
-                }
+    @MainActor
+    private func createPaymentSection() async -> Section {
+        var rows: [Row] = [.payment, .customerPaid]
+        if condensedRefunds.isNotEmpty {
+            rows.append(contentsOf: Array(repeating: .refund, count: condensedRefunds.count))
+            rows.append(.netAmount)
+        }
+        if isEligibleForPayment {
+            rows.append(.collectCardPaymentButton)
+        }
+        if orderHasLocalReceipt {
+            rows.append(.seeLegacyReceipt)
+        } else if await isEligibleForBackendReceipt() {
+            rows.append(.seeReceipt)
+        }
+        return buildPaymentSection(from: rows)
+    }
 
-                let rows: [Row] = Array(repeating: .subscriptions, count: self.orderSubscriptions.count)
-                return Section(category: .subscriptions, title: Title.subscriptions, rows: rows)
-            }()
-
-            let giftCards: Section? = {
-                guard self.shouldShowGiftCards else {
-                    return nil
-                }
-
-                let rows: [Row] = Array(repeating: .giftCards, count: self.appliedGiftCards.count)
-                return Section(category: .giftCards, title: Title.giftCards, rows: rows)
-            }()
-
-            let tracking: Section? = {
-                // Tracking section is hidden if there are non-empty non-refunded shipping labels.
-                guard self.shippingLabels.nonRefunded.isEmpty else {
-                    return nil
-                }
-
-                guard self.orderTracking.count > 0 else {
-                    return nil
-                }
-
-                let rows: [Row] = Array(repeating: .tracking, count: self.orderTracking.count)
-                return Section(category: .tracking, title: Title.tracking, rows: rows)
-            }()
-
-            let addTracking: Section? = {
-                // Add tracking section is hidden if there are non-empty non-refunded shipping labels.
-                guard self.shippingLabels.nonRefunded.isEmpty else {
-                    return nil
-                }
-
-                // Hide the section if the shipment
-                // tracking plugin is not installed
-                guard self.trackingIsReachable else {
-                    return nil
-                }
-
-                let title: String?
-                if self.orderTracking.count == 0 {
-                    title = NSLocalizedString(
-                        "orderDetails.addTrackingRow.title",
-                        value: "Optional Tracking Information",
-                        comment: "Title for the row to add tracking information."
-                    )
-                } else {
-                    title = nil
-                }
-                let row = Row.trackingAdd
-
-                return Section(category: .addTracking, title: title, rightTitle: nil, rows: [row])
-            }()
-
-            let notes: Section = {
-                let rows = [.addOrderNote] + self.orderNotesSections.map {$0.row}
-                return Section(category: .notes, title: Title.notes, rows: rows)
-            }()
-
-            let attribution: Section? = {
-                let rows: [Row] = {
-                    var rows: [Row] = [.attributionOrigin]
-
-                    guard let orderAttributionInfo = self.order.attributionInfo else {
-                        return rows
-                    }
-
-                    if let _ = orderAttributionInfo.sourceType {
-                        rows.append(.attributionSourceType)
-                    }
-
-                    if let _ = orderAttributionInfo.campaign {
-                        rows.append(.attributionCampaign)
-                    }
-
-                    if let _ = orderAttributionInfo.source {
-                        rows.append(.attributionSource)
-                    }
-
-                    if let _ = orderAttributionInfo.medium {
-                        rows.append(.attributionMedium)
-                    }
-
-                    if let _ = orderAttributionInfo.deviceType {
-                        rows.append(.attributionDeviceType)
-                    }
-
-                    if let _ = orderAttributionInfo.sessionPageViews {
-                        rows.append(.attributionSessionPageViews)
-                    }
-
-                    return rows
-                }()
-
-                return Section(category: .attribution, title: Title.orderAttribution, rows: rows)
-            }()
-
-            let trashOrderSection: Section? = {
-                return Section(category: .trashOrder, rows: [.trashOrder])
-            }()
-
-            self.sections = ([summary,
-                              products,
-                              customAmountsSection,
-                              customFields,
-                              installWCShipSection,
-                              refundedProducts] +
-                             shippingLabelSections +
-                             [subscriptions,
-                              shippingLinesSection,
-                              paymentSection,
-                              customerInformation,
-                              attribution,
-                              giftCards,
-                              tracking,
-                              addTracking,
-                              notes,
-                              trashOrderSection]).compactMap { $0 }
-
-            self.updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
-            self.onUIReloadRequired?()
+    @MainActor
+    private func isEligibleForBackendReceipt() async -> Bool {
+        guard !isEligibleForPayment else { return false }
+        return await withCheckedContinuation { continuation in
+            ReceiptEligibilityUseCase().isEligibleForBackendReceipts { isEligible in
+                continuation.resume(returning: isEligible)
+            }
         }
     }
 
@@ -2006,43 +1932,11 @@ extension OrderDetailsDataSource {
 }
 
 private extension OrderDetailsDataSource {
-    private func createPaymentSection(completion: @escaping (Section) -> Void) {
-        var rows: [Row] = [.payment, .customerPaid]
-
-        if condensedRefunds.isNotEmpty {
-            let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
-            rows.append(contentsOf: refunds)
-            rows.append(.netAmount)
-        }
-
-        if isEligibleForPayment {
-            rows.append(.collectCardPaymentButton)
-        }
-
-        switch orderHasLocalReceipt {
-        case true:
-            rows.append(.seeLegacyReceipt)
-            let section = buildPaymentSection(from: rows)
-            completion(section)
-        case false:
-            isEligibleForBackendReceipt { [weak self] isEligible in
-                guard let self else { return }
-                var updatedRows = rows
-                if isEligible {
-                    updatedRows.append(.seeReceipt)
-                }
-                let section = self.buildPaymentSection(from: updatedRows)
-                completion(section)
-            }
-        }
-    }
-
     private func buildPaymentSection(from rows: [Row]) -> Section {
         var updatedRows = rows
         if isEligibleForRefund {
             updatedRows.append(.issueRefundButton)
         }
-
         return Section(category: .payment,
                        title: Title.payment,
                        rows: updatedRows)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -126,7 +126,9 @@ final class OrderDetailsViewModel {
     var orderNotes: [OrderNote] = [] {
         didSet {
             dataSource.orderNotes = orderNotes
-            dataSource.reloadSections()
+            Task { @MainActor in
+                await dataSource.reloadSections()
+            }
             onUIReloadRequired?()
         }
     }
@@ -461,8 +463,8 @@ extension OrderDetailsViewModel {
 
 
 extension OrderDetailsViewModel {
-    func reloadSections() {
-        dataSource.reloadSections()
+    func reloadSections() async {
+        await dataSource.reloadSections()
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -129,7 +129,6 @@ final class OrderDetailsViewModel {
             Task { @MainActor in
                 await dataSource.reloadSections()
             }
-            onUIReloadRequired?()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -270,7 +270,9 @@ private extension OrderDetailsViewController {
 private extension OrderDetailsViewController {
 
     func reloadSections() {
-        viewModel.reloadSections()
+        Task {
+            await viewModel.reloadSections()
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -410,7 +410,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         order = order.copy(shippingLabels: [shippingLabel])
         insert(shippingLabel: shippingLabel, order: order)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration, receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -41,7 +41,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(
             order: order,
             storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration
+            cardPresentPaymentsConfiguration: Mocks.configuration,
+            receiptEligibilityUseCase: MockReceiptEligibilityUseCase()
         )
 
         dataSource.configureResultsControllers { }
@@ -62,6 +63,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             Title.notes
         ]
 
+        // TODO: Order is wrong, the payment comes last as is async.
         XCTAssertEqual(actualTitles, expectedTitles)
     }
 
@@ -79,7 +81,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(
             order: order,
             storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration
+            cardPresentPaymentsConfiguration: Mocks.configuration,
+            receiptEligibilityUseCase: MockReceiptEligibilityUseCase()
         )
 
         dataSource.configureResultsControllers { }
@@ -112,7 +115,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_reloadSections_when_there_is_no_paid_date_then_customer_paid_row_is_visible() async throws {
         // Given
         let order = Order.fake()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -126,7 +132,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_reloadSections_when_there_is_a_paid_date_then_customer_paid_row_is_visible() async throws {
         // Given
         let order = Order.fake().copy(datePaid: Date())
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -140,7 +149,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_refund_button_is_visible() async throws {
         // Given
         let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -158,7 +170,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
                                                 cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                refundableOrderItemsDeterminer: orderRefundsOptionsDeterminer)
+                                                refundableOrderItemsDeterminer: orderRefundsOptionsDeterminer,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -172,7 +185,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_refund_button_is_not_visible_when_the_order_status_is_refunded() async throws {
         // Given
         let order = MockOrders().makeOrder(status: .refunded, items: [makeOrderItem()])
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -190,7 +206,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
                                                 cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                refundableOrderItemsDeterminer: orderRefundsOptionsDeterminer)
+                                                refundableOrderItemsDeterminer: orderRefundsOptionsDeterminer,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -204,7 +221,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_markOrderComplete_button_is_visible_and_primary_style_if_order_is_processing_and_not_eligible_for_shipping_label_creation() async throws {
         // Given
         let order = makeOrder().copy(status: .processing)
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = false
 
         // When
@@ -218,7 +238,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() async throws {
         // Given
         let order = makeOrder().copy(status: .processing)
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -233,7 +256,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_markOrderComplete_button_is_hidden_if_order_is_not_processing() async throws {
         // Given
         let order = makeOrder().copy(status: .onHold)
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -247,7 +273,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_reloadSections_when_isEligibleForPayment_is_false_then_collect_payment_button_is_not_visible() async throws {
         //Given
         let order = makeOrder().copy(datePaid: .some(Date())) // Paid orders are not eligible for payment
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -260,7 +289,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_reloadSections_when_isEligibleForPayment_is_true_then_collect_payment_button_is_visible() async throws {
         //Given
         let order = makeOrder().copy(datePaid: .some(nil)) // Unpaid orders are eligible for payment
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -273,7 +305,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_create_shipping_label_button_is_visible_for_eligible_order_with_no_labels() async throws {
         // Given
         let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -291,7 +326,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: ShippingLabelRefund.fake())
         insert(shippingLabel: refundedShippingLabel, order: order)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -311,7 +349,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         order = order.copy(shippingLabels: [shippingLabel])
         insert(shippingLabel: shippingLabel, order: order)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -327,7 +368,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_create_shipping_label_button_is_not_visible_for_ineligible_order() async throws {
         // Given
         let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = false
 
         // When
@@ -342,7 +386,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_create_shipping_label_button_is_not_visible_when_order_is_eligible_for_payment() async throws {
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -362,7 +409,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         order = order.copy(shippingLabels: [shippingLabel])
         insert(shippingLabel: shippingLabel, order: order)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration, receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -400,8 +447,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
                                                 cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase(),
                                                 currencySettings: currencySettings,
-                                                siteSettings: [siteSetting], featureFlags: MockFeatureFlagService(shippingLabelsOnboardingM1: true))
+                                                siteSettings: [siteSetting],
+                                                featureFlags: MockFeatureFlagService(shippingLabelsOnboardingM1: true))
         dataSource.configureResultsControllers { }
 
         // When
@@ -433,6 +482,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
                                                 cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration(country: .US),
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase(),
                                                 currencySettings: currencySettings,
                                                 siteSettings: [siteSetting],
                                                 userIsAdmin: true,
@@ -458,7 +508,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         order = order.copy(shippingLabels: [refundedShippingLabel])
         insert(shippingLabel: refundedShippingLabel, order: order)
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -477,7 +530,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let order = makeOrder()
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 
@@ -496,7 +552,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let order = makeOrder()
 
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = false
         dataSource.configureResultsControllers { }
 
@@ -514,7 +573,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_more_button_is_not_visible_in_product_section_for_cash_on_delivery_order() async throws {
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100", paymentMethodID: "cod")
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
@@ -536,7 +598,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         ])
         let dataSource = OrderDetailsDataSource(
             order: order, storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration
+            cardPresentPaymentsConfiguration: Mocks.configuration,
+            receiptEligibilityUseCase: MockReceiptEligibilityUseCase()
         )
 
         // When
@@ -552,7 +615,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = MockOrders().makeOrder(customFields: [])
         let dataSource = OrderDetailsDataSource(
             order: order, storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration
+            cardPresentPaymentsConfiguration: Mocks.configuration,
+            receiptEligibilityUseCase: MockReceiptEligibilityUseCase()
         )
 
         // When
@@ -568,11 +632,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = MockOrders().makeOrder()
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase()
         )
 
         // When
         dataSource.orderSubscriptions = [Subscription.fake()]
+        await dataSource.reloadSections()
 
         // Then
         let subscriptionSection = section(withCategory: .subscriptions, from: dataSource)
@@ -584,7 +650,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = MockOrders().makeOrder()
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase()
         )
 
         // When
@@ -600,7 +667,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = MockOrders().makeOrder(fees: [OrderFeeLine.fake()])
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         insertFee(with: order)
@@ -617,7 +685,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = MockOrders().makeOrder(fees: [])
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -632,7 +701,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake().copy(appliedGiftCards: [.init(giftCardID: 2, code: "SU9F-MGB5-KS5V-EZFT", amount: 20)])
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -647,7 +717,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake()
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -664,7 +735,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake().copy(attributionInfo: .some(nil))
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -678,7 +750,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_hides_source_type_row_when_sourceType_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sourceType: .some(nil)))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -692,7 +767,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_shows_source_type_row_when_sourceType_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sourceType: "Source type"))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -706,7 +784,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_hides_campaign_row_when_campaign_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(campaign: .some(nil)))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -720,7 +801,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_shows_campaign_row_when_campaign_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(campaign: "Campaign"))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -734,7 +818,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_hides_source_row_when_source_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(source: .some(nil)))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -748,7 +835,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_shows_source_row_when_source_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(source: "Source"))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -762,7 +852,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_hides_medium_row_when_medium_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(medium: .some(nil)))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -776,7 +869,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_shows_medium_row_when_medium_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(medium: "Medium"))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -790,7 +886,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_hides_deviceType_row_when_deviceType_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(deviceType: .some(nil)))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -804,7 +903,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_shows_deviceType_row_when_deviceType_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(deviceType: "Device type"))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -818,7 +920,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_hides_sessionPageViews_row_when_sessionPageViews_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sessionPageViews: .some(nil)))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -832,7 +937,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_order_attribution_section_shows_sessionPageViews_row_when_sessionPageViews_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sessionPageViews: "3"))
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -846,7 +954,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_shipping_section_hidden_when_order_has_no_shipping_lines() async throws {
         // Given
         let order = Order.fake()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()
@@ -861,7 +972,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake().copy(shippingLines: [.fake()])
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
 
         // When
         await dataSource.reloadSections()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -343,7 +343,6 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     }
 
     func test_create_shipping_label_button_is_not_visible_for_eligible_order_with_labels() async throws {
-        throw XCTSkip("Skipping temporarily.")
         // Given
         var order = makeOrder()
         let shippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID)
@@ -353,7 +352,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
                                                 cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase())
+                                                receiptEligibilityUseCase: MockReceiptEligibilityUseCase(),
+                                                featureFlags: MockFeatureFlagService(revampedShippingLabelCreation: false))
         dataSource.isEligibleForShippingLabelCreation = true
         dataSource.configureResultsControllers { }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -31,9 +31,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_payment_section_is_shown_right_after_the_products_custom_amounts_refunded_products_and_shipping_sections() {
+    func test_payment_section_is_shown_right_after_the_products_custom_amounts_refunded_products_and_shipping_sections() async throws {
         // Given
-        let order = makeOrder()
+        let order = makeOrder().copy(datePaid: Date())
 
         insert(refund: makeRefund(refundID: 1, orderID: order.orderID, siteID: order.siteID))
         insertFee(with: order)
@@ -47,7 +47,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let actualTitles = dataSource.sections.compactMap(\.title)
@@ -65,7 +65,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertEqual(actualTitles, expectedTitles)
     }
 
-    func test_refunds_data_in_unpaid_order_is_acessible_by_indexes() throws {
+    func test_refunds_data_in_unpaid_order_is_acessible_by_indexes() async throws {
         // Given
         let refundItems = [
             OrderRefundCondensed(refundID: 1, reason: nil, total: "1"),
@@ -89,7 +89,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         tableView.registerNib(for: TwoColumnHeadlineFootnoteTableViewCell.self)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Get IndexPaths for all `refund` rows
         var refundsRowsIndexes: [IndexPath] = []
@@ -109,13 +109,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertEqual(expectedRefunds.count, refundsRowsIndexes.count)
     }
 
-    func test_reloadSections_when_there_is_no_paid_date_then_customer_paid_row_is_visible() throws {
+    func test_reloadSections_when_there_is_no_paid_date_then_customer_paid_row_is_visible() async throws {
         // Given
         let order = Order.fake()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
@@ -123,13 +123,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(customerPaidRow)
     }
 
-    func test_reloadSections_when_there_is_a_paid_date_then_customer_paid_row_is_visible() throws {
+    func test_reloadSections_when_there_is_a_paid_date_then_customer_paid_row_is_visible() async throws {
         // Given
         let order = Order.fake().copy(datePaid: Date())
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
@@ -137,13 +137,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(customerPaidRow)
     }
 
-    func test_refund_button_is_visible() throws {
+    func test_refund_button_is_visible() async throws {
         // Given
         let order = makeOrder()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
@@ -151,7 +151,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(issueRefundRow)
     }
 
-    func test_refund_button_is_not_visible_when_there_is_no_date_paid() throws {
+    func test_refund_button_is_not_visible_when_there_is_no_date_paid() async throws {
         // Given
         let order = makeOrder().copy(datePaid: .some(nil))
         let orderRefundsOptionsDeterminer = MockOrderRefundsOptionsDeterminer(isAnythingToRefund: true)
@@ -161,7 +161,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
                                                 refundableOrderItemsDeterminer: orderRefundsOptionsDeterminer)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
@@ -169,13 +169,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(issueRefundRow)
     }
 
-    func test_refund_button_is_not_visible_when_the_order_status_is_refunded() throws {
+    func test_refund_button_is_not_visible_when_the_order_status_is_refunded() async throws {
         // Given
         let order = MockOrders().makeOrder(status: .refunded, items: [makeOrderItem()])
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
@@ -183,7 +183,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(issueRefundRow)
     }
 
-    func test_refund_button_is_not_visible_when_the_status_is_other_than_refunded_but_the_order_is_not_refundable() throws {
+    func test_refund_button_is_not_visible_when_the_status_is_other_than_refunded_but_the_order_is_not_refundable() async throws {
         // Given
         let order = Order.fake().copy(status: .processing, items: [makeOrderItem()], refunds: [OrderRefundCondensed.fake()])
         let orderRefundsOptionsDeterminer = MockOrderRefundsOptionsDeterminer(isAnythingToRefund: false)
@@ -193,7 +193,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
                                                 refundableOrderItemsDeterminer: orderRefundsOptionsDeterminer)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
@@ -201,28 +201,28 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(issueRefundRow)
     }
 
-    func test_markOrderComplete_button_is_visible_and_primary_style_if_order_is_processing_and_not_eligible_for_shipping_label_creation() throws {
+    func test_markOrderComplete_button_is_visible_and_primary_style_if_order_is_processing_and_not_eligible_for_shipping_label_creation() async throws {
         // Given
         let order = makeOrder().copy(status: .processing)
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = false
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
         XCTAssertNotNil(row(row: .markCompleteButton(style: .primary, showsBottomSpacing: true), in: productsSection))
     }
 
-    func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() throws {
+    func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() async throws {
         // Given
         let order = makeOrder().copy(status: .processing)
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
@@ -230,13 +230,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row(row: .shippingLabelCreationInfo(showsSeparator: false), in: productsSection))
     }
 
-    func test_markOrderComplete_button_is_hidden_if_order_is_not_processing() throws {
+    func test_markOrderComplete_button_is_hidden_if_order_is_not_processing() async throws {
         // Given
         let order = makeOrder().copy(status: .onHold)
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
@@ -244,40 +244,40 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row(row: .markCompleteButton(style: .secondary, showsBottomSpacing: false), in: productsSection))
     }
 
-    func test_reloadSections_when_isEligibleForPayment_is_false_then_collect_payment_button_is_not_visible() throws {
+    func test_reloadSections_when_isEligibleForPayment_is_false_then_collect_payment_button_is_not_visible() async throws {
         //Given
         let order = makeOrder().copy(datePaid: .some(Date())) // Paid orders are not eligible for payment
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
     }
 
-    func test_reloadSections_when_isEligibleForPayment_is_true_then_collect_payment_button_is_visible() throws {
+    func test_reloadSections_when_isEligibleForPayment_is_true_then_collect_payment_button_is_visible() async throws {
         //Given
         let order = makeOrder().copy(datePaid: .some(nil)) // Unpaid orders are eligible for payment
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
     }
 
-    func test_create_shipping_label_button_is_visible_for_eligible_order_with_no_labels() throws {
+    func test_create_shipping_label_button_is_visible_for_eligible_order_with_no_labels() async throws {
         // Given
         let order = makeOrder()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -285,7 +285,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(createShippingLabelRow)
     }
 
-    func test_create_shipping_label_button_is_visible_for_eligible_order_with_only_refunded_labels() throws {
+    func test_create_shipping_label_button_is_visible_for_eligible_order_with_only_refunded_labels() async throws {
         // Given
         let order = makeOrder()
         let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: ShippingLabelRefund.fake())
@@ -296,7 +296,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -304,7 +304,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(createShippingLabelRow)
     }
 
-    func test_create_shipping_label_button_is_not_visible_for_eligible_order_with_labels() throws {
+    func test_create_shipping_label_button_is_not_visible_for_eligible_order_with_labels() async throws {
         // Given
         var order = makeOrder()
         let shippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID)
@@ -316,7 +316,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -324,14 +324,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(createShippingLabelRow)
     }
 
-    func test_create_shipping_label_button_is_not_visible_for_ineligible_order() throws {
+    func test_create_shipping_label_button_is_not_visible_for_ineligible_order() async throws {
         // Given
         let order = makeOrder()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = false
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -339,7 +339,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(createShippingLabelRow)
     }
 
-    func test_create_shipping_label_button_is_not_visible_when_order_is_eligible_for_payment() throws {
+    func test_create_shipping_label_button_is_not_visible_when_order_is_eligible_for_payment() async throws {
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -347,7 +347,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // When
         dataSource.configureResultsControllers { }
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -355,7 +355,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(createShippingLabelRow)
     }
 
-    func test_more_button_is_visible_in_product_section_for_eligible_order_without_refunded_labels() throws {
+    func test_more_button_is_visible_in_product_section_for_eligible_order_without_refunded_labels() async throws {
         // Given
         var order = makeOrder()
         let shippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID)
@@ -367,7 +367,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -377,7 +377,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
     }
 
-    func test_WCShip_installation_section_is_not_visible_when_WCShip_plugin_is_installed_and_active() throws {
+    func test_WCShip_installation_section_is_not_visible_when_WCShip_plugin_is_installed_and_active() async throws {
         // Given
         let sampleSiteID: Int64 = 1234
         let order = makeOrder()
@@ -405,14 +405,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let wcShipSection = section(withCategory: .installWCShip, from: dataSource)
         XCTAssertNil(wcShipSection)
     }
 
-    func test_WCShip_installation_section_is_visible_for_eligible_order() throws {
+    func test_WCShip_installation_section_is_visible_for_eligible_order() async throws {
         // Given
         let sampleSiteID: Int64 = 1234
         let order = makeOrder()
@@ -440,7 +440,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         guard let wcShipSection = section(withCategory: .installWCShip, from: dataSource) else {
@@ -451,7 +451,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(wcShipRow)
     }
 
-    func test_more_button_is_visible_in_product_section_for_eligible_order_with_refunded_labels() throws {
+    func test_more_button_is_visible_in_product_section_for_eligible_order_with_refunded_labels() async throws {
         // Given
         var order = makeOrder()
         let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: ShippingLabelRefund.fake())
@@ -463,7 +463,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -473,7 +473,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
     }
 
-    func test_more_button_is_not_visible_in_product_section_for_eligible_order_without_shipping_labels() throws {
+    func test_more_button_is_not_visible_in_product_section_for_eligible_order_without_shipping_labels() async throws {
         // Given
         let order = makeOrder()
 
@@ -482,7 +482,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -492,7 +492,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
     }
 
-    func test_more_button_is_not_visible_in_product_section_for_ineligible_order() throws {
+    func test_more_button_is_not_visible_in_product_section_for_ineligible_order() async throws {
         // Given
         let order = makeOrder()
 
@@ -501,7 +501,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.configureResultsControllers { }
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -511,7 +511,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
     }
 
-    func test_more_button_is_not_visible_in_product_section_for_cash_on_delivery_order() throws {
+    func test_more_button_is_not_visible_in_product_section_for_cash_on_delivery_order() async throws {
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
@@ -519,7 +519,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // When
         dataSource.configureResultsControllers { }
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let productSection = try section(withTitle: Title.products, from: dataSource)
@@ -529,7 +529,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
     }
 
-    func test_custom_fields_button_is_visible() throws {
+    func test_custom_fields_button_is_visible() async throws {
         // Given
         let order = MockOrders().makeOrder(customFields: [
             MetaData(metadataID: 123, key: "Key", value: "Value")
@@ -540,14 +540,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         )
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let customFieldSection = section(withCategory: .customFields, from: dataSource)
         XCTAssertNotNil(customFieldSection)
     }
 
-    func test_custom_fields_button_is_visible_when_order_contains_no_custom_fields_to_display() throws {
+    func test_custom_fields_button_is_visible_when_order_contains_no_custom_fields_to_display() async throws {
         // Given
         let order = MockOrders().makeOrder(customFields: [])
         let dataSource = OrderDetailsDataSource(
@@ -556,14 +556,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         )
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let customFieldSection = section(withCategory: .customFields, from: dataSource)
         XCTAssertNotNil(customFieldSection)
     }
 
-    func test_subscriptions_section_is_visible_when_order_has_associated_subscriptions() throws {
+    func test_subscriptions_section_is_visible_when_order_has_associated_subscriptions() async throws {
         // Given
         let order = MockOrders().makeOrder()
         let dataSource = OrderDetailsDataSource(order: order,
@@ -579,7 +579,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(subscriptionSection)
     }
 
-    func test_subscriptions_section_is_hidden_when_order_has_no_associated_subscriptions() throws {
+    func test_subscriptions_section_is_hidden_when_order_has_no_associated_subscriptions() async throws {
         // Given
         let order = MockOrders().makeOrder()
         let dataSource = OrderDetailsDataSource(order: order,
@@ -595,7 +595,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(subscriptionSection)
     }
 
-    func test_reloadSections_when_order_has_custom_amounts_then_custom_amounts_section_is_visible() {
+    func test_reloadSections_when_order_has_custom_amounts_then_custom_amounts_section_is_visible() async throws {
         // Given
         let order = MockOrders().makeOrder(fees: [OrderFeeLine.fake()])
         let dataSource = OrderDetailsDataSource(order: order,
@@ -605,14 +605,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // When
         insertFee(with: order)
         dataSource.configureResultsControllers { }
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let customAmountsSection = section(withCategory: .customAmounts, from: dataSource)
         XCTAssertNotNil(customAmountsSection)
     }
 
-    func test_reloadSections_when_order_has_not_custom_amounts_then_custom_amounts_section_is_hidden() {
+    func test_reloadSections_when_order_has_not_custom_amounts_then_custom_amounts_section_is_hidden() async throws {
         // Given
         let order = MockOrders().makeOrder(fees: [])
         let dataSource = OrderDetailsDataSource(order: order,
@@ -620,14 +620,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
                                                 cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let customAmountsSection = section(withCategory: .customAmounts, from: dataSource)
         XCTAssertNil(customAmountsSection)
     }
 
-    func test_giftCards_section_is_visible_when_order_has_gift_cards() throws {
+    func test_giftCards_section_is_visible_when_order_has_gift_cards() async throws {
         // Given
         let order = Order.fake().copy(appliedGiftCards: [.init(giftCardID: 2, code: "SU9F-MGB5-KS5V-EZFT", amount: 20)])
         let dataSource = OrderDetailsDataSource(order: order,
@@ -635,14 +635,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
                                                 cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let giftCardsSection = section(withCategory: .giftCards, from: dataSource)
         XCTAssertNotNil(giftCardsSection)
     }
 
-    func test_giftCards_section_is_hidden_when_order_has_no_gift_cards() throws {
+    func test_giftCards_section_is_hidden_when_order_has_no_gift_cards() async throws {
         // Given
         let order = Order.fake()
         let dataSource = OrderDetailsDataSource(order: order,
@@ -650,7 +650,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
                                                 cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let giftCardsSection = section(withCategory: .giftCards, from: dataSource)
@@ -659,7 +659,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     // MARK: Order Attribution
 
-    func test_order_attribution_section_is_shown_with_origin_row_even_if_order_has_no_attribution_info() throws {
+    func test_order_attribution_section_is_shown_with_origin_row_even_if_order_has_no_attribution_info() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .some(nil))
         let dataSource = OrderDetailsDataSource(order: order,
@@ -667,7 +667,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
                                                 cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -675,13 +675,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(originRow)
     }
 
-    func test_order_attribution_section_hides_source_type_row_when_sourceType_is_nil() throws {
+    func test_order_attribution_section_hides_source_type_row_when_sourceType_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sourceType: .some(nil)))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -689,13 +689,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row)
     }
 
-    func test_order_attribution_section_shows_source_type_row_when_sourceType_is_not_nil() throws {
+    func test_order_attribution_section_shows_source_type_row_when_sourceType_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sourceType: "Source type"))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -703,13 +703,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row)
     }
 
-    func test_order_attribution_section_hides_campaign_row_when_campaign_is_nil() throws {
+    func test_order_attribution_section_hides_campaign_row_when_campaign_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(campaign: .some(nil)))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -717,13 +717,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row)
     }
 
-    func test_order_attribution_section_shows_campaign_row_when_campaign_is_not_nil() throws {
+    func test_order_attribution_section_shows_campaign_row_when_campaign_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(campaign: "Campaign"))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -731,13 +731,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row)
     }
 
-    func test_order_attribution_section_hides_source_row_when_source_is_nil() throws {
+    func test_order_attribution_section_hides_source_row_when_source_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(source: .some(nil)))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -745,13 +745,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row)
     }
 
-    func test_order_attribution_section_shows_source_row_when_source_is_not_nil() throws {
+    func test_order_attribution_section_shows_source_row_when_source_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(source: "Source"))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -759,13 +759,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row)
     }
 
-    func test_order_attribution_section_hides_medium_row_when_medium_is_nil() throws {
+    func test_order_attribution_section_hides_medium_row_when_medium_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(medium: .some(nil)))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -773,13 +773,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row)
     }
 
-    func test_order_attribution_section_shows_medium_row_when_medium_is_not_nil() throws {
+    func test_order_attribution_section_shows_medium_row_when_medium_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(medium: "Medium"))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -787,13 +787,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row)
     }
 
-    func test_order_attribution_section_hides_deviceType_row_when_deviceType_is_nil() throws {
+    func test_order_attribution_section_hides_deviceType_row_when_deviceType_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(deviceType: .some(nil)))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -801,13 +801,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row)
     }
 
-    func test_order_attribution_section_shows_deviceType_row_when_deviceType_is_not_nil() throws {
+    func test_order_attribution_section_shows_deviceType_row_when_deviceType_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(deviceType: "Device type"))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -815,13 +815,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row)
     }
 
-    func test_order_attribution_section_hides_sessionPageViews_row_when_sessionPageViews_is_nil() throws {
+    func test_order_attribution_section_hides_sessionPageViews_row_when_sessionPageViews_is_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sessionPageViews: .some(nil)))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -829,13 +829,13 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row)
     }
 
-    func test_order_attribution_section_shows_sessionPageViews_row_when_sessionPageViews_is_not_nil() throws {
+    func test_order_attribution_section_shows_sessionPageViews_row_when_sessionPageViews_is_not_nil() async throws {
         // Given
         let order = Order.fake().copy(attributionInfo: .fake().copy(sessionPageViews: "3"))
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
@@ -843,20 +843,20 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(row)
     }
 
-    func test_shipping_section_hidden_when_order_has_no_shipping_lines() {
+    func test_shipping_section_hidden_when_order_has_no_shipping_lines() async throws {
         // Given
         let order = Order.fake()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let shippingSection = section(withCategory: .shippingLines, from: dataSource)
         XCTAssertNil(shippingSection)
     }
 
-    func test_shipping_section_shows_shipping_line_row_when_order_has_shipping_line() throws {
+    func test_shipping_section_shows_shipping_line_row_when_order_has_shipping_line() async throws {
         // Given
         let order = Order.fake().copy(shippingLines: [.fake()])
         let dataSource = OrderDetailsDataSource(order: order,
@@ -864,7 +864,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
                                                 cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
-        dataSource.reloadSections()
+        await dataSource.reloadSections()
 
         // Then
         let shippingSection = try section(withTitle: Title.shippingLines, from: dataSource)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -33,7 +33,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_payment_section_is_shown_right_after_the_products_custom_amounts_refunded_products_and_shipping_sections() async throws {
         // Given
-        let order = makeOrder().copy(datePaid: Date())
+        let order = makeOrder()
 
         insert(refund: makeRefund(refundID: 1, orderID: order.orderID, siteID: order.siteID))
         insertFee(with: order)
@@ -63,7 +63,6 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             Title.notes
         ]
 
-        // TODO: Order is wrong, the payment comes last as is async.
         XCTAssertEqual(actualTitles, expectedTitles)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -343,6 +343,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     }
 
     func test_create_shipping_label_button_is_not_visible_for_eligible_order_with_labels() async throws {
+        throw XCTSkip("Skipping temporarily.")
         // Given
         var order = makeOrder()
         let shippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
@@ -31,7 +31,7 @@ final class OrderDetailsViewControllerTests: XCTestCase {
     }
 
     @MainActor
-    func test_products_cell_is_visible_on_order_with_items() throws {
+    func test_products_cell_is_visible_on_order_with_items() async throws {
         // Given
         let storageManager = MockStorageManager()
         let order = MockOrders().sampleOrderWithItems()
@@ -43,6 +43,7 @@ final class OrderDetailsViewControllerTests: XCTestCase {
         // When
         _ = try XCTUnwrap(viewController.view)
         viewController.viewWillAppear(false)
+        await viewModel.reloadSections()
 
         // Then
         let mirror = try Self.mirror(of: viewController)
@@ -52,7 +53,7 @@ final class OrderDetailsViewControllerTests: XCTestCase {
     }
 
     @MainActor
-    func test_tapping_products_cell_presents_product_loader() throws {
+    func test_tapping_products_cell_presents_product_loader() async throws {
         // Given
         let presentationVerifier = PresentationVerifier()
         let storageManager = MockStorageManager()
@@ -65,6 +66,7 @@ final class OrderDetailsViewControllerTests: XCTestCase {
         // When
         _ = try XCTUnwrap(viewController.view)
         viewController.viewWillAppear(false)
+        await viewModel.reloadSections()
 
         let mirror = try Self.mirror(of: viewController)
         let (_, indexPath) = try XCTUnwrap(Self.findCell(type: ProductDetailsTableViewCell.self, on: mirror.tableView))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-424

## Description
This PR builds from the idea of https://github.com/woocommerce/woocommerce-ios/commit/2cc6ceb53c30e40915d0a3743c19627d0a4dbf18 of not assuming that all order detail rows will be built immediately. We refactor how we create those by separating into static and payments sections for now, wrap everything in a task, and only return when all sections are ready. 

This is pre-work to be able to use async-await for displaying failed receipts ([#](https://github.com/woocommerce/woocommerce-ios/pull/15558)), as well as a general improvement for future cases where rows might depend on network requests.

## Testing information

Smoke test order creation & order details, check that we can process a payment correctly, and see that dynamic rows are generated when needed (eg: shipping label button for physical products, receipts row after a card payment transaction, ...).

I sprinkled a few of main actors around around payment section creation, as otherwise we would crash when performing actions like generating shipping labels (as accesses storage and dispatches actions internally), as well as when checking receipt eligibility. I've also injected a new dependency for receipt eligibility, otherwise unit tests will be blocked due leaking continuations.

I had some troubles with a shipping labels [test](https://github.com/woocommerce/woocommerce-ios/pull/15588/commits/c2b5c9bc9027aff380d918e9399bfd817b899c80), and confirmed with @itsmeichigo that was [missing a flag](https://github.com/woocommerce/woocommerce-ios/pull/15588/commits/2a081cf87db41ce08e4b08baccbfebf1b7e0fa4c), which made it never fail CI but fail locally because running in debug.

## Screenshots
_Too big for GH: https://indiemelon.mystagingwebsite.com/wp-content/uploads/2025/05/Simulator-Screen-Recording-iPhone-16-US-store-2025-05-02-at-13.46.17.gif_

---

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
