### PR TITLE
Shipping Labels: Update logic for showing notices

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -241,7 +241,7 @@ private extension WooShippingCreateLabelsView {
                 .foregroundStyle(Color(.primary))
                 .bold()
 
-            if isReadyToShowErrorNotice {
+            if viewModel.shouldShowInitialNotices {
                 // Unverified notice for origin address
                 if let originAddressUnverifiedNoticeLabel = viewModel.originAddressUnverifiedNoticeLabel {
                     verificationNotice(with: originAddressUnverifiedNoticeLabel,
@@ -257,8 +257,7 @@ private extension WooShippingCreateLabelsView {
                 }
 
                 // Verification notice for destination address
-                if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel,
-                   viewModel.canViewLabel == false {
+                if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel {
                     verificationNotice(with: destinationAddressStatusNoticeLabel,
                                        isVerified: isDestinationAddressVerified,
                                        onDismiss: {
@@ -286,13 +285,6 @@ private extension WooShippingCreateLabelsView {
                         showingCustomsForm = true
                     })
                 }
-            }
-        }
-        .onAppear {
-            /// A brief delay in requesting user attention after the UI loads
-            /// to avoid overwhelming them with too many changes at once when opening the screen.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                self.isReadyToShowErrorNotice = true
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -37,8 +37,6 @@ struct WooShippingCreateLabelsView: View {
     /// Whether the origin address list sheet is presented.
     @State private var isOriginAddressListPresented = false
 
-    @State private var isReadyToShowErrorNotice = false
-
     @State private var showingCustomsForm = false
     @State private var showingSplitShipments = false
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -257,7 +257,8 @@ private extension WooShippingCreateLabelsView {
                 }
 
                 // Verification notice for destination address
-                if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel {
+                if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel,
+                   viewModel.canViewLabel == false {
                     verificationNotice(with: destinationAddressStatusNoticeLabel,
                                        isVerified: isDestinationAddressVerified,
                                        onDismiss: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -241,7 +241,7 @@ private extension WooShippingCreateLabelsView {
                 .foregroundStyle(Color(.primary))
                 .bold()
 
-            if viewModel.shouldShowInitialNotices {
+            if viewModel.shouldShowNotices {
                 // Unverified notice for origin address
                 if let originAddressUnverifiedNoticeLabel = viewModel.originAddressUnverifiedNoticeLabel {
                     verificationNotice(with: originAddressUnverifiedNoticeLabel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -20,7 +20,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let stores: StoresManager
     private let currencySettings: CurrencySettings
     private var subscriptions: Set<AnyCancellable> = []
-    private let noticeDelay: RunLoop.SchedulerTimeType.Stride
+    private let initialNoticeDelay: RunLoop.SchedulerTimeType.Stride
 
     private(set) var orderItems: WooShippingItemsViewModel
 
@@ -184,7 +184,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          stores: StoresManager = ServiceLocator.stores,
-         noticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2),
+         initialNoticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
         self.shippingLabels = order.shippingLabels
@@ -197,7 +197,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.stores = stores
         self.shippingSettingsService = shippingSettingsService
-        self.noticeDelay = noticeDelay
+        self.initialNoticeDelay = initialNoticeDelay
 
         let splitShipmentsViewModel = WooShippingSplitShipmentsViewModel(order: order,
                                                                          config: nil,
@@ -226,7 +226,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          stores: StoresManager = ServiceLocator.stores,
-         noticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2)) {
+         initialNoticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2)) {
         self.order = order
         self.shippingSettingsService = shippingSettingsService
         self.shippingLabels = order.shippingLabels
@@ -238,7 +238,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.destinationAddressStatus = .verified
         self.onLabelPurchase = nil
         self.stores = stores
-        self.noticeDelay = noticeDelay
+        self.initialNoticeDelay = initialNoticeDelay
 
         let splitShipmentsViewModel = WooShippingSplitShipmentsViewModel(order: order,
                                                                          config: nil,
@@ -548,7 +548,7 @@ private extension WooShippingCreateLabelsViewModel {
             .filter { shouldShowNotices, destinationNotice in
                 shouldShowNotices && destinationNotice == Localization.DestinationAddressStatus.verified
             }
-            .delay(for: noticeDelay, scheduler: RunLoop.current)
+            .delay(for: .seconds(2), scheduler: RunLoop.current)
             .map { _ in nil }
             .assign(to: &$destinationAddressStatusNoticeLabel)
     }
@@ -557,11 +557,12 @@ private extension WooShippingCreateLabelsViewModel {
     /// to avoid overwhelming users with too many information at once when opening the screen.
     func observeViewStates() {
         $state
+            .filter { $0 == .ready }
+            .delay(for: initialNoticeDelay, scheduler: RunLoop.current)
             .combineLatest($shipments, $selectedShipmentIndex)
-            .map { state, shipments, selectedIndex in
-                state == .ready && shipments[selectedIndex].isPurchased == false
+            .map { _, shipments, selectedIndex in
+                shipments[selectedIndex].isPurchased == false
             }
-            .delay(for: noticeDelay, scheduler: RunLoop.current)
             .assign(to: &$shouldShowNotices)
 
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -60,6 +60,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     @Published private(set) var state = ContentState.loading
 
+    @Published private(set) var shouldShowInitialNotices = false
+
     /// View model for split shipments.
     private(set) var splitShipmentsViewModel: WooShippingSplitShipmentsViewModel
 
@@ -208,6 +210,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         loadDestinationAddress()
         observeSelectedOriginAddress()
         observeDestinationAddress()
+        observeViewStates()
 
         Task {
             await loadRequiredData()
@@ -242,6 +245,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
 
         updateShipmentDetailsViewModels()
+        observeViewStates()
 
         Task { @MainActor in
             await loadRequiredData()
@@ -534,11 +538,27 @@ private extension WooShippingCreateLabelsViewModel {
             .assign(to: &$destinationAddressStatusNoticeLabel)
 
         /// Clear the notice after a delay when the address is verified.
-        $destinationAddressStatusNoticeLabel
-            .filter { $0 == Localization.DestinationAddressStatus.verified }
+        $shouldShowInitialNotices
+            .combineLatest($destinationAddressStatusNoticeLabel)
+            .filter { shouldShowNotices, destinationNotice in
+                shouldShowNotices && destinationNotice == Localization.DestinationAddressStatus.verified
+            }
             .delay(for: .seconds(2), scheduler: RunLoop.current)
             .map { _ in nil }
             .assign(to: &$destinationAddressStatusNoticeLabel)
+    }
+
+    /// Ensures that initial notices are only displayed 2 seconds after the view is ready
+    /// to avoid overwhelming users with too many information at once when opening the screen.
+    func observeViewStates() {
+        $state
+            .combineLatest($shipments, $selectedShipmentIndex)
+            .map { state, shipments, selectedIndex in
+                state == .ready && shipments[selectedIndex].isPurchased == false
+            }
+            .delay(for: .seconds(2), scheduler: RunLoop.current)
+            .assign(to: &$shouldShowInitialNotices)
+
     }
 
     /// Gets the destination address as a `ShippingLabelAddress`.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -20,6 +20,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private let stores: StoresManager
     private let currencySettings: CurrencySettings
     private var subscriptions: Set<AnyCancellable> = []
+    private let noticeDelay: RunLoop.SchedulerTimeType.Stride
 
     private(set) var orderItems: WooShippingItemsViewModel
 
@@ -183,6 +184,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          stores: StoresManager = ServiceLocator.stores,
+         noticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
         self.shippingLabels = order.shippingLabels
@@ -195,6 +197,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
         self.stores = stores
         self.shippingSettingsService = shippingSettingsService
+        self.noticeDelay = noticeDelay
 
         let splitShipmentsViewModel = WooShippingSplitShipmentsViewModel(order: order,
                                                                          config: nil,
@@ -222,7 +225,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          selectedShippingLabel: ShippingLabel,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         noticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2)) {
         self.order = order
         self.shippingSettingsService = shippingSettingsService
         self.shippingLabels = order.shippingLabels
@@ -234,6 +238,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.destinationAddressStatus = .verified
         self.onLabelPurchase = nil
         self.stores = stores
+        self.noticeDelay = noticeDelay
 
         let splitShipmentsViewModel = WooShippingSplitShipmentsViewModel(order: order,
                                                                          config: nil,
@@ -424,7 +429,6 @@ private extension WooShippingCreateLabelsViewModel {
         }
 
         if let config {
-            // TODO-15483: map `shippingLabels` using `config`'s purchased labels.
             splitShipmentsViewModel = WooShippingSplitShipmentsViewModel(order: order,
                                                                          config: config,
                                                                          items: itemsDataSource.items,
@@ -544,12 +548,12 @@ private extension WooShippingCreateLabelsViewModel {
             .filter { shouldShowNotices, destinationNotice in
                 shouldShowNotices && destinationNotice == Localization.DestinationAddressStatus.verified
             }
-            .delay(for: .seconds(2), scheduler: RunLoop.current)
+            .delay(for: noticeDelay, scheduler: RunLoop.current)
             .map { _ in nil }
             .assign(to: &$destinationAddressStatusNoticeLabel)
     }
 
-    /// Ensures that initial notices are only displayed 2 seconds after the view is ready
+    /// Ensures that initial notices are only displayed after the view is ready
     /// to avoid overwhelming users with too many information at once when opening the screen.
     func observeViewStates() {
         $state
@@ -557,7 +561,7 @@ private extension WooShippingCreateLabelsViewModel {
             .map { state, shipments, selectedIndex in
                 state == .ready && shipments[selectedIndex].isPurchased == false
             }
-            .delay(for: .seconds(2), scheduler: RunLoop.current)
+            .delay(for: noticeDelay, scheduler: RunLoop.current)
             .assign(to: &$shouldShowNotices)
 
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -245,6 +245,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
 
         updateShipmentDetailsViewModels()
+        observeDestinationAddress()
         observeViewStates()
 
         Task { @MainActor in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -564,7 +564,6 @@ private extension WooShippingCreateLabelsViewModel {
                 shipments[selectedIndex].isPurchased == false
             }
             .assign(to: &$shouldShowNotices)
-
     }
 
     /// Gets the destination address as a `ShippingLabelAddress`.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -60,7 +60,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     @Published private(set) var state = ContentState.loading
 
-    @Published private(set) var shouldShowInitialNotices = false
+    @Published private(set) var shouldShowNotices = false
 
     /// View model for split shipments.
     private(set) var splitShipmentsViewModel: WooShippingSplitShipmentsViewModel
@@ -539,7 +539,7 @@ private extension WooShippingCreateLabelsViewModel {
             .assign(to: &$destinationAddressStatusNoticeLabel)
 
         /// Clear the notice after a delay when the address is verified.
-        $shouldShowInitialNotices
+        $shouldShowNotices
             .combineLatest($destinationAddressStatusNoticeLabel)
             .filter { shouldShowNotices, destinationNotice in
                 shouldShowNotices && destinationNotice == Localization.DestinationAddressStatus.verified
@@ -558,7 +558,7 @@ private extension WooShippingCreateLabelsViewModel {
                 state == .ready && shipments[selectedIndex].isPurchased == false
             }
             .delay(for: .seconds(2), scheduler: RunLoop.current)
-            .assign(to: &$shouldShowInitialNotices)
+            .assign(to: &$shouldShowNotices)
 
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -519,6 +519,63 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.addressToEdit)
     }
 
+    func test_shouldShowNotices_is_updated_correctly_for_unfulfilled_shipment() {
+        // Given
+        let order = Order.fake().copy(shippingAddress: nil)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .verifyDestinationAddress(_, _, let completion):
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
+                                                                               isTrivialNormalization: nil,
+                                                                               isVerified: true)))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadOriginAddresses(_, let completion):
+                let originAddress = WooShippingOriginAddress.fake().copy(address1: "123 Main Street", defaultAddress: true)
+                completion(.success([originAddress]))
+            case .loadConfig(_, _, let completion):
+                // There exist 2 shipments, one of which has been fulfilled.
+                let shippingLabel = ShippingLabel.fake().copy(shippingLabelID: 134)
+                let shipments = ["shipment_0": [WooShippingShipmentItem.fake()],
+                                 "shipment_1": [WooShippingShipmentItem.fake()]]
+                let shippingLabelData = WooShippingLabelData(currentOrderLabels: [
+                    ShippingLabelPurchase.fake().copy(shippingLabelID: shippingLabel.shippingLabelID,
+                                                      shipmentID: "shipment_0")
+                ])
+                completion(.success(WooShippingConfig.fake().copy(shipments: shipments,
+                                                                  shippingLabelData: shippingLabelData)))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores, noticeDelay: .seconds(0))
+        XCTAssertFalse(viewModel.shouldShowNotices)
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then: first shipment is fulfilled
+        XCTAssertFalse(viewModel.shouldShowNotices)
+
+        // When: switching to unfulfilled shipment
+        viewModel.selectedShipmentIndex = 1
+
+        // Then
+        waitUntil {
+            viewModel.shouldShowNotices == true
+        }
+        XCTAssertNotNil(viewModel.destinationAddressStatusNoticeLabel)
+
+        /// The notice should be dismissed after a bit
+        waitUntil {
+            viewModel.destinationAddressStatusNoticeLabel == nil
+        }
+    }
+
     func test_hazmatNotice_is_updated_after_setting_new_hazmat_category() {
         // Given
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -551,7 +551,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores, noticeDelay: .seconds(0))
+        let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores, initialNoticeDelay: .seconds(0))
         XCTAssertFalse(viewModel.shouldShowNotices)
 
         waitUntil {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-441
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The current logic for showing notices has some issues:
- Verified destination address notice is displayed even for purchased labels. This is unnecessary.
- The same notice is not displayed when opening the creation form with no purchased label.

This PR fixes the above logic by:
- Removing the manual state `isReadyToShowErrorNotice`.
- Add a new property `shouldShowNotices` to ensure that notices are only available for unfulfilled shipments and are displayed a few seconds after the view is ready.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the WooShipping plugin set up.
2. Navigate to the Orders tab and open a completed order with several physical products.
3. Select Create Shipping Label and select the bottom sheet to update the destination address to be verified.
4. Navigate back, then tap Create shipping label again. Confirm that a notice for the verified destination address is displayed briefly after the loading state.
5. Select Split shipments > move items to 2 shipments > tap Done.
6. Proceed to purchase the first shipment, then navigate back to the Order details.
7. Select Create shipping label again. Confirm that the verified destination address notice is not displayed for the purchased label.
8. Switch to the tab of the unfulfilled shipment. Confirm that the verified destination address notice is displayed briefly.
9. Navigate back to the order details screen and repeat steps 7 & 8 from the entry point of the purchased label. Confirm the same behavior of the notice.

Optionally: test and confirm that the unverified origin address & missing ITN field in customs form notices are still displayed correctly for unfulfilled shipments.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Tested and confirmed the above tests using simulator iPhone 16 Pro iOS 18.2.
- Added unit test to confirm the logic for `shouldShowNotices`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/bf81ba1c-8b46-468c-8612-15ba4dce2be3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
