### PR TITLE
[Woo POS] Fix non-English characters rendering in coupon error messages

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -124,6 +124,7 @@ private extension String {
     }
 }
 
+#if DEBUG
 #Preview {
     if #available(iOS 17.0, *) {
         PointOfSaleOrderSyncCouponsErrorMessageView(message: "An error happened!") {}
@@ -137,3 +138,4 @@ private extension String {
             .environment(POSPreviewHelpers.makePreviewAggregateModel())
     }
 }
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -134,7 +134,7 @@ private extension String {
 
 #Preview {
     if #available(iOS 17.0, *) {
-        PointOfSaleOrderSyncCouponsErrorMessageView(message: "Lo siento, este cupón no se puede aplicar a los productos seleccionados.") {}
+        PointOfSaleOrderSyncCouponsErrorMessageView(message: "Lo sentimos, este cupón no se puede aplicar a los productos seleccionados.") {}
             .environment(POSPreviewHelpers.makePreviewAggregateModel())
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -105,18 +105,15 @@ private extension PointOfSaleOrderSyncCouponsErrorMessageView {
     }
 }
 
-#Preview {
-    if #available(iOS 17.0, *) {
-        PointOfSaleOrderSyncCouponsErrorMessageView(message: "An error happened!") {}
-    }
-}
-
 private extension String {
     var attributedHTMLString: AttributedString {
         if let data = self.data(using: .utf8),
            let nsAttributedString = try? NSAttributedString(
                data: data,
-               options: [.documentType: NSAttributedString.DocumentType.html],
+               options: [
+                   .documentType: NSAttributedString.DocumentType.html,
+                   .characterEncoding: String.Encoding.utf8.rawValue
+               ],
                documentAttributes: nil) {
             var attributedString = AttributedString(nsAttributedString)
             attributedString.font = POSFontStyle.posBodyLargeRegular().font()
@@ -124,5 +121,19 @@ private extension String {
             return attributedString
         }
         return AttributedString(self)
+    }
+}
+
+#Preview {
+    if #available(iOS 17.0, *) {
+        PointOfSaleOrderSyncCouponsErrorMessageView(message: "An error happened!") {}
+            .environment(POSPreviewHelpers.makePreviewAggregateModel())
+    }
+}
+
+#Preview {
+    if #available(iOS 17.0, *) {
+        PointOfSaleOrderSyncCouponsErrorMessageView(message: "Lo siento, este cupón no se puede aplicar a los productos seleccionados.") {}
+            .environment(POSPreviewHelpers.makePreviewAggregateModel())
     }
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -220,7 +220,7 @@ struct POSPreviewHelpers {
             orderController: orderController,
             collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
             searchHistoryService: searchHistoryService,
-            popularItemsController: popularItemsController as! PointOfSalePopularItemsController
+            popularItemsController: popularItemsController
         )
     }
 }


### PR DESCRIPTION
## Description

HTML coupon error messages containing non-English characters weren't displaying correctly. Character encoding was added to properly render special characters in coupon error messages, and a Spanish preview was added for testing.

## Steps to reproduce

1. Change WordPress site language to Spanish
2. Open POS
3. Add Invalid Coupon
4. Checkout
5. Confirm non-English characters appear correctly

or

test in previews

## Testing information

Tested on iPad Air 11 inch M2 iOS 18.4

## Screenshots

![image](https://github.com/user-attachments/assets/169a7eb9-f14c-4bef-9f61-209983e3849c)

### Before
Special characters like accented vowels in non-English error messages would display incorrectly.

### After
Error messages with special characters are now correctly displayed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.