### PR TITLE
Shipping Labels: Fix issue marking order as complete after purchasing label

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
@@ -25,6 +25,10 @@ extension ShippingLabelAddress {
     var formattedPostalAddress: String? {
         return postalAddress.formatted(as: .mailingAddress)
     }
+
+    var formattedInlineAddress: String? {
+        formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ")
+    }
 }
 
 private extension ShippingLabelAddress {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -2043,6 +2043,7 @@ extension OrderDetailsDataSource {
         case collectPayment
         case reprintShippingLabel(shippingLabel: ShippingLabel)
         case createShippingLabel
+        case openShippingLabelForm(shippingLabel: ShippingLabel)
         case shippingLabelTrackingMenu(shippingLabel: ShippingLabel, sourceView: UIView)
         case viewAddOns(addOns: [OrderItemProductAddOn])
         case editCustomerNote

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -507,9 +507,7 @@ extension OrderDetailsViewModel {
                 return
             }
             if dataSource.isEligibleForWooShipping {
-                let viewModel = WooShippingCreateLabelsViewModel(order: order, selectedShippingLabel: shippingLabel)
-                let shippingLabelDetailsViewController = WooShippingCreateLabelsViewHostingController(viewModel: viewModel)
-                viewController.present(shippingLabelDetailsViewController, animated: true)
+                onCellAction?(.openShippingLabelForm(shippingLabel: shippingLabel), indexPath)
             } else {
                 let shippingLabelDetailsViewController = ShippingLabelDetailsViewController(shippingLabel: shippingLabel)
                 viewController.show(shippingLabelDetailsViewController, sender: viewController)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -413,6 +413,8 @@ private extension OrderDetailsViewController {
             present(printNavigationController, animated: true)
         case .createShippingLabel:
             navigateToCreateShippingLabelForm()
+        case .openShippingLabelForm(let shippingLabel):
+            navigateToCreateShippingLabelForm(shippingLabel: shippingLabel)
         case .shippingLabelTrackingMenu(let shippingLabel, let sourceView):
             shippingLabelTrackingMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)
         case let .viewAddOns(addOns):
@@ -426,7 +428,7 @@ private extension OrderDetailsViewController {
         }
     }
 
-    func navigateToCreateShippingLabelForm() {
+    func navigateToCreateShippingLabelForm(shippingLabel: ShippingLabel? = nil) {
         guard viewModel.dataSource.isEligibleForWooShipping else {
             // Navigate to legacy shipping label creation form if Woo Shipping extension is not supported.
             let shippingLabelFormVC = ShippingLabelFormViewController(order: viewModel.order)
@@ -455,7 +457,9 @@ private extension OrderDetailsViewController {
             return
         }
 
-        let shippingLabelCreationVM = WooShippingCreateLabelsViewModel(order: viewModel.order, onLabelPurchase: { [weak self] markOrderComplete in
+        let shippingLabelCreationVM = WooShippingCreateLabelsViewModel(order: viewModel.order,
+                                                                       selectedShippingLabel: shippingLabel,
+                                                                       onLabelPurchase: { [weak self] markOrderComplete in
             if markOrderComplete {
                 self?.markOrderCompleteFromShippingLabels()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -211,7 +211,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
         } else {
             destinationAddress = getDestinationAddress(order: order, address: order.shippingAddress)
-            verifyDestinationAddress()
+            loadDestinationAddress()
         }
 
         updateShipmentDetailsViewModels()
@@ -406,7 +406,7 @@ private extension WooShippingCreateLabelsViewModel {
 
     /// Loads destination address of the order from remote.
     ///
-    func verifyDestinationAddress() {
+    func loadDestinationAddress() {
         let action = WooShippingAction.verifyDestinationAddress(siteID: order.siteID,
                                                                 orderID: order.orderID) { [weak self] result in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -178,9 +178,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
-    /// Initialize the view model without an existing shipping label.
+    /// Initialize the view model with or without an existing shipping label.
     init(order: Order,
-         selectedOriginAddress: WooShippingOriginAddress? = nil,
          selectedShippingLabel: ShippingLabel? = nil,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
@@ -212,8 +211,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
         } else {
             destinationAddress = getDestinationAddress(order: order, address: order.shippingAddress)
-            self.selectedOriginAddress = selectedOriginAddress
-            loadDestinationAddress()
+            verifyDestinationAddress()
         }
 
         updateShipmentDetailsViewModels()
@@ -408,7 +406,7 @@ private extension WooShippingCreateLabelsViewModel {
 
     /// Loads destination address of the order from remote.
     ///
-    func loadDestinationAddress() {
+    func verifyDestinationAddress() {
         let action = WooShippingAction.verifyDestinationAddress(siteID: order.siteID,
                                                                 orderID: order.orderID) { [weak self] result in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -181,6 +181,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Initialize the view model without an existing shipping label.
     init(order: Order,
          selectedOriginAddress: WooShippingOriginAddress? = nil,
+         selectedShippingLabel: ShippingLabel? = nil,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          stores: StoresManager = ServiceLocator.stores,
@@ -188,8 +189,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
         self.shippingLabels = order.shippingLabels
-        let itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
-        self.itemsDataSource = itemsDataSource
+        self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.onLabelPurchase = onLabelPurchase
         self.currencySettings = currencySettings
@@ -206,50 +206,18 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.splitShipmentsViewModel = splitShipmentsViewModel
         self.shipments = splitShipmentsViewModel.shipments
 
-        destinationAddress = getDestinationAddress(order: order, address: order.shippingAddress)
-        self.selectedOriginAddress = selectedOriginAddress
-
-        updateShipmentDetailsViewModels()
-        loadDestinationAddress()
-        observeSelectedOriginAddress()
-        observeDestinationAddress()
-        observeViewStates()
-
-        Task {
-            await loadRequiredData()
+        if let selectedShippingLabel {
+            destinationAddressStatus = .verified
+            destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
+            originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
+        } else {
+            destinationAddress = getDestinationAddress(order: order, address: order.shippingAddress)
+            self.selectedOriginAddress = selectedOriginAddress
+            loadDestinationAddress()
         }
-    }
-
-    /// Initialize the view model from an existing shipping label.
-    init(order: Order,
-         selectedShippingLabel: ShippingLabel,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
-         stores: StoresManager = ServiceLocator.stores,
-         initialNoticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2)) {
-        self.order = order
-        self.shippingSettingsService = shippingSettingsService
-        self.shippingLabels = order.shippingLabels
-        self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
-        self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
-        self.currencySettings = currencySettings
-        self.shippingLines = order.shippingLines.map({ WooShipping_ShippingLineViewModel(shippingLine: $0, currency: order.currency) })
-        self.originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
-        self.destinationAddressStatus = .verified
-        self.onLabelPurchase = nil
-        self.stores = stores
-        self.initialNoticeDelay = initialNoticeDelay
-
-        let splitShipmentsViewModel = WooShippingSplitShipmentsViewModel(order: order,
-                                                                         config: nil,
-                                                                         items: itemsDataSource.items,
-                                                                         stores: stores)
-        self.splitShipmentsViewModel = splitShipmentsViewModel
-        self.shipments = splitShipmentsViewModel.shipments
-
-        destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
 
         updateShipmentDetailsViewModels()
+        observeSelectedOriginAddress()
         observeDestinationAddress()
         observeViewStates()
 
@@ -258,7 +226,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
             // After shipment configs are updated, shipments are updated with purchased label details
             // Update the selected tab now by comparing the purchased labels with the initial selected label.
-            if let matchingIndex = shipments.firstIndex(where: { $0.purchasedLabelID == selectedShippingLabel.shippingLabelID }) {
+            if let selectedShippingLabel,
+                let matchingIndex = shipments.firstIndex(where: { $0.purchasedLabelID == selectedShippingLabel.shippingLabelID }) {
                 selectedShipmentIndex = matchingIndex
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -208,7 +208,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         if let selectedShippingLabel {
             destinationAddressStatus = .verified
             destinationAddress = selectedShippingLabel.destinationAddress.toWooShippingAddress()
-            originAddress = selectedShippingLabel.originAddress.formattedPostalAddress?.replacingOccurrences(of: "\n", with: ", ") ?? ""
+            originAddress = selectedShippingLabel.originAddress.formattedInlineAddress ?? ""
         } else {
             destinationAddress = getDestinationAddress(order: order, address: order.shippingAddress)
             loadDestinationAddress()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-444
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Problem
When the user navigates to the shipping label creation form from a purchased label on the order details screen, there's an issue with marking the order as complete when enabling the option upon purchasing a label.

### Cause
We're using a different initializer to open the form with an existing shipping label. This version doesn't accept a closure to mark the order as complete. This initializer was created when we didn't support multiple shipments and expected the read-only version of the form.

### Solution
This PR fixes the issue by unifying the initializer of `WooShippingCreateLabelsViewModel` to avoid missing logic when maintaining two versions.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Marking the order as complete when purchasing a label
1. Log in to a test store with the WooShipping plugin set up.
2. Navigate to the Orders tab and open a paid order with several physical products. Mark the order as Processing.
3. Select Create shipping label > Split shipments > move items to 2 shipments > tap Done.
4. Proceed to purchase the first shipment.
5. Navigate back to the order and select View purchased shipping label.
6. Proceed to purchase the second shipment while enabling the checkbox to mark the order as complete.
7. Navigate to the Order details screen and confirm that the order status is now Completed.

### Regression check
Test the origin and destination addresses displayed for fulfilled and unfulfilled shipments when navigating from the Create shipping label to confirm that no regression was created.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed the above test cases on simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4fb407b2-fc25-4256-90d2-380ab278f926



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
