### PR TITLE
[WatchdogTermination] Make `currentController` weak

### DIFF
--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -55,7 +55,7 @@ extension WooNavigationController {
 private class WooNavigationControllerDelegate: NSObject, UINavigationControllerDelegate {
 
     private let connectivityObserver: ConnectivityObserver
-    private var currentController: UIViewController?
+    private weak var currentController: UIViewController?
     private var subscriptions: Set<AnyCancellable> = []
 
     init(connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver) {


### PR DESCRIPTION
Part of: WOOMOB-420
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description

This PR addresses an action point identified in pe5sF9-4h9-p2.
- Makes `currentController` in `WooNavigationControllerDelegate` `weak` to avoid holding a view controller instance after popping.

## Steps to reproduce

- Run `trunk` from Xcode
- Open the "Products" tab on your testing store
- Select any product
- Make sure the product details screen is opened and pop back to products list screen
- Open "Memory graph" view in Xcode and filter results by `ProductFormViewController<ProductFormViewModel>`
- There will be a `ProductFormViewController` held in memory despite the fact that the VC is closed.

## Testing information

- Repeat testing steps after running from the current branch with the fix.
- Make sure the `ProductFormViewController` is no longer present in memory graph entries.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.