### PR TITLE
Shipping Labels: Add new view for requesting refund

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
@@ -178,3 +178,11 @@ enum ShippingLabelDecodingError: Error {
     case missingSiteID
     case missingOrderID
 }
+
+public extension ShippingLabel {
+    /// Following logic in the plugin
+    /// https://github.com/woocommerce/woocommerce-shipping/blob/0f67a1eb349cbe90ce471d88c7b31bd4950d6744/client/utils/label/refund.ts#L5
+    var refundDuration: Int {
+        carrierID == "dhlexpress" ? 31 : 14
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -23,7 +23,7 @@ struct WooShippingRefundView: View {
                 .bold()
                 .padding(.vertical, Layout.titleExtraPadding)
 
-            Text(Localization.description)
+            Text(String.localizedStringWithFormat(Localization.description, viewModel.refundDuration))
 
             Text(Localization.purchaseDate).bold() +
             Text(" ") +
@@ -69,8 +69,9 @@ private extension WooShippingRefundView {
             "wooShippingRefundView.description",
             value: "Request a refund for your unused shipping label. " +
             "The refund process for the shipping label will begin immediately and " +
-            "is typically completed within 14 business days.",
-            comment: "Description on the Request shipping label refund view"
+            "is typically completed within %1$d business days.",
+            comment: "Description on the Request shipping label refund view. " +
+            "The placeholder is the number of day to process the refund."
         )
         static let purchaseDate = NSLocalizedString(
             "wooShippingRefundView.purchaseDate",
@@ -102,5 +103,7 @@ private extension WooShippingRefundView {
 }
 
 #Preview {
-    WooShippingRefundView(viewModel: .init(refundableAmount: 11.33, purchaseDate: Date()))
+    WooShippingRefundView(viewModel: .init(refundableAmount: 11.33,
+                                           refundDuration: 14,
+                                           purchaseDate: Date()))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct WooShippingRefundView: View {
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Text("")
+            }
+        }
+    }
+}
+
+private extension WooShippingRefundView {
+    enum Localization {
+        static let description = NSLocalizedString(
+            "wooShippingRefundView.description",
+            value: "Request a refund for your unused shipping label. " +
+            "The refund process for the shipping label will begin immediately and " +
+            "is typically completed within 14 business days.",
+            comment: "Description on the Request shipping label refund view"
+        )
+        static let purchaseDate = NSLocalizedString(
+            "wooShippingRefundView.purchaseDate",
+            value: "Purchase date: %1$@",
+            comment: "Purchase date label on the Request shipping label refund view. " +
+            "The placeholder is the date of the purchase. Reads as: 'Purchase date: Feb 19, 2025'"
+        )
+        static let refundAmount = NSLocalizedString(
+            "wooShippingRefundView.refundAmount",
+            value: "Amount eligible for refund: %1$@",
+            comment: "Refund amount label on the Request shipping label refund view. " +
+            "The placeholder is the amount to be refunded. Reads as: 'Amount eligible for refund: $11.33'"
+        )
+        static let note = NSLocalizedString(
+            "wooShippingRefundView.note",
+            value: "Please note that this refund request applies only to the unused " +
+            "shipping label and will not affect the order itself.",
+            comment: "Note on the Request shipping label refund view"
+        )
+    }
+}
+
+#Preview {
+    WooShippingRefundView()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -1,13 +1,17 @@
 import SwiftUI
 
+/// View for requesting refund for a shipping label.
+///
 struct WooShippingRefundView: View {
+    @Environment(\.dismiss) var dismiss
+
     let viewModel: WooShippingRefundViewModel
 
     var body: some View {
-        ScrollableVStack(alignment: .leading, spacing: 8) {
+        ScrollableVStack(alignment: .leading, spacing: Layout.contentSpacing) {
             HStack {
                 Button(Localization.cancelButton) {
-                    // TODO
+                    dismiss()
                 }
                 Spacer()
             }
@@ -15,7 +19,7 @@ struct WooShippingRefundView: View {
             Text(Localization.title)
                 .font(.title2)
                 .bold()
-                .padding(.vertical, 16)
+                .padding(.vertical, Layout.titleExtraPadding)
 
             Text(Localization.description)
 
@@ -46,6 +50,11 @@ struct WooShippingRefundView: View {
 }
 
 private extension WooShippingRefundView {
+    enum Layout {
+        static let contentSpacing = CGFloat(8)
+        static let titleExtraPadding = CGFloat(16)
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "wooShippingRefundView.title",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -35,6 +35,7 @@ struct WooShippingRefundView: View {
                 .italic()
             Spacer()
         }
+        .font(.subheadline)
         .multilineTextAlignment(.leading)
         .safeAreaInset(edge: .bottom) {
             VStack {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -8,7 +8,9 @@ struct WooShippingRefundView: View {
     let viewModel: WooShippingRefundViewModel
 
     var body: some View {
-        ScrollableVStack(alignment: .leading, spacing: Layout.contentSpacing) {
+        ScrollableVStack(alignment: .leading,
+                         padding: Layout.contentPadding,
+                         spacing: Layout.contentSpacing) {
             HStack {
                 Button(Localization.cancelButton) {
                     dismiss()
@@ -54,6 +56,7 @@ private extension WooShippingRefundView {
     enum Layout {
         static let contentSpacing = CGFloat(8)
         static let titleExtraPadding = CGFloat(16)
+        static let contentPadding = CGFloat(16)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -1,17 +1,57 @@
 import SwiftUI
 
 struct WooShippingRefundView: View {
+    let viewModel: WooShippingRefundViewModel
+
     var body: some View {
-        NavigationStack {
-            VStack {
-                Text("")
+        ScrollableVStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Button(Localization.cancelButton) {
+                    // TODO
+                }
+                Spacer()
             }
+
+            Text(Localization.title)
+                .font(.title2)
+                .bold()
+                .padding(.vertical, 16)
+
+            Text(Localization.description)
+
+            Text(Localization.purchaseDate).bold() +
+            Text(" ") +
+            Text(viewModel.formattedPurchaseDate)
+
+            Text(Localization.refundAmount).bold() +
+            Text(" ") +
+            Text(viewModel.formattedRefundAmount)
+
+            Text(Localization.note)
+                .italic()
+            Spacer()
+        }
+        .multilineTextAlignment(.leading)
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                Button(String.localizedStringWithFormat(Localization.submitButton, "-" + viewModel.formattedRefundAmount)) {
+                    viewModel.submitRefundRequest()
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: false))
+                .padding()
+            }
+            .background(Color(.systemBackground))
         }
     }
 }
 
 private extension WooShippingRefundView {
     enum Localization {
+        static let title = NSLocalizedString(
+            "wooShippingRefundView.title",
+            value: "Request a shipping label refund",
+            comment: "title on the Request shipping label refund view"
+        )
         static let description = NSLocalizedString(
             "wooShippingRefundView.description",
             value: "Request a refund for your unused shipping label. " +
@@ -21,15 +61,13 @@ private extension WooShippingRefundView {
         )
         static let purchaseDate = NSLocalizedString(
             "wooShippingRefundView.purchaseDate",
-            value: "Purchase date: %1$@",
-            comment: "Purchase date label on the Request shipping label refund view. " +
-            "The placeholder is the date of the purchase. Reads as: 'Purchase date: Feb 19, 2025'"
+            value: "Purchase date:",
+            comment: "Purchase date label on the Request shipping label refund view."
         )
         static let refundAmount = NSLocalizedString(
             "wooShippingRefundView.refundAmount",
-            value: "Amount eligible for refund: %1$@",
-            comment: "Refund amount label on the Request shipping label refund view. " +
-            "The placeholder is the amount to be refunded. Reads as: 'Amount eligible for refund: $11.33'"
+            value: "Amount eligible for refund:",
+            comment: "Refund amount label on the Request shipping label refund view."
         )
         static let note = NSLocalizedString(
             "wooShippingRefundView.note",
@@ -37,9 +75,19 @@ private extension WooShippingRefundView {
             "shipping label and will not affect the order itself.",
             comment: "Note on the Request shipping label refund view"
         )
+        static let cancelButton = NSLocalizedString(
+            "wooShippingRefundView.cancelButton",
+            value: "Cancel",
+            comment: "Button to dismiss the Request shipping label refund view"
+        )
+        static let submitButton = NSLocalizedString(
+            "wooShippingRefundView.submitButton",
+            value: "Refund Label (%1$@)",
+            comment: "Button to submit refund request the Request shipping label refund view"
+        )
     }
 }
 
 #Preview {
-    WooShippingRefundView()
+    WooShippingRefundView(viewModel: .init(refundableAmount: 11.33, purchaseDate: Date()))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
@@ -7,14 +7,17 @@ import WooFoundation
 final class WooShippingRefundViewModel {
     private let stores: StoresManager
 
-    private(set) var formattedPurchaseDate: String
-    private(set) var formattedRefundAmount: String
+    let formattedPurchaseDate: String
+    let formattedRefundAmount: String
+    let refundDuration: Int
 
     init(refundableAmount: Double,
+         refundDuration: Int,
          purchaseDate: Date,
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.stores = stores
+        self.refundDuration = refundDuration
 
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         formattedRefundAmount = currencyFormatter.formatAmount(refundableAmount.description) ?? refundableAmount.description

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Yosemite
+import WooFoundation
+
+/// View model for `WooShippingRefundView`
+///
+final class WooShippingRefundViewModel {
+    private let stores: StoresManager
+
+    private(set) var formattedPurchaseDate: String
+    private(set) var formattedRefundAmount: String
+
+    init(refundableAmount: Double,
+         purchaseDate: Date,
+         stores: StoresManager = ServiceLocator.stores,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        self.stores = stores
+
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        formattedRefundAmount = currencyFormatter.formatAmount(refundableAmount.description) ?? refundableAmount.description
+
+        formattedPurchaseDate = purchaseDate.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    func submitRefundRequest() {
+        // TODO: integrate refund API
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct WooShippingShipmentDetailsView: View {
     @ObservedObject private var viewModel: WooShippingShipmentDetailsViewModel
+    @State private var showingRefundRequest = false
 
     init(viewModel: WooShippingShipmentDetailsViewModel) {
         self.viewModel = viewModel
@@ -10,7 +11,9 @@ struct WooShippingShipmentDetailsView: View {
     var body: some View {
         VStack(spacing: Layout.verticalSpacing) {
             if viewModel.canViewLabel, let postPurchase = viewModel.postPurchase {
-                WooShippingPostPurchaseView(viewModel: postPurchase)
+                WooShippingPostPurchaseView(viewModel: postPurchase, onRefundRequest: {
+                    showingRefundRequest = true
+                })
             }
 
             WooShippingItems(itemsCountLabel: viewModel.itemsCountLabel,
@@ -35,6 +38,11 @@ struct WooShippingShipmentDetailsView: View {
                 WooShippingServiceView(viewModel: shippingService)
             } else {
                 WooShippingPackageAndRatePlaceholder(onSelectPackage: viewModel.selectPackage)
+            }
+        }
+        .sheet(isPresented: $showingRefundRequest) {
+            if let refundViewModel = viewModel.refundViewModel {
+                WooShippingRefundView(viewModel: refundViewModel)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -129,6 +129,14 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
                                     customsForm: customsForm)
     }
 
+    var refundViewModel: WooShippingRefundViewModel? {
+        guard let shippingLabel else {
+            return nil
+        }
+        return WooShippingRefundViewModel(refundableAmount: shippingLabel.refundableAmount,
+                                          purchaseDate: shippingLabel.dateCreated)
+    }
+
     private var debounceDuration: Double
 
     init(order: Order,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -134,6 +134,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
             return nil
         }
         return WooShippingRefundViewModel(refundableAmount: shippingLabel.refundableAmount,
+                                          refundDuration: shippingLabel.refundDuration,
                                           purchaseDate: shippingLabel.dateCreated)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct WooShippingPostPurchaseView: View {
     @ObservedObject private(set) var viewModel: WooShippingPostPurchaseViewModel
 
+    let onRefundRequest: () -> Void
+
     @State private var isPrintingLabel = false
     @State private var showingLabelPrintingError = false
 
@@ -105,7 +107,7 @@ struct WooShippingPostPurchaseView: View {
                         }
                     }
                     Button {
-                        // TODO: Request label refund
+                        onRefundRequest()
                     } label: {
                         Text(Localization.requestRefund)
                     }
@@ -263,7 +265,8 @@ private extension WooShippingPostPurchaseView {
                                                                             labelSizes: [.label, .legal, .a4],
                                                                             trackingURL: URL(string: "https://woocommerce.com"),
                                                                             pickupURL: WooShippingCarrier.usps.pickupURL,
-                                                                            commercialInvoiceURL: URL(string: "https://example.com")))
+                                                                            commercialInvoiceURL: URL(string: "https://example.com")),
+                                onRefundRequest: {})
         .padding()
 }
 
@@ -273,6 +276,7 @@ private extension WooShippingPostPurchaseView {
                                                                             labelSizes: [.label, .legal, .a4],
                                                                             trackingURL: nil,
                                                                             pickupURL: nil,
-                                                                            commercialInvoiceURL: nil))
+                                                                            commercialInvoiceURL: nil),
+                                onRefundRequest: {})
         .padding()
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2737,6 +2737,7 @@
 		DE653EAF2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */; };
 		DE65C1F72C48E7DC003EF8D1 /* SupportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE65C1F62C48E7DC003EF8D1 /* SupportButton.swift */; };
 		DE65C1F92C48E89C003EF8D1 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE65C1F82C48E89C003EF8D1 /* WebCheckoutViewModel.swift */; };
+		DE6627E42DCC503E0068E12E /* WooShippingRefundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6627E32DCC503E0068E12E /* WooShippingRefundView.swift */; };
 		DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
@@ -5997,6 +5998,7 @@
 		DE653EAE2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+TestOrder.swift"; sourceTree = "<group>"; };
 		DE65C1F62C48E7DC003EF8D1 /* SupportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportButton.swift; sourceTree = "<group>"; };
 		DE65C1F82C48E89C003EF8D1 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
+		DE6627E32DCC503E0068E12E /* WooShippingRefundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingRefundView.swift; sourceTree = "<group>"; };
 		DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordDisabledViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
@@ -12630,6 +12632,7 @@
 		CEAB739A2C81E3A000A7EB39 /* WooShipping Create Shipping Labels */ = {
 			isa = PBXGroup;
 			children = (
+				DE6627E22DCC50000068E12E /* Refund */,
 				DEDC5F5C2D9E7CB8005E38BD /* ShipmentDetails */,
 				EE7E75A62D83EAD200E6FF5B /* WooShipping Split Shipments */,
 				B90DD08C2D12FA6600EFC06A /* WooShipping Customs */,
@@ -13470,6 +13473,14 @@
 				95B6C60D2D9DA99200E1A661 /* WPComMagicLinkRequestViewModel.swift */,
 			);
 			path = WPComLogin;
+			sourceTree = "<group>";
+		};
+		DE6627E22DCC50000068E12E /* Refund */ = {
+			isa = PBXGroup;
+			children = (
+				DE6627E32DCC503E0068E12E /* WooShippingRefundView.swift */,
+			);
+			path = Refund;
 			sourceTree = "<group>";
 		};
 		DE68979D2A8F7C8C00154588 /* AccountSettings */ = {
@@ -16230,6 +16241,7 @@
 				456BEFB626D912EC002AC16C /* AuthenticatedWebView.swift in Sources */,
 				310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */,
 				AE1CC33829129A010021C8EF /* LinkBehavior.swift in Sources */,
+				DE6627E42DCC503E0068E12E /* WooShippingRefundView.swift in Sources */,
 				209CA0EE2B50070D0073D1AC /* WooTabContainerController.swift in Sources */,
 				26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */,
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2738,6 +2738,7 @@
 		DE65C1F72C48E7DC003EF8D1 /* SupportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE65C1F62C48E7DC003EF8D1 /* SupportButton.swift */; };
 		DE65C1F92C48E89C003EF8D1 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE65C1F82C48E89C003EF8D1 /* WebCheckoutViewModel.swift */; };
 		DE6627E42DCC503E0068E12E /* WooShippingRefundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6627E32DCC503E0068E12E /* WooShippingRefundView.swift */; };
+		DE6627E62DCC52230068E12E /* WooShippingRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6627E52DCC52180068E12E /* WooShippingRefundViewModel.swift */; };
 		DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
@@ -5999,6 +6000,7 @@
 		DE65C1F62C48E7DC003EF8D1 /* SupportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportButton.swift; sourceTree = "<group>"; };
 		DE65C1F82C48E89C003EF8D1 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
 		DE6627E32DCC503E0068E12E /* WooShippingRefundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingRefundView.swift; sourceTree = "<group>"; };
+		DE6627E52DCC52180068E12E /* WooShippingRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingRefundViewModel.swift; sourceTree = "<group>"; };
 		DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordDisabledViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
@@ -13479,6 +13481,7 @@
 			isa = PBXGroup;
 			children = (
 				DE6627E32DCC503E0068E12E /* WooShippingRefundView.swift */,
+				DE6627E52DCC52180068E12E /* WooShippingRefundViewModel.swift */,
 			);
 			path = Refund;
 			sourceTree = "<group>";
@@ -16092,6 +16095,7 @@
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
 				AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */,
 				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,
+				DE6627E62DCC52230068E12E /* WooShippingRefundViewModel.swift in Sources */,
 				45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */,
 				DEC51A9D274F8528009F3DF4 /* JCPJetpackInstallStepsViewModel.swift in Sources */,
 				455DC3A327393C7E00D4644C /* OrderDatesFilterViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-447
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new UI for requesting refund for shipping labels and navigation to the new screen.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a paid order with physical products.
3. Create a shipping label for the order if there isn't one yet.
4. Open the created shipping label and select Request refund.
5. Confirm that a new screen is displayed with refund details. The screen should match the design.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested the UI on Xcode preview for different screen sizes/text sizes/light and dark modes.
Tested the navigation on simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/361e6001-2c1d-48df-b3b3-93b95b7892bb" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
