### PR TITLE
Temporarily resolve missing order destination address update

### DIFF
--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -296,6 +296,7 @@ private extension WooShippingStore {
                                   address: WooShippingDestinationAddress,
                                   completion: @escaping (Result<WooShippingDestinationAddressUpdate, Error>) -> Void) {
         remote.updateDestinationAddress(siteID: siteID, orderID: orderID, address: address, completion: completion)
+        setLastModifiedDateForOrder(siteID: siteID, orderID: orderID)
     }
 
     func loadConfig(siteID: Int64,
@@ -527,6 +528,21 @@ private extension WooShippingStore {
         let predefinedPackage = storageSavedPackage.package ?? storage.insertNewObject(ofType: Storage.WooShippingPredefinedPackage.self)
         predefinedPackage.update(with: readOnlySavedPackage.package)
         storageSavedPackage.package = predefinedPackage
+    }
+
+    /// Updates order's `dateModified` locally
+    /// Used as temp workaround to reflect that the order instance was updated
+    private func setLastModifiedDateForOrder(siteID: Int64, orderID: Int64) {
+        storageManager.performAndSave({ derivedStorage in
+            guard let storedOrder = derivedStorage.loadOrder(
+                siteID: siteID,
+                orderID: orderID
+            ) else {
+                return
+            }
+
+            storedOrder.dateModified = Date()
+        }, completion: nil, on: .main)
     }
 }
 

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -295,8 +295,12 @@ private extension WooShippingStore {
                                   orderID: Int64,
                                   address: WooShippingDestinationAddress,
                                   completion: @escaping (Result<WooShippingDestinationAddressUpdate, Error>) -> Void) {
-        remote.updateDestinationAddress(siteID: siteID, orderID: orderID, address: address, completion: completion)
-        setLastModifiedDateForOrder(siteID: siteID, orderID: orderID)
+        remote.updateDestinationAddress(siteID: siteID, orderID: orderID, address: address) { [weak self] result in
+            completion(result)
+
+            guard let self, case .success = result else { return }
+            setLastModifiedDateForOrder(siteID: siteID, orderID: orderID)
+        }
     }
 
     func loadConfig(siteID: Int64,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-80

## Description

This temporary change is introduced to make sure the order on order details screen gets updated when a shipment destination address is changed.

## Steps to reproduce
- Build and run from `trunk`
- Log in to a test store with the WooShipping plugin set up.
- Navigate to the Orders tab and open a paid order with physical products.
- Select Create shipping label > Split shipments.
- Change a destination address of an unfulfilled shipment in the bottom sheet. Make sure it's verified and applied.
- Go back to the order details screen
- The "Shipping Details" cell will present old destination address.

## Test the fix
- Use the rogue build or build and run from branch
- Repeat steps from above
- After going back to the order details screen and a brief delay the shipping address should be updated and reflect the relevant one.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.