### PR TITLE
[Woo POS]Track time taken for search requests

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -99,7 +99,11 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
             .flatMap { Int($0.value) }
         let hasMorePages = totalPages.map { pageNumber < $0 } ?? true
 
-        return PagedItems(items: variations, hasMorePages: hasMorePages)
+        // Extract total count from X-WP-Total header
+        let totalItems = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalCount.lowercased() })
+            .flatMap { Int($0.value) }
+
+        return PagedItems(items: variations, hasMorePages: hasMorePages, totalItems: totalItems)
     }
 
     private func productVariationsRequest(for siteID: Int64,

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -294,7 +294,11 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             .flatMap { Int($0.value) }
         let hasMorePages = totalPages.map { pageNumber < $0 } ?? true
 
-        return .init(items: products, hasMorePages: hasMorePages)
+        // Extract total count from X-WP-Total header
+        let totalItems = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalCount.lowercased() })
+            .flatMap { Int($0.value) }
+
+        return .init(items: products, hasMorePages: hasMorePages, totalItems: totalItems)
     }
 
     /// Remote search of products for the Point of Sale. Simple and variable products are loaded for WC version 9.6+, otherwise only simple products are loaded.

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -346,12 +346,19 @@ private extension Remote {
 
 /// Contains the result of a paginated request.
 public struct PagedItems<T> {
+    /// Items fetched in this page
     public let items: [T]
+
+    /// Whether there are more pages after this one
     public let hasMorePages: Bool
 
-    public init(items: [T], hasMorePages: Bool) {
+    /// Number of items available, across all pages, whether loaded or not
+    public let totalItems: Int?
+
+    public init(items: [T], hasMorePages: Bool, totalItems: Int?) {
         self.items = items
         self.hasMorePages = hasMorePages
+        self.totalItems = totalItems
     }
 }
 
@@ -365,6 +372,7 @@ public extension Remote {
 
     enum PaginationHeaderKey {
         static let totalPagesCount = "x-wp-totalpages"
+        static let totalCount = "x-wp-total"
     }
 
     enum JSONParsingErrorUserInfoKey {

--- a/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -214,4 +214,47 @@ struct POSProductsNetworkingTests {
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: String])
         #expect(queryParametersDictionary["_fields"] == POSProduct.requestFields.joined(separator: ","))
     }
+
+    @Test func loadProductsForPointOfSale_returns_total_items_from_header() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        let expectedTotalItems = 25
+        network.responseHeaders = ["X-WP-Total": "\(expectedTotalItems)"]
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
+
+        // When
+        let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
+
+        // Then
+        #expect(pagedProducts.totalItems == expectedTotalItems)
+    }
+
+    @Test func searchProductsForPointOfSale_returns_total_items_from_header() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        let expectedTotalItems = 10
+        network.responseHeaders = ["X-WP-Total": "\(expectedTotalItems)"]
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        let pagedProducts = try await remote.searchProductsForPointOfSale(
+            for: sampleSiteID,
+            query: "photo")
+
+        // Then
+        #expect(pagedProducts.totalItems == expectedTotalItems)
+    }
+
+    @Test func loadProductsForPointOfSale_returns_nil_total_items_when_header_missing() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.responseHeaders = nil
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
+
+        // When
+        let pagedProducts = try await remote.loadProductsForPointOfSale(for: sampleSiteID)
+
+        // Then
+        #expect(pagedProducts.totalItems == nil)
+    }
 }

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -224,6 +224,33 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertEqual(firstVariation.menuOrder, 8)
     }
 
+    func test_loadVariationsForPointOfSale_returns_total_items_from_header() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let expectedTotalItems = 15
+        network.responseHeaders = ["X-WP-Total": "\(expectedTotalItems)"]
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+
+        // When
+        let pagedVariations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID)
+
+        // Then
+        XCTAssertEqual(pagedVariations.totalItems, expectedTotalItems)
+    }
+
+    func test_loadVariationsForPointOfSale_returns_nil_total_items_when_header_missing() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        network.responseHeaders = nil
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+
+        // When
+        let pagedVariations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID)
+
+        // Then
+        XCTAssertNil(pagedVariations.totalItems)
+    }
+
     func test_loadVariationsForPointOfSale_returns_page_details() async throws {
         // Given
         let remote = ProductVariationsRemote(network: network)

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -151,6 +151,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSalePreSearchRecentTermTapped,
             WooAnalyticsStat.pointOfSaleKeyboardDismissedInSearch,
             WooAnalyticsStat.pointOfSaleItemsNextPageLoaded,
+            WooAnalyticsStat.pointOfSaleSearchRemoteResultsFetched,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1311,6 +1311,7 @@ enum WooAnalyticsStat: String {
     case pointOfSalePreSearchRecentTermTapped = "pre_search_recent_term_tapped"
     case pointOfSaleKeyboardDismissedInSearch = "keyboard_dismissed_in_search"
     case pointOfSaleItemsNextPageLoaded = "items_next_page_loaded"
+    case pointOfSaleSearchRemoteResultsFetched = "search_remote_results_fetched"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/POS/Analytics/POSSearchAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSSearchAnalytics.swift
@@ -1,0 +1,34 @@
+import Foundation
+import WooFoundation
+import enum Yosemite.POSItemType
+
+/// Analytics tracking for Point of Sale search functionality
+struct POSSearchAnalytics {
+    /// The type of item being searched for
+    private let itemType: POSItemType
+    /// The analytics service to use for tracking
+    private let analytics: Analytics
+
+    /// Creates a new analytics tracker for the given item type
+    /// - Parameters:
+    ///   - itemType: The type of item being searched for (e.g. "product", "variation")
+    ///   - analytics: The analytics service to use for tracking. Defaults to ServiceLocator.analytics
+    init(itemType: POSItemType, analytics: Analytics = ServiceLocator.analytics) {
+        self.itemType = itemType
+        self.analytics = analytics
+    }
+
+    /// Tracks when a remote search results fetch completes
+    /// - Parameters:
+    ///   - milliseconds: The time taken to fetch results in milliseconds
+    ///   - totalItems: The total number of items found in the search
+    func trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
+        analytics.track(
+            event: .PointOfSale.pointOfSaleSearchRemoteResultsFetched(
+                itemType: itemType,
+                resultsCount: totalItems,
+                millisecondsSinceRequestSent: millisecondsSinceRequestSent
+            )
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Analytics/POSSearchAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSSearchAnalytics.swift
@@ -1,9 +1,10 @@
 import Foundation
 import WooFoundation
 import enum Yosemite.POSItemType
+import protocol Yosemite.POSSearchAnalyticsTracking
 
 /// Analytics tracking for Point of Sale search functionality
-struct POSSearchAnalytics {
+struct POSSearchAnalytics: POSSearchAnalyticsTracking {
     /// The type of item being searched for
     private let itemType: POSItemType
     /// The analytics service to use for tracking

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -23,6 +23,8 @@ extension WooAnalyticsEvent {
             static let waitingTime = "waiting_time"
             static let source = "source"
             static let search = "search"
+            static let resultsCount = "results_count"
+            static let millisecondsSinceRequestSent = "milliseconds_since_request_sent"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -94,6 +96,17 @@ extension WooAnalyticsEvent {
                                 Key.itemListType: itemType.analyticsValue,
                                 Key.search: searching
             ])
+        }
+
+        static func pointOfSaleSearchRemoteResultsFetched(itemType: POSItemType,
+                                                          resultsCount: Int,
+                                                          millisecondsSinceRequestSent: Int) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSaleSearchRemoteResultsFetched,
+                              properties: [
+                                Key.itemListType: itemType.analyticsValue,
+                                Key.resultsCount: "\(resultsCount)",
+                                Key.millisecondsSinceRequestSent: "\(millisecondsSinceRequestSent)"
+                              ])
         }
     }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -65,7 +65,8 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
 
     @MainActor
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async {
-        fetchStrategy = itemFetchStrategyFactory.searchStrategy(searchTerm: searchTerm)
+        fetchStrategy = itemFetchStrategyFactory.searchStrategy(searchTerm: searchTerm,
+                                                                analytics: POSSearchAnalytics(itemType: .product))
         setSearchingState(base: baseItem)
         await loadFirstPage(base: baseItem)
     }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -47,13 +47,13 @@ struct POSProductPreview: POSOrderableItem, Equatable {
 final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
     func providePointOfSaleItems(pageNumber: Int,
                                  fetchStrategy: PointOfSalePurchasableItemFetchStrategy) async throws -> PagedItems<POSItem> {
-        .init(items: [], hasMorePages: true)
+        .init(items: [], hasMorePages: true, totalItems: nil)
     }
 
     func providePointOfSaleVariationItems(for parentProduct: POSVariableParentProduct,
                                           pageNumber: Int,
                                           fetchStrategy: PointOfSalePurchasableItemFetchStrategy) async throws -> PagedItems<POSItem> {
-        .init(items: mockVariationItems, hasMorePages: true)
+        .init(items: mockVariationItems, hasMorePages: true, totalItems: nil)
     }
 
     func providePointOfSaleItems() -> [POSItem] {
@@ -71,11 +71,11 @@ final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
 
 struct PointOfSalePreviewPurchasableItemFetchStrategy: PointOfSalePurchasableItemFetchStrategy {
     func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
-        return .init(items: [], hasMorePages: true)
+        return .init(items: [], hasMorePages: true, totalItems: nil)
     }
 
     func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {
-        return .init(items: [], hasMorePages: true)
+        return .init(items: [], hasMorePages: true, totalItems: nil)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 		209AD3D22AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		209B7A682CEB6742003BDEF0 /* PointOfSalePaymentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B7A672CEB6742003BDEF0 /* PointOfSalePaymentState.swift */; };
+		209C60FD2DCCFC7100AB2D39 /* POSPreSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20050F182DC3E37400E12021 /* POSPreSearchView.swift */; };
 		209CA0EE2B50070D0073D1AC /* WooTabContainerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */; };
 		209E96BD2DB681B50089F3D2 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E96BC2DB681B50089F3D2 /* KeyboardObserver.swift */; };
 		209ECA812DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209ECA802DB8FC280089F3D2 /* PointOfSaleViewStateCoordinator.swift */; };
@@ -16432,6 +16433,7 @@
 				02C27BCE282CB52F0065471A /* CardPresentPaymentReceiptEmailCoordinator.swift in Sources */,
 				026826AA2BF59DF70036F959 /* CartView.swift in Sources */,
 				2647F7BA292BE2F900D59FDF /* AnalyticsReportCard.swift in Sources */,
+				209C60FD2DCCFC7100AB2D39 /* POSPreSearchView.swift in Sources */,
 				01BD774A2C58D29700147191 /* PointOfSaleCardPresentPaymentDisconnectedMessageView.swift in Sources */,
 				451526392577D89E0076B03C /* AddAttributeViewModel.swift in Sources */,
 				68709D3D2A2ED94900A7FA6C /* UpgradesView.swift in Sources */,
@@ -16554,7 +16556,6 @@
 				023453F22579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift in Sources */,
 				024DF31223742B18006658FE /* AztecItalicFormatBarCommand.swift in Sources */,
 				02AAD54525023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift in Sources */,
-				20050F192DC3E37400E12021 /* POSPreSearchView.swift in Sources */,
 				B9DC770329F18A8D0013B191 /* TopProductsFromCachedOrdersProvider.swift in Sources */,
 				86023FB12B199F6200A28F07 /* ThemesCarouselView.swift in Sources */,
 				EE19058C2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -802,7 +802,7 @@
 		2004E2E92C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E82C0DFE2B00D62521 /* PointOfSaleCardPresentPaymentAlert.swift */; };
 		2004E2EB2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2EA2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift */; };
 		2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */; };
-		20050F192DC3E37400E12021 /* POSPreSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20050F182DC3E37400E12021 /* POSPreSearchView.swift */; };
+		200559092DCCEEAB00E12021 /* POSSearchAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200559082DCCEEAB00E12021 /* POSSearchAnalytics.swift */; };
 		2005D3F32DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005D3F22DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift */; };
 		2005D7A72DC240CB00E12021 /* POSSearchTextFieldStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005D7A62DC240CB00E12021 /* POSSearchTextFieldStyle.swift */; };
 		2005FC9D2DC37E4D00E12021 /* POSPageHeaderBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005FC9C2DC37E4D00E12021 /* POSPageHeaderBackButton.swift */; };
@@ -4080,6 +4080,7 @@
 		2004E2EA2C0E219D00D62521 /* CardPresentPaymentPreflightAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentPreflightAdaptor.swift; sourceTree = "<group>"; };
 		2004E2EC2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift; sourceTree = "<group>"; };
 		20050F182DC3E37400E12021 /* POSPreSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPreSearchView.swift; sourceTree = "<group>"; };
+		200559082DCCEEAB00E12021 /* POSSearchAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchAnalytics.swift; sourceTree = "<group>"; };
 		2005D3F22DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListAnalyticsTracker.swift; sourceTree = "<group>"; };
 		2005D7A62DC240CB00E12021 /* POSSearchTextFieldStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchTextFieldStyle.swift; sourceTree = "<group>"; };
 		2005FC9C2DC37E4D00E12021 /* POSPageHeaderBackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPageHeaderBackButton.swift; sourceTree = "<group>"; };
@@ -7902,6 +7903,7 @@
 				68F68A4F2D6730DF00BB9568 /* POSCollectOrderPaymentAnalyticsTracking.swift */,
 				68F896412D5E4321000B308B /* POSCollectOrderPaymentAnalytics.swift */,
 				02D1D2D92CD3CD8D0069A93F /* WooAnalyticsEvent+PointOfSale.swift */,
+				200559082DCCEEAB00E12021 /* POSSearchAnalytics.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -16537,6 +16539,7 @@
 				45527A412472C6160078D609 /* SwitchStoreUseCase.swift in Sources */,
 				D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */,
 				E1308381270311E200D5A68D /* CardPresentModalUpdateFailedLowBattery.swift in Sources */,
+				200559092DCCEEAB00E12021 /* POSSearchAnalytics.swift in Sources */,
 				CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */,
 				7441E1D221503F77004E6ECE /* IntrinsicTableView.swift in Sources */,
 				EE505DDD2B3C2690006E3323 /* BlazeCreateCampaignIntroView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Notifications/MockPointOfSalePurchasableItemFetchStrategy.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/MockPointOfSalePurchasableItemFetchStrategy.swift
@@ -8,7 +8,7 @@ final class MockPointOfSalePurchasableItemFetchStrategy: PointOfSalePurchasableI
     func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         fetchProductsCalled = true
         spyFetchProductsPageNumber = 5
-        return .init(items: [], hasMorePages: false)
+        return .init(items: [], hasMorePages: false, totalItems: nil)
     }
 
     var fetchVariationsCalled = false
@@ -18,6 +18,6 @@ final class MockPointOfSalePurchasableItemFetchStrategy: PointOfSalePurchasableI
         fetchVariationsCalled = true
         spyFetchVariationsParentProductID = parentProductID
         spyFetchProductsPageNumber = pageNumber
-        return .init(items: [], hasMorePages: false)
+        return .init(items: [], hasMorePages: false, totalItems: nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -19,14 +19,14 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
             throw errorToThrow
         }
         if shouldReturnZeroItems {
-            return .init(items: [], hasMorePages: false)
+            return .init(items: [], hasMorePages: false, totalItems: 0)
         }
         if shouldSimulateTwoPages {
             return pageNumber > 1 ?
-                .init(items: MockPointOfSaleItemService.makeSecondPageItems(), hasMorePages: shouldSimulateMorePages):
-                .init(items: MockPointOfSaleItemService.makeInitialItems(), hasMorePages: shouldSimulateTwoPages)
+                .init(items: MockPointOfSaleItemService.makeSecondPageItems(), hasMorePages: shouldSimulateMorePages, totalItems: 4):
+                .init(items: MockPointOfSaleItemService.makeInitialItems(), hasMorePages: shouldSimulateTwoPages, totalItems: 4)
         }
-        return .init(items: (itemPages[safe: pageNumber - 1] ?? []), hasMorePages: itemPages.count > pageNumber)
+        return .init(items: (itemPages[safe: pageNumber - 1] ?? []), hasMorePages: itemPages.count > pageNumber, totalItems: 2)
     }
 
     var shouldSimulateTwoPagesOfVariations = false
@@ -41,10 +41,10 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
         }
         if shouldSimulateTwoPagesOfVariations,
            pageNumber > 1 {
-            return .init(items: MockPointOfSaleItemService.makeSecondPageVariationItems(), hasMorePages: shouldSimulateMorePagesOfVariations)
+            return .init(items: MockPointOfSaleItemService.makeSecondPageVariationItems(), hasMorePages: shouldSimulateMorePagesOfVariations, totalItems: 4)
         }
 
-        return .init(items: MockPointOfSaleItemService.makeInitialVariationItems(), hasMorePages: shouldSimulateTwoPagesOfVariations)
+        return .init(items: MockPointOfSaleItemService.makeInitialVariationItems(), hasMorePages: shouldSimulateTwoPagesOfVariations, totalItems: 2)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponService.swift
@@ -23,14 +23,14 @@ final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
             throw error
         }
         if shouldReturnZeroItems {
-            return .init(items: [], hasMorePages: false)
+            return .init(items: [], hasMorePages: false, totalItems: nil)
         }
         if shouldSimulateTwoPages {
             return pageNumber > 1 ?
-                .init(items: Self.makeSecondPageCoupons(), hasMorePages: shouldSimulateMorePages):
-                .init(items: Self.makeInitialCoupons(), hasMorePages: shouldSimulateTwoPages)
+                .init(items: Self.makeSecondPageCoupons(), hasMorePages: shouldSimulateMorePages, totalItems: nil):
+                .init(items: Self.makeInitialCoupons(), hasMorePages: shouldSimulateTwoPages, totalItems: nil)
         }
-        return .init(items: Self.makeInitialCoupons(), hasMorePages: false)
+        return .init(items: Self.makeInitialCoupons(), hasMorePages: false, totalItems: nil)
     }
 
     static func makeInitialCoupons() -> [POSItem] {

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -158,7 +158,7 @@
 		077F39E226A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */; };
 		077F39E526A5C98200ABEADC /* SystemStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
-		200525492DCBA0F500E12021 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200525482DCBA0F500E12021 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift */; };
+		2005590B2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005590A2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift */; };
 		204CBD2F2D43C516006FF89A /* PaymentsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CBD2E2D43C516006FF89A /* PaymentsError.swift */; };
 		206643572DAEABF7002D5191 /* POSSearchHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */; };
 		206643592DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */; };
@@ -725,7 +725,7 @@
 		077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStore.swift; sourceTree = "<group>"; };
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStoreTests.swift; sourceTree = "<group>"; };
-		200525482DCBA0F500E12021 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePopularPurchasableItemFetchStrategyTests.swift; sourceTree = "<group>"; };
+		2005590A2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchAnalyticsTracking.swift; sourceTree = "<group>"; };
 		204CBD2E2D43C516006FF89A /* PaymentsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsError.swift; sourceTree = "<group>"; };
 		206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryService.swift; sourceTree = "<group>"; };
 		206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryServiceTests.swift; sourceTree = "<group>"; };
@@ -1643,6 +1643,7 @@
 				0149547A2DBBA50A00C8870D /* Items */,
 				206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */,
 				2066435A2DAEAC76002D5191 /* POSItemType.swift */,
+				2005590A2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift */,
 			);
 			path = PointOfSale;
 			sourceTree = "<group>";
@@ -2713,6 +2714,7 @@
 				247CE8442582F3BB00F9D9D1 /* MockSettingActionHandler.swift in Sources */,
 				B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */,
 				5726456F250BD4E4005BBD7C /* OrdersUpsertUseCase.swift in Sources */,
+				2005590B2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift in Sources */,
 				DEB387822C2AB4370025256E /* GoogleAdsStore.swift in Sources */,
 				3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */,
 				02EF1668292DB68C00D90AD6 /* PaymentAction.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		077F39E526A5C98200ABEADC /* SystemStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		2005590B2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005590A2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift */; };
+		2005590D2DCCF7CF00E12021 /* PointOfSaleSearchPurchasableItemFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005590C2DCCF7CF00E12021 /* PointOfSaleSearchPurchasableItemFetchStrategyTests.swift */; };
 		204CBD2F2D43C516006FF89A /* PaymentsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CBD2E2D43C516006FF89A /* PaymentsError.swift */; };
 		206643572DAEABF7002D5191 /* POSSearchHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */; };
 		206643592DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */; };
@@ -726,6 +727,7 @@
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		077F39E426A5C98200ABEADC /* SystemStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStoreTests.swift; sourceTree = "<group>"; };
 		2005590A2DCCF15200E12021 /* POSSearchAnalyticsTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchAnalyticsTracking.swift; sourceTree = "<group>"; };
+		2005590C2DCCF7CF00E12021 /* PointOfSaleSearchPurchasableItemFetchStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleSearchPurchasableItemFetchStrategyTests.swift; sourceTree = "<group>"; };
 		204CBD2E2D43C516006FF89A /* PaymentsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsError.swift; sourceTree = "<group>"; };
 		206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryService.swift; sourceTree = "<group>"; };
 		206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryServiceTests.swift; sourceTree = "<group>"; };
@@ -1632,6 +1634,7 @@
 				687F83712C0EBF8900460AB3 /* PointOfSaleItemServiceTests.swift */,
 				200525482DCBA0F500E12021 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift */,
 				206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */,
+				2005590C2DCCF7CF00E12021 /* PointOfSaleSearchPurchasableItemFetchStrategyTests.swift */,
 			);
 			path = PointOfSale;
 			sourceTree = "<group>";
@@ -2872,6 +2875,7 @@
 				03EB99922907EBB300F06A39 /* JustInTimeMessageStoreTests.swift in Sources */,
 				026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */,
 				7492FAE1217FB87100ED2C69 /* SettingStoreTests.swift in Sources */,
+				2005590D2DCCF7CF00E12021 /* PointOfSaleSearchPurchasableItemFetchStrategyTests.swift in Sources */,
 				EE4D51B82ACD3C9800783D77 /* MockProductCategoriesRemote.swift in Sources */,
 				016EFCB02C41559D0016BDAA /* OrderItem+BasePriceTests.swift in Sources */,
 				45ED4F16239E939A004F1BE3 /* TaxStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
+++ b/Yosemite/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
@@ -29,7 +29,7 @@ public struct PointOfSaleDefaultCouponFetchStrategy: PointOfSaleCouponFetchStrat
         let hasMorePages = try await syncCouponsFromRemote(pageNumber: pageNumber)
         // Return all local coupons, including updated ones from the remote
         let coupons = await fetchLocalCoupons(limit: nil)
-        return .init(items: coupons, hasMorePages: hasMorePages)
+        return .init(items: coupons, hasMorePages: hasMorePages, totalItems: nil)
     }
 
     /// fetchLocalCoupons provides an array of coupons that are stored locally
@@ -93,7 +93,7 @@ public struct PointOfSaleSearchCouponFetchStrategy: PointOfSaleCouponFetchStrate
                                                    pageSize: PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize)
         let results = await getSearchResults()
         let hasMorePages = results.count == PointOfSaleDefaultCouponFetchStrategy.Constants.defaultPageSize * pageNumber
-        return PagedItems(items: results, hasMorePages: hasMorePages)
+        return PagedItems(items: results, hasMorePages: hasMorePages, totalItems: nil)
     }
 
     @MainActor

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
@@ -16,7 +16,8 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
     private let productsRemote: ProductsRemote
     private let variationsRemote: ProductVariationsRemote
 
-    public init(siteID: Int64, credentials: Credentials?) {
+    public init(siteID: Int64,
+                credentials: Credentials?) {
         self.siteID = siteID
         let network = AlamofireNetwork(credentials: credentials)
         self.productsRemote = ProductsRemote(network: network)
@@ -28,12 +29,13 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
                                                        productsRemote: productsRemote,
                                                        variationsRemote: variationsRemote)
     }
-
-    public func searchStrategy(searchTerm: String) -> PointOfSalePurchasableItemFetchStrategy {
+    public func searchStrategy(searchTerm: String,
+                               analytics: POSSearchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
         PointOfSaleSearchPurchasableItemFetchStrategy(siteID: siteID,
                                                       searchTerm: searchTerm,
                                                       productsRemote: productsRemote,
-                                                      variationsRemote: variationsRemote)
+                                                      variationsRemote: variationsRemote,
+                                                      analytics: analytics)
     }
 
     public func popularStrategy(pageSize: Int = 10) -> PointOfSalePurchasableItemFetchStrategy {

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
@@ -6,7 +6,8 @@ import class Networking.AlamofireNetwork
 public protocol PointOfSaleItemFetchStrategyFactoryProtocol {
     var defaultStrategy: PointOfSalePurchasableItemFetchStrategy { get }
 
-    func searchStrategy(searchTerm: String) -> PointOfSalePurchasableItemFetchStrategy
+    func searchStrategy(searchTerm: String,
+                        analytics: POSSearchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy
 
     func popularStrategy(pageSize: Int) -> PointOfSalePurchasableItemFetchStrategy
 }
@@ -57,7 +58,8 @@ public final class PointOfSaleFixedItemFetchStrategyFactory: PointOfSaleItemFetc
         fixedStrategy
     }
 
-    public func searchStrategy(searchTerm: String) -> PointOfSalePurchasableItemFetchStrategy {
+    public func searchStrategy(searchTerm: String,
+                               analytics: POSSearchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
         fixedStrategy
     }
 

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
@@ -31,10 +31,12 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             let products = pagedProducts.items
 
             if pageNumber != 1 && products.count == 0 {
-                return .init(items: [], hasMorePages: false)
+                return .init(items: [], hasMorePages: false, totalItems: 0)
             }
 
-            return .init(items: mapProductsToPOSItems(products: products), hasMorePages: pagedProducts.hasMorePages)
+            return .init(items: mapProductsToPOSItems(products: products),
+                         hasMorePages: pagedProducts.hasMorePages,
+                         totalItems: pagedProducts.totalItems)
         } catch AFError.explicitlyCancelled {
             throw PointOfSaleItemServiceError.requestCancelled
         }
@@ -66,7 +68,8 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                                          variationID: variation.productVariationID,
                                          parentProductName: parentProduct.name))
                 }),
-                hasMorePages: pagedVariations.hasMorePages
+                hasMorePages: pagedVariations.hasMorePages,
+                totalItems: pagedVariations.totalItems
             )
         } catch AFError.explicitlyCancelled {
             throw PointOfSaleItemServiceError.requestCancelled

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -44,20 +44,32 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
 
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
+    private let analytics: POSSearchAnalyticsTracking
 
-
-    init(siteID: Int64, searchTerm: String, productsRemote: ProductsRemoteProtocol, variationsRemote: ProductVariationsRemoteProtocol) {
+    init(siteID: Int64,
+         searchTerm: String,
+         productsRemote: ProductsRemoteProtocol,
+         variationsRemote: ProductVariationsRemoteProtocol,
+         analytics: POSSearchAnalyticsTracking) {
         self.siteID = siteID
         self.searchTerm = searchTerm
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
+        self.analytics = analytics
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
-        return try await productsRemote.searchProductsForPointOfSale(for: siteID,
-                                                                     query: searchTerm,
-                                                                     productTypes: productTypes,
-                                                                     pageNumber: pageNumber)
+        let startTime = Date()
+        let pagedProducts = try await productsRemote.searchProductsForPointOfSale(for: siteID,
+                                                                                  query: searchTerm,
+                                                                                  productTypes: productTypes,
+                                                                                  pageNumber: pageNumber)
+        if pageNumber == 1 {
+            let milliseconds = Int(Date().timeIntervalSince(startTime) * Double(MSEC_PER_SEC))
+            analytics.trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: milliseconds,
+                                                            totalItems: pagedProducts.totalItems ?? 0)
+        }
+        return pagedProducts
     }
 
     public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -102,7 +102,8 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
                                                                                        pageNumber: pageNumber,
                                                                                        perPage: pageSize)
         let modifiedItems = PagedItems<POSProduct>(items: receivedItems.items,
-                                                   hasMorePages: false)
+                                                   hasMorePages: false,
+                                                   totalItems: receivedItems.totalItems)
         return modifiedItems
     }
 

--- a/Yosemite/Yosemite/PointOfSale/POSSearchAnalyticsTracking.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSSearchAnalyticsTracking.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Protocol defining analytics tracking for Point of Sale search functionality
+public protocol POSSearchAnalyticsTracking {
+    /// Tracks when a remote search results fetch completes
+    /// - Parameters:
+    ///   - millisecondsSinceRequestSent: The time taken to fetch results in milliseconds
+    ///   - totalItems: The total number of items found in the search
+    func trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int)
+}

--- a/Yosemite/YosemiteTests/Mocks/MockPointOfSalePurchasableItemFetchStrategy.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockPointOfSalePurchasableItemFetchStrategy.swift
@@ -8,7 +8,7 @@ final class MockPointOfSalePurchasableItemFetchStrategy: PointOfSalePurchasableI
     func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         fetchProductsCalled = true
         spyFetchProductsPageNumber = pageNumber
-        return .init(items: [], hasMorePages: false)
+        return .init(items: [], hasMorePages: false, totalItems: nil)
     }
 
     var fetchVariationsCalled = false
@@ -18,6 +18,6 @@ final class MockPointOfSalePurchasableItemFetchStrategy: PointOfSalePurchasableI
         fetchVariationsCalled = true
         spyFetchVariationsParentProductID = parentProductID
         spyFetchVariationsPageNumber = pageNumber
-        return .init(items: [], hasMorePages: false)
+        return .init(items: [], hasMorePages: false, totalItems: nil)
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -107,7 +107,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
         }
         switch result {
         case let .success(variations):
-            return PagedItems(items: variations, hasMorePages: false)
+            return PagedItems(items: variations, hasMorePages: false, totalItems: 0)
         case let .failure(error):
             throw error
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -68,13 +68,13 @@ final class MockProductsRemote {
     private(set) var lastRequestedPageSize: Int?
 
     /// The results to return based on the given site ID in `loadProductsForPointOfSale`
-    private var posProductsResultsBySiteID = [Int64: Result<[POSProduct], Error>]()
+    private var posProductsResultsBySiteID = [Int64: Result<PagedItems<POSProduct>, Error>]()
 
     /// The results to return based on the given query in `searchProductsForPointOfSale`
-    private var posSearchResultsByQuery = [String: Result<[POSProduct], Error>]()
+    private var posSearchResultsByQuery = [String: Result<PagedItems<POSProduct>, Error>]()
 
     /// The results to return based on the given site ID in `loadPopularProductsForPointOfSale`
-    private var posPopularProductsResultsBySiteID = [Int64: Result<[POSProduct], Error>]()
+    private var posPopularProductsResultsBySiteID = [Int64: Result<PagedItems<POSProduct>, Error>]()
 
     /// Set the value passed to the `completion` block if `addProduct()` is called.
     ///
@@ -153,19 +153,19 @@ final class MockProductsRemote {
 
     /// Set the value passed to the `completion` block if `loadProductsForPointOfSale()` is called.
     ///
-    func whenLoadingProductsForPointOfSale(siteID: Int64, thenReturn result: Result<[POSProduct], Error>) {
+    func whenLoadingProductsForPointOfSale(siteID: Int64, thenReturn result: Result<PagedItems<POSProduct>, Error>) {
         posProductsResultsBySiteID[siteID] = result
     }
 
     /// Set the value passed to the `completion` block if `searchProductsForPointOfSale()` is called.
     ///
-    func whenSearchingProductsForPointOfSale(query: String, thenReturn result: Result<[POSProduct], Error>) {
+    func whenSearchingProductsForPointOfSale(query: String, thenReturn result: Result<PagedItems<POSProduct>, Error>) {
         posSearchResultsByQuery[query] = result
     }
 
     /// Set the value passed to the `completion` block if `loadPopularProductsForPointOfSale()` is called.
     ///
-    func whenLoadingPopularProductsForPointOfSale(siteID: Int64, thenReturn result: Result<[POSProduct], Error>) {
+    func whenLoadingPopularProductsForPointOfSale(siteID: Int64, thenReturn result: Result<PagedItems<POSProduct>, Error>) {
         posPopularProductsResultsBySiteID[siteID] = result
     }
 }
@@ -418,8 +418,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
             throw NetworkError.notFound()
         }
         switch result {
-        case let .success(products):
-            return PagedItems(items: products, hasMorePages: false)
+        case let .success(pagedProducts):
+            return pagedProducts
         case let .failure(error):
             throw error
         }
@@ -433,8 +433,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
             throw NetworkError.notFound()
         }
         switch result {
-        case let .success(products):
-            return PagedItems(items: products, hasMorePages: false)
+        case let .success(pagedProducts):
+            return pagedProducts
         case let .failure(error):
             throw error
         }
@@ -449,8 +449,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
             throw NetworkError.notFound()
         }
         switch result {
-        case let .success(products):
-            return PagedItems(items: products, hasMorePages: false)
+        case let .success(pagedProducts):
+            return pagedProducts
         case let .failure(error):
             throw error
         }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -62,7 +62,7 @@ struct PointOfSaleCouponServiceTests {
     @Test func providePointOfSaleCoupons_when_enabled_then_calls_strategy() async throws {
         // Given
         settingStoreMethods.couponsEnabled = true
-        let expectedCoupons = PagedItems(items: [POSItem.coupon(POSCoupon(id: UUID(), code: "test", summary: "test", dateExpires: nil))], hasMorePages: false)
+        let expectedCoupons = PagedItems(items: [POSItem.coupon(POSCoupon(id: UUID(), code: "test", summary: "test", dateExpires: nil))], hasMorePages: false, totalItems: nil)
         mockStrategy.fetchCouponsResult = expectedCoupons
 
         // When
@@ -122,7 +122,7 @@ private class MockPointOfSaleCouponFetchStrategy: PointOfSaleCouponFetchStrategy
         if let error = fetchCouponsError {
             throw error
         }
-        return fetchCouponsResult ?? .init(items: [], hasMorePages: false)
+        return fetchCouponsResult ?? .init(items: [], hasMorePages: false, totalItems: nil)
     }
 
     func fetchLocalCoupons() async throws -> [POSItem] {

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -62,7 +62,12 @@ struct PointOfSaleCouponServiceTests {
     @Test func providePointOfSaleCoupons_when_enabled_then_calls_strategy() async throws {
         // Given
         settingStoreMethods.couponsEnabled = true
-        let expectedCoupons = PagedItems(items: [POSItem.coupon(POSCoupon(id: UUID(), code: "test", summary: "test", dateExpires: nil))], hasMorePages: false, totalItems: nil)
+        let expectedCoupons = PagedItems(items: [POSItem.coupon(POSCoupon(id: UUID(),
+                                                                          code: "test",
+                                                                          summary: "test",
+                                                                          dateExpires: nil))],
+                                         hasMorePages: false,
+                                         totalItems: nil)
         mockStrategy.fetchCouponsResult = expectedCoupons
 
         // When

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleSearchPurchasableItemFetchStrategyTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleSearchPurchasableItemFetchStrategyTests.swift
@@ -1,15 +1,15 @@
-import XCTest
+import Testing
 import Networking
 @testable import Yosemite
 
-final class PointOfSaleSearchPurchasableItemFetchStrategyTests: XCTestCase {
+struct PointOfSaleSearchPurchasableItemFetchStrategyTests {
     private let siteID: Int64 = 123
     private let searchTerm = "test search"
     private let productsRemote = MockProductsRemote()
     private let variationsRemote = MockProductVariationsRemote()
     private let mockAnalytics = MockPOSSearchAnalyticsTracking()
 
-    func test_fetchProducts_tracks_analytics_for_first_page() async throws {
+    @Test func fetchProducts_tracks_analytics_for_first_page() async throws {
         // Given
         let strategy = PointOfSaleSearchPurchasableItemFetchStrategy(
             siteID: siteID,
@@ -19,17 +19,20 @@ final class PointOfSaleSearchPurchasableItemFetchStrategyTests: XCTestCase {
             analytics: mockAnalytics
         )
         let expectedTotalItems = 10
-        productsRemote.mockPagedProducts = .init(items: [], hasMorePages: true, totalItems: expectedTotalItems)
+        productsRemote.whenSearchingProductsForPointOfSale(query: searchTerm,
+                                                           thenReturn: .success(.init(items: [],
+                                                                                      hasMorePages: true,
+                                                                                      totalItems: expectedTotalItems)))
 
         // When
         _ = try await strategy.fetchProducts(pageNumber: 1)
 
         // Then
-        XCTAssertEqual(mockAnalytics.spyMillisecondsSinceRequestSent, 0) // We can't test exact timing
-        XCTAssertEqual(mockAnalytics.spyTotalItems, expectedTotalItems)
+        #expect(mockAnalytics.spyMillisecondsSinceRequestSent == 0) // We can't test exact timing
+        #expect(mockAnalytics.spyTotalItems == expectedTotalItems)
     }
 
-    func test_fetchProducts_does_not_track_analytics_for_subsequent_pages() async throws {
+    @Test func fetchProducts_does_not_track_analytics_for_subsequent_pages() async throws {
         // Given
         let strategy = PointOfSaleSearchPurchasableItemFetchStrategy(
             siteID: siteID,
@@ -38,38 +41,21 @@ final class PointOfSaleSearchPurchasableItemFetchStrategyTests: XCTestCase {
             variationsRemote: variationsRemote,
             analytics: mockAnalytics
         )
-        productsRemote.mockPagedProducts = .init(items: [], hasMorePages: true, totalItems: 10)
+        productsRemote.whenSearchingProductsForPointOfSale(query: searchTerm,
+                                                           thenReturn: .success(.init(items: [],
+                                                                                      hasMorePages: true,
+                                                                                      totalItems: 10)))
 
         // When
         _ = try await strategy.fetchProducts(pageNumber: 2)
 
         // Then
-        XCTAssertNil(mockAnalytics.spyMillisecondsSinceRequestSent)
-        XCTAssertNil(mockAnalytics.spyTotalItems)
+        #expect(mockAnalytics.spyMillisecondsSinceRequestSent == nil)
+        #expect(mockAnalytics.spyTotalItems == nil)
     }
 }
 
 // MARK: - Mocks
-
-private final class MockProductsRemote: ProductsRemote {
-    var mockPagedProducts: PagedItems<POSProduct>?
-
-    override func searchProductsForPointOfSale(for siteID: Int64,
-                                              query: String,
-                                              productTypes: [ProductType],
-                                              pageNumber: Int) async throws -> PagedItems<POSProduct> {
-        return mockPagedProducts ?? .init(items: [], hasMorePages: false, totalItems: nil)
-    }
-}
-
-private final class MockProductVariationsRemote: ProductVariationsRemote {
-    override func loadVariationsForPointOfSale(for siteID: Int64,
-                                              parentProductID: Int64,
-                                              pageNumber: Int) async throws -> PagedItems<ProductVariation> {
-        return .init(items: [], hasMorePages: false, totalItems: nil)
-    }
-}
-
 private final class MockPOSSearchAnalyticsTracking: POSSearchAnalyticsTracking {
     private(set) var spyMillisecondsSinceRequestSent: Int?
     private(set) var spyTotalItems: Int?

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleSearchPurchasableItemFetchStrategyTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleSearchPurchasableItemFetchStrategyTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import Networking
+@testable import Yosemite
+
+final class PointOfSaleSearchPurchasableItemFetchStrategyTests: XCTestCase {
+    private let siteID: Int64 = 123
+    private let searchTerm = "test search"
+    private let productsRemote = MockProductsRemote()
+    private let variationsRemote = MockProductVariationsRemote()
+    private let mockAnalytics = MockPOSSearchAnalyticsTracking()
+
+    func test_fetchProducts_tracks_analytics_for_first_page() async throws {
+        // Given
+        let strategy = PointOfSaleSearchPurchasableItemFetchStrategy(
+            siteID: siteID,
+            searchTerm: searchTerm,
+            productsRemote: productsRemote,
+            variationsRemote: variationsRemote,
+            analytics: mockAnalytics
+        )
+        let expectedTotalItems = 10
+        productsRemote.mockPagedProducts = .init(items: [], hasMorePages: true, totalItems: expectedTotalItems)
+
+        // When
+        _ = try await strategy.fetchProducts(pageNumber: 1)
+
+        // Then
+        XCTAssertEqual(mockAnalytics.spyMillisecondsSinceRequestSent, 0) // We can't test exact timing
+        XCTAssertEqual(mockAnalytics.spyTotalItems, expectedTotalItems)
+    }
+
+    func test_fetchProducts_does_not_track_analytics_for_subsequent_pages() async throws {
+        // Given
+        let strategy = PointOfSaleSearchPurchasableItemFetchStrategy(
+            siteID: siteID,
+            searchTerm: searchTerm,
+            productsRemote: productsRemote,
+            variationsRemote: variationsRemote,
+            analytics: mockAnalytics
+        )
+        productsRemote.mockPagedProducts = .init(items: [], hasMorePages: true, totalItems: 10)
+
+        // When
+        _ = try await strategy.fetchProducts(pageNumber: 2)
+
+        // Then
+        XCTAssertNil(mockAnalytics.spyMillisecondsSinceRequestSent)
+        XCTAssertNil(mockAnalytics.spyTotalItems)
+    }
+}
+
+// MARK: - Mocks
+
+private final class MockProductsRemote: ProductsRemote {
+    var mockPagedProducts: PagedItems<POSProduct>?
+
+    override func searchProductsForPointOfSale(for siteID: Int64,
+                                              query: String,
+                                              productTypes: [ProductType],
+                                              pageNumber: Int) async throws -> PagedItems<POSProduct> {
+        return mockPagedProducts ?? .init(items: [], hasMorePages: false, totalItems: nil)
+    }
+}
+
+private final class MockProductVariationsRemote: ProductVariationsRemote {
+    override func loadVariationsForPointOfSale(for siteID: Int64,
+                                              parentProductID: Int64,
+                                              pageNumber: Int) async throws -> PagedItems<ProductVariation> {
+        return .init(items: [], hasMorePages: false, totalItems: nil)
+    }
+}
+
+private final class MockPOSSearchAnalyticsTracking: POSSearchAnalyticsTracking {
+    private(set) var spyMillisecondsSinceRequestSent: Int?
+    private(set) var spyTotalItems: Int?
+
+    func trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
+        spyMillisecondsSinceRequestSent = millisecondsSinceRequestSent
+        spyTotalItems = totalItems
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-456
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds tracking for the time taken to make remote requests for product search.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Open search
3. Type a search term
4. Observe that `pos_search_remote_results_fetched` is tracked with the total number of results from all pages, and the item list type.

Note that when you scroll down and load a new page, the event is not tracked.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested on a simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/c720fc63-6249-4101-a21a-e8160028d7a7



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.