### PR TITLE
[Woo POS] Dismiss the keyboard when scrolling search results

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 22.4
 -----
-
+- [*] POS: Scrolling search results now dismisses the keyboard [https://github.com/woocommerce/woocommerce-ios/pull/15606]
 
 22.3
 -----

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -144,6 +144,7 @@ struct ItemListView: View {
                 ) { _ in
                     itemListContent(selectedItemListType)
                 }
+                .scrollDismissesKeyboard(.immediately)
                 .transition(.opacity.combined(with: .move(edge: .trailing)))
                 .zIndex(1)
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-402
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures the keyboard is dismissed when we scroll search results or pre-search content.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This can be tested with or without the `searchProductsInPOSPt2PopularProducts` flag enabled

1. Launch the app and go to POS
2. Tap the search button, ensuring the full-size software keyboard is shown
3. If you have enough pre-search content, scroll it slightly. Otherwise, add more saved searches.
4. Observe that the keyboard is dismissed on scroll

Repeat the above test with search results.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested this on an iPad Air running iOS 17.7.2, and a simulator running iOS 18.4.

I've tested with a software keyboard, and with the floating keyboard, as well as the fullsize keyboards. Only the fullsize keyboard should be dismissed.

This also works for Coupons

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/user-attachments/assets/c53df8fb-d8ee-41c6-b2b7-7b8b70b40829

---


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.