### PR TITLE
Skip test that crashes on iOS 18.4

### DIFF
--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -415,6 +415,10 @@ final class ReceiptStoreTests: XCTestCase {
     }
 
     func test_generateContent_callsGenerate_passingUnmodified_customerNote() throws {
+        if #available(iOS 18.4, *) {
+            throw XCTSkip("Skipped on iOS 18.4 because of a WebKit crash when running on that OS.")
+        }
+
         // Given
         let mockIntent = PaymentIntent.fake().copy(charges: [Mocks.cardPresentCharge])
         let mockParameters = try XCTUnwrap(mockIntent.receiptParameters())


### PR DESCRIPTION
This works around a WebKit crash we are seeing in the tests in iOS 18.4:

![image](https://github.com/user-attachments/assets/808a5645-81d5-457e-9d1d-27129cd0c775)

Internal ref p1746701273593869-slack-C6H8C3G23

It obviously is not a solution, but I thought I push it anyway just in case others might need it. I plan to track it locally in https://github.com/woocommerce/woocommerce-ios/pull/15597 and see if it helps me understand the issue I'm seeing there.