### PR TITLE
Provision Sourcery via SwiftPM instead of CocoaPods

### DIFF
--- a/BuildTools/.sourcery.yml
+++ b/BuildTools/.sourcery.yml
@@ -1,0 +1,19 @@
+# At the time of writing and with Sourcery 2.2.6, running the tool via `swift
+# package plugin` ignores the --config parameter, looking instead for the
+# .sourcery.yml configuration file.
+#
+# That means we cannot invoke Sourcery individually for each target.
+#
+# Luckily, the configuration files supports child configurations, so we can
+# achieve the same result this way.
+configurations:
+  - child: ../CodeGeneration/Sourcery/Copiable/Hardware-Copiable.sourcery.yaml
+  - child: ../CodeGeneration/Sourcery/Copiable/Networking-Copiable.sourcery.yaml
+  - child: ../CodeGeneration/Sourcery/Copiable/Storage-Copiable.sourcery.yaml
+  - child: ../CodeGeneration/Sourcery/Copiable/WooCommerce-Copiable.sourcery.yaml
+  - child: ../CodeGeneration/Sourcery/Copiable/WooFoundation-Copiable.sourcery.yaml
+  - child: ../CodeGeneration/Sourcery/Copiable/Yosemite-Copiable.sourcery.yaml
+  - child: ../CodeGeneration/Sourcery/Fakes/Hardware-Fakes.yaml
+  - child: ../CodeGeneration/Sourcery/Fakes/Networking-Fakes.yaml
+  - child: ../CodeGeneration/Sourcery/Fakes/WooFoundation-Fakes.yaml
+  - child: ../CodeGeneration/Sourcery/Fakes/Yosemite-Fakes.yaml

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,6 +1,168 @@
 {
-  "originHash" : "cd02791f9079102404056ed65d89c5c6bb997332bbfd1b03550dfdd51e57551e",
+  "originHash" : "bb374fb1cfe6769494b51a8da522b904ded4d3987ad68cd369eadb59e59f5e74",
   "pins" : [
+    {
+      "identity" : "aexml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tadija/AEXML.git",
+      "state" : {
+        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+        "version" : "4.6.1"
+      }
+    },
+    {
+      "identity" : "commander",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Commander.git",
+      "state" : {
+        "revision" : "4b6133c3071d521489a80c38fb92d7983f19d438",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "sourcery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzysztofzablocki/Sourcery.git",
+      "state" : {
+        "revision" : "83205514943652219cb3b974fe0dc48db9ceddb1",
+        "version" : "2.2.6"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "stencil",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/art-divin/Stencil.git",
+      "state" : {
+        "revision" : "03a1dca8923bef5a34c08f5a560fb420326f7244",
+        "version" : "0.15.3"
+      }
+    },
+    {
+      "identity" : "stencilswiftkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/art-divin/StencilSwiftKit.git",
+      "state" : {
+        "revision" : "6b07f85def6984e7015d65502d41b91f3f8db6d5",
+        "version" : "2.10.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "01d7664523af5c169f26038f1e5d444ce47ae5ff",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "629f0b679d0fd0a6ae823d7f750b9ab032c00b80",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "swift-driver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/art-divin/swift-driver.git",
+      "state" : {
+        "revision" : "1c07ced84c1dfc1f9c3253dcbaa216fc9c76ee25",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-llbuild",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/art-divin/swift-llbuild.git",
+      "state" : {
+        "revision" : "783aec21649a6c47d1a8314db4144bdceb11df30",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/art-divin/swift-package-manager.git",
+      "state" : {
+        "revision" : "7df9321541e544d711dd93f5b97dd4e8bf7e100e",
+        "version" : "1.0.8"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "836bc4557b74fe6d2660218d56e3ce96aff76574",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/art-divin/swift-tools-support-core.git",
+      "state" : {
+        "revision" : "930e82e5ae2432c71fe05f440b5d778285270bdb",
+        "version" : "1.0.0"
+      }
+    },
     {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",
@@ -8,6 +170,24 @@
       "state" : {
         "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
         "version" : "0.58.2"
+      }
+    },
+    {
+      "identity" : "xcodeproj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/XcodeProj.git",
+      "state" : {
+        "revision" : "f6c9cb05835086af13f91317f92693848b43ea47",
+        "version" : "8.24.6"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
       }
     }
   ],

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     platforms: [.macOS(.v10_13)],
     dependencies: [
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: loadSwiftLintVersion()),
+        .package(url: "https://github.com/krzysztofzablocki/Sourcery.git", from: "2.2.6")
     ],
     targets: [.target(name: "BuildTools", path: "")]
 )

--- a/Podfile
+++ b/Podfile
@@ -64,7 +64,6 @@ def networking_pods
   alamofire
   cocoa_lumberjack
 
-  pod 'Sourcery', '~> 2.2.6', configuration: 'Debug'
   wordpress_shared
 
   # Used for HTML parsing

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -32,9 +32,6 @@ PODS:
     - Sentry/Core (= 8.46.0)
   - Sentry/Core (8.46.0)
   - Sodium (0.9.1)
-  - Sourcery (2.2.6):
-    - Sourcery/CLI-Only (= 2.2.6)
-  - Sourcery/CLI-Only (2.2.6)
   - Specta (1.0.7)
   - StripeTerminal (4.2.0)
   - SVProgressHUD (2.2.5)
@@ -74,7 +71,6 @@ DEPENDENCIES:
   - OHHTTPStubs (~> 9.0)
   - OHHTTPStubs/Swift (~> 9.0)
   - Sentry (~> 8.46.0)
-  - Sourcery (~> 2.2.6)
   - Specta (= 1.0.7)
   - StripeTerminal (~> 4.2.0)
   - SVProgressHUD (= 2.2.5)
@@ -101,7 +97,6 @@ SPEC REPOS:
     - OHHTTPStubs
     - Sentry
     - Sodium
-    - Sourcery
     - Specta
     - StripeTerminal
     - SVProgressHUD
@@ -134,7 +129,6 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
-  Sourcery: 4427fd22f0c12bd1ef75dd9045d50e01c17a43e1
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   StripeTerminal: 58a08668f6731666fc1ab878ac4a510ecfb403c9
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -154,6 +148,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 281acf2bb731d2a67f913cfe653ed0da9f5b2f42
   ZendeskSupportSDK: b512cfc74b6bf8490e589f02cf52e27ed4f2bebe
 
-PODFILE CHECKSUM: bf1e4c8d480a1b0f40989e79260099831f2d01e8
+PODFILE CHECKSUM: 8e9a923af752885a3d6c8d622c176c342fac5156
 
 COCOAPODS: 1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -145,7 +145,7 @@ task :generate do
     puts "\n\nGenerating Copiable for #{prefix}..."
     puts '=' * 100
 
-    sh "./Pods/Sourcery/bin/sourcery --config CodeGeneration/Sourcery/Copiable/#{prefix}-Copiable.sourcery.yaml"
+    sourcery(args: ["--config CodeGeneration/Sourcery/Copiable/#{prefix}-Copiable.sourcery.yaml"])
   end
 
   puts "\n\nDONE. Generated Copiable for all projects."
@@ -154,7 +154,7 @@ task :generate do
     puts "\n\nGenerating Fakes for #{prefix}..."
     puts '=' * 100
 
-    sh "./Pods/Sourcery/bin/sourcery --config CodeGeneration/Sourcery/Fakes/#{prefix}-Fakes.yaml"
+    sourcery(args: ["--config CodeGeneration/Sourcery/Fakes/#{prefix}-Fakes.yaml"])
   end
 
   puts "\n\nDONE. Generated Fakes."
@@ -228,10 +228,16 @@ def check_dependencies_hook
   end
 end
 
-def swiftlint(additional_args = [])
-  run_in_build_tools(
-    cmd: "swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory swiftlint --working-directory .. --quiet #{additional_args.join(' ')}"
-  )
+def swiftlint(additional_args: [])
+  run_package_plugin(cmd: "swiftlint --working-directory .. --quiet #{additional_args.join(' ')}")
+end
+
+def sourcery(args: [])
+  run_package_plugin(cmd: "sourcery-command #{args.join(' ')}")
+end
+
+def run_package_plugin(cmd:)
+  run_in_build_tools(cmd: "swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory #{cmd}")
 end
 
 # We could use more idiomatic Ruby here, with `Dir.chdir`, but leaving as raw shell commands for when we'll drop Ruby and rake for tooling.

--- a/Rakefile
+++ b/Rakefile
@@ -122,19 +122,17 @@ task :clean do
   xcodebuild(:clean)
 end
 
-# rubocop:disable Layout/LineLength
 desc 'Checks the source for style errors'
 task :lint do
-  sh 'pushd BuildTools; export SDKROOT=$(xcrun --sdk macosx --show-sdk-path); swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory swiftlint --working-directory .. --quiet; popd'
+  swiftlint
 end
 
 namespace :lint do
   desc 'Automatically corrects style errors where possible'
   task :autocorrect do
-    sh 'pushd BuildTools; export SDKROOT=$(xcrun --sdk macosx --show-sdk-path); swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory swiftlint --fix --working-directory .. --quiet; popd'
+    swiftlint(additional_args: ['--fix'])
   end
 end
-# rubocop:enable Layout/LineLength
 
 desc 'Open the project in Xcode'
 task xcode: [:dependencies] do
@@ -228,4 +226,15 @@ def check_dependencies_hook
     puts e.message
     exit 1
   end
+end
+
+def swiftlint(additional_args = [])
+  run_in_build_tools(
+    cmd: "swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory swiftlint --working-directory .. --quiet #{additional_args.join(' ')}"
+  )
+end
+
+# We could use more idiomatic Ruby here, with `Dir.chdir`, but leaving as raw shell commands for when we'll drop Ruby and rake for tooling.
+def run_in_build_tools(cmd:)
+  sh "pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && #{cmd} && popd"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -141,23 +141,8 @@ end
 
 desc 'Run all code generation tasks'
 task :generate do
-  %w[Hardware Networking Storage Yosemite WooCommerce WooFoundation].each do |prefix|
-    puts "\n\nGenerating Copiable for #{prefix}..."
-    puts '=' * 100
-
-    sourcery(args: ["--config CodeGeneration/Sourcery/Copiable/#{prefix}-Copiable.sourcery.yaml"])
-  end
-
-  puts "\n\nDONE. Generated Copiable for all projects."
-
-  %w[Hardware Networking Yosemite WooFoundation].each do |prefix|
-    puts "\n\nGenerating Fakes for #{prefix}..."
-    puts '=' * 100
-
-    sourcery(args: ["--config CodeGeneration/Sourcery/Fakes/#{prefix}-Fakes.yaml"])
-  end
-
-  puts "\n\nDONE. Generated Fakes."
+  # See note in BuildTools/.sourcery.yml for why we call without arguments
+  run_package_plugin(cmd: 'sourcery-command')
 end
 
 def fold(label)
@@ -230,10 +215,6 @@ end
 
 def swiftlint(additional_args: [])
   run_package_plugin(cmd: "swiftlint --working-directory .. --quiet #{additional_args.join(' ')}")
-end
-
-def sourcery(args: [])
-  run_package_plugin(cmd: "sourcery-command #{args.join(' ')}")
 end
 
 def run_package_plugin(cmd:)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -6396,7 +6396,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		3F09041C2D26A40800D8ACCE /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		3F09041C2D26A40800D8ACCE /* Exceptions for "WordPressAuthenticator" folder in "WordPressAuthenticator" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -6437,7 +6437,7 @@
 			);
 			target = 3F0904002D26A40700D8ACCE /* WordPressAuthenticator */;
 		};
-		3FD28D5E2D271391002EBB3D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		3FD28D5E2D271391002EBB3D /* Exceptions for "WordPressAuthenticatorTests" folder in "WordPressAuthenticatorTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -6451,8 +6451,30 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		3F0904022D26A40800D8ACCE /* WordPressAuthenticator */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3F09041C2D26A40800D8ACCE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WordPressAuthenticator; sourceTree = "<group>"; };
-		3F09040E2D26A40800D8ACCE /* WordPressAuthenticatorTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3FD28D5E2D271391002EBB3D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WordPressAuthenticatorTests; sourceTree = "<group>"; };
+		3F0904022D26A40800D8ACCE /* WordPressAuthenticator */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				3F09041C2D26A40800D8ACCE /* Exceptions for "WordPressAuthenticator" folder in "WordPressAuthenticator" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = WordPressAuthenticator;
+			sourceTree = "<group>";
+		};
+		3F09040E2D26A40800D8ACCE /* WordPressAuthenticatorTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				3FD28D5E2D271391002EBB3D /* Exceptions for "WordPressAuthenticatorTests" folder in "WordPressAuthenticatorTests" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = WordPressAuthenticatorTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -15225,13 +15247,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -15410,13 +15428,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -15453,13 +15467,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -2415,13 +2415,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION

## Description

This is part of the ongoing work to move away from CocoaPods, https://linear.app/a8c/issue/AINFRA-216.

https://github.com/woocommerce/woocommerce-ios/pull/15598 established a `BuildTools` folder with a Swift package dedicated to dependencies that we only use as tools—i.e. not imported in the code base.

Sourcery is one such dependency and this PR moves it to be provisioned via SwiftPM instead of CocoaPods.

See also https://linear.app/a8c/issue/AINFRA-404.

## Steps to reproduce & Testing information

To verify the change works, checkout the branch and run `bundle exec rake generate`. You'll see SwiftPM fetching all the Sourcery dependencies and after that running the binary to generate the various Swift files from the Sourcery templates. Because the templates have not changed ,there should be no additional change in your local repo.

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/6d5fb7b3-8591-46a0-8320-ea1742d9ed2b" />

To verify Sourcery actually can generate update files, modify one of the two templates:

- `CodeGeneration/Sourcery/Copiable/Models+Copiable.swifttemplate`
- `CodeGeneration/Sourcery/Fakes/Fakes.swifttemplate`

and verify the updated files are consistent with the changes you made. Example:

**Template change**

![image](https://github.com/user-attachments/assets/a25c5e86-53f1-422d-80b1-1ca8ec0f3b30)


**Generated changes**

![image](https://github.com/user-attachments/assets/53a34c30-e49e-4ca4-95bc-38dec120f85c)

![image](https://github.com/user-attachments/assets/64f8dc66-d302-4161-ab23-171e1dbf2c79)


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.