### PR TITLE
Fix flaky site settings unit tests

### DIFF
--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -59,7 +59,7 @@ public class SiteSettingsRemote: Remote {
                                      path: path,
                                      parameters: nil,
                                      availableAsRESTRequest: true)
-        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
+        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: settingGroup)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -86,7 +86,7 @@ public class SiteSettingsRemote: Remote {
                                      path: path,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
+        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: settingGroup)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Yosemite/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Yosemite/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -222,9 +222,9 @@ private extension SettingStoreMethods {
     }
 
     func upsertSingleSetting(_ readOnlySiteSetting: SiteSetting, in storage: StorageType, siteID: Int64) {
-        let storageSiteSettings = storage.loadSiteSettings(siteID: siteID, settingGroupKey: readOnlySiteSetting.settingGroupKey)
+        let existingStorageItem = storage.loadSiteSetting(siteID: siteID, settingID: readOnlySiteSetting.settingID)
 
-        if let existingStorageItem = storageSiteSettings?.first(where: { $0.settingID == readOnlySiteSetting.settingID }) {
+        if let existingStorageItem {
             existingStorageItem.update(with: readOnlySiteSetting)
         } else {
             let newStorageItem = storage.insertNewObject(ofType: Storage.SiteSetting.self)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There was a fix recently to optimize site settings update #15497. This fix added a new method `upsertSingleSetting`, which then [looks for](https://github.com/woocommerce/woocommerce-ios/blob/4f3f84aa6f81cf55b3fb0c52a20166a79a836fc8/Yosemite/Yosemite/Stores/Helpers/SettingStoreMethods.swift#L225) a single setting with the setting group set to it in storage.

As a result, unit tests regarding analytics setting (which belongs to the `advanced` settings group) keep being flaky. I looked around and found an issue with the mapping of settings from long ago, which set `general` as the default setting group for any retrieved or updated settings.

The solution is to fix the mapping and at the same time update `upsertSingleSetting` to only fetch the necessary setting to update.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Confirm that unit tests regarding analytics settings no longer fail in CI.

## Regression

Confirm that `retrieveCouponSetting` and `enableCouponSetting` continue to work.

1. Disable coupons in (WooCommerce -> Settings)
2. Switch to Hub Menu tab
3. Open Coupons section (it calls retrieveCouponSetting)
4. Confirm disabled state is shown
5. Tap Enable
6. Confirm it's enabled

Confirm that `retrieveAnalyticsSetting` continues to work.

1. Disable analytics in (WooCommerce > Settings > Advanced > Features)
2. Switch the My Store tab and pull to refresh the dashboard.
3. Confirm disabled state is shown in Performance and Top Performers cards.
5. Enable analytics in WooCommerce settings.
6. Pull to refresh the dashboard and confirm that the Performance and Top Performers cards show data again.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Did regression testing and onfirmed unit tests are succeeding.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
