### PR TITLE
Shipping Label: Update refund UI from the order details screen for the new flow

### DIFF
--- a/WooCommerce/Classes/Extensions/ShippingLabel+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/ShippingLabel+Helpers.swift
@@ -25,4 +25,8 @@ extension ShippingLabel {
         }
         return true
     }
+
+    var hasCustomsForm: Bool {
+        commercialInvoiceURL?.isNotEmpty == true
+    }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1318,10 +1318,15 @@ extension OrderDetailsDataSource {
                     headerStyle = .primary
                 } else {
                     rows = [.shippingLabelProducts, .shippingLabelReprintButton, .shippingLabelPrintingInfo, .shippingLabelTrackingNumber, .shippingLabelDetail]
-                    let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
-                        self?.onShippingLabelMoreMenuTapped?(shippingLabel, sourceView)
+
+                    if shippingLabel.isRefundable || shippingLabel.hasCustomsForm {
+                        let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
+                            self?.onShippingLabelMoreMenuTapped?(shippingLabel, sourceView)
+                        }
+                        headerStyle = .actionablePrimary(actionConfig: headerActionConfig)
+                    } else {
+                        headerStyle = .primary
                     }
-                    headerStyle = .actionablePrimary(actionConfig: headerActionConfig)
                 }
                 return Section(category: .shippingLabel, title: title, rows: rows, headerStyle: headerStyle)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -548,12 +548,22 @@ private extension OrderDetailsViewController {
 
         if shippingLabel.isRefundable {
             actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelMoreMenu.requestRefundAction) { [weak self] _ in
-                let refundViewController = RefundShippingLabelViewController(shippingLabel: shippingLabel) { [weak self] in
-                    self?.navigationController?.popViewController(animated: true)
+                guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation) else {
+                    let refundViewController = RefundShippingLabelViewController(shippingLabel: shippingLabel) { [weak self] in
+                        self?.navigationController?.popViewController(animated: true)
+                    }
+                    // Disables the bottom bar (tab bar) when requesting a refund.
+                    refundViewController.hidesBottomBarWhenPushed = true
+                    self?.show(refundViewController, sender: self)
+                    return
                 }
-                // Disables the bottom bar (tab bar) when requesting a refund.
-                refundViewController.hidesBottomBarWhenPushed = true
-                self?.show(refundViewController, sender: self)
+
+                let viewModel = WooShippingRefundViewModel(refundableAmount: shippingLabel.refundableAmount,
+                                                           refundDuration: shippingLabel.refundDuration,
+                                                           purchaseDate: shippingLabel.dateCreated)
+                let view = WooShippingRefundView(viewModel: viewModel)
+                let refundViewController = UIHostingController(rootView: view)
+                self?.present(refundViewController, animated: true)
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -546,13 +546,15 @@ private extension OrderDetailsViewController {
 
         actionSheet.addCancelActionWithTitle(Localization.ShippingLabelMoreMenu.cancelAction)
 
-        actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelMoreMenu.requestRefundAction) { [weak self] _ in
-            let refundViewController = RefundShippingLabelViewController(shippingLabel: shippingLabel) { [weak self] in
-                self?.navigationController?.popViewController(animated: true)
+        if shippingLabel.isRefundable {
+            actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelMoreMenu.requestRefundAction) { [weak self] _ in
+                let refundViewController = RefundShippingLabelViewController(shippingLabel: shippingLabel) { [weak self] in
+                    self?.navigationController?.popViewController(animated: true)
+                }
+                // Disables the bottom bar (tab bar) when requesting a refund.
+                refundViewController.hidesBottomBarWhenPushed = true
+                self?.show(refundViewController, sender: self)
             }
-            // Disables the bottom bar (tab bar) when requesting a refund.
-            refundViewController.hidesBottomBarWhenPushed = true
-            self?.show(refundViewController, sender: self)
         }
 
         if let url = shippingLabel.commercialInvoiceURL, url.isNotEmpty {

--- a/WooCommerce/WooCommerceTests/Extensions/ShippingLabelHelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/ShippingLabelHelpersTests.swift
@@ -96,4 +96,21 @@ struct ShippingLabelHelpersTests {
         // Then
         #expect(label.isRefundable)
     }
+
+    @Test(arguments: [
+        ShippingLabel.fake().copy(commercialInvoiceURL: nil),
+        ShippingLabel.fake().copy(commercialInvoiceURL: "")
+    ])
+    func hasCustomsForm_is_false_when_commercialInvoiceURL_is_nil_or_empty(label: ShippingLabel) {
+        // Then
+        #expect(label.hasCustomsForm == false)
+    }
+
+    @Test func hasCustomsForm_is_true_when_commercialInvoiceURL_is_not_empty() {
+        // Given
+        let label = ShippingLabel.fake().copy(commercialInvoiceURL: "https://example.com/form.pdf")
+
+        // Then
+        #expect(label.hasCustomsForm)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-465
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the ellipsis menu in the (purchased) shipping label section on the order details screen:
- Use the new refund UI for the new flow.
- Hide the refund button when a label is not refundable.
- Hide the ellipsis menu if the label is not refundable and has no customs form.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
2. Select an order with a shipping label created less than 30 days ago (or create a new one).
3. On the order details screen, select the ellipsis menu in the purchased label section.
4. Tap Request a refund and confirm that the new UI is displayed.
5. Switch to an order with a shipping label created less than 30 days ago (or mock the response for a label's created date).
6. On the order details screen, confirm that the ellipsis menu in the purchased label section has only the option to print the customs form if the label has one. Otherwise, the ellipsis menu should be hidden.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed the tests above with simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before:


https://github.com/user-attachments/assets/352ccb39-0de3-4712-98c0-18d23f5900a6

After:


https://github.com/user-attachments/assets/3854ced9-ec2b-4e73-9ae1-ee55d3f05763



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
