### PR TITLE
[Shipping labels] Disable "Select all" for fulfilled shipments

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -62,7 +62,7 @@ struct WooShippingSplitShipmentsView: View {
                         viewModel.selectAll()
                     }
                     .disabled(
-                        viewModel.currentShipment.isPurchased
+                        viewModel.isSelectAllItemsDisabled
                     )
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -61,7 +61,9 @@ struct WooShippingSplitShipmentsView: View {
                     Button(Localization.selectAll) {
                         viewModel.selectAll()
                     }
-                    .disabled(viewModel.isSavingShipmentInfo)
+                    .disabled(
+                        viewModel.currentShipment.isPurchased
+                    )
                 }
 
                 ToolbarItem(placement: .confirmationAction) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -89,6 +89,10 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         shipments[selectedShipmentIndex]
     }
 
+    var isSelectAllItemsDisabled: Bool {
+        return currentShipment.isPurchased || isSavingShipmentInfo
+    }
+
     @Published private(set) var moveToNoticeViewModel: MoveToShipmentNoticeViewModel?
 
     @Published private(set) var instructions: AttributedString?


### PR DESCRIPTION
## Description

Makes the "Select all" navigation bar item disabled for a fulfilled shipment. More in discussion: p1745586909868109-slack-C03L1NF1EA3

## Testing steps

- Log in to a test store with Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with at lest one shipment with a purchased label and at least one shipment without a label.
- Select the fulfilled shipment.
- Make sure the top left "Select all" option is disabled.
- Switch to unfulfilled shipment and make sure the "Select all" get enabled.
- Switch between shipments and make sure the "Select all" has corresponding valid enabled/disabled state.  

## Screenshots

Before | After
--- | ---
![Снимок экрана 2025-05-09 в 15 52 30](https://github.com/user-attachments/assets/4766ad4a-ff3c-41c3-836b-80835f82693e) | ![Снимок экрана 2025-05-09 в 15 44 23](https://github.com/user-attachments/assets/23842947-108e-403b-b8ee-9972d854d6f9)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.