### PR TITLE
Remove filters for non-purchasable product variations

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.4
 -----
 - [*] POS: Scrolling search results now dismisses the keyboard [https://github.com/woocommerce/woocommerce-ios/pull/15606]
+- [*] Order Creation: Display non-purchasable, zero-priced variable product variations [https://github.com/woocommerce/woocommerce-ios/pull/15620]
 
 22.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -409,7 +409,6 @@ final class ProductSelectorViewModel: ObservableObject {
         return ProductVariationSelectorViewModel(siteID: siteID,
                                                  product: variableProduct,
                                                  selectedProductVariationIDs: selectedItems,
-                                                 purchasableItemsOnly: purchasableItemsOnly,
                                                  orderSyncState: orderSyncState,
                                                  onVariationSelectionStateChanged: { [weak self] productVariation, product, selected in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -115,10 +115,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         return resultsController
     }()
 
-    /// Whether the variation list should contains only purchasable items.
-    ///
-    private let purchasableItemsOnly: Bool
-
     private var orderSyncState: Published<OrderSyncState>.Publisher?
 
     init(siteID: Int64,
@@ -127,7 +123,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          productAttributes: [ProductAttribute],
          allowedProductVariationIDs: [Int64] = [],
          selectedProductVariationIDs: [Int64] = [],
-         purchasableItemsOnly: Bool = false,
          orderSyncState: Published<OrderSyncState>.Publisher? = nil,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
@@ -143,7 +138,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.onVariationSelectionStateChanged = onVariationSelectionStateChanged
         self.allowedProductVariationIDs = allowedProductVariationIDs
         self.selectedProductVariationIDs = selectedProductVariationIDs
-        self.purchasableItemsOnly = purchasableItemsOnly
         self.onSelectionsCleared = onSelectionsCleared
 
         configureSyncingCoordinator()
@@ -156,7 +150,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      product: Product,
                      allowedProductVariationIDs: [Int64] = [],
                      selectedProductVariationIDs: [Int64] = [],
-                     purchasableItemsOnly: Bool = false,
                      orderSyncState: Published<OrderSyncState>.Publisher? = nil,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
@@ -168,7 +161,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   productAttributes: product.attributesForVariations,
                   allowedProductVariationIDs: allowedProductVariationIDs,
                   selectedProductVariationIDs: selectedProductVariationIDs,
-                  purchasableItemsOnly: purchasableItemsOnly,
                   orderSyncState: orderSyncState,
                   storageManager: storageManager,
                   stores: stores,
@@ -300,11 +292,7 @@ private extension ProductVariationSelectorViewModel {
     func updateProductVariationsResultsController() {
         do {
             try productVariationsResultsController.performFetch()
-            if purchasableItemsOnly {
-                productVariations = productVariationsResultsController.fetchedObjects.filter { $0.purchasable }
-            } else {
-                productVariations = productVariationsResultsController.fetchedObjects
-            }
+            productVariations = productVariationsResultsController.fetchedObjects
             observeSelections()
         } catch {
             DDLogError("⛔️ Error fetching product variations for new order: \(error)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-121
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

The review is not urgent

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

WOOMOB-121 reported an issue where, in some cases:
- Some variations didn't loaded
- No variations loaded

This happens due to local filters only showing `.purchasable` variations. Since variations without the price are non-purchasable, if all the first page of variation results don't have a price, then no variations get loaded.

No other platform or use-case filters out non-purchasable variations:
- iOS doesn’t use it for POS
- Android doesn’t use it for both IPP and POS
- Web checkout shows non-purchasable variations, but doesn’t allow adding them to the cart
- WP-Admin allows searching for and selecting non-purchasable variations

## Other change

Removed `favoriteProducts` feature flag that I saw 

## Other Issues

The same type of local filtering exists for products as well. However, I didn't manage to fix it cleanly in the planned amount of time. Removing `.purchasable` from local product filtering makes draft products appear. In the order creation case, I added a remote parameter to only fetch published products and removed product status from product filters. 

Unfortunately, remote results replace the local cache. Therefore, when we switch between the Orders and Products tabs, draft products keep appearing and disappearing after a delay when remote results come in. 

I will create another task for it.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a variable product with variations that include some with a price and some without a price.
2. Open the Woo app products tab, open the product variation details, and confirm all variations are loaded.
3. Open the Woo app orders tab, create a new order, select a variable product, and confirm all variations are loaded.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11 inch 18.4. 

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
