### PR TITLE
Provision CocoaLumberjack from CocoaPods to SwiftPM

### DIFF
--- a/Experiments/Experiments.xcodeproj/project.pbxproj
+++ b/Experiments/Experiments.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 		3F8115032DD2A6EC0042DDB6 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = 3F8115022DD2A6EC0042DDB6 /* AutomatticTracks */; };
 		3F8B84192DD2FEC2002DD6E8 /* Experiments.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 3F8B84182DD2FEC2002DD6E8 /* Experiments.xctestplan */; };
 		3F8B841B2DD301C6002DD6E8 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = 3F8B841A2DD301C6002DD6E8 /* AutomatticTracks */; };
-		BC10218D75FEA979BDA1E68C /* Pods_Experiments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CEC0C5283FD4C9EF8C6A3C /* Pods_Experiments.framework */; };
-		C8E16F0EE6954B58A1C402F0 /* Pods_ExperimentsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC7C082DD376957B4676401 /* Pods_ExperimentsTests.framework */; };
 		CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB47275E426900C4CA4F /* ABTest.swift */; };
 		EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */; };
 		EEC8C0ED298A92F10047B4CB /* CachedABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8C0EC298A92F10047B4CB /* CachedABTestVariationProvider.swift */; };
@@ -46,16 +44,10 @@
 		0270C0A427069B8900FC799F /* DefaultFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeatureFlagService.swift; sourceTree = "<group>"; };
 		0270C0A627069BA500FC799F /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		02AB82EE27069D93008D7334 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		2B7FCE683D4058A7A16F7946 /* Pods-Experiments.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Experiments.debug.xcconfig"; path = "Target Support Files/Pods-Experiments/Pods-Experiments.debug.xcconfig"; sourceTree = "<group>"; };
-		3022E2766134CE2735C73FC6 /* Pods-ExperimentsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExperimentsTests.debug.xcconfig"; path = "Target Support Files/Pods-ExperimentsTests/Pods-ExperimentsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		33CEC0C5283FD4C9EF8C6A3C /* Pods_Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F8B84182DD2FEC2002DD6E8 /* Experiments.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Experiments.xctestplan; sourceTree = "<group>"; };
-		3F9DB5FBFF7A42EFBCB746F3 /* Pods-ExperimentsTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExperimentsTests.release-alpha.xcconfig"; path = "Target Support Files/Pods-ExperimentsTests/Pods-ExperimentsTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		3FA7D9FB2D547E1700CE5611 /* Experiments.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Experiments.xcconfig; sourceTree = "<group>"; };
-		7C831644164B49828A485590 /* Pods-ExperimentsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExperimentsTests.release.xcconfig"; path = "Target Support Files/Pods-ExperimentsTests/Pods-ExperimentsTests.release.xcconfig"; sourceTree = "<group>"; };
-		8CB554DFAAD3EF41D17099C4 /* Pods-Experiments.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Experiments.release-alpha.xcconfig"; path = "Target Support Files/Pods-Experiments/Pods-Experiments.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		AAC7C082DD376957B4676401 /* Pods_ExperimentsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExperimentsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AF72D9DB7771E7A5105C88B0 /* Pods-Experiments.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Experiments.release.xcconfig"; path = "Target Support Files/Pods-Experiments/Pods-Experiments.release.xcconfig"; sourceTree = "<group>"; };
 		CC53FB47275E426900C4CA4F /* ABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTest.swift; sourceTree = "<group>"; };
 		EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestVariationProvider.swift; sourceTree = "<group>"; };
 		EEC8C0EC298A92F10047B4CB /* CachedABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedABTestVariationProvider.swift; sourceTree = "<group>"; };
@@ -69,7 +61,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC10218D75FEA979BDA1E68C /* Pods_Experiments.framework in Frameworks */,
 				3F8115032DD2A6EC0042DDB6 /* AutomatticTracks in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -79,7 +70,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0270C08B27069A8900FC799F /* Experiments.framework in Frameworks */,
-				C8E16F0EE6954B58A1C402F0 /* Pods_ExperimentsTests.framework in Frameworks */,
 				3F8B841B2DD301C6002DD6E8 /* AutomatticTracks in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -139,12 +129,6 @@
 		4E1989AAB68578443A38332F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2B7FCE683D4058A7A16F7946 /* Pods-Experiments.debug.xcconfig */,
-				AF72D9DB7771E7A5105C88B0 /* Pods-Experiments.release.xcconfig */,
-				8CB554DFAAD3EF41D17099C4 /* Pods-Experiments.release-alpha.xcconfig */,
-				3022E2766134CE2735C73FC6 /* Pods-ExperimentsTests.debug.xcconfig */,
-				7C831644164B49828A485590 /* Pods-ExperimentsTests.release.xcconfig */,
-				3F9DB5FBFF7A42EFBCB746F3 /* Pods-ExperimentsTests.release-alpha.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -177,7 +161,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0270C09527069A8900FC799F /* Build configuration list for PBXNativeTarget "Experiments" */;
 			buildPhases = (
-				620F249CED3F18B3ACC4F79A /* [CP] Check Pods Manifest.lock */,
 				0270C07C27069A8900FC799F /* Headers */,
 				0270C07D27069A8900FC799F /* Sources */,
 				0270C07E27069A8900FC799F /* Frameworks */,
@@ -196,11 +179,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0270C09827069A8900FC799F /* Build configuration list for PBXNativeTarget "ExperimentsTests" */;
 			buildPhases = (
-				97E6ECC11AE05E56176EF2BA /* [CP] Check Pods Manifest.lock */,
 				0270C08627069A8900FC799F /* Sources */,
 				0270C08727069A8900FC799F /* Frameworks */,
 				0270C08827069A8900FC799F /* Resources */,
-				3AB0CD346AF01D971274BF7B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -271,70 +252,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		3AB0CD346AF01D971274BF7B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExperimentsTests/Pods-ExperimentsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExperimentsTests/Pods-ExperimentsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExperimentsTests/Pods-ExperimentsTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		620F249CED3F18B3ACC4F79A /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Experiments-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		97E6ECC11AE05E56176EF2BA /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ExperimentsTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		0270C07D27069A8900FC799F /* Sources */ = {
@@ -498,7 +415,6 @@
 		};
 		0270C09627069A8900FC799F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2B7FCE683D4058A7A16F7946 /* Pods-Experiments.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -529,7 +445,6 @@
 		};
 		0270C09727069A8900FC799F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AF72D9DB7771E7A5105C88B0 /* Pods-Experiments.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -559,7 +474,6 @@
 		};
 		0270C09927069A8900FC799F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3022E2766134CE2735C73FC6 /* Pods-ExperimentsTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -580,7 +494,6 @@
 		};
 		0270C09A27069A8900FC799F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7C831644164B49828A485590 /* Pods-ExperimentsTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -660,7 +573,6 @@
 		};
 		02AB82F12706A9EA008D7334 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8CB554DFAAD3EF41D17099C4 /* Pods-Experiments.release-alpha.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -690,7 +602,6 @@
 		};
 		02AB82F22706A9EA008D7334 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3F9DB5FBFF7A42EFBCB746F3 /* Pods-ExperimentsTests.release-alpha.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/Experiments/Experiments.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Experiments/Experiments.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Experiments/Experiments.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Experiments/Experiments.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "f2f7b4585393ebf464885986c1da5d0a04c6032495d823e3a8413cec09992947",
+  "pins" : [
+    {
+      "identity" : "automattic-tracks-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
+      "state" : {
+        "revision" : "437f586a62c07c6ceec9baf043237b2afe7ea1ac",
+        "version" : "3.5.2"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "d87b07a27cd9a082d367261d7199a96a54e59f1d",
+        "version" : "8.50.2"
+      }
+    },
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium",
+      "state" : {
+        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "uideviceidentifier",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/squarefrog/UIDeviceIdentifier",
+      "state" : {
+        "revision" : "4699794b08bb79a4d77785edaba6ea739e298e4b",
+        "version" : "2.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975BF274EB1F9004357B1 /* DeclineReason.swift */; };
 		317975C2274EBC1F004357B1 /* DeclineReason+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */; };
 		317975C4274ED591004357B1 /* DeclineReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C3274ED591004357B1 /* DeclineReasonTests.swift */; };
+		3FF80E3B2DD322880049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF80E3A2DD322880049E028 /* CocoaLumberjackSwift */; };
 		55CD4BB4273E617C007686D3 /* ReceiptRendererTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CD4BB3273E617C007686D3 /* ReceiptRendererTest.swift */; };
 		5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */; };
 		8FFAA245E257B9EB98E2FCBD /* Pods_SampleReceiptPrinter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */; };
@@ -293,6 +294,7 @@
 			files = (
 				02B5147A28254ED300750B71 /* Codegen in Frameworks */,
 				C5D2CB7D21CEE28FEBF18BF6 /* Pods_Hardware.framework in Frameworks */,
+				3FF80E3B2DD322880049E028 /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -616,6 +618,7 @@
 			name = Hardware;
 			packageProductDependencies = (
 				02B5147928254ED300750B71 /* Codegen */,
+				3FF80E3A2DD322880049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = Hardware;
 			productReference = D88FDAFF25DD216B00CB0DBD /* Hardware.framework */;
@@ -694,6 +697,9 @@
 				Base,
 			);
 			mainGroup = D88FDAF525DD216B00CB0DBD;
+			packageReferences = (
+				3FF80E392DD322880049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
+			);
 			productRefGroup = D88FDB0025DD216B00CB0DBD /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1421,10 +1427,26 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3FF80E392DD322880049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.8.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		02B5147928254ED300750B71 /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Codegen;
+		};
+		3FF80E3A2DD322880049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF80E392DD322880049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Hardware/Hardware/Internal/Logging.swift
+++ b/Hardware/Hardware/Internal/Logging.swift
@@ -10,18 +10,18 @@
 // `@inline(__always)` to enfore inlining, but that attribute is not officially
 // supported as of Swift 4.0.)
 
-import CocoaLumberjack
+import CocoaLumberjackSwift
 
 /// The logging level threshold for DDLog… calls from Swift.
 /// Change this to adjust the verbosity of the log.
 ///
 /// Example:
 ///     internal var defaultDebugLevel: DDLogLevel = .verbose
-internal var defaultDebugLevel: DDLogLevel = CocoaLumberjack.dynamicLogLevel
+internal var defaultDebugLevel: DDLogLevel = CocoaLumberjackSwift.dynamicLogLevel
 
 /// Reset the logging level threshold to the app-wide default.
 internal func resetDefaultDebugLevel() {
-    defaultDebugLevel = CocoaLumberjack.dynamicLogLevel
+    defaultDebugLevel = CocoaLumberjackSwift.dynamicLogLevel
 }
 
 internal func DDLogDebug(_ message: @autoclosure () -> String,
@@ -31,7 +31,7 @@ internal func DDLogDebug(_ message: @autoclosure () -> String,
                          line: UInt = #line, tag: Any? = nil,
                          asynchronous async: Bool = true,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug("\(message())",
+    CocoaLumberjackSwift.DDLogDebug("\(message())",
                                level: level,
                                context: context,
                                file: file,
@@ -49,7 +49,7 @@ internal func DDLogInfo(_ message: @autoclosure () -> String,
                         line: UInt = #line, tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo("\(message())",
+    CocoaLumberjackSwift.DDLogInfo("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -67,7 +67,7 @@ internal func DDLogWarn(_ message: @autoclosure () -> String,
                         line: UInt = #line, tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn("\(message())",
+    CocoaLumberjackSwift.DDLogWarn("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -85,7 +85,7 @@ internal func DDLogVerbose(_ message: @autoclosure () -> String,
                            line: UInt = #line, tag: Any? = nil,
                            asynchronous async: Bool = true,
                            ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose("\(message())",
+    CocoaLumberjackSwift.DDLogVerbose("\(message())",
                                  level: level,
                                  context: context,
                                  file: file,
@@ -103,7 +103,7 @@ internal func DDLogError(_ message: @autoclosure () -> String,
                          line: UInt = #line, tag: Any? = nil,
                          asynchronous async: Bool = false,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError("\(message())",
+    CocoaLumberjackSwift.DDLogError("\(message())",
                                level: level,
                                context: context,
                                file: file,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -426,6 +426,8 @@
 		31D27C8F2602B553002EDB1D /* plugins.json in Resources */ = {isa = PBXBuildFile; fileRef = 31D27C8E2602B553002EDB1D /* plugins.json */; };
 		31D27C952602B737002EDB1D /* SitePluginsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C942602B737002EDB1D /* SitePluginsRemoteTests.swift */; };
 		3F368D9E2DCB750B0065B48F /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3F368D9D2DCB750B0065B48F /* TestKit */; };
+		3FF8370C2DD322FF0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8370B2DD322FF0049E028 /* CocoaLumberjackSwift */; };
+		3FF8371F2DD32CB30049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8371E2DD32CB30049E028 /* CocoaLumberjackSwift */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
@@ -2595,6 +2597,7 @@
 			files = (
 				26B542452BEAC6A6003A55B5 /* Pods_NetworkingWatchOS.framework in Frameworks */,
 				269014C72BEA9166006056E0 /* Codegen in Frameworks */,
+				3FF8370C2DD322FF0049E028 /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2604,6 +2607,7 @@
 			files = (
 				263E37D22641ACEA00260D3B /* Codegen in Frameworks */,
 				68FBC5B828928C8C00A05461 /* WooFoundation.framework in Frameworks */,
+				3FF8371F2DD32CB30049E028 /* CocoaLumberjackSwift in Frameworks */,
 				6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4367,6 +4371,7 @@
 			name = NetworkingWatchOS;
 			packageProductDependencies = (
 				269014C62BEA9166006056E0 /* Codegen */,
+				3FF8370B2DD322FF0049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = NetworkingWatchOS;
 			productReference = 26DAAB4F2BEA8D3400CE399E /* NetworkingWatchOS.framework */;
@@ -4389,6 +4394,7 @@
 			name = Networking;
 			packageProductDependencies = (
 				263E37D12641ACEA00260D3B /* Codegen */,
+				3FF8371E2DD32CB30049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = Networking;
 			productReference = B557D9E3209753AA005962F4 /* Networking.framework */;
@@ -4452,6 +4458,9 @@
 				Base,
 			);
 			mainGroup = B557D9D9209753AA005962F4;
+			packageReferences = (
+				3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
+			);
 			productRefGroup = B557D9E4209753AA005962F4 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -6417,6 +6426,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.8.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		263E37D12641ACEA00260D3B /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -6433,6 +6453,16 @@
 		3F368D9D2DCB750B0065B48F /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestKit;
+		};
+		3FF8370B2DD322FF0049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
+		};
+		3FF8371E2DD32CB30049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Networking/Networking/Logging.swift
+++ b/Networking/Networking/Logging.swift
@@ -10,18 +10,18 @@
 // `@inline(__always)` to enfore inlining, but that attribute is not officially
 // supported as of Swift 4.0.)
 
-import CocoaLumberjack
+import CocoaLumberjackSwift
 
 /// The logging level threshold for DDLog… calls from Swift.
 /// Change this to adjust the verbosity of the log.
 ///
 /// Example:
 ///     internal var defaultDebugLevel: DDLogLevel = .verbose
-internal var defaultDebugLevel: DDLogLevel = CocoaLumberjack.dynamicLogLevel
+internal var defaultDebugLevel: DDLogLevel = CocoaLumberjackSwift.dynamicLogLevel
 
 /// Reset the logging level threshold to the app-wide default.
 internal func resetDefaultDebugLevel() {
-    defaultDebugLevel = CocoaLumberjack.dynamicLogLevel
+    defaultDebugLevel = CocoaLumberjackSwift.dynamicLogLevel
 }
 
 internal func DDLogDebug(_ message: @autoclosure () -> String,
@@ -31,7 +31,7 @@ internal func DDLogDebug(_ message: @autoclosure () -> String,
                          line: UInt = #line, tag: Any? = nil,
                          asynchronous async: Bool = true,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug("\(message())",
+    CocoaLumberjackSwift.DDLogDebug("\(message())",
                                level: level,
                                context: context,
                                file: file,
@@ -49,7 +49,7 @@ internal func DDLogInfo(_ message: @autoclosure () -> String,
                         line: UInt = #line, tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo("\(message())",
+    CocoaLumberjackSwift.DDLogInfo("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -67,7 +67,7 @@ internal func DDLogWarn(_ message: @autoclosure () -> String,
                         line: UInt = #line, tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn("\(message())",
+    CocoaLumberjackSwift.DDLogWarn("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -85,7 +85,7 @@ internal func DDLogVerbose(_ message: @autoclosure () -> String,
                            line: UInt = #line, tag: Any? = nil,
                            asynchronous async: Bool = true,
                            ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose("\(message())",
+    CocoaLumberjackSwift.DDLogVerbose("\(message())",
                                  level: level,
                                  context: context,
                                  file: file,
@@ -103,7 +103,7 @@ internal func DDLogError(_ message: @autoclosure () -> String,
                          line: UInt = #line, tag: Any? = nil,
                          asynchronous async: Bool = false,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError("\(message())",
+    CocoaLumberjackSwift.DDLogError("\(message())",
                                level: level,
                                context: context,
                                file: file,

--- a/Podfile
+++ b/Podfile
@@ -45,17 +45,12 @@ def alamofire
   pod 'Alamofire', '~> 5.0'
 end
 
-def cocoa_lumberjack
-  pod 'CocoaLumberjack/Swift', '~> 3.8.5'
-end
-
 def stripe_terminal
   pod 'StripeTerminal', '~> 4.2.0'
 end
 
 def networking_pods
   alamofire
-  cocoa_lumberjack
 
   wordpress_shared
 
@@ -68,7 +63,6 @@ end
 
 def networking_watch_os_pods
   alamofire
-  cocoa_lumberjack
   keychain
 end
 
@@ -106,7 +100,6 @@ target 'WooCommerce' do
   # ==================
   #
   alamofire
-  cocoa_lumberjack
   keychain
   pod 'ZendeskSupportSDK', '~> 9.0.0'
   stripe_terminal
@@ -153,7 +146,6 @@ end
 def yosemite_pods
   alamofire
   stripe_terminal
-  cocoa_lumberjack
   networking_pods
 
   aztec
@@ -173,40 +165,6 @@ end
 target 'YosemiteTests' do
   project 'Yosemite/Yosemite.xcodeproj'
   yosemite_pods
-end
-
-# WooFoundation Layer:
-# ===============
-#
-def woofoundation_pods
-  cocoa_lumberjack
-end
-
-def woofoundation_watchos_pods
-  cocoa_lumberjack
-end
-
-# Tools Target:
-# ================
-#
-target 'WooFoundation' do
-  project 'WooFoundation/WooFoundation.xcodeproj'
-  woofoundation_pods
-end
-
-target 'WooFoundationWatchOS' do
-  project 'WooFoundation/WooFoundation.xcodeproj'
-  platform :watchos, app_watchos_deployment_target.version
-
-  woofoundation_watchos_pods
-end
-
-# Unit Tests
-# ==========
-#
-target 'WooFoundationTests' do
-  project 'WooFoundation/WooFoundation.xcodeproj'
-  woofoundation_pods
 end
 
 # Networking Target:
@@ -238,35 +196,11 @@ target 'NetworkingTests' do
   yosemite_pods
 end
 
-# Storage Layer:
-# ==============
-#
-def storage_pods
-  cocoa_lumberjack
-end
-
-# Storage Target:
-# ===============
-#
-target 'Storage' do
-  project 'Storage/Storage.xcodeproj'
-  storage_pods
-end
-
-# Unit Tests
-# ==========
-#
-target 'StorageTests' do
-  project 'Storage/Storage.xcodeproj'
-  storage_pods
-end
-
 # Hardware Layer:
 # =================
 #
 def hardware_pods
   stripe_terminal
-  cocoa_lumberjack
 end
 
 # Hardware Target:
@@ -291,29 +225,6 @@ end
 target 'SampleReceiptPrinter' do
   project 'Hardware/Hardware.xcodeproj'
   hardware_pods
-end
-
-# Experiments Layer:
-# ==================
-#
-def experiments_pods
-  cocoa_lumberjack
-end
-
-# Experiments Target:
-# ===================
-#
-target 'Experiments' do
-  project 'Experiments/Experiments.xcodeproj'
-  experiments_pods
-end
-
-# Unit Tests
-# ==========
-#
-target 'ExperimentsTests' do
-  project 'Experiments/Experiments.xcodeproj'
-  experiments_pods
 end
 
 # WordPressAuthenticator

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,5 @@
 PODS:
   - Alamofire (5.8.1)
-  - CocoaLumberjack/Core (3.8.5)
-  - CocoaLumberjack/Swift (3.8.5):
-    - CocoaLumberjack/Core
   - Gridicons (1.2.0)
   - KeychainAccess (4.2.2)
   - Kingfisher (7.6.2)
@@ -52,7 +49,6 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 5.0)
-  - CocoaLumberjack/Swift (~> 3.8.5)
   - Gridicons (~> 1.2.0)
   - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 7.6.2)
@@ -74,7 +70,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Alamofire
-    - CocoaLumberjack
     - Gridicons
     - KeychainAccess
     - Kingfisher
@@ -101,7 +96,6 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: 3ca42e259043ee0dc5c0cdd76c4bc568b8e42af7
-  CocoaLumberjack: 6a459bc897d6d80bd1b8c78482ec7ad05dffc3f0
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
@@ -126,6 +120,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 281acf2bb731d2a67f913cfe653ed0da9f5b2f42
   ZendeskSupportSDK: b512cfc74b6bf8490e589f02cf52e27ed4f2bebe
 
-PODFILE CHECKSUM: 0bcc33e3f57eb06d5e7354ff8f7a420eab49c5ce
+PODFILE CHECKSUM: d34daa04154fd73f4a565d54cee6f58d87a1a730
 
 COCOAPODS: 1.16.2

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		31D9C8C826684AEC000AC134 /* PaymentGatewayAccount+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D9C8C626684AEC000AC134 /* PaymentGatewayAccount+CoreDataClass.swift */; };
 		31D9C8C926684AEC000AC134 /* PaymentGatewayAccount+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D9C8C726684AEC000AC134 /* PaymentGatewayAccount+CoreDataProperties.swift */; };
 		3F368D9C2DCB74DF0065B48F /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3F368D9B2DCB74DF0065B48F /* TestKit */; };
+		3FF837162DD32B150049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837152DD32B150049E028 /* CocoaLumberjackSwift */; };
+		3FF837182DD32B2E0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837172DD32B2E0049E028 /* CocoaLumberjackSwift */; };
 		450106892399AC7400E24722 /* TaxClass+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */; };
 		4501068B2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */; };
 		452C23B427B4129300822986 /* InboxAction+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452C23B027B4129300822986 /* InboxAction+CoreDataClass.swift */; };
@@ -112,8 +114,6 @@
 		6889089C28F66DED0081A07E /* Customer+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6889089828F66DED0081A07E /* Customer+CoreDataProperties.swift */; };
 		6889089D28F66DED0081A07E /* CustomerSearchResult+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6889089928F66DED0081A07E /* CustomerSearchResult+CoreDataClass.swift */; };
 		688908AA28FD00320081A07E /* WooCommerceModelV74toV75.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 688908A928FD00320081A07E /* WooCommerceModelV74toV75.xcmappingmodel */; };
-		68BC97FB41770051C287D1A8 /* Pods_StorageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */; };
-		7028A41485A08AC748206184 /* Pods_Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */; };
 		7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */; };
 		7426A05120F69D00002A4E07 /* OrderCoupon+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426A04F20F69D00002A4E07 /* OrderCoupon+CoreDataProperties.swift */; };
 		7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426A05220F69DA4002A4E07 /* OrderItem+CoreDataClass.swift */; };
@@ -405,7 +405,6 @@
 		57A29FB725226BDC004DEE01 /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
 		57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralAppSettings.swift; sourceTree = "<group>"; };
 		57CEB1A12525349B00D8544F /* ProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationTests.swift; sourceTree = "<group>"; };
-		5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.debug.xcconfig"; sourceTree = "<group>"; };
 		686C01A32A39BC8600BBCF2F /* Model 90.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 90.xcdatamodel"; sourceTree = "<group>"; };
 		6889088D28F668330081A07E /* Model 74.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 74.xcdatamodel"; sourceTree = "<group>"; };
 		6889089628F66DED0081A07E /* CustomerSearchResult+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CustomerSearchResult+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -448,14 +447,12 @@
 		74B7D6AC20F90CBB002667AC /* OrderNote+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderNote+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		74F009BE2183B99B002B4566 /* Note+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+CoreDataClass.swift"; sourceTree = "<group>"; };
 		74F009BF2183B99B002B4566 /* Note+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		7C81935EDD982072BBDCC837 /* Pods-Storage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Storage/Pods-Storage.release.xcconfig"; sourceTree = "<group>"; };
 		860C0F3B2C7CB1CA0061CB3E /* MetaData+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MetaData+CoreDataClass.swift"; sourceTree = "<group>"; };
 		860C0F3C2C7CB1CA0061CB3E /* MetaData+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MetaData+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		86C265CF2AF34FE900F28E0A /* Model 101.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 101.xcdatamodel"; sourceTree = "<group>"; };
 		9302E3A5220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataIterativeMigrator.swift; sourceTree = "<group>"; };
 		9302E3AB220E1CE900DA5018 /* CoreDataIterativeMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataIterativeMigratorTests.swift; sourceTree = "<group>"; };
 		933A272F2222344D00C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
-		A3821B262583F14863740A37 /* Pods-Storage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Storage/Pods-Storage.debug.xcconfig"; sourceTree = "<group>"; };
 		AE7DF9FA2919023100C4D1ED /* Model 77.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 77.xcdatamodel"; sourceTree = "<group>"; };
 		AE93BE8F272C0E9F001B55EA /* GeneralStoreSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralStoreSettings.swift; sourceTree = "<group>"; };
 		AEC4481B290853C300BAA299 /* Model 76.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 76.xcdatamodel"; sourceTree = "<group>"; };
@@ -496,7 +493,6 @@
 		BAB373732796310100837B4A /* Model 61.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 61.xcdatamodel"; sourceTree = "<group>"; };
 		BAB373742796327000837B4A /* OrderTaxLine+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderTaxLine+CoreDataClass.swift"; sourceTree = "<group>"; };
 		BAB373752796327000837B4A /* OrderTaxLine+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderTaxLine+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		BB0EDB0E92A719168B18DAFE /* Pods-StorageTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.release.xcconfig"; sourceTree = "<group>"; };
 		CC24A4EB29ED416E0009D6DA /* Model 83.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 83.xcdatamodel"; sourceTree = "<group>"; };
 		CC24A4EC29ED43D60009D6DA /* ProductSubscription+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CC24A4ED29ED43D60009D6DA /* ProductSubscription+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -564,7 +560,6 @@
 		CEE9188829F7E8D2004B23FF /* OrderGiftCard+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderGiftCard+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		CEF88DB0233EAAF000BED485 /* OrderRefundCondensed+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderRefundCondensed+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CEF88DB1233EAAF000BED485 /* OrderRefundCondensed+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderRefundCondensed+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		D0FEE3A91785B0F2C3641C27 /* Pods-Storage.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Storage/Pods-Storage.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		D4466F5526D524FC003E931B /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		D4ABCACE26D6E7E400CD18F4 /* Announcement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Announcement.swift; sourceTree = "<group>"; };
 		D82164572239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProvider+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -685,7 +680,6 @@
 		EE8A303C2B7352D0001D7C66 /* OrderAttributionInfo+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderAttributionInfo+CoreDataClass.swift"; sourceTree = "<group>"; };
 		EE8A303D2B7352D1001D7C66 /* OrderAttributionInfo+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderAttributionInfo+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		EE94345329F038DF002B1900 /* Model 84.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 84.xcdatamodel"; sourceTree = "<group>"; };
-		F0439F2ADB3B211DF5C44D83 /* Pods-StorageTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		FEDD70AC26A5DBDD00194C3A /* EligibilityErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EligibilityErrorInfo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -696,7 +690,7 @@
 			files = (
 				263E37D72641AD5100260D3B /* Codegen in Frameworks */,
 				B54CA5B520A4BC0300F38CD1 /* CoreData.framework in Frameworks */,
-				7028A41485A08AC748206184 /* Pods_Storage.framework in Frameworks */,
+				3FF837162DD32B150049E028 /* CocoaLumberjackSwift in Frameworks */,
 				B9EFC27728903F7C00667217 /* WooFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -707,7 +701,7 @@
 			files = (
 				3F368D9C2DCB74DF0065B48F /* TestKit in Frameworks */,
 				B54CA5A320A4BBA600F38CD1 /* Storage.framework in Frameworks */,
-				68BC97FB41770051C287D1A8 /* Pods_StorageTests.framework in Frameworks */,
+				3FF837182DD32B2E0049E028 /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -763,12 +757,6 @@
 		4DD3D0BDDE216A90FC1335D7 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A3821B262583F14863740A37 /* Pods-Storage.debug.xcconfig */,
-				7C81935EDD982072BBDCC837 /* Pods-Storage.release.xcconfig */,
-				5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */,
-				BB0EDB0E92A719168B18DAFE /* Pods-StorageTests.release.xcconfig */,
-				D0FEE3A91785B0F2C3641C27 /* Pods-Storage.release-alpha.xcconfig */,
-				F0439F2ADB3B211DF5C44D83 /* Pods-StorageTests.release-alpha.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -1232,7 +1220,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B54CA5AD20A4BBA600F38CD1 /* Build configuration list for PBXNativeTarget "Storage" */;
 			buildPhases = (
-				3A8FEF735A87B89A39A6FF95 /* [CP] Check Pods Manifest.lock */,
 				B54CA59620A4BBA500F38CD1 /* Headers */,
 				B54CA59420A4BBA500F38CD1 /* Sources */,
 				B54CA59520A4BBA500F38CD1 /* Frameworks */,
@@ -1245,6 +1232,7 @@
 			name = Storage;
 			packageProductDependencies = (
 				263E37D62641AD5100260D3B /* Codegen */,
+				3FF837152DD32B150049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = Storage;
 			productReference = B54CA59920A4BBA500F38CD1 /* Storage.framework */;
@@ -1254,11 +1242,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B54CA5B020A4BBA600F38CD1 /* Build configuration list for PBXNativeTarget "StorageTests" */;
 			buildPhases = (
-				B5A9361234BC984EB7277688 /* [CP] Check Pods Manifest.lock */,
 				B54CA59E20A4BBA600F38CD1 /* Sources */,
 				B54CA59F20A4BBA600F38CD1 /* Frameworks */,
 				B54CA5A020A4BBA600F38CD1 /* Resources */,
-				E73E84823B544CDE60613A23 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1268,6 +1254,7 @@
 			name = StorageTests;
 			packageProductDependencies = (
 				3F368D9B2DCB74DF0065B48F /* TestKit */,
+				3FF837172DD32B2E0049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = StorageTests;
 			productReference = B54CA5A220A4BBA600F38CD1 /* StorageTests.xctest */;
@@ -1303,6 +1290,9 @@
 				Base,
 			);
 			mainGroup = B54CA58F20A4BBA500F38CD1;
+			packageReferences = (
+				3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
+			);
 			productRefGroup = B54CA59A20A4BBA500F38CD1 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1330,62 +1320,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		3A8FEF735A87B89A39A6FF95 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Storage-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B5A9361234BC984EB7277688 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-StorageTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E73E84823B544CDE60613A23 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-StorageTests/Pods-StorageTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-StorageTests/Pods-StorageTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-StorageTests/Pods-StorageTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		B54CA59420A4BBA500F38CD1 /* Sources */ = {
@@ -1735,7 +1669,6 @@
 		};
 		1A96903C2359D9AF0061E383 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0FEE3A91785B0F2C3641C27 /* Pods-Storage.release-alpha.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1767,7 +1700,6 @@
 		};
 		1A96903D2359D9AF0061E383 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F0439F2ADB3B211DF5C44D83 /* Pods-StorageTests.release-alpha.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -1916,7 +1848,6 @@
 		};
 		B54CA5AE20A4BBA600F38CD1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3821B262583F14863740A37 /* Pods-Storage.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1948,7 +1879,6 @@
 		};
 		B54CA5AF20A4BBA600F38CD1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7C81935EDD982072BBDCC837 /* Pods-Storage.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1979,7 +1909,6 @@
 		};
 		B54CA5B120A4BBA600F38CD1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -2003,7 +1932,6 @@
 		};
 		B54CA5B220A4BBA600F38CD1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BB0EDB0E92A719168B18DAFE /* Pods-StorageTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -2059,10 +1987,31 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.8.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		263E37D62641AD5100260D3B /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Codegen;
+		};
+		3FF837152DD32B150049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
+		};
+		3FF837172DD32B2E0049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
 		};
 		3F368D9B2DCB74DF0065B48F /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Storage/Storage/Logging.swift
+++ b/Storage/Storage/Logging.swift
@@ -10,18 +10,18 @@
 // `@inline(__always)` to enfore inlining, but that attribute is not officially
 // supported as of Swift 4.0.)
 
-import CocoaLumberjack
+import CocoaLumberjackSwift
 
 /// The logging level threshold for DDLog… calls from Swift.
 /// Change this to adjust the verbosity of the log.
 ///
 /// Example:
 ///     internal var defaultDebugLevel: DDLogLevel = .verbose
-internal var defaultDebugLevel: DDLogLevel = CocoaLumberjack.dynamicLogLevel
+internal var defaultDebugLevel: DDLogLevel = CocoaLumberjackSwift.dynamicLogLevel
 
 /// Reset the logging level threshold to the app-wide default.
 internal func resetDefaultDebugLevel() {
-    defaultDebugLevel = CocoaLumberjack.dynamicLogLevel
+    defaultDebugLevel = CocoaLumberjackSwift.dynamicLogLevel
 }
 
 internal func DDLogDebug(_ message: @autoclosure () -> String,
@@ -33,7 +33,7 @@ internal func DDLogDebug(_ message: @autoclosure () -> String,
                          tag: Any? = nil,
                          asynchronous async: Bool = true,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug("\(message())",
+    CocoaLumberjackSwift.DDLogDebug("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -53,7 +53,7 @@ internal func DDLogInfo(_ message: @autoclosure () -> String,
                         tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo("\(message())",
+    CocoaLumberjackSwift.DDLogInfo("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -73,7 +73,7 @@ internal func DDLogWarn(_ message: @autoclosure () -> String,
                         tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn("\(message())",
+    CocoaLumberjackSwift.DDLogWarn("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -93,7 +93,7 @@ internal func DDLogVerbose(_ message: @autoclosure () -> String,
                            tag: Any? = nil,
                            asynchronous async: Bool = true,
                            ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose("\(message())",
+    CocoaLumberjackSwift.DDLogVerbose("\(message())",
                                  level: level,
                                  context: context,
                                  file: file,
@@ -113,7 +113,7 @@ internal func DDLogError(_ message: @autoclosure () -> String,
                          tag: Any? = nil,
                          asynchronous async: Bool = false,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError("\(message())",
+    CocoaLumberjackSwift.DDLogError("\(message())",
                                level: level,
                                context: context,
                                file: file,

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import TestKit
-import CocoaLumberjack
+import CocoaLumberjackSwift
 import CoreData
 @testable import Storage
 

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "CocoaLumberjack",
+        "repositoryURL": "https://github.com/CocoaLumberjack/CocoaLumberjack",
+        "state": {
+          "branch": null,
+          "revision": "4b8714a7fb84d42393314ce897127b3939885ec3",
+          "version": "3.8.5"
+        }
+      },
+      {
         "package": "ConfettiSwiftUI",
         "repositoryURL": "https://github.com/simibac/ConfettiSwiftUI.git",
         "state": {
@@ -125,6 +134,15 @@
           "branch": null,
           "revision": "f6919dfc309e7f1b56224378b11e28bab5bccc42",
           "version": "1.2.0"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log",
+        "state": {
+          "branch": null,
+          "revision": "3d8596ed08bd13520157f0355e35caed215ffbfa",
+          "version": "1.6.3"
         }
       },
       {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -8,7 +8,7 @@ import protocol WooFoundation.Analytics
 import protocol Yosemite.StoresManager
 import struct Yosemite.Site
 
-import CocoaLumberjack
+import CocoaLumberjackSwift
 import KeychainAccess
 import WordPressUI
 import WordPressAuthenticator
@@ -368,7 +368,7 @@ private extension AppDelegate {
     /// Sets up the current Log Level.
     ///
     func setupLogLevel(_ level: DDLogLevel) {
-        CocoaLumberjack.dynamicLogLevel = level
+        CocoaLumberjackSwift.dynamicLogLevel = level
     }
 
     /// Setup: Notice Presenter

--- a/WooCommerce/Classes/Tools/Logging/Logging.swift
+++ b/WooCommerce/Classes/Tools/Logging/Logging.swift
@@ -10,18 +10,18 @@
 // `@inline(__always)` to enfore inlining, but that attribute is not officially
 // supported as of Swift 4.0.)
 
-import CocoaLumberjack
+import CocoaLumberjackSwift
 
 /// The logging level threshold for DDLog… calls from Swift.
 /// Change this to adjust the verbosity of the log.
 ///
 /// Example:
 ///     internal var defaultDebugLevel: DDLogLevel = .verbose
-internal var defaultDebugLevel: DDLogLevel = CocoaLumberjack.dynamicLogLevel
+internal var defaultDebugLevel: DDLogLevel = CocoaLumberjackSwift.dynamicLogLevel
 
 /// Reset the logging level threshold to the app-wide default.
 internal func resetDefaultDebugLevel() {
-    defaultDebugLevel = CocoaLumberjack.dynamicLogLevel
+    defaultDebugLevel = CocoaLumberjackSwift.dynamicLogLevel
 }
 
 internal func DDLogDebug(_ message: @autoclosure () -> String,
@@ -34,7 +34,7 @@ internal func DDLogDebug(_ message: @autoclosure () -> String,
                          asynchronous async: Bool = true,
                          ddlog: DDLog = DDLog.sharedInstance) {
 
-    CocoaLumberjack.DDLogDebug("\(message())",
+    CocoaLumberjackSwift.DDLogDebug("\(message())",
                                level: level,
                                context: context,
                                file: file,
@@ -55,7 +55,7 @@ internal func DDLogInfo(_ message: @autoclosure () -> String,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
 
-    CocoaLumberjack.DDLogInfo("\(message())",
+    CocoaLumberjackSwift.DDLogInfo("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -76,7 +76,7 @@ internal func DDLogWarn(_ message: @autoclosure () -> String,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
 
-    CocoaLumberjack.DDLogWarn("\(message())",
+    CocoaLumberjackSwift.DDLogWarn("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -97,7 +97,7 @@ internal func DDLogVerbose(_ message: @autoclosure () -> String,
                            asynchronous async: Bool = true,
                            ddlog: DDLog = DDLog.sharedInstance) {
 
-    CocoaLumberjack.DDLogVerbose("\(message())",
+    CocoaLumberjackSwift.DDLogVerbose("\(message())",
                                  level: level,
                                  context: context,
                                  file: file,
@@ -118,7 +118,7 @@ internal func DDLogError(_ message: @autoclosure () -> String,
                          asynchronous async: Bool = false,
                          ddlog: DDLog = DDLog.sharedInstance) {
 
-    CocoaLumberjack.DDLogError("\(message())",
+    CocoaLumberjackSwift.DDLogError("\(message())",
                                level: level,
                                context: context,
                                file: file,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1334,6 +1334,7 @@
 		3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
 		3FF837132DD326850049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837122DD326850049E028 /* CocoaLumberjackSwift */; };
 		3FF8371A2DD32B8D0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */; };
+		3FF837212DD32F5C0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837202DD32F5C0049E028 /* CocoaLumberjackSwift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -6616,6 +6617,7 @@
 				3F368D982DCB74490065B48F /* TestKit in Frameworks */,
 				263E38462641FF3400260D3B /* Codegen in Frameworks */,
 				3F2C8A19285B038800B1A5BB /* BuildkiteTestCollector in Frameworks */,
+				3FF837212DD32F5C0049E028 /* CocoaLumberjackSwift in Frameworks */,
 				2621D1F72C810DB800654C4C /* ViewControllerPresentationSpy in Frameworks */,
 				3F8BACEB2DD309E0002DD6E8 /* AutomatticTracks in Frameworks */,
 				26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */,
@@ -14747,6 +14749,7 @@
 				2621D1F62C810DB800654C4C /* ViewControllerPresentationSpy */,
 				3F368D972DCB74490065B48F /* TestKit */,
 				3F8BACEA2DD309E0002DD6E8 /* AutomatticTracks */,
+				3FF837202DD32F5C0049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = WooCommerceTests;
 			productReference = B56DB3DD2049BFAA00D4AA8E /* WooCommerceTests.xctest */;
@@ -20051,6 +20054,11 @@
 			productName = CocoaLumberjackSwift;
 		};
 		3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
+		};
+		3FF837202DD32F5C0049E028 /* CocoaLumberjackSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
 			productName = CocoaLumberjackSwift;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1332,6 +1332,8 @@
 		3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
 		3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
 		3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
+		3FF837132DD326850049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837122DD326850049E028 /* CocoaLumberjackSwift */; };
+		3FF8371A2DD32B8D0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -6534,6 +6536,7 @@
 				26B542432BEAC68B003A55B5 /* Codegen in Frameworks */,
 				26B542402BEAC4DC003A55B5 /* Pods_Woo_Watch_App.framework in Frameworks */,
 				269FFA462BF40768004E6B86 /* WooFoundationWatchOS.framework in Frameworks */,
+				3FF8371A2DD32B8D0049E028 /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6591,6 +6594,7 @@
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */,
 				3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
+				3FF837132DD326850049E028 /* CocoaLumberjackSwift in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
 				DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */,
 				3F8115072DD2AB2A0042DDB6 /* AutomatticEncryptedLogs in Frameworks */,
@@ -14583,6 +14587,7 @@
 			name = "Woo Watch App";
 			packageProductDependencies = (
 				26B542422BEAC68B003A55B5 /* Codegen */,
+				3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = "Woo Watch App";
 			productReference = 26F81B152BE433A2009EC58E /* Woo Watch App.app */;
@@ -14713,6 +14718,7 @@
 				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
 				3F81114D2DD2A64E0042DDB6 /* AutomatticTracks */,
 				3F8115062DD2AB2A0042DDB6 /* AutomatticEncryptedLogs */,
+				3FF837122DD326850049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -14905,6 +14911,7 @@
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
 				2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */,
 				3F81114C2DD2A64E0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */,
+				3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -19896,6 +19903,14 @@
 				minimumVersion = 0.3.0;
 			};
 		};
+		3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.8.5;
+			};
+		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/markiv/SwiftUI-Shimmer";
@@ -20029,6 +20044,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;
+		};
+		3FF837122DD326850049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
+		};
+		3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
 		};
 		45455E312657C3F300BBB0C4 /* Shimmer */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -44,7 +44,8 @@
 		26AF1F5528B8362800937BA9 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5128B8362800937BA9 /* UIColor+ColorStudio.swift */; };
 		26AF1F5628B8362800937BA9 /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5228B8362800937BA9 /* UIColor+SystemColors.swift */; };
 		26AF1F5928B9011100937BA9 /* WooStyleModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5828B9011100937BA9 /* WooStyleModifiers.swift */; };
-		397702D42D32EAEEEA3B29FC /* Pods_WooFoundationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 532D4D63493CE8FA6F13C85B /* Pods_WooFoundationTests.framework */; };
+		3FF80E382DD322300049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF80E372DD322300049E028 /* CocoaLumberjackSwift */; };
+		3FF8370E2DD323380049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8370D2DD323380049E028 /* CocoaLumberjackSwift */; };
 		686BE912288EE0D300967C86 /* TypedPredicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE911288EE0D300967C86 /* TypedPredicates.swift */; };
 		686BE915288EE2CA00967C86 /* TypedPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE914288EE2CA00967C86 /* TypedPredicateTests.swift */; };
 		6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6874E81328998AD300074A97 /* LogErrorAndExit.swift */; };
@@ -53,13 +54,11 @@
 		689D11D02891B3A300F6A83F /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689D11CF2891B3A300F6A83F /* CrashLogger.swift */; };
 		689D11D32891B7D800F6A83F /* MockCrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689D11D22891B7D800F6A83F /* MockCrashLogger.swift */; };
 		68FBC5B328926B2C00A05461 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBC5B228926B2C00A05461 /* Collection+Extensions.swift */; };
-		7A8A7FB1C1B872009917940A /* Pods_WooFoundationWatchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72956724B0AE377A044EDF4 /* Pods_WooFoundationWatchOS.framework */; };
 		9502369C2D2C1A9F00E2F796 /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 265C99D728B93F04005E6117 /* ColorPalette.xcassets */; };
 		9502369E2D2C1AB600E2F796 /* ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5028B8362800937BA9 /* ColorStudio.swift */; };
 		950236A12D2C1BCF00E2F796 /* Color+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0331A75A2A3B553A001D2C2C /* Color+ColorStudio.swift */; };
 		950236A42D2C1C0A00E2F796 /* WooFoundationBundleClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950236A32D2C1C0A00E2F796 /* WooFoundationBundleClass.swift */; };
 		950236A52D2C1C0A00E2F796 /* WooFoundationBundleClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950236A32D2C1C0A00E2F796 /* WooFoundationBundleClass.swift */; };
-		9FA5113235035AC9A6079B0D /* Pods_WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1733C61561AE3A1AD3C16B7 /* Pods_WooFoundation.framework */; };
 		AE948D0A28CF67CF009F3246 /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */; };
 		AE948D0D28CF6D50009F3246 /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE948D0C28CF6D50009F3246 /* DateStartAndEndTests.swift */; };
 		B95B15CB2B15FA3A00A54044 /* Publishers+KeyboardFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95B15CA2B15FA3A00A54044 /* Publishers+KeyboardFrame.swift */; };
@@ -140,7 +139,6 @@
 		26AF1F5828B9011100937BA9 /* WooStyleModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WooStyleModifiers.swift; sourceTree = "<group>"; };
 		3FA7D9FE2D547EDC00CE5611 /* WooFoundation.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WooFoundation.xcconfig; sourceTree = "<group>"; };
 		532D4D63493CE8FA6F13C85B /* Pods_WooFoundationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooFoundationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5BC355411C0A805BF29F38A6 /* Pods-WooFoundationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationTests.release.xcconfig"; path = "Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests.release.xcconfig"; sourceTree = "<group>"; };
 		686BE911288EE0D300967C86 /* TypedPredicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedPredicates.swift; sourceTree = "<group>"; };
 		686BE914288EE2CA00967C86 /* TypedPredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedPredicateTests.swift; sourceTree = "<group>"; };
 		6874E81328998AD300074A97 /* LogErrorAndExit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogErrorAndExit.swift; sourceTree = "<group>"; };
@@ -149,12 +147,7 @@
 		689D11CF2891B3A300F6A83F /* CrashLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashLogger.swift; sourceTree = "<group>"; };
 		689D11D22891B7D800F6A83F /* MockCrashLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCrashLogger.swift; sourceTree = "<group>"; };
 		68FBC5B228926B2C00A05461 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
-		73D31B9496B7C29667554A6E /* Pods-WooFoundationWatchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationWatchOS.release.xcconfig"; path = "Target Support Files/Pods-WooFoundationWatchOS/Pods-WooFoundationWatchOS.release.xcconfig"; sourceTree = "<group>"; };
-		81B8569CD52D20EAE64EE737 /* Pods-WooFoundation.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundation.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooFoundation/Pods-WooFoundation.release-alpha.xcconfig"; sourceTree = "<group>"; };
-		8E30B666ED4157ED247C4485 /* Pods-WooFoundationWatchOS.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationWatchOS.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooFoundationWatchOS/Pods-WooFoundationWatchOS.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		950236A32D2C1C0A00E2F796 /* WooFoundationBundleClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooFoundationBundleClass.swift; sourceTree = "<group>"; };
-		99861FECBD0975C25DA03D80 /* Pods-WooFoundation.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundation.debug.xcconfig"; path = "Target Support Files/Pods-WooFoundation/Pods-WooFoundation.debug.xcconfig"; sourceTree = "<group>"; };
-		A21D73D352B4162AB096E276 /* Pods-WooFoundationTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationTests.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		A72956724B0AE377A044EDF4 /* Pods_WooFoundationWatchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooFoundationWatchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		AE948D0C28CF6D50009F3246 /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
@@ -176,10 +169,7 @@
 		B9C9C65F283E71F4001B879F /* Double+Woo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Double+Woo.swift"; sourceTree = "<group>"; };
 		B9C9C662283E7296001B879F /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		B9C9C665283E72ED001B879F /* CocoaLumberjack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CocoaLumberjack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BCA82452EA8EE0170C1AA258 /* Pods-WooFoundationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationTests.debug.xcconfig"; path = "Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1733C61561AE3A1AD3C16B7 /* Pods_WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D64F2A76E9373989B3F181FC /* Pods-WooFoundation.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundation.release.xcconfig"; path = "Target Support Files/Pods-WooFoundation/Pods-WooFoundation.release.xcconfig"; sourceTree = "<group>"; };
-		ECDCBBC381959DB4653FBFD0 /* Pods-WooFoundationWatchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationWatchOS.debug.xcconfig"; path = "Target Support Files/Pods-WooFoundationWatchOS/Pods-WooFoundationWatchOS.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,8 +177,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF8370E2DD323380049E028 /* CocoaLumberjackSwift in Frameworks */,
 				269FFA4F2BF5B040004E6B86 /* Codegen in Frameworks */,
-				7A8A7FB1C1B872009917940A /* Pods_WooFoundationWatchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -196,8 +186,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF80E382DD322300049E028 /* CocoaLumberjackSwift in Frameworks */,
 				20AD34D32B0CDB8900F38F44 /* Codegen in Frameworks */,
-				9FA5113235035AC9A6079B0D /* Pods_WooFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -207,7 +197,6 @@
 			files = (
 				036563D728F93F8D00D84BFD /* TestKit in Frameworks */,
 				B9C9C63F283E703C001B879F /* WooFoundation.framework in Frameworks */,
-				397702D42D32EAEEEA3B29FC /* Pods_WooFoundationTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -429,15 +418,6 @@
 		C8E281DD95DE8EF39194328A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				99861FECBD0975C25DA03D80 /* Pods-WooFoundation.debug.xcconfig */,
-				D64F2A76E9373989B3F181FC /* Pods-WooFoundation.release.xcconfig */,
-				BCA82452EA8EE0170C1AA258 /* Pods-WooFoundationTests.debug.xcconfig */,
-				5BC355411C0A805BF29F38A6 /* Pods-WooFoundationTests.release.xcconfig */,
-				81B8569CD52D20EAE64EE737 /* Pods-WooFoundation.release-alpha.xcconfig */,
-				A21D73D352B4162AB096E276 /* Pods-WooFoundationTests.release-alpha.xcconfig */,
-				ECDCBBC381959DB4653FBFD0 /* Pods-WooFoundationWatchOS.debug.xcconfig */,
-				73D31B9496B7C29667554A6E /* Pods-WooFoundationWatchOS.release.xcconfig */,
-				8E30B666ED4157ED247C4485 /* Pods-WooFoundationWatchOS.release-alpha.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -468,7 +448,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 264E9EA22BF4037D009C48FD /* Build configuration list for PBXNativeTarget "WooFoundationWatchOS" */;
 			buildPhases = (
-				474919A7190423CC4A2DAB24 /* [CP] Check Pods Manifest.lock */,
 				264E9E962BF4037D009C48FD /* Headers */,
 				264E9E972BF4037D009C48FD /* Sources */,
 				264E9E982BF4037D009C48FD /* Frameworks */,
@@ -482,6 +461,7 @@
 			name = WooFoundationWatchOS;
 			packageProductDependencies = (
 				269FFA4E2BF5B040004E6B86 /* Codegen */,
+				3FF8370D2DD323380049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = WooFoundationWatchOS;
 			productReference = 264E9E9B2BF4037D009C48FD /* WooFoundationWatchOS.framework */;
@@ -491,7 +471,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B9C9C646283E703C001B879F /* Build configuration list for PBXNativeTarget "WooFoundation" */;
 			buildPhases = (
-				785F98CEE4A25B52E109348C /* [CP] Check Pods Manifest.lock */,
 				B9C9C630283E703C001B879F /* Headers */,
 				B9C9C631283E703C001B879F /* Sources */,
 				B9C9C632283E703C001B879F /* Frameworks */,
@@ -505,6 +484,7 @@
 			name = WooFoundation;
 			packageProductDependencies = (
 				20AD34D22B0CDB8900F38F44 /* Codegen */,
+				3FF80E372DD322300049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = Tools;
 			productReference = B9C9C635283E703C001B879F /* WooFoundation.framework */;
@@ -514,11 +494,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B9C9C649283E703C001B879F /* Build configuration list for PBXNativeTarget "WooFoundationTests" */;
 			buildPhases = (
-				8412E9AEB5C292FAFA14BB34 /* [CP] Check Pods Manifest.lock */,
 				B9C9C63A283E703C001B879F /* Sources */,
 				B9C9C63B283E703C001B879F /* Frameworks */,
 				B9C9C63C283E703C001B879F /* Resources */,
-				D8F50D6FB8B57B87F4399E61 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -563,6 +541,9 @@
 				Base,
 			);
 			mainGroup = B9C9C5ED283E6FAA001B879F;
+			packageReferences = (
+				3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
+			);
 			productRefGroup = B9C9C5FB283E6FAB001B879F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -599,92 +580,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		474919A7190423CC4A2DAB24 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-WooFoundationWatchOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		785F98CEE4A25B52E109348C /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-WooFoundation-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8412E9AEB5C292FAFA14BB34 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-WooFoundationTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D8F50D6FB8B57B87F4399E61 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		264E9E972BF4037D009C48FD /* Sources */ = {
@@ -780,7 +675,6 @@
 /* Begin XCBuildConfiguration section */
 		264E9E9F2BF4037D009C48FD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ECDCBBC381959DB4653FBFD0 /* Pods-WooFoundationWatchOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -823,7 +717,6 @@
 		};
 		264E9EA02BF4037D009C48FD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 73D31B9496B7C29667554A6E /* Pods-WooFoundationWatchOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -866,7 +759,6 @@
 		};
 		264E9EA12BF4037D009C48FD /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8E30B666ED4157ED247C4485 /* Pods-WooFoundationWatchOS.release-alpha.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -962,7 +854,6 @@
 		};
 		B9BD4BD52844E20300F835D6 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 81B8569CD52D20EAE64EE737 /* Pods-WooFoundation.release-alpha.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -999,7 +890,6 @@
 		};
 		B9BD4BD62844E20300F835D6 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A21D73D352B4162AB096E276 /* Pods-WooFoundationTests.release-alpha.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1131,7 +1021,6 @@
 		};
 		B9C9C647283E703C001B879F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 99861FECBD0975C25DA03D80 /* Pods-WooFoundation.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1167,7 +1056,6 @@
 		};
 		B9C9C648283E703C001B879F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D64F2A76E9373989B3F181FC /* Pods-WooFoundation.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1204,7 +1092,6 @@
 		};
 		B9C9C64A283E703C001B879F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BCA82452EA8EE0170C1AA258 /* Pods-WooFoundationTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1221,7 +1108,6 @@
 		};
 		B9C9C64B283E703C001B879F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5BC355411C0A805BF29F38A6 /* Pods-WooFoundationTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1282,6 +1168,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.8.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		036563D628F93F8D00D84BFD /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1294,6 +1191,16 @@
 		269FFA4E2BF5B040004E6B86 /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Codegen;
+		};
+		3FF80E372DD322300049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
+		};
+		3FF8370D2DD323380049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WooFoundation/WooFoundation/Internal/Logging.swift
+++ b/WooFoundation/WooFoundation/Internal/Logging.swift
@@ -10,18 +10,18 @@
 // `@inline(__always)` to enfore inlining, but that attribute is not officially
 // supported as of Swift 4.0.)
 
-import CocoaLumberjack
+import CocoaLumberjackSwift
 
 /// The logging level threshold for DDLog… calls from Swift.
 /// Change this to adjust the verbosity of the log.
 ///
 /// Example:
 ///     internal var defaultDebugLevel: DDLogLevel = .verbose
-internal var defaultDebugLevel: DDLogLevel = CocoaLumberjack.dynamicLogLevel
+internal var defaultDebugLevel: DDLogLevel = CocoaLumberjackSwift.dynamicLogLevel
 
 /// Reset the logging level threshold to the app-wide default.
 internal func resetDefaultDebugLevel() {
-    defaultDebugLevel = CocoaLumberjack.dynamicLogLevel
+    defaultDebugLevel = CocoaLumberjackSwift.dynamicLogLevel
 }
 
 internal func DDLogDebug(_ message: @autoclosure () -> String,
@@ -33,7 +33,7 @@ internal func DDLogDebug(_ message: @autoclosure () -> String,
                          tag: Any? = nil,
                          asynchronous async: Bool = true,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug("\(message())",
+    CocoaLumberjackSwift.DDLogDebug("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -53,7 +53,7 @@ internal func DDLogInfo(_ message: @autoclosure () -> String,
                         tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo("\(message())",
+    CocoaLumberjackSwift.DDLogInfo("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -73,7 +73,7 @@ internal func DDLogWarn(_ message: @autoclosure () -> String,
                         tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn("\(message())",
+    CocoaLumberjackSwift.DDLogWarn("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -93,7 +93,7 @@ internal func DDLogVerbose(_ message: @autoclosure () -> String,
                            tag: Any? = nil,
                            asynchronous async: Bool = true,
                            ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose("\(message())",
+    CocoaLumberjackSwift.DDLogVerbose("\(message())",
                                  level: level,
                                  context: context,
                                  file: file,
@@ -113,7 +113,7 @@ internal func DDLogError(_ message: @autoclosure () -> String,
                          tag: Any? = nil,
                          asynchronous async: Bool = false,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError("\(message())",
+    CocoaLumberjackSwift.DDLogError("\(message())",
                                level: level,
                                context: context,
                                file: file,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		3F368D9A2DCB74B80065B48F /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3F368D992DCB74B80065B48F /* TestKit */; };
 		3F7E6AC82DDAD3C1008309F0 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7E6AC72DDAD3C1008309F0 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift */; };
+		3FF8371D2DD32C360049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8371C2DD32C360049E028 /* CocoaLumberjackSwift */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
 		45010693239A6C9F00E24722 /* TaxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010692239A6C9F00E24722 /* TaxStore.swift */; };
 		45010695239A6CDE00E24722 /* TaxAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010694239A6CDE00E24722 /* TaxAction.swift */; };
@@ -1137,6 +1138,7 @@
 				689D11D52891B9A400F6A83F /* WooFoundation.framework in Frameworks */,
 				D88FDB3E25DD222600CB0DBD /* Hardware.framework in Frameworks */,
 				B5B19DE020E6A45900899568 /* Storage.framework in Frameworks */,
+				3FF8371D2DD32C360049E028 /* CocoaLumberjackSwift in Frameworks */,
 				263E37DC2641AD6B00260D3B /* Codegen in Frameworks */,
 				0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */,
 			);
@@ -2303,6 +2305,7 @@
 			name = Yosemite;
 			packageProductDependencies = (
 				263E37DB2641AD6B00260D3B /* Codegen */,
+				3FF8371C2DD32C360049E028 /* CocoaLumberjackSwift */,
 			);
 			productName = FluxC;
 			productReference = B5C9DDF52087FEC0006B910A /* Yosemite.framework */;
@@ -2363,6 +2366,9 @@
 				Base,
 			);
 			mainGroup = B5C9DDEB2087FEC0006B910A;
+			packageReferences = (
+				3FF8371B2DD32C360049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
+			);
 			productRefGroup = B5C9DDF62087FEC0006B910A /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -3374,6 +3380,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3FF8371B2DD32C360049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.8.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		263E37DB2641AD6B00260D3B /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -3386,6 +3403,11 @@
 		3F368D992DCB74B80065B48F /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestKit;
+		};
+		3FF8371C2DD32C360049E028 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF8371B2DD32C360049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Yosemite/Yosemite/Internal/Logging.swift
+++ b/Yosemite/Yosemite/Internal/Logging.swift
@@ -10,18 +10,18 @@
 // `@inline(__always)` to enfore inlining, but that attribute is not officially
 // supported as of Swift 4.0.)
 
-import CocoaLumberjack
+import CocoaLumberjackSwift
 
 /// The logging level threshold for DDLog… calls from Swift.
 /// Change this to adjust the verbosity of the log.
 ///
 /// Example:
 ///     internal var defaultDebugLevel: DDLogLevel = .verbose
-internal var defaultDebugLevel: DDLogLevel = CocoaLumberjack.dynamicLogLevel
+internal var defaultDebugLevel: DDLogLevel = CocoaLumberjackSwift.dynamicLogLevel
 
 /// Reset the logging level threshold to the app-wide default.
 internal func resetDefaultDebugLevel() {
-    defaultDebugLevel = CocoaLumberjack.dynamicLogLevel
+    defaultDebugLevel = CocoaLumberjackSwift.dynamicLogLevel
 }
 
 internal func DDLogDebug(_ message: @autoclosure () -> String,
@@ -33,7 +33,7 @@ internal func DDLogDebug(_ message: @autoclosure () -> String,
                          tag: Any? = nil,
                          asynchronous async: Bool = true,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug("\(message())",
+    CocoaLumberjackSwift.DDLogDebug("\(message())",
                                level: level,
                                context: context,
                                file: file,
@@ -53,7 +53,7 @@ internal func DDLogInfo(_ message: @autoclosure () -> String,
                         tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo("\(message())",
+    CocoaLumberjackSwift.DDLogInfo("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -73,7 +73,7 @@ internal func DDLogWarn(_ message: @autoclosure () -> String,
                         tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn("\(message())",
+    CocoaLumberjackSwift.DDLogWarn("\(message())",
                               level: level,
                               context: context,
                               file: file,
@@ -93,7 +93,7 @@ internal func DDLogVerbose(_ message: @autoclosure () -> String,
                         tag: Any? = nil,
                         asynchronous async: Bool = true,
                         ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose("\(message())",
+    CocoaLumberjackSwift.DDLogVerbose("\(message())",
                                  level: level,
                                  context: context,
                                  file: file,
@@ -113,7 +113,7 @@ internal func DDLogError(_ message: @autoclosure () -> String,
                          tag: Any? = nil,
                          asynchronous async: Bool = false,
                          ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError("\(message())",
+    CocoaLumberjackSwift.DDLogError("\(message())",
                                level: level,
                                context: context,
                                file: file,


### PR DESCRIPTION
## Description

As part of the move away from CocoaPods, this PR provisions CocoaLumberjack via SwiftPM.

Merging this will also unblock moving a couple of frameworks to Swift package modules.

See https://linear.app/a8c/issue/AINFRA-402

## Steps to reproduce && Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
See green CI and prototype build.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N.A.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.