### PR TITLE
Shipping Label: Handle refund on UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -562,9 +562,20 @@ private extension OrderDetailsViewController {
                     return
                 }
 
-                let viewModel = WooShippingRefundViewModel(shippingLabel: shippingLabel)
-                let view = WooShippingRefundView(viewModel: viewModel) { updatedLabel in
-                    // TODO
+                let refundViewModel = WooShippingRefundViewModel(shippingLabel: shippingLabel)
+                let view = WooShippingRefundView(viewModel: refundViewModel) { [weak self] updatedLabel in
+                    guard let self else { return }
+                    presentedViewController?.dismiss(animated: true)
+
+                    var allLabels = viewModel.order.shippingLabels
+                    guard let index = allLabels.firstIndex(where: { $0.shippingLabelID == updatedLabel.shippingLabelID }) else {
+                        return
+                    }
+                    allLabels[index] = updatedLabel
+                    let updatedOrder = viewModel.order.copy(shippingLabels: allLabels)
+
+                    viewModel.update(order: updatedOrder)
+                    reloadTableViewSectionsAndData()
                 }
                 let refundViewController = UIHostingController(rootView: view)
                 self?.present(refundViewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -562,9 +562,7 @@ private extension OrderDetailsViewController {
                     return
                 }
 
-                let viewModel = WooShippingRefundViewModel(refundableAmount: shippingLabel.refundableAmount,
-                                                           refundDuration: shippingLabel.refundDuration,
-                                                           purchaseDate: shippingLabel.dateCreated)
+                let viewModel = WooShippingRefundViewModel(shippingLabel: shippingLabel)
                 let view = WooShippingRefundView(viewModel: viewModel)
                 let refundViewController = UIHostingController(rootView: view)
                 self?.present(refundViewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -563,7 +563,9 @@ private extension OrderDetailsViewController {
                 }
 
                 let viewModel = WooShippingRefundViewModel(shippingLabel: shippingLabel)
-                let view = WooShippingRefundView(viewModel: viewModel)
+                let view = WooShippingRefundView(viewModel: viewModel) { updatedLabel in
+                    // TODO
+                }
                 let refundViewController = UIHostingController(rootView: view)
                 self?.present(refundViewController, animated: true)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -55,6 +55,22 @@ struct WooShippingRefundView: View {
             }
             .background(Color(.systemBackground))
         }
+        .alert(Localization.ErrorAlert.title, isPresented: $didFailToRequestRefund) {
+            Button(role: .cancel, action: {}, label: {
+                Text(Localization.ErrorAlert.cancel)
+            })
+
+            Button {
+                Task { @MainActor in
+                    await submitRefundRequest()
+                }
+            } label: {
+                Text(Localization.ErrorAlert.retry)
+            }
+        } message: {
+            Text(Localization.ErrorAlert.message)
+        }
+
     }
 }
 
@@ -120,6 +136,28 @@ private extension WooShippingRefundView {
             value: "Refund Label (%1$@)",
             comment: "Button to submit refund request the Request shipping label refund view"
         )
+        enum ErrorAlert {
+            static let title = NSLocalizedString(
+                "wooShippingRefundView.errorAlert.title",
+                value: "Refund request failed",
+                comment: "Title of the error alert when requesting refund for a shipping label fails"
+            )
+            static let message = NSLocalizedString(
+                "wooShippingRefundView.errorAlert.message",
+                value: "We were unable to request a refund for your label. Please try again",
+                comment: "Message on the error alert when requesting refund for a shipping label fails"
+            )
+            static let retry = NSLocalizedString(
+                "wooShippingRefundView.errorAlert.retry",
+                value: "Retry",
+                comment: "Button to retry when requesting refund for a shipping label fails"
+            )
+            static let cancel = NSLocalizedString(
+                "wooShippingRefundView.errorAlert.cancel",
+                value: "Cancel",
+                comment: "Button to dismiss the error alert when requesting refund for a shipping label fails"
+            )
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -144,7 +144,7 @@ private extension WooShippingRefundView {
             )
             static let message = NSLocalizedString(
                 "wooShippingRefundView.errorAlert.message",
-                value: "We were unable to request a refund for your label. Please try again",
+                value: "We were unable to request a refund for your label. Please try again.",
                 comment: "Message on the error alert when requesting refund for a shipping label fails"
             )
             static let retry = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -4,9 +4,12 @@ import Yosemite
 /// View for requesting refund for a shipping label.
 ///
 struct WooShippingRefundView: View {
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.dismiss) private var dismiss
+    @State private var isRequestingRefund = false
+    @State private var didFailToRequestRefund = false
 
     let viewModel: WooShippingRefundViewModel
+    let onRefundRequested: (_ updatedLabel: ShippingLabel) -> Void
 
     var body: some View {
         ScrollableVStack(alignment: .leading,
@@ -43,12 +46,29 @@ struct WooShippingRefundView: View {
         .safeAreaInset(edge: .bottom) {
             VStack {
                 Button(String.localizedStringWithFormat(Localization.submitButton, "-" + viewModel.formattedRefundAmount)) {
-                    viewModel.submitRefundRequest()
+                    Task { @MainActor in
+                        await submitRefundRequest()
+                    }
                 }
-                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: false))
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isRequestingRefund))
                 .padding()
             }
             .background(Color(.systemBackground))
+        }
+    }
+}
+
+private extension WooShippingRefundView {
+    func submitRefundRequest() async {
+        isRequestingRefund = true
+        defer {
+            isRequestingRefund = false
+        }
+        do {
+            let updatedLabel = try await viewModel.submitRefundRequest()
+            onRefundRequested(updatedLabel)
+        } catch {
+            didFailToRequestRefund = true
         }
     }
 }
@@ -143,5 +163,5 @@ private extension WooShippingRefundView {
             usedDate: nil,
             expiryDate: nil
         )
-    ))
+    ), onRefundRequested: { _ in })
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 /// View for requesting refund for a shipping label.
 ///
@@ -103,7 +104,44 @@ private extension WooShippingRefundView {
 }
 
 #Preview {
-    WooShippingRefundView(viewModel: .init(refundableAmount: 11.33,
-                                           refundDuration: 14,
-                                           purchaseDate: Date()))
+    WooShippingRefundView(viewModel: .init(
+        shippingLabel: ShippingLabel(
+            siteID: 123,
+            orderID: 456,
+            shippingLabelID: 789,
+            carrierID: "usps",
+            dateCreated: Date(),
+            packageName: "unknown",
+            rate: 12.11,
+            currency: "usd",
+            trackingNumber: "1345",
+            serviceName: "",
+            refundableAmount: 11.22,
+            status: .purchased,
+            refund: nil,
+            originAddress: ShippingLabelAddress(company: "Automattic Inc.",
+                                                name: "Tes",
+                                                phone: "01234567",
+                                                country: "USA",
+                                                state: "CA",
+                                                address1: "Woo Street",
+                                                address2: "",
+                                                city: "San Francisco",
+                                                postcode: "90210"),
+            destinationAddress: ShippingLabelAddress(company: "",
+                                                     name: "La",
+                                                     phone: "01234567",
+                                                     country: "USA",
+                                                     state: "NY",
+                                                     address1: "Main Street",
+                                                     address2: "",
+                                                     city: "New York",
+                                                     postcode: "10023"),
+            productIDs: [],
+            productNames: [],
+            commercialInvoiceURL: nil,
+            usedDate: nil,
+            expiryDate: nil
+        )
+    ))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
@@ -5,24 +5,24 @@ import WooFoundation
 /// View model for `WooShippingRefundView`
 ///
 final class WooShippingRefundViewModel {
+    private let shippingLabel: ShippingLabel
     private let stores: StoresManager
 
     let formattedPurchaseDate: String
     let formattedRefundAmount: String
     let refundDuration: Int
 
-    init(refundableAmount: Double,
-         refundDuration: Int,
-         purchaseDate: Date,
+    init(shippingLabel: ShippingLabel,
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.stores = stores
-        self.refundDuration = refundDuration
+        self.shippingLabel = shippingLabel
+        self.refundDuration = shippingLabel.refundDuration
 
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        formattedRefundAmount = currencyFormatter.formatAmount(refundableAmount.description) ?? refundableAmount.description
+        formattedRefundAmount = currencyFormatter.formatAmount(shippingLabel.refundableAmount.description) ?? shippingLabel.refundableAmount.description
 
-        formattedPurchaseDate = purchaseDate.formatted(date: .abbreviated, time: .omitted)
+        formattedPurchaseDate = shippingLabel.dateCreated.formatted(date: .abbreviated, time: .omitted)
     }
 
     func submitRefundRequest() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/Refund/WooShippingRefundViewModel.swift
@@ -25,7 +25,12 @@ final class WooShippingRefundViewModel {
         formattedPurchaseDate = shippingLabel.dateCreated.formatted(date: .abbreviated, time: .omitted)
     }
 
-    func submitRefundRequest() {
-        // TODO: integrate refund API
+    @MainActor
+    func submitRefundRequest() async throws -> ShippingLabel {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(WooShippingAction.refundShippingLabel(shippingLabel: shippingLabel) { result in
+                continuation.resume(with: result)
+            })
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
@@ -42,7 +42,9 @@ struct WooShippingShipmentDetailsView: View {
         }
         .sheet(isPresented: $showingRefundRequest) {
             if let refundViewModel = viewModel.refundViewModel {
-                WooShippingRefundView(viewModel: refundViewModel)
+                WooShippingRefundView(viewModel: refundViewModel) { updatedLabel in
+                    viewModel.didRequestRefund(updatedLabel: updatedLabel)
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
@@ -43,6 +43,7 @@ struct WooShippingShipmentDetailsView: View {
         .sheet(isPresented: $showingRefundRequest) {
             if let refundViewModel = viewModel.refundViewModel {
                 WooShippingRefundView(viewModel: refundViewModel) { updatedLabel in
+                    showingRefundRequest = false
                     viewModel.didRequestRefund(updatedLabel: updatedLabel)
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -204,6 +204,10 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: updatedLabel)
         onLabelPurchase?(updatedLabel)
     }
+
+    func didRequestRefund(updatedLabel: ShippingLabel) {
+        // TODO
+    }
 }
 
 private extension WooShippingShipmentDetailsViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -133,9 +133,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         guard let shippingLabel, shippingLabel.isRefundable else {
             return nil
         }
-        return WooShippingRefundViewModel(refundableAmount: shippingLabel.refundableAmount,
-                                          refundDuration: shippingLabel.refundDuration,
-                                          purchaseDate: shippingLabel.dateCreated)
+        return WooShippingRefundViewModel(shippingLabel: shippingLabel)
     }
 
     private var debounceDuration: Double


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of WOOMOB-368
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR integrates the refund API endpoint into the refund UI. UI updates for the create shipping label flow screens will be added in a subsequent PR.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Please note: Since refunding in staging only works within 1-2 minutes after a label purchase, please be mindful of the timing to test the success case of requesting refunds.

1. Log in to a test store with the Woo Shipping plugin set up.
2. Navigate to the Orders tab and select an order with at least one physical products.
3. Select Create shipping label and proceed to purchase a label for the order.
4. Navigate back to the order details screen > select the ellipsis menu  > select Request a refund > tap the Refund button on the refund view.
5. When the request succeeds, confirm that the refund view is dismissed. The order details screen should display the refund details on the shipping label section.
6. Repeat steps 2-4 but with the Internet disconnected before tapping the Refund button. Confirm that an error alert is displayed with the option to retry.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed using simulator iPhone 16 Pro iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/197eec76-5ac0-4d13-9a90-694657416b8e


Error case:

<img src="https://github.com/user-attachments/assets/edb4c670-dd4f-415e-a66c-3d5cf4a1b5e9" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
