### PR TITLE
[Woo POS] Remove excessive animations from the search content view

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -145,7 +145,6 @@ struct ItemListView: View {
                     itemListContent(selectedItemListType)
                 }
                 .scrollDismissesKeyboard(.immediately)
-                .transition(.opacity.combined(with: .move(edge: .trailing)))
                 .zIndex(1)
             }
         }
@@ -228,9 +227,7 @@ private extension ItemListView {
                                                                  itemsController: searchItemsController,
                                                                  searchHistoryProvider: posModel.searchHistoryService),
                                 onBack: {
-                                    withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                                        setSearch(false)
-                                    }
+                                    setSearch(false)
                                 }
                             )
                             .transition(.opacity.combined(with: .move(edge: .trailing)))
@@ -239,10 +236,8 @@ private extension ItemListView {
                                 .renderedIf(isCouponsFeatureEnabled)
 
                             POSPageHeaderActionButton(systemName: "magnifyingglass") {
-                                withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                                    analyticsTracker.trackSearchTapped()
-                                    setSearch(true)
-                                }
+                                analyticsTracker.trackSearchTapped()
+                                setSearch(true)
                             }
                             .transition(.opacity.combined(with: .scale))
                         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Context: p1747064076211369-slack-C070SJRA8DP

Switching to search while popular products are enabled produces messy transitions:
Search tapped -> for a moment, products appear -> transition to recent view.

## Solution

Remove:
- Unnecessary `withAnimation` block when search is started and ended, we already have `.animation` when `.isSearching` changes
- `.opacity + .trailing` transition from content view

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Enable `searchProductsInPOSPt2PopularProducts` feature flag
2. Open POS
3. Switch to coupons and come back multiple times
4. Confirm there are no more messy transitions as seen in screenshots

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on iPad Air 11' M2 18.3 device and iPad Air 13 inch 17.5 simulator

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

![image](https://github.com/user-attachments/assets/6fc68468-f570-4407-9ff9-07987c91e851)
![image](https://github.com/user-attachments/assets/d9770b68-edfb-4ade-88b3-77b58539f535)
![image](https://github.com/user-attachments/assets/499728f0-036d-47c4-a400-0f253f350ac1)

https://github.com/user-attachments/assets/f56faa38-849c-45a6-bb71-bca4adfd256c

### After

https://github.com/user-attachments/assets/8b7d0c62-c3aa-40e5-bdf4-b952b9dffb53

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.