### PR TITLE
Use an iPad Simulator compatible with Xcode 16.3 in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,7 +127,7 @@ steps:
           context: UI Tests (iPhone)
 
   - label: ":microscope: UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh UITests "iPad (10th generation)"
+    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Pro 13-inch (M4)"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
     if: build.branch == 'trunk' || build.branch =~ /^release\//

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,10 +115,10 @@ steps:
   # UI Tests
   #################
   - label: ":microscope: UI Tests (iPhone)"
-    command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 16'
+    command: .buildkite/commands/run-ui-tests.sh UITests "iPhone 16"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == 'trunk' || build.branch =~ /^release\//
+    if: build.branch == "trunk" || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*
@@ -130,7 +130,7 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad Pro 13-inch (M4)"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == 'trunk' || build.branch =~ /^release\//
+    if: build.branch == "trunk" || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*


### PR DESCRIPTION


## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes the CI failure on `trunk` reported seen in https://buildkite.com/automattic/woocommerce-ios/builds/29823 and caused by the tooling upgrade from #15608 .

CI did not catch this issue in the PR because UI tests run only on `trunk` and `release/` branched (notice this PR's branch starts with `release/` to verify)

## Steps to reproduce & Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
See CI.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.