### PR TITLE
Shipping Labels: Update creation flow after requesting refund

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2142,7 +2142,8 @@ extension Networking.ShippingLabelPurchase {
             status: .fake(),
             productIDs: .fake(),
             productNames: .fake(),
-            shipmentID: .fake()
+            shipmentID: .fake(),
+            refund: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3332,7 +3332,8 @@ extension Networking.ShippingLabelPurchase {
         status: CopiableProp<ShippingLabelStatus> = .copy,
         productIDs: CopiableProp<[Int64]> = .copy,
         productNames: CopiableProp<[String]> = .copy,
-        shipmentID: NullableCopiableProp<String> = .copy
+        shipmentID: NullableCopiableProp<String> = .copy,
+        refund: NullableCopiableProp<ShippingLabelRefund> = .copy
     ) -> Networking.ShippingLabelPurchase {
         let siteID = siteID ?? self.siteID
         let orderID = orderID ?? self.orderID
@@ -3347,6 +3348,7 @@ extension Networking.ShippingLabelPurchase {
         let productIDs = productIDs ?? self.productIDs
         let productNames = productNames ?? self.productNames
         let shipmentID = shipmentID ?? self.shipmentID
+        let refund = refund ?? self.refund
 
         return Networking.ShippingLabelPurchase(
             siteID: siteID,
@@ -3361,7 +3363,8 @@ extension Networking.ShippingLabelPurchase {
             status: status,
             productIDs: productIDs,
             productNames: productNames,
-            shipmentID: shipmentID
+            shipmentID: shipmentID,
+            refund: refund
         )
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
@@ -47,6 +47,9 @@ public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFake
     /// Shipment ID - Used for the split shipments feature
     public let shipmentID: String?
 
+    /// Optional refund details if the user has requested refund for the shipping label.
+    public let refund: ShippingLabelRefund?
+
     public init(siteID: Int64,
                 orderID: Int64,
                 shippingLabelID: Int64,
@@ -59,7 +62,8 @@ public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFake
                 status: ShippingLabelStatus,
                 productIDs: [Int64],
                 productNames: [String],
-                shipmentID: String?) {
+                shipmentID: String?,
+                refund: ShippingLabelRefund?) {
         self.siteID = siteID
         self.orderID = orderID
         self.shippingLabelID = shippingLabelID
@@ -73,6 +77,7 @@ public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFake
         self.productIDs = productIDs
         self.productNames = productNames
         self.shipmentID = shipmentID
+        self.refund = refund
     }
 }
 
@@ -107,6 +112,7 @@ extension ShippingLabelPurchase: Decodable {
         let shipmentID = container.failsafeDecodeIfPresent(targetType: String.self,
                                                            forKey: .shipmentID,
                                                            alternativeTypes: [.integer(transform: { String($0) })])
+        let refund = try container.decodeIfPresent(ShippingLabelRefund.self, forKey: .refund)
 
         self.init(siteID: siteID,
                   orderID: orderID,
@@ -120,7 +126,8 @@ extension ShippingLabelPurchase: Decodable {
                   status: status,
                   productIDs: productIDs,
                   productNames: productNames,
-                  shipmentID: shipmentID)
+                  shipmentID: shipmentID,
+                  refund: refund)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -137,6 +144,7 @@ extension ShippingLabelPurchase: Decodable {
         case productIDs = "product_ids"
         case productNames = "product_names"
         case shipmentID = "id"
+        case refund
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -610,6 +610,7 @@ private extension ShippingLabelRemoteTests {
                                      status: ShippingLabelStatus.purchaseInProgress,
                                      productIDs: [],
                                      productNames: ["Beanie"],
-                                     shipmentID: "0")
+                                     shipmentID: "0",
+                                     refund: nil)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1314,7 +1314,11 @@ extension OrderDetailsDataSource {
                 let rows: [Row]
                 let headerStyle: Section.HeaderStyle
                 if isRefunded {
-                    rows = [.shippingLabelRefunded]
+                    if featureFlags.isFeatureFlagEnabled(.revampedShippingLabelCreation) {
+                        rows = [.shippingLabelRefunded]
+                    } else {
+                        rows = [.shippingLabelRefunded, .shippingLabelDetail]
+                    }
                     headerStyle = .primary
                 } else {
                     rows = [.shippingLabelProducts, .shippingLabelReprintButton, .shippingLabelPrintingInfo, .shippingLabelTrackingNumber, .shippingLabelDetail]

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1314,7 +1314,7 @@ extension OrderDetailsDataSource {
                 let rows: [Row]
                 let headerStyle: Section.HeaderStyle
                 if isRefunded {
-                    rows = [.shippingLabelRefunded, .shippingLabelDetail]
+                    rows = [.shippingLabelRefunded]
                     headerStyle = .primary
                 } else {
                     rows = [.shippingLabelProducts, .shippingLabelReprintButton, .shippingLabelPrintingInfo, .shippingLabelTrackingNumber, .shippingLabelDetail]

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -506,7 +506,7 @@ extension OrderDetailsViewModel {
             guard let shippingLabel = dataSource.shippingLabel(at: indexPath) else {
                 return
             }
-            if dataSource.isEligibleForWooShipping && shippingLabel.refund == nil {
+            if dataSource.isEligibleForWooShipping {
                 onCellAction?(.openShippingLabelForm(shippingLabel: shippingLabel), indexPath)
             } else {
                 let shippingLabelDetailsViewController = ShippingLabelDetailsViewController(shippingLabel: shippingLabel)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -506,7 +506,7 @@ extension OrderDetailsViewModel {
             guard let shippingLabel = dataSource.shippingLabel(at: indexPath) else {
                 return
             }
-            if dataSource.isEligibleForWooShipping {
+            if dataSource.isEligibleForWooShipping && shippingLabel.refund == nil {
                 onCellAction?(.openShippingLabelForm(shippingLabel: shippingLabel), indexPath)
             } else {
                 let shippingLabelDetailsViewController = ShippingLabelDetailsViewController(shippingLabel: shippingLabel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsView.swift
@@ -44,7 +44,7 @@ struct WooShippingShipmentDetailsView: View {
             if let refundViewModel = viewModel.refundViewModel {
                 WooShippingRefundView(viewModel: refundViewModel) { updatedLabel in
                     showingRefundRequest = false
-                    viewModel.didRequestRefund(updatedLabel: updatedLabel)
+                    viewModel.didRequestRefund(for: updatedLabel.shippingLabelID)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -9,6 +9,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     private let stores: StoresManager
     private let currencyFormatter: CurrencyFormatter
     private let onLabelPurchase: ((ShippingLabel) -> Void)?
+    private let onLabelRefund: ((Int64) -> Void)?
     private var subscriptions: Set<AnyCancellable> = []
 
     @Published var hazmatCategory: ShippingLabelHazmatCategory?
@@ -146,13 +147,15 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          debounceDuration: Double = 1,
-         onLabelPurchase: ((ShippingLabel) -> Void)? = nil) {
+         onLabelPurchase: ((ShippingLabel) -> Void)? = nil,
+         onLabelRefund: ((Int64) -> Void)? = nil) {
         self.order = order
         self.stores = stores
         self.shipment = shipment
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.debounceDuration = debounceDuration
         self.onLabelPurchase = onLabelPurchase
+        self.onLabelRefund = onLabelRefund
 
         if let shippingLabel {
             self.postPurchase = WooShippingPostPurchaseViewModel(shippingLabel: shippingLabel)
@@ -205,8 +208,10 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         onLabelPurchase?(updatedLabel)
     }
 
-    func didRequestRefund(updatedLabel: ShippingLabel) {
-        // TODO
+    func didRequestRefund(for labelID: Int64) {
+        shippingLabel = nil
+        postPurchase = nil
+        onLabelRefund?(labelID)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -157,6 +157,21 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
                                     shippingSettingsService: shippingSettingsService)
     }
 
+    func didRequestRefund(for shipmentID: String) {
+        guard let index = shipments.firstIndex(where: { $0.id == shipmentID }) else {
+            return
+        }
+        let currentShipment = shipments[index]
+        let updatedContents = currentShipment.contents.map {
+            CollapsibleShipmentItemCardViewModel(item: $0.packageItem, isSelectable: true, currency: order.currency)
+        }
+        shipments[index] = Shipment(contents: updatedContents,
+                                    purchasedLabelID: nil,
+                                    currency: order.currency,
+                                    currencySettings: currencySettings,
+                                    shippingSettingsService: shippingSettingsService)
+    }
+
     func moveSelectedItems(to destination: MoveToShipmentNoticeViewModel.Destination) {
         moveToNoticeViewModel = nil
         instructions = nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -483,11 +483,10 @@ extension WooShippingSplitShipmentsViewModel {
                 continue
             }
 
-            let purchasedLabelID = currentOrderLabels
-                .first(where: { $0.shipmentID == key && $0.status == .purchased })
-                .map(\.shippingLabelID)
+            let purchasedLabel = currentOrderLabels
+                .first(where: { $0.shipmentID == key && $0.status == .purchased && $0.refund == nil})
 
-            let isPurchased = purchasedLabelID != nil
+            let isPurchased = purchasedLabel != nil
 
             var shipmentContents = ShipmentContents()
             for shipmentItem in shipmentItems {
@@ -505,7 +504,7 @@ extension WooShippingSplitShipmentsViewModel {
             }
 
             let shipment = Shipment(contents: shipmentContents,
-                                    purchasedLabelID: purchasedLabelID,
+                                    purchasedLabelID: purchasedLabel?.shippingLabelID,
                                     currency: currency,
                                     currencySettings: currencySettings,
                                     shippingSettingsService: shippingSettingsService)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -98,6 +98,7 @@ struct WooShippingCreateLabelsView: View {
             }
             .notice($viewModel.labelPurchaseErrorNotice, autoDismiss: false)
             .notice($viewModel.hazmatNotice)
+            .notice($viewModel.refundNotice)
             .fullScreenCover(isPresented: $showingSplitShipments) {
                 WooShippingSplitShipmentsView(viewModel: viewModel.splitShipmentsViewModel) { updatedShipments in
                     viewModel.updateShipments(updatedShipments)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -169,6 +169,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     @Published var hazmatNotice: Notice?
 
+    @Published var refundNotice: Notice?
+
     /// Selected package data for the shipping label.
     @Published private var selectedPackage: WooShippingPackageDataRepresentable?
 
@@ -453,27 +455,51 @@ private extension WooShippingCreateLabelsViewModel {
             let originAddressPublisher = $selectedOriginAddress
                 .map { $0?.toWooShippingAddress() }
                 .eraseToAnyPublisher()
-            return WooShippingShipmentDetailsViewModel(order: order,
-                                                       shipment: shipment,
-                                                       shippingLabel: matchingShippingLabel,
-                                                       originAddress: originAddressPublisher,
-                                                       destinationAddress: $destinationAddress.eraseToAnyPublisher(),
-                                                       stores: stores) { [weak self] newLabel in
-                guard let self, let index = shipments.firstIndex(where: { $0.id == shipment.id }) else { return }
-                shippingLabels.append(newLabel)
-                shipments[index] = Shipment(contents: shipment.contents,
-                                            purchasedLabelID: newLabel.shippingLabelID,
-                                            currency: order.currency,
-                                            currencySettings: currencySettings,
-                                            shippingSettingsService: shippingSettingsService)
-                splitShipmentsViewModel.didPurchaseLabel(for: shipment.id,
-                                                         purchasedLabelID: newLabel.shippingLabelID)
-                onLabelPurchase?(markOrderComplete)
-            }
+            return WooShippingShipmentDetailsViewModel(
+                order: order,
+                shipment: shipment,
+                shippingLabel: matchingShippingLabel,
+                originAddress: originAddressPublisher,
+                destinationAddress: $destinationAddress.eraseToAnyPublisher(),
+                stores: stores,
+                onLabelPurchase: { [weak self] newLabel in
+                    self?.handleLabelPurchaseSuccess(newLabel: newLabel, in: shipment)
+                }, onLabelRefund: { [weak self] labelID in
+                    self?.handleLabelRefundRequested(labelID: labelID, in: shipment)
+                })
         }
         observeHAZMATNotices()
         observeSelectedPackage()
         observeSelectedRates()
+    }
+
+    func handleLabelPurchaseSuccess(newLabel: ShippingLabel, in shipment: Shipment) {
+        guard let index = shipments.firstIndex(where: { $0.id == shipment.id }) else { return }
+        shippingLabels.append(newLabel)
+        shipments[index] = Shipment(contents: shipment.contents,
+                                    purchasedLabelID: newLabel.shippingLabelID,
+                                    currency: order.currency,
+                                    currencySettings: currencySettings,
+                                    shippingSettingsService: shippingSettingsService)
+        splitShipmentsViewModel.didPurchaseLabel(for: shipment.id,
+                                                 purchasedLabelID: newLabel.shippingLabelID)
+        onLabelPurchase?(markOrderComplete)
+    }
+
+    func handleLabelRefundRequested(labelID: Int64,
+                                    in shipment: Shipment) {
+        let shipmentIndex = shipments.firstIndex(where: { $0.id == shipment.id })
+        let labelIndex = shippingLabels.firstIndex(where: { $0.shippingLabelID == labelID })
+
+        guard let shipmentIndex, let labelIndex else { return }
+        shipments[shipmentIndex] = Shipment(contents: shipment.contents,
+                                            purchasedLabelID: nil,
+                                            currency: order.currency,
+                                            currencySettings: currencySettings,
+                                            shippingSettingsService: shippingSettingsService)
+        shippingLabels.remove(at: labelIndex)
+        splitShipmentsViewModel.didRequestRefund(for: shipment.id)
+        refundNotice = Notice(message: Localization.refundNotice)
     }
 
     /// Observes the selected origin address and updates the displayed origin address and shipping service.
@@ -586,6 +612,12 @@ private extension WooShippingCreateLabelsViewModel {
                                                    value: "Retry",
                                                    comment: "Button to retry label purchase when an error occurs")
         }
+
+        static let refundNotice = NSLocalizedString(
+            "wooShipping.createLabels.refundNotice",
+            value: "You have successfully submitted a request for refund. You can purchase a new label.",
+            comment: "Notice to display after requesting refund for a shipping label"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -187,7 +187,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          initialNoticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
-        self.shippingLabels = order.shippingLabels
+        self.shippingLabels = order.shippingLabels.filter { $0.refund == nil }
         self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.onLabelPurchase = onLabelPurchase

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -761,6 +761,47 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.shipments[1].purchasedLabelID)
     }
 
+    // MARK: - `didRequestRefund`
+    func test_didRequestRefund_updates_shipment_correctly() throws {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1),
+                     sampleItem(id: 3, weight: 4, value: 5, quantity: 3)]
+
+        let shippingLabelData = WooShippingLabelData(
+            currentOrderLabels: [
+                ShippingLabelPurchase.fake().copy(shipmentID: "1")
+            ]
+        )
+        let config = WooShippingConfig(siteID: 123, shipments: [
+            "1": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+            "2": [WooShippingShipmentItem(id: 2, subItems: [])]
+        ], shippingLabelData: shippingLabelData)
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           config: config,
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+
+        // Confidence check
+        XCTAssertTrue(viewModel.shipments[0].contents.allSatisfy({ $0.mainItemRow.isSelectable == false }))
+
+        // When
+        let shipmentID = viewModel.shipments[0].id
+        viewModel.didRequestRefund(for: shipmentID)
+
+        // Then
+        XCTAssertEqual(viewModel.shipments.count, 2)
+        XCTAssertNil(viewModel.shipments[0].purchasedLabelID)
+        XCTAssertTrue(viewModel.shipments[0].contents[0].mainItemRow.isSelectable)
+        XCTAssertTrue(viewModel.shipments[0].contents[0].childItemRows.allSatisfy({ $0.isSelectable }))
+
+
+        XCTAssertEqual(viewModel.shipments[1].contents.count, 1)
+        XCTAssertTrue(viewModel.shipments[1].contents[0].mainItemRow.isSelectable)
+        XCTAssertNil(viewModel.shipments[1].purchasedLabelID)
+    }
+
     // MARK: - `enableDoneButton`
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-368
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR wraps up the feature for shipping label refund. Changes include:
- Updated the create label flow:
  - Disregard refunded labels when displaying shipments.
  - Enable re-creating labels immediately after requesting a refund.
- Updated the order details screen to hide the View purchased shipping label button for refunded label.

Note: There's a known bug [p1747199056902499-slack-C05VBLKHHV1] on the backend side after re-fulfilling a shipment whose label is refunded.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a completed order with more than one physical product.
3. Select Create shipping label and move the order items to different shipments.
4. Proceed to purchase a label then immediately request a refund. 
5. After the request succeeds, confirm that the shipment UI is updated so that the shipment can be fulfilled again. A notice should be displayed saying "You have successfully submitted a request for refund. You can purchase a new label."
6. Navigate back to the order details screen. Confirm that a refunded label is displayed without the CTA to view the purchased label.
7. Select Create shipping label again, confirm that no fulfilled shipment is displayed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed the above testing steps on simulator iPhone 16 Pro iOS 18.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

After refunding labels:


https://github.com/user-attachments/assets/ff217539-6421-4df3-9189-04c2f64cbff2

Updated order details screen:

<img src="https://github.com/user-attachments/assets/0f052708-36bf-4320-9465-082ebbc05441" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
