### PR TITLE
Fix crash on order details when sections are updated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] POS: Scrolling search results now dismisses the keyboard [https://github.com/woocommerce/woocommerce-ios/pull/15606]
 - [*] Order Creation: Display non-purchasable, zero-priced variable product variations [https://github.com/woocommerce/woocommerce-ios/pull/15620]
+- [*] Order Details: Fixed crash reloading the screen after refunding an order on the web. [https://github.com/woocommerce/woocommerce-ios/pull/15633]
 
 22.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -213,7 +213,7 @@ private extension OrderDetailsViewController {
 
     private func configureViewModel() {
         viewModel.onUIReloadRequired = { [weak self] in
-            self?.reloadTableViewDataIfPossible()
+            self?.reloadTableViewData()
         }
 
         viewModel.configureResultsControllers { [weak self] in
@@ -235,11 +235,7 @@ private extension OrderDetailsViewController {
 
     /// Reloads the tableView's data, assuming the view has been loaded.
     ///
-    func reloadTableViewDataIfPossible() {
-        guard isViewLoaded else {
-            return
-        }
-
+    func reloadTableViewData() {
         tableView.reloadData()
     }
 
@@ -248,7 +244,7 @@ private extension OrderDetailsViewController {
     func reloadTableViewSectionsAndData() {
         configureNavigationBar()
         reloadSections()
-        reloadTableViewDataIfPossible()
+        reloadTableViewData()
     }
 
     /// Registers all of the available TableViewCells

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -244,7 +244,6 @@ private extension OrderDetailsViewController {
     func reloadTableViewSectionsAndData() {
         configureNavigationBar()
         reloadSections()
-        reloadTableViewData()
     }
 
     /// Registers all of the available TableViewCells


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-482
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a crash when the order details screen cannot reload after its sections are updated. Steps to reproduce:
1. Open a completed order on the app.
2. On the web, refund the same order
3. On the app, pull to refresh the screen. The app would crash when rendering a row that no longer exists (e.g. shipping label related row if the app has Woo Shipping or WCS&T plugin set up).

The crash was due to a check for `isViewLoaded` and the table view reloading is skipped if the view is not yet loaded into memory. This check is from a legacy [commit](https://github.com/woocommerce/woocommerce-ios/commit/c5588c8) from long ago that is now redundant. Removing the check enables the table to load properly when needed.

## Testing instructions
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open a completed order on the app.
2. On the web, refund the same order
3. On the app, pull to refresh the screen. Confirm that the app does not crash.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested following the steps above on simulator iPhone 16 Pro iOS 18.2 and confirmed that the app no longer crashes.

Also did some smoke testing on the order details screen and confirmed that the screen loads correctly for orders of different statuses.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/43471c14-e643-4757-bb6d-5c90b07ebce9



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
