### PR TITLE
[Payment] Add payment method line for album orientation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -209,7 +209,13 @@ private extension WooShippingCreateLabelsView {
                     }
                 } else {
                     HStack(alignment: .top, spacing: Layout.bottomSheetPadding) {
-                        orderDetails
+                        VStack(spacing: Layout.bottomSheetPadding) {
+                            orderDetails
+                            if let line = viewModel.paymentMethodLine {
+                                Divider()
+                                paymentMethod(line)
+                            }
+                        }
                         Divider()
                             .padding(.trailing, -Layout.bottomSheetPadding)
                         shipmentDetails

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -157,13 +157,12 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                     }
                 }
         )
-        .ignoresSafeArea(edges: .bottom)
         .background(Color(.listForeground(modal: false)))
     }
 
     private func calculateHeight(offsetBy dragAmount: CGFloat = 0) -> CGFloat {
         let collapsedHeight = fixedContentSize.height + chevronSize.height + Layout.chevronPadding
-        let screenHeight = UIScreen.main.bounds.height
+        let screenHeight = UIScreen.main.bounds.height - safeAreaInsets.bottom - safeAreaInsets.top
         let maxExpandedHeight = screenHeight * 0.8
         let fullHeight = min(collapsedHeight + expandingContentSize.height + Layout.dividerPadding, maxExpandedHeight)
         let currentHeight = isExpanded ? fullHeight : collapsedHeight


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-486
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As discussed in p1747053309917289-slack-C03L1NF1EA3 - the "Payment method" line should be placed into the bottom sheet for album orientation as well.

- Since the line was presented in the same container with "Order details" and "Shipment" costs - I decided to maintain this approach and do the same for the album version. I placed the line in the left column of the scrollable content within `ExpandableSheet`.
- Also fixed the bottom safe area overlap in bottom sheet.

## Testing steps
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Log in to a test store with Woo Shipping plugin set up.
- Rotate device/simulator into album orientation.
- Navigate to the Orders tab and select a completed order with at lest one shipment with a purchased label and at least one shipment without a label.
- Navigate to "Create shipping labels"
- Open bottom sheet with order details.
- Make sure the "Payment method" section is not visible for fulfilled shipments.
- Make sure the "Payment method" section is presented for unfulfilled shipment and it reveals the relevant payment card assiciated with the account.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
|Before|
|---|
|<img width="1002" alt="Снимок экрана 2025-05-15 в 15 10 18" src="https://github.com/user-attachments/assets/c2c2e0a0-0f76-4715-9eb7-d0d7b9460da6" />|

|After|
|---|
|<img width="1003" alt="Снимок экрана 2025-05-15 в 14 46 24" src="https://github.com/user-attachments/assets/2f6ea7cd-c5f5-4c92-9a74-7a30abde1be1" />|

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.