### PR TITLE
Add note about OS deployment targets in `xcconfig` vs `Package.swift`

### DIFF
--- a/config/Common.xcconfig
+++ b/config/Common.xcconfig
@@ -1,5 +1,8 @@
 // This file is shared by all the projects in the WooCommerce workspace by
 // means of each project having a top-level xcconfig file that includes this.
+
+// The deployment targets are currently duplicated in Modules/Package.swift.
+// If you change them here, make sure to update them there, too.
 IPHONEOS_DEPLOYMENT_TARGET = 16.0
 MACOSX_DEPLOYMENT_TARGET = 14.0
 WATCHOS_DEPLOYMENT_TARGET = 9.0


### PR DESCRIPTION

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Following up on a suggestion by @AliSoftware in https://github.com/woocommerce/woocommerce-ios/pull/15612#discussion_r2090672928



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A. Just a code comment.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.