### PR TITLE
[Woo POS payments onboarding] Fix POS modal close button not always vertically positioned the same

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -13,34 +13,36 @@ struct InPersonPaymentsOnboardingError: View {
     var secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
 
     var body: some View {
-        VStack {
-            Spacer()
+        ScrollableVStack(padding: 0) {
+            VStack {
+                Spacer()
 
-            InPersonPaymentsOnboardingErrorMainContentView(
-                title: title,
-                message: message,
-                secondaryMessage: nil,
-                image: image,
-                supportLink: supportLink
-            )
+                InPersonPaymentsOnboardingErrorMainContentView(
+                    title: title,
+                    message: message,
+                    secondaryMessage: nil,
+                    image: image,
+                    supportLink: supportLink
+                )
 
-            Spacer()
+                Spacer()
 
-            if let buttonViewModel = buttonViewModel {
-                Button(buttonViewModel.text, action: buttonViewModel.action)
-                    .buttonStyle(PrimaryButtonStyle())
-                    .padding(.bottom, secondaryButtonViewModel == nil ? 24.0 : 0)
-            }
-            if let secondaryButtonViewModel = secondaryButtonViewModel {
-                Button(secondaryButtonViewModel.text, action: secondaryButtonViewModel.action)
-                    .buttonStyle(SecondaryButtonStyle())
-            }
-            if learnMore {
-                InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(paymentGateway: plugin ?? .wcPay,
-                                                                        tappedAnalyticEvent: learnMoreAnalyticEvent))
+                if let buttonViewModel = buttonViewModel {
+                    Button(buttonViewModel.text, action: buttonViewModel.action)
+                        .buttonStyle(PrimaryButtonStyle())
+                        .padding(.bottom, secondaryButtonViewModel == nil ? 24.0 : 0)
+                }
+                if let secondaryButtonViewModel = secondaryButtonViewModel {
+                    Button(secondaryButtonViewModel.text, action: secondaryButtonViewModel.action)
+                        .buttonStyle(SecondaryButtonStyle())
+                }
+                if learnMore {
+                    InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(paymentGateway: plugin ?? .wcPay,
+                                                                            tappedAnalyticEvent: learnMoreAnalyticEvent))
                     .padding(.vertical, 8)
-            }
-        }.padding()
+                }
+            }.padding()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-94
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Why

The issue was that the close button in the POS payments onboarding modal can be vertically positioned differently based on the onboarding content type. Examples:

loading | overdue requirements error
-- | --
![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 26 12](https://github.com/user-attachments/assets/b627a38e-43b9-43fe-814c-d5b410c87b24) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 26 14](https://github.com/user-attachments/assets/13e668c9-3c7f-4cee-bc38-a830b57b0d41)

I spent quite some time looking for the root cause, thinking it was some SwiftUI modifiers/layout. After debugging, my conclusion is that when the onboarding content height is taller than the allowed vertical space (as the modal size is fixed), the content overflows into the [padding space](https://github.com/woocommerce/woocommerce-ios/blob/9a8a7f3c729d381ea340a7481bd17412d90b5e37/WooCommerce/Classes/POS/Presentation/Reusable%20Views/POSModalSizing.swift#L15) of the POS modal. Updating the padding to a smaller can fix the issue, but that'd require a design discussion. In IPP, this actually could be an issue especially in larger font sizes because the onboarding content can be cut off without a way to see all the content like the CTAs (there's another `Refresh` CTA below):

<img src="https://github.com/user-attachments/assets/10ba1235-126c-4b4f-98ea-08ad38ae71f8" width="400" />

After inspecting various onboarding views that can be [shown in different onboarding states](https://github.com/woocommerce/woocommerce-ios/blob/9a8a7f3c729d381ea340a7481bd17412d90b5e37/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/CardPresentPaymentsOnboardingViewController.swift#L39-L94), all the views except for `InPersonPaymentsOnboardingError` are wrapped in a scroll view `ScrollableVStack`. This ensures that the view can be any height and would not overflow to padding space.

### The fix

In `InPersonPaymentsOnboardingError`, I put content inside a `ScrollableVStack` so that the content view height can be dynamic and does not overflow to the padding space in the POS modal. I tested a few different error states and made sure all views from the onboarding states are either `InPersonPaymentsOnboardingError` now wrapped in a `ScrollableVStack` or views within a `ScrollableVStack`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Whether the original close button position issue could be reproduced depends on the screen size & font size. For easier reproducing, I used iPad (10th gen) simulator with the 4/5th smallest font size.

- Switch to a store eligible for POS, and payments plugin has overdue requirements or not set up
- Go to Menu > Point of Sale Mode
- Tap on Connect your reader --> notice that the X button for the "loading" and "plugin not set up/overdue requirements" (and maybe other error states) should stay at the same vertical position at the top

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | loading | error
-- | -- | --
POS (small font size) |![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 15 58](https://github.com/user-attachments/assets/3ec7c3c2-ffab-4094-a12c-6f545d2e9280) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 16 01](https://github.com/user-attachments/assets/ca252746-f6d4-4301-a3c1-23abc41621bb)
POS (large font size) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 16 58](https://github.com/user-attachments/assets/486903c2-ebfd-4c51-81db-68ef4709f9b0) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 17 04](https://github.com/user-attachments/assets/c635709a-5c5f-4d7b-a4d3-2aa9f087def1)
IPP (small font size) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 15 48](https://github.com/user-attachments/assets/f760f481-9b75-4c94-8ab6-259c38f637af) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 15 52](https://github.com/user-attachments/assets/c64be848-a4b1-4d09-a145-1a81d71167d7)
IPP (large font size) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 16 36](https://github.com/user-attachments/assets/c9996b0c-223c-445b-b0d8-c51617aedb55) | ![Simulator Screenshot - iPad (10th generation) - 2025-05-16 at 11 16 46](https://github.com/user-attachments/assets/9672b6a4-3b13-45f5-b428-60f3d96b44c0)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.