### PR TITLE
[Woo POS][Product labels] Add flag for `inventoryProductLabelsInPOS`

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -105,6 +105,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .searchCouponsInPOS:
             return true
+        case .inventoryProductLabelsInPOS:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleReceipts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -225,6 +225,10 @@ public enum FeatureFlag: Int {
     ///
     case searchCouponsInPOS
 
+    /// Shows inventory levels and inventory status in POS item cards
+    ///
+    case inventoryProductLabelsInPOS
+
     /// Enables sending POS specific email receipts for eligible stores
     ///
     case pointOfSaleReceipts


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-487
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
Adds a feature flag for displaying product labels for inventory levels and inventory status in POS. Ref pdfdoF-795-p2

## Testing information
There are no functional changes. CI should pass.


## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
