### PR TITLE
Improve dynamic size of shipment details bottom sheet

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -737,4 +737,3 @@ private extension WooShippingCreateLabelsView {
         )
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -325,7 +325,7 @@ private extension WooShippingCreateLabelsView {
                             Text(Localization.BottomSheet.markComplete)
                                 .font(.subheadline)
                                 .lineLimit(Layout.toggleTextLineLimit)
-                                .dynamicTypeSize(...Layout.toggleTextMaxDynamicTypeSizeAlbum)
+                                .dynamicTypeSize(...Layout.toggleTextMaxDynamicTypeSizeLandscape)
                         }
                         .tint(Color(.primary))
                         .fixedSize(horizontal: false, vertical: true)
@@ -619,7 +619,7 @@ private extension WooShippingCreateLabelsView {
 
         static let toggleTextLineLimit = 3
         static let toggleTextMaxDynamicTypeSizePortrait = DynamicTypeSize.accessibility1
-        static let toggleTextMaxDynamicTypeSizeAlbum = DynamicTypeSize.xxxLarge
+        static let toggleTextMaxDynamicTypeSizeLandscape = DynamicTypeSize.xxxLarge
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -400,7 +400,7 @@ private extension WooShippingCreateLabelsView {
                 Text(Localization.BottomSheet.orderDetails)
                     .footnoteStyle()
             }
-            AdaptiveStack {
+            HStack {
                 Image(uiImage: .productIcon)
                     .frame(width: Layout.iconSize)
                 Text(viewModel.orderItems.itemsCountLabel)
@@ -409,7 +409,7 @@ private extension WooShippingCreateLabelsView {
                 Text(viewModel.orderItems.itemsPriceLabel)
             }
             ForEach(viewModel.shippingLines) { shippingLine in
-                AdaptiveStack {
+                HStack {
                     Image(uiImage: .shippingIcon)
                         .frame(width: Layout.iconSize)
                     Text(shippingLine.title)
@@ -493,7 +493,7 @@ private extension WooShippingCreateLabelsView {
     }
 
     func shippingRateRow(label: String, amount: String?) -> some View {
-        AdaptiveStack {
+        HStack {
             Text(label)
             Spacer()
             Text(amount ?? "$0.00")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -305,9 +305,13 @@ private extension WooShippingCreateLabelsView {
             if isiPhonePortrait {
                 VStack(spacing: Layout.bottomSheetSpacing) {
                     if isShipmentDetailsExpanded {
-                        Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
-                            .font(.subheadline)
-                            .tint(Color(.primary))
+                        Toggle(isOn: $viewModel.markOrderComplete) {
+                            Text(Localization.BottomSheet.markComplete)
+                                .font(.subheadline)
+                                .lineLimit(Layout.toggleTextLineLimit)
+                                .dynamicTypeSize(...Layout.toggleTextMaxDynamicTypeSizePortrait)
+                        }
+                        .tint(Color(.primary))
                     }
                     if isShipmentDetailsExpanded || viewModel.currentShipmentDetailsViewModel.selectedPackage != nil {
                         purchaseButton
@@ -317,10 +321,14 @@ private extension WooShippingCreateLabelsView {
             else {
                 HStack(spacing: Layout.bottomSheetSpacing) {
                     if viewModel.currentShipmentDetailsViewModel.selectedPackage != nil || isShipmentDetailsExpanded {
-                        Toggle(Localization.BottomSheet.markComplete, isOn: $viewModel.markOrderComplete)
-                            .font(.subheadline)
-                            .tint(Color(.primary))
-                            .fixedSize(horizontal: false, vertical: true)
+                        Toggle(isOn: $viewModel.markOrderComplete) {
+                            Text(Localization.BottomSheet.markComplete)
+                                .font(.subheadline)
+                                .lineLimit(Layout.toggleTextLineLimit)
+                                .dynamicTypeSize(...Layout.toggleTextMaxDynamicTypeSizeAlbum)
+                        }
+                        .tint(Color(.primary))
+                        .fixedSize(horizontal: false, vertical: true)
                         purchaseButton
                     }
                 }
@@ -608,6 +616,10 @@ private extension WooShippingCreateLabelsView {
         static let gradientViewWidth: CGFloat = 32
         static let purchasedIconWidth: CGFloat = 16
         static let purchasedIcon = UIImage(systemName: "checkmark.circle.fill")?.withRenderingMode(.alwaysTemplate)
+
+        static let toggleTextLineLimit = 3
+        static let toggleTextMaxDynamicTypeSizePortrait = DynamicTypeSize.accessibility1
+        static let toggleTextMaxDynamicTypeSizeAlbum = DynamicTypeSize.xxxLarge
     }
 
     enum Localization {
@@ -725,3 +737,4 @@ private extension WooShippingCreateLabelsView {
         )
     }
 }
+

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -408,7 +408,6 @@ private extension WooShippingCreateLabelsView {
                 Spacer()
                 Text(viewModel.orderItems.itemsPriceLabel)
             }
-            .frame(idealHeight: Layout.rowHeight)
             ForEach(viewModel.shippingLines) { shippingLine in
                 AdaptiveStack {
                     Image(uiImage: .shippingIcon)
@@ -419,7 +418,6 @@ private extension WooShippingCreateLabelsView {
                     Spacer()
                     Text(shippingLine.formattedTotal)
                 }
-                .frame(idealHeight: Layout.rowHeight)
             }
         }
     }
@@ -491,7 +489,6 @@ private extension WooShippingCreateLabelsView {
                 shippingRateRow(label: Localization.BottomSheet.total, amount: viewModel.totalCost)
                     .bold()
             }
-            .frame(idealHeight: Layout.rowHeight)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -164,6 +164,15 @@ struct TopTabView<Content: View>: View {
                                                     scrollFocusTab(in: scrollViewProxy, at: index)
                                                 }
                                             }
+                                            .onChange(of: geometry.size) { newSize in
+                                                /// Support dynamic type size change
+                                                if index < tabWidths.count {
+                                                    tabWidths[index] = newSize.width
+                                                    if index == selectedTab {
+                                                        underlineTabWith(tabGeometry: geometry)
+                                                    }
+                                                }
+                                            }
                                         })
                                 }
                             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-476
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The change in this PR fixes overlapping and shifting layout after applying a larger dynamic-type size.

- Deletes occurrences `.frame(idealHeight: Layout.rowHeight)` from `WooShippingCreateLabelsView`
- Replaces `AdaptiveStack` with `HStack`. Adaptive stack flips into a vertical stack when there is not enough width (widths becomes compact) making inline components to re-arrange vertically even if there is still some space available.
- Restricts the "notify the customer" toggle  label lines by 3 to avoid the CTA area of bottom sheet growing too much and covering the expandable content.
- Restricts the toggle label maximum dynamic type size for same reason.
- Updates the top tabs selection indicator in case of dynamic type size change.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Log in to a test store with Woo Shipping plugin set up.
- Navigate to the Orders tab and select a completed order with at lest one shipment with a purchased label and at least one shipment without a label.
- Navigate to "Create shipping labels"
- Use option+command + (+/-) combination to adjust dynamic type size or do it manually in Settings -> Accessibility -> Display & Text Size -> Larger Text. 
- Follow steps in demo video examples. Content should be readable and should not overlap.


## Before - Album
https://github.com/user-attachments/assets/12c625b6-0eef-435e-b45b-7b3eda71cf4e

## After - Album
https://github.com/user-attachments/assets/1464bb0c-2120-4bcf-8c0b-678bcf405e6a

## Before - Portrait
https://github.com/user-attachments/assets/fcc794a0-9ab6-4b4f-a5e2-de316c4a80bc

## After - Portrait
https://github.com/user-attachments/assets/363c347a-47e3-4e5d-b18d-62523cb5d5ca

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.