### PR TITLE
Migrate SVProgressHUD from CocoaPods to SwiftPM

### DIFF
--- a/Experiments/Experiments.xcodeproj/project.pbxproj
+++ b/Experiments/Experiments.xcodeproj/project.pbxproj
@@ -13,9 +13,9 @@
 		0270C0A327069B7800FC799F /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0270C0A227069B7800FC799F /* FeatureFlagService.swift */; };
 		0270C0A527069B8900FC799F /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0270C0A427069B8900FC799F /* DefaultFeatureFlagService.swift */; };
 		0270C0A727069BA500FC799F /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0270C0A627069BA500FC799F /* BuildConfiguration.swift */; };
-		3F8115032DD2A6EC0042DDB6 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = 3F8115022DD2A6EC0042DDB6 /* AutomatticTracks */; };
+		3F2B4ACA2DDC30E000E5E49C /* XcodeTarget_Experiments in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AC92DDC30E000E5E49C /* XcodeTarget_Experiments */; };
+		3F2B4ACC2DDC30E800E5E49C /* XcodeTarget_ExperimentsTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ACB2DDC30E800E5E49C /* XcodeTarget_ExperimentsTests */; };
 		3F8B84192DD2FEC2002DD6E8 /* Experiments.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 3F8B84182DD2FEC2002DD6E8 /* Experiments.xctestplan */; };
-		3F8B841B2DD301C6002DD6E8 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = 3F8B841A2DD301C6002DD6E8 /* AutomatticTracks */; };
 		CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB47275E426900C4CA4F /* ABTest.swift */; };
 		EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */; };
 		EEC8C0ED298A92F10047B4CB /* CachedABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8C0EC298A92F10047B4CB /* CachedABTestVariationProvider.swift */; };
@@ -61,7 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F8115032DD2A6EC0042DDB6 /* AutomatticTracks in Frameworks */,
+				3F2B4ACA2DDC30E000E5E49C /* XcodeTarget_Experiments in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,8 +69,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F2B4ACC2DDC30E800E5E49C /* XcodeTarget_ExperimentsTests in Frameworks */,
 				0270C08B27069A8900FC799F /* Experiments.framework in Frameworks */,
-				3F8B841B2DD301C6002DD6E8 /* AutomatticTracks in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,9 +222,6 @@
 				Base,
 			);
 			mainGroup = 0270C07727069A8900FC799F;
-			packageReferences = (
-				3F8115012DD2A6EC0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */,
-			);
 			productRefGroup = 0270C08227069A8900FC799F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -654,27 +651,14 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3F8115012DD2A6EC0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.5.2;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		3F8115022DD2A6EC0042DDB6 /* AutomatticTracks */ = {
+		3F2B4AC92DDC30E000E5E49C /* XcodeTarget_Experiments */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F8115012DD2A6EC0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
-			productName = AutomatticTracks;
+			productName = XcodeTarget_Experiments;
 		};
-		3F8B841A2DD301C6002DD6E8 /* AutomatticTracks */ = {
+		3F2B4ACB2DDC30E800E5E49C /* XcodeTarget_ExperimentsTests */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F8115012DD2A6EC0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
-			productName = AutomatticTracks;
+			productName = XcodeTarget_ExperimentsTests;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Fakes/Fakes.xcodeproj/project.pbxproj
+++ b/Fakes/Fakes.xcodeproj/project.pbxproj
@@ -10,13 +10,13 @@
 		02B5147E2825532A00750B71 /* Hardware.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B5147D2825532A00750B71 /* Hardware.generated.swift */; };
 		20AD34D12B0CD9AF00F38F44 /* WooFoundation.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AD34D02B0CD9AF00F38F44 /* WooFoundation.generated.swift */; };
 		26106B3D25FA4F6C0000DF30 /* ProductFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26106B3C25FA4F6C0000DF30 /* ProductFactory.swift */; };
-		263E383C2641FED600260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E383B2641FED600260D3B /* Codegen */; };
 		26CA6D2625F6C87800B01F48 /* Fakes.h in Headers */ = {isa = PBXBuildFile; fileRef = 26CA6D2425F6C87800B01F48 /* Fakes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26CA6D2F25F6C8FC00B01F48 /* Fake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA6D2D25F6C8FB00B01F48 /* Fake.swift */; };
 		26CA6D3625F6C93C00B01F48 /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26CA6D3525F6C93C00B01F48 /* Networking.framework */; };
 		26EEDC8D26FE1C1C00D5BA0E /* Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26EEDC8C26FE1C1C00D5BA0E /* Yosemite.framework */; };
 		26EEDC9026FE1C7B00D5BA0E /* Networking.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EEDC8E26FE1C7B00D5BA0E /* Networking.generated.swift */; };
 		26EEDC9126FE1C7B00D5BA0E /* Yosemite.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EEDC8F26FE1C7B00D5BA0E /* Yosemite.generated.swift */; };
+		3F2B4AC22DDC30B200E5E49C /* XcodeTarget_Fakes in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AC12DDC30B200E5E49C /* XcodeTarget_Fakes */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -53,9 +53,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F2B4AC22DDC30B200E5E49C /* XcodeTarget_Fakes in Frameworks */,
 				26EEDC8D26FE1C1C00D5BA0E /* Yosemite.framework in Frameworks */,
 				26CA6D3625F6C93C00B01F48 /* Networking.framework in Frameworks */,
-				263E383C2641FED600260D3B /* Codegen in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -143,7 +143,7 @@
 			);
 			name = Fakes;
 			packageProductDependencies = (
-				263E383B2641FED600260D3B /* Codegen */,
+				3F2B4AC12DDC30B200E5E49C /* XcodeTarget_Fakes */,
 			);
 			productName = Fakes;
 			productReference = 26CA6D2125F6C87800B01F48 /* Fakes.framework */;
@@ -414,9 +414,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		263E383B2641FED600260D3B /* Codegen */ = {
+		3F2B4AC12DDC30B200E5E49C /* XcodeTarget_Fakes */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_Fakes;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		019A77CA2D88645100ABBB71 /* PaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A77C92D88645100ABBB71 /* PaymentMethodType.swift */; };
 		028C39E028255CFE0007BA25 /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028C39DF28255CFE0007BA25 /* Models+Copiable.generated.swift */; };
-		02B5147A28254ED300750B71 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 02B5147928254ED300750B71 /* Codegen */; };
 		02FDAB102CEEF11F00B6C8AA /* PaymentChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FDAB0F2CEEF11D00B6C8AA /* PaymentChannel.swift */; };
 		030338102705F7D400764131 /* ReceiptTotalLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0303380F2705F7D400764131 /* ReceiptTotalLine.swift */; };
 		035DBA3929251ED6003E5125 /* CardReaderInputOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA3829251ED6003E5125 /* CardReaderInputOptions.swift */; };
@@ -28,7 +27,9 @@
 		317975C0274EB1F9004357B1 /* DeclineReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975BF274EB1F9004357B1 /* DeclineReason.swift */; };
 		317975C2274EBC1F004357B1 /* DeclineReason+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C1274EBC1F004357B1 /* DeclineReason+Stripe.swift */; };
 		317975C4274ED591004357B1 /* DeclineReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317975C3274ED591004357B1 /* DeclineReasonTests.swift */; };
-		3FF80E3B2DD322880049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF80E3A2DD322880049E028 /* CocoaLumberjackSwift */; };
+		3F2B4AC42DDC30C300E5E49C /* XcodeTarget_Hardware in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AC32DDC30C300E5E49C /* XcodeTarget_Hardware */; };
+		3F2B4AC62DDC30D000E5E49C /* XcodeTarget_HardwareTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AC52DDC30D000E5E49C /* XcodeTarget_HardwareTests */; };
+		3F2B4AC82DDC30D800E5E49C /* XcodeTarget_SampleReceiptPrinter in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AC72DDC30D800E5E49C /* XcodeTarget_SampleReceiptPrinter */; };
 		55CD4BB4273E617C007686D3 /* ReceiptRendererTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CD4BB3273E617C007686D3 /* ReceiptRendererTest.swift */; };
 		5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */; };
 		8FFAA245E257B9EB98E2FCBD /* Pods_SampleReceiptPrinter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */; };
@@ -292,9 +293,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				02B5147A28254ED300750B71 /* Codegen in Frameworks */,
 				C5D2CB7D21CEE28FEBF18BF6 /* Pods_Hardware.framework in Frameworks */,
-				3FF80E3B2DD322880049E028 /* CocoaLumberjackSwift in Frameworks */,
+				3F2B4AC42DDC30C300E5E49C /* XcodeTarget_Hardware in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -302,6 +302,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F2B4AC62DDC30D000E5E49C /* XcodeTarget_HardwareTests in Frameworks */,
 				D88FDB0925DD216B00CB0DBD /* Hardware.framework in Frameworks */,
 				5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */,
 			);
@@ -311,6 +312,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F2B4AC82DDC30D800E5E49C /* XcodeTarget_SampleReceiptPrinter in Frameworks */,
 				E1CFC16D2643EBCB0089F86F /* Hardware.framework in Frameworks */,
 				8FFAA245E257B9EB98E2FCBD /* Pods_SampleReceiptPrinter.framework in Frameworks */,
 			);
@@ -617,8 +619,7 @@
 			);
 			name = Hardware;
 			packageProductDependencies = (
-				02B5147928254ED300750B71 /* Codegen */,
-				3FF80E3A2DD322880049E028 /* CocoaLumberjackSwift */,
+				3F2B4AC32DDC30C300E5E49C /* XcodeTarget_Hardware */,
 			);
 			productName = Hardware;
 			productReference = D88FDAFF25DD216B00CB0DBD /* Hardware.framework */;
@@ -698,7 +699,6 @@
 			);
 			mainGroup = D88FDAF525DD216B00CB0DBD;
 			packageReferences = (
-				3FF80E392DD322880049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 			);
 			productRefGroup = D88FDB0025DD216B00CB0DBD /* Products */;
 			projectDirPath = "";
@@ -1427,26 +1427,18 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3FF80E392DD322880049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.8.5;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		02B5147928254ED300750B71 /* Codegen */ = {
+		3F2B4AC32DDC30C300E5E49C /* XcodeTarget_Hardware */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_Hardware;
 		};
-		3FF80E3A2DD322880049E028 /* CocoaLumberjackSwift */ = {
+		3F2B4AC52DDC30D000E5E49C /* XcodeTarget_HardwareTests */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3FF80E392DD322880049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
+			productName = XcodeTarget_HardwareTests;
+		};
+		3F2B4AC72DDC30D800E5E49C /* XcodeTarget_SampleReceiptPrinter */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_SampleReceiptPrinter;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Modules/.swiftpm/xcode/xcshareddata/xcschemes/Codegen.xcscheme
+++ b/Modules/.swiftpm/xcode/xcshareddata/xcschemes/Codegen.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Codegen"
+               BuildableName = "Codegen"
+               BlueprintName = "Codegen"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Codegen"
+            BuildableName = "Codegen"
+            BlueprintName = "Codegen"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "bb29d6323b456e7e7de7e41c0a33bb51a2970f028b1f718f84781c3170a1023e",
+  "originHash" : "0b6c18d217b4fbc73445b82e280af4b49389be115a57dce761235ee35a22fb35",
   "pins" : [
+    {
+      "identity" : "automattic-tracks-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/Automattic-Tracks-iOS.git",
+      "state" : {
+        "revision" : "437f586a62c07c6ceec9baf043237b2afe7ea1ac",
+        "version" : "3.5.2"
+      }
+    },
     {
       "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
@@ -35,6 +44,33 @@
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "6c81e671154e63464dd6749b7ba3279dd390a146",
+        "version" : "8.50.1"
+      }
+    },
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium",
+      "state" : {
+        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "uideviceidentifier",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/squarefrog/UIDeviceIdentifier",
+      "state" : {
+        "revision" : "4699794b08bb79a4d77785edaba6ea739e298e4b",
+        "version" : "2.3.0"
       }
     }
   ],

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0b6c18d217b4fbc73445b82e280af4b49389be115a57dce761235ee35a22fb35",
+  "originHash" : "018c7e8efebfcfa33d43c333b0db93ee0064d913e4937998dd2227260c2763e6",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",
@@ -8,6 +8,42 @@
       "state" : {
         "revision" : "437f586a62c07c6ceec9baf043237b2afe7ea1ac",
         "version" : "3.5.2"
+      }
+    },
+    {
+      "identity" : "automatticabout-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/AutomatticAbout-swift.git",
+      "state" : {
+        "revision" : "606384a7492faa1139d489080dd961b0b57f9fd9",
+        "version" : "1.1.5"
+      }
+    },
+    {
+      "identity" : "charts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/danielgindi/Charts.git",
+      "state" : {
+        "revision" : "dd9c72e3d7e751e769971092a6bd72d39198ae63",
+        "version" : "5.1.0"
+      }
+    },
+    {
+      "identity" : "cocoalumberjack",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack",
+      "state" : {
+        "revision" : "4b8714a7fb84d42393314ce897127b3939885ec3",
+        "version" : "3.8.5"
+      }
+    },
+    {
+      "identity" : "confettiswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/simibac/ConfettiSwiftUI.git",
+      "state" : {
+        "revision" : "f45961f97bbae6fff6e2e64546fea0189425ad92",
+        "version" : "1.1.0"
       }
     },
     {
@@ -38,12 +74,48 @@
       }
     },
     {
+      "identity" : "embassy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/envoy/Embassy",
+      "state" : {
+        "revision" : "8469f2c1b334a7c1c3566e2cb2f97826c7cca898",
+        "version" : "4.1.6"
+      }
+    },
+    {
+      "identity" : "inject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzysztofzablocki/Inject.git",
+      "state" : {
+        "branch" : "1.1.1",
+        "revision" : "c0ed5f5de62475e286a3b7c676cec99fa34533ce"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
+      }
+    },
+    {
+      "identity" : "screenobject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/ScreenObject",
+      "state" : {
+        "revision" : "5a62548524a0ad65d8e2e5d4f665981c48066253",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "scrollviewsectionkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pavolkmet/ScrollViewSectionKit",
+      "state" : {
+        "revision" : "c0163ebb5583c63a63f367517dee1a3259a25b75",
+        "version" : "1.5.0"
       }
     },
     {
@@ -56,12 +128,57 @@
       }
     },
     {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    },
+    {
       "identity" : "swift-sodium",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jedisct1/swift-sodium",
       "state" : {
         "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
         "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swiftui-shimmer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/markiv/SwiftUI-Shimmer",
+      "state" : {
+        "revision" : "0226e21f9bf355d40e07e5f5e1c33679d50e167f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "test-collector-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/buildkite/test-collector-swift",
+      "state" : {
+        "revision" : "261b2feaafd601e5b35edb68f402d34ad8210967",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "018c7e8efebfcfa33d43c333b0db93ee0064d913e4937998dd2227260c2763e6",
+  "originHash" : "9ea1ab4271974e9606eddf01e2528d962e975d6abd3fb314fae28d3eeeb07fe9",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",
@@ -128,6 +128,15 @@
       }
     },
     {
+      "identity" : "svprogresshud",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SVProgressHUD/SVProgressHUD",
+      "state" : {
+        "revision" : "c33f7c775ba7feea6047a1fc3257f2e5863b44f7",
+        "version" : "2.3.1"
+      }
+    },
+    {
       "identity" : "swift-algorithms",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms.git",
@@ -188,6 +197,24 @@
       "state" : {
         "revision" : "4699794b08bb79a4d77785edaba6ea739e298e4b",
         "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "viewcontrollerpresentationspy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jonreid/ViewControllerPresentationSpy",
+      "state" : {
+        "revision" : "e58d38ab5a32f7c0baf63cbcc5f7cdf02bb12a99",
+        "version" : "7.0.1"
+      }
+    },
+    {
+      "identity" : "viewinspector",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nalexn/ViewInspector",
+      "state" : {
+        "revision" : "788e7879d38a839c4e348ab0762dcc0364e646a2",
+        "version" : "0.10.1"
       }
     }
   ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
         .package(url: "https://github.com/pavolkmet/ScrollViewSectionKit", from: "1.2.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
         .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
+        .package(url: "https://github.com/SVProgressHUD/SVProgressHUD", from: "2.2.5"),
     ],
     targets: XcodeSupport.targets + [
         .target(name: "Modules"),
@@ -276,7 +277,12 @@ enum XcodeSupport {
                     .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
                 ]
             ),
-            .xcodeTarget(XcodeTargetNames.wordPressAuthenticator, dependencies: []),
+            .xcodeTarget(
+                XcodeTargetNames.wordPressAuthenticator,
+                dependencies: [
+                    .product(name: "SVProgressHUD", package: "SVProgressHUD")
+                ]
+            ),
             .xcodeTarget(
                 XcodeTargetNames.wordPressAuthenticatorTests,
                 dependencies: [XcodeTargetNames.wordPressAuthenticator.asDependency]

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
         .package(url: "https://github.com/Automattic/AutomatticAbout-swift.git", from: "1.1.5"),
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
+        .package(url: "https://github.com/danielgindi/Charts.git", from: "5.1.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
     ],
@@ -200,7 +201,8 @@ enum XcodeSupport {
                     .product(name: "AutomatticAbout", package: "AutomatticAbout-swift"),
                     .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
                     .product(name: "AutomatticEncryptedLogs", package: "Automattic-Tracks-iOS"),
-                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
+                    .product(name: "DGCharts", package: "Charts"),
                 ]
             ),
             .xcodeTarget(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/krzysztofzablocki/Inject.git", revision: "1.1.1"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
+        .package(url: "https://github.com/pavolkmet/ScrollViewSectionKit", from: "1.2.0"),
     ],
     targets: XcodeSupport.targets + [
         .target(name: "Modules"),
@@ -214,7 +215,8 @@ enum XcodeSupport {
                     .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                     .product(name: "ConfettiSwiftUI", package: "ConfettiSwiftUI"),
                     .product(name: "DGCharts", package: "Charts"),
-                    .product(name: "Inject", package: "Inject")
+                    .product(name: "Inject", package: "Inject"),
+                    .product(name: "ScrollViewSectionKit", package: "ScrollViewSectionKit")
                 ]
             ),
             .xcodeTarget(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(url: "https://github.com/Automattic/AutomatticAbout-swift.git", from: "1.1.5"),
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
@@ -196,6 +197,7 @@ enum XcodeSupport {
                 XcodeTargetNames.wooCommerce,
                 dependencies: [
                     "Codegen",
+                    .product(name: "AutomatticAbout", package: "AutomatticAbout-swift"),
                     .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
                     .product(name: "AutomatticEncryptedLogs", package: "Automattic-Tracks-iOS"),
                     .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -29,14 +29,16 @@ let package = Package(
         .package(url: "https://github.com/Automattic/AutomatticAbout-swift.git", from: "1.1.5"),
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
         .package(url: "https://github.com/Automattic/ScreenObject", from: "0.3.0"),
+        .package(url: "https://github.com/buildkite/test-collector-swift", from: "0.3.0"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/danielgindi/Charts.git", from: "5.1.0"),
         .package(url: "https://github.com/envoy/Embassy", from: "4.1.2"),
-        .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/krzysztofzablocki/Inject.git", revision: "1.1.1"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
+        .package(url: "https://github.com/markiv/SwiftUI-Shimmer", from: "1.0.0"),
         .package(url: "https://github.com/pavolkmet/ScrollViewSectionKit", from: "1.2.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
+        .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
     ],
     targets: XcodeSupport.targets + [
         .target(name: "Modules"),
@@ -218,7 +220,8 @@ enum XcodeSupport {
                     .product(name: "ConfettiSwiftUI", package: "ConfettiSwiftUI"),
                     .product(name: "DGCharts", package: "Charts"),
                     .product(name: "Inject", package: "Inject"),
-                    .product(name: "ScrollViewSectionKit", package: "ScrollViewSectionKit")
+                    .product(name: "ScrollViewSectionKit", package: "ScrollViewSectionKit"),
+                    .product(name: "Shimmer", package: "SwiftUI-Shimmer")
                 ]
             ),
             .xcodeTarget(
@@ -234,6 +237,7 @@ enum XcodeSupport {
                 dependencies: [
                     "Codegen",
                     "TestKit",
+                    .product(name: "BuildkiteTestCollector", package: "test-collector-swift"),
                     XcodeTargetNames.wooCommerce.asDependency
                 ]
             ),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -37,6 +37,7 @@ let package = Package(
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/krzysztofzablocki/Inject.git", revision: "1.1.1"),
         .package(url: "https://github.com/markiv/SwiftUI-Shimmer", from: "1.0.0"),
+        .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.0"),
         .package(url: "https://github.com/pavolkmet/ScrollViewSectionKit", from: "1.2.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
         .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
@@ -240,6 +241,7 @@ enum XcodeSupport {
                     "TestKit",
                     .product(name: "BuildkiteTestCollector", package: "test-collector-swift"),
                     .product(name: "ViewControllerPresentationSpy", package: "ViewControllerPresentationSpy"),
+                    .product(name: "ViewInspector", package: "ViewInspector"),
                     XcodeTargetNames.wooCommerce.asDependency
                 ]
             ),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/danielgindi/Charts.git", from: "5.1.0"),
         .package(url: "https://github.com/envoy/Embassy", from: "4.1.2"),
+        .package(url: "https://github.com/jonreid/ViewControllerPresentationSpy", from: "7.0.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/krzysztofzablocki/Inject.git", revision: "1.1.1"),
         .package(url: "https://github.com/markiv/SwiftUI-Shimmer", from: "1.0.0"),
@@ -238,6 +239,7 @@ enum XcodeSupport {
                     "Codegen",
                     "TestKit",
                     .product(name: "BuildkiteTestCollector", package: "test-collector-swift"),
+                    .product(name: "ViewControllerPresentationSpy", package: "ViewControllerPresentationSpy"),
                     XcodeTargetNames.wooCommerce.asDependency
                 ]
             ),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -5,16 +5,18 @@ import PackageDescription
 let package = Package(
     name: "Modules",
     platforms: [
-        .iOS(.v16) // Keep in sync with Common.xcconfig
+        // Keep in sync with Common.xcconfig
+        .iOS(.v16),
+        .macOS(.v10_14),
+        .watchOS(.v9)
     ],
-    products: [
+    products: XcodeSupport.products + [
         .library(
             name: "Modules",
             targets: ["Modules"]
         ),
         .library(
             name: "Codegen",
-            type: .dynamic,
             targets: ["Codegen"]
         ),
         .library(
@@ -23,10 +25,12 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
+        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
     ],
-    targets: [
+    targets: XcodeSupport.targets + [
         .target(name: "Modules"),
         .testTarget(
             name: "ModulesTests",
@@ -42,3 +46,260 @@ let package = Package(
         ),
     ]
 )
+
+// MARK: - XcodeSupport (Xcode Targets)
+
+// Below are dependencies for the respective Xcode targets.
+//
+// You can add internal or third-party dependencies to these targets or even
+// source files and resources.
+//
+// - note: SwiftPM automatically detects which modules are shared between
+//   multiple targets and decides when to use dynamic frameworks.
+//
+// ## Known Issues
+//
+// - SwiftPM copies resource bundles from a target, including dynamic
+//   frameworks, into every target that depends on it. Make sure to avoid
+//   including frameworks with large resources bundled into multiple targets.
+
+enum XcodeTargetNames {
+    static let experiments = "Experiments"
+    static let experimentsTests = "ExperimentsTests"
+    static let fakes = "Fakes"
+    static let hardware = "Hardware"
+    static let hardwareTests = "HardwareTests"
+    static let networking = "Networking"
+    static let networkingTests = "NetworkingTests"
+    static let networkingWatchOS = "NetworkingWatchOS"
+    static let notificationExtension = "NotificationExtension"
+    static let sampleReceiptPrinter = "SampleReceiptPrinter"
+    static let storage = "Storage"
+    static let storageTests = "StorageTests"
+    static let storeWidgetsExtension = "StoreWidgetsExtension"
+    static let uiTestsFoundation = "UITestsFoundation"
+    static let wooCommerce = "WooCommerce"
+    static let wooCommerceScreenshots = "WooCommerceScreenshots"
+    static let wooCommerceTests = "WooCommerceTests"
+    static let wooCommerceUITests = "WooCommerceUITests"
+    static let wooCommerceWatchApp = "Woo Watch App"
+    static let wooFoundation = "WooFoundation"
+    static let wooFoundationTests = "WooFoundationTests"
+    static let wooFoundationWatchOS = "WooFoundationWatchOS"
+    static let wordPressAuthenticator = "WordPressAuthenticator"
+    static let wordPressAuthenticatorTests = "WordPressAuthenticatorTests"
+    static let yosemite = "Yosemite"
+    static let yosemiteTests = "YosemiteTests"
+}
+
+enum XcodeSupport {
+    static var products: [Product] {
+        [
+            support(forXcodeTarget: XcodeTargetNames.experiments),
+            support(forXcodeTarget: XcodeTargetNames.experimentsTests),
+            support(forXcodeTarget: XcodeTargetNames.fakes),
+            support(forXcodeTarget: XcodeTargetNames.hardware),
+            support(forXcodeTarget: XcodeTargetNames.hardwareTests),
+            support(forXcodeTarget: XcodeTargetNames.networking),
+            support(forXcodeTarget: XcodeTargetNames.networkingTests),
+            support(forXcodeTarget: XcodeTargetNames.networkingWatchOS),
+            support(forXcodeTarget: XcodeTargetNames.notificationExtension),
+            support(forXcodeTarget: XcodeTargetNames.sampleReceiptPrinter),
+            support(forXcodeTarget: XcodeTargetNames.storage),
+            support(forXcodeTarget: XcodeTargetNames.storageTests),
+            support(forXcodeTarget: XcodeTargetNames.storeWidgetsExtension),
+            support(forXcodeTarget: XcodeTargetNames.uiTestsFoundation),
+            support(forXcodeTarget: XcodeTargetNames.wooCommerce),
+            support(forXcodeTarget: XcodeTargetNames.wooCommerceScreenshots),
+            support(forXcodeTarget: XcodeTargetNames.wooCommerceTests),
+            support(forXcodeTarget: XcodeTargetNames.wooCommerceUITests),
+            support(forXcodeTarget: XcodeTargetNames.wooCommerceWatchApp),
+            support(forXcodeTarget: XcodeTargetNames.wooFoundation),
+            support(forXcodeTarget: XcodeTargetNames.wooFoundationTests),
+            support(forXcodeTarget: XcodeTargetNames.wooFoundationWatchOS),
+            support(forXcodeTarget: XcodeTargetNames.wordPressAuthenticator),
+            support(forXcodeTarget: XcodeTargetNames.wordPressAuthenticatorTests),
+            support(forXcodeTarget: XcodeTargetNames.yosemite),
+            support(forXcodeTarget: XcodeTargetNames.yosemiteTests)
+        ]
+    }
+
+    static var targets: [Target] {
+        [
+            .xcodeTarget(
+                XcodeTargetNames.experiments,
+                dependencies: [
+                    .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.experimentsTests,
+                dependencies: [
+                    .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
+                    XcodeTargetNames.experiments.asDependency
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.fakes,
+                dependencies: ["Codegen"]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.hardware,
+                dependencies: [
+                    "Codegen",
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.hardwareTests,
+                dependencies: [XcodeTargetNames.hardware.asDependency]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.networking,
+                dependencies: [
+                    "Codegen",
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
+                    XcodeTargetNames.wooFoundation.asDependency
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.networkingTests,
+                dependencies: [
+                    "Codegen",
+                    "TestKit",
+                    XcodeTargetNames.networking.asDependency
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.networkingWatchOS,
+                dependencies: [
+                    "Codegen",
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                ]
+            ),
+            .xcodeTarget(XcodeTargetNames.notificationExtension, dependencies: []),
+            .xcodeTarget(
+                XcodeTargetNames.sampleReceiptPrinter,
+                dependencies: [XcodeTargetNames.hardware.asDependency]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.storage,
+                dependencies: ["Codegen", XcodeTargetNames.wooFoundation.asDependency]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.storageTests,
+                dependencies: ["TestKit", XcodeTargetNames.storage.asDependency]
+            ),
+            .xcodeTarget(XcodeTargetNames.storeWidgetsExtension, dependencies: []),
+            .xcodeTarget(XcodeTargetNames.uiTestsFoundation, dependencies: []),
+            .xcodeTarget(
+                XcodeTargetNames.wooCommerce,
+                dependencies: [
+                    "Codegen",
+                    .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
+                    .product(name: "AutomatticEncryptedLogs", package: "Automattic-Tracks-iOS"),
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.wooCommerceScreenshots,
+                dependencies: [XcodeTargetNames.wooCommerce.asDependency]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.wooCommerceTests,
+                dependencies: [
+                    "Codegen",
+                    "TestKit",
+                    XcodeTargetNames.wooCommerce.asDependency
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.wooCommerceUITests,
+                dependencies: [XcodeTargetNames.wooCommerce.asDependency]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.wooCommerceWatchApp,
+                dependencies: [
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.wooFoundation,
+                dependencies: [
+                    "Codegen",
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.wooFoundationTests,
+                dependencies: ["TestKit", XcodeTargetNames.wooFoundation.asDependency]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.wooFoundationWatchOS,
+                dependencies: [
+                    "Codegen",
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                ]
+            ),
+            .xcodeTarget(XcodeTargetNames.wordPressAuthenticator, dependencies: []),
+            .xcodeTarget(
+                XcodeTargetNames.wordPressAuthenticatorTests,
+                dependencies: [XcodeTargetNames.wordPressAuthenticator.asDependency]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.yosemite,
+                dependencies: [
+                    "Codegen",
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
+                ]
+            ),
+            .xcodeTarget(
+                XcodeTargetNames.yosemiteTests,
+                dependencies: [
+                    "Codegen",
+                    "TestKit",
+                    XcodeTargetNames.yosemite.asDependency
+                ]
+            )
+        ]
+    }
+}
+
+// Does not work, gives:
+//
+// > Static member 'support' cannot be used on instance of type 'Product'
+//
+//extension Product {
+//    static func support(forXcodeTarget targetName: String) -> Product {
+//        .library(
+//            name: "XcodeTarget_\(targetName)",
+//            targets: ["XcodeTarget_\(targetName)"]
+//        )
+//    }
+//}
+func support(forXcodeTarget targetName: String) -> Product {
+    .library(
+        name: targetName.supportingName,
+        targets: [targetName.supportingName]
+    )
+}
+
+extension Target {
+    static func xcodeTarget(_ name: String, dependencies: [Dependency]) -> Target {
+        .target(
+            name: name.supportingName,
+            dependencies: dependencies,
+            path: "Sources/XcodeSupport/\(name.replacing(" ", with: "-").supportingName)"
+        )
+    }
+}
+
+extension String {
+    var supportingName: String {
+        "XcodeTarget_\(self)"
+    }
+
+    var asDependency: Target.Dependency {
+        .target(name: self.supportingName)
+    }
+}

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/danielgindi/Charts.git", from: "5.1.0"),
+        .package(url: "https://github.com/envoy/Embassy", from: "4.1.2"),
         .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
@@ -204,12 +205,15 @@ enum XcodeSupport {
                     .product(name: "AutomatticEncryptedLogs", package: "Automattic-Tracks-iOS"),
                     .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                     .product(name: "ConfettiSwiftUI", package: "ConfettiSwiftUI"),
-                    .product(name: "DGCharts", package: "Charts"),
+                    .product(name: "DGCharts", package: "Charts")
                 ]
             ),
             .xcodeTarget(
                 XcodeTargetNames.wooCommerceScreenshots,
-                dependencies: [XcodeTargetNames.wooCommerce.asDependency]
+                dependencies: [
+                    .product(name: "Embassy", package: "Embassy"),
+                    XcodeTargetNames.wooCommerce.asDependency
+                ]
             ),
             .xcodeTarget(
                 XcodeTargetNames.wooCommerceTests,

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -27,11 +27,13 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Automattic/AutomatticAbout-swift.git", from: "1.1.5"),
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
+        .package(url: "https://github.com/Automattic/ScreenObject", from: "0.3.0"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/danielgindi/Charts.git", from: "5.1.0"),
         .package(url: "https://github.com/envoy/Embassy", from: "4.1.2"),
         .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
+        .package(url: "https://github.com/krzysztofzablocki/Inject.git", revision: "1.1.1"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
     ],
     targets: XcodeSupport.targets + [
@@ -195,7 +197,13 @@ enum XcodeSupport {
                 dependencies: ["TestKit", XcodeTargetNames.storage.asDependency]
             ),
             .xcodeTarget(XcodeTargetNames.storeWidgetsExtension, dependencies: []),
-            .xcodeTarget(XcodeTargetNames.uiTestsFoundation, dependencies: []),
+            .xcodeTarget(
+                XcodeTargetNames.uiTestsFoundation,
+                dependencies: [
+                    .product(name: "ScreenObject", package: "ScreenObject"),
+                    .product(name: "XCUITestHelpers", package: "ScreenObject"),
+                ]
+            ),
             .xcodeTarget(
                 XcodeTargetNames.wooCommerce,
                 dependencies: [
@@ -205,13 +213,15 @@ enum XcodeSupport {
                     .product(name: "AutomatticEncryptedLogs", package: "Automattic-Tracks-iOS"),
                     .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                     .product(name: "ConfettiSwiftUI", package: "ConfettiSwiftUI"),
-                    .product(name: "DGCharts", package: "Charts")
+                    .product(name: "DGCharts", package: "Charts"),
+                    .product(name: "Inject", package: "Inject")
                 ]
             ),
             .xcodeTarget(
                 XcodeTargetNames.wooCommerceScreenshots,
                 dependencies: [
                     .product(name: "Embassy", package: "Embassy"),
+                    .product(name: "ScreenObject", package: "ScreenObject"),
                     XcodeTargetNames.wooCommerce.asDependency
                 ]
             ),
@@ -225,7 +235,10 @@ enum XcodeSupport {
             ),
             .xcodeTarget(
                 XcodeTargetNames.wooCommerceUITests,
-                dependencies: [XcodeTargetNames.wooCommerce.asDependency]
+                dependencies: [
+                    .product(name: "ScreenObject", package: "ScreenObject"),
+                    XcodeTargetNames.wooCommerce.asDependency
+                ]
             ),
             .xcodeTarget(
                 XcodeTargetNames.wooCommerceWatchApp,

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/danielgindi/Charts.git", from: "5.1.0"),
+        .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
     ],
@@ -202,6 +203,7 @@ enum XcodeSupport {
                     .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
                     .product(name: "AutomatticEncryptedLogs", package: "Automattic-Tracks-iOS"),
                     .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
+                    .product(name: "ConfettiSwiftUI", package: "ConfettiSwiftUI"),
                     .product(name: "DGCharts", package: "Charts"),
                 ]
             ),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
         .package(url: "https://github.com/Automattic/AutomatticAbout-swift.git", from: "1.1.5"),
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "3.5.2"),
         .package(url: "https://github.com/Automattic/ScreenObject", from: "0.3.0"),
@@ -209,6 +210,7 @@ enum XcodeSupport {
                 XcodeTargetNames.wooCommerce,
                 dependencies: [
                     "Codegen",
+                    .product(name: "Algorithms", package: "swift-algorithms"),
                     .product(name: "AutomatticAbout", package: "AutomatticAbout-swift"),
                     .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS"),
                     .product(name: "AutomatticEncryptedLogs", package: "Automattic-Tracks-iOS"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -108,33 +108,33 @@ enum XcodeTargetNames {
 enum XcodeSupport {
     static var products: [Product] {
         [
-            support(forXcodeTarget: XcodeTargetNames.experiments),
-            support(forXcodeTarget: XcodeTargetNames.experimentsTests),
-            support(forXcodeTarget: XcodeTargetNames.fakes),
-            support(forXcodeTarget: XcodeTargetNames.hardware),
-            support(forXcodeTarget: XcodeTargetNames.hardwareTests),
-            support(forXcodeTarget: XcodeTargetNames.networking),
-            support(forXcodeTarget: XcodeTargetNames.networkingTests),
-            support(forXcodeTarget: XcodeTargetNames.networkingWatchOS),
-            support(forXcodeTarget: XcodeTargetNames.notificationExtension),
-            support(forXcodeTarget: XcodeTargetNames.sampleReceiptPrinter),
-            support(forXcodeTarget: XcodeTargetNames.storage),
-            support(forXcodeTarget: XcodeTargetNames.storageTests),
-            support(forXcodeTarget: XcodeTargetNames.storeWidgetsExtension),
-            support(forXcodeTarget: XcodeTargetNames.uiTestsFoundation),
-            support(forXcodeTarget: XcodeTargetNames.wooCommerce),
-            support(forXcodeTarget: XcodeTargetNames.wooCommerceScreenshots),
-            support(forXcodeTarget: XcodeTargetNames.wooCommerceTests),
-            support(forXcodeTarget: XcodeTargetNames.wooCommerceUITests),
-            support(forXcodeTarget: XcodeTargetNames.wooCommerceWatchApp),
-            support(forXcodeTarget: XcodeTargetNames.wooFoundation),
-            support(forXcodeTarget: XcodeTargetNames.wooFoundationTests),
-            support(forXcodeTarget: XcodeTargetNames.wooFoundationWatchOS),
-            support(forXcodeTarget: XcodeTargetNames.wordPressAuthenticator),
-            support(forXcodeTarget: XcodeTargetNames.wordPressAuthenticatorTests),
-            support(forXcodeTarget: XcodeTargetNames.yosemite),
-            support(forXcodeTarget: XcodeTargetNames.yosemiteTests)
-        ]
+            XcodeTargetNames.experiments,
+            XcodeTargetNames.experimentsTests,
+            XcodeTargetNames.fakes,
+            XcodeTargetNames.hardware,
+            XcodeTargetNames.hardwareTests,
+            XcodeTargetNames.networking,
+            XcodeTargetNames.networkingTests,
+            XcodeTargetNames.networkingWatchOS,
+            XcodeTargetNames.notificationExtension,
+            XcodeTargetNames.sampleReceiptPrinter,
+            XcodeTargetNames.storage,
+            XcodeTargetNames.storageTests,
+            XcodeTargetNames.storeWidgetsExtension,
+            XcodeTargetNames.uiTestsFoundation,
+            XcodeTargetNames.wooCommerce,
+            XcodeTargetNames.wooCommerceScreenshots,
+            XcodeTargetNames.wooCommerceTests,
+            XcodeTargetNames.wooCommerceUITests,
+            XcodeTargetNames.wooCommerceWatchApp,
+            XcodeTargetNames.wooFoundation,
+            XcodeTargetNames.wooFoundationTests,
+            XcodeTargetNames.wooFoundationWatchOS,
+            XcodeTargetNames.wordPressAuthenticator,
+            XcodeTargetNames.wordPressAuthenticatorTests,
+            XcodeTargetNames.yosemite,
+            XcodeTargetNames.yosemiteTests
+        ].map { .supportingProduct(forXcodeTarget: $0) }
     }
 
     static var targets: [Target] {
@@ -310,19 +310,13 @@ enum XcodeSupport {
 //
 // > Static member 'support' cannot be used on instance of type 'Product'
 //
-//extension Product {
-//    static func support(forXcodeTarget targetName: String) -> Product {
-//        .library(
-//            name: "XcodeTarget_\(targetName)",
-//            targets: ["XcodeTarget_\(targetName)"]
-//        )
-//    }
-//}
-func support(forXcodeTarget targetName: String) -> Product {
-    .library(
-        name: targetName.supportingName,
-        targets: [targetName.supportingName]
-    )
+extension Product {
+    static func supportingProduct(forXcodeTarget targetName: String) -> Product {
+        .library(
+            name: "XcodeTarget_\(targetName)",
+            targets: ["XcodeTarget_\(targetName)"]
+        )
+    }
 }
 
 extension Target {

--- a/Modules/Sources/XcodeSupport/XcodeTarget_Experiments/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_Experiments/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_ExperimentsTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_ExperimentsTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_Fakes/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_Fakes/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_Hardware/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_Hardware/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_HardwareTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_HardwareTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_Networking/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_Networking/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_NetworkingTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_NetworkingTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_NetworkingWatchOS/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_NetworkingWatchOS/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_NotificationExtension/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_NotificationExtension/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_SampleReceiptPrinter/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_SampleReceiptPrinter/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_Storage/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_Storage/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_StorageTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_StorageTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_StoreWidgetsExtension/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_StoreWidgetsExtension/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_UITestsFoundation/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_UITestsFoundation/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_Woo-Watch-App/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_Woo-Watch-App/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerce/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerce/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerceScreenshots/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerceScreenshots/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerceTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerceTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerceUITests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WooCommerceUITests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WooFoundation/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WooFoundation/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WooFoundationTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WooFoundationTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WooFoundationWatchOS/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WooFoundationWatchOS/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WordPressAuthenticator/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WordPressAuthenticator/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_WordPressAuthenticatorTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_WordPressAuthenticatorTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_Yosemite/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_Yosemite/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Modules/Sources/XcodeSupport/XcodeTarget_YosemiteTests/Empty.swift
+++ b/Modules/Sources/XcodeSupport/XcodeTarget_YosemiteTests/Empty.swift
@@ -1,0 +1,7 @@
+// We need this file with a dummy type in the package to avoid the following
+// error:
+//
+// > target 'XcodeTarget_<name>' referenced in product 'XcodeTarget_<name>' is empty
+import Foundation
+
+public struct __Empty {}

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -273,9 +273,6 @@
 		263A6DBC2BEAA49B00C292B2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452387121124B7700A973CD /* AnyDecodable.swift */; };
 		263A6DBD2BEAA49B00C292B2 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452386F21124B7700A973CD /* AnyEncodable.swift */; };
 		263A6DBE2BEAA4A900C292B2 /* MIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D3BD132114FE6900A6E85E /* MIContainer.swift */; };
-		263E37D22641ACEA00260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37D12641ACEA00260D3B /* Codegen */; };
-		263E383F2641FF1600260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E383E2641FF1600260D3B /* Codegen */; };
-		263E38402641FF1600260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E383E2641FF1600260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		264541B72CA64522006C13A2 /* WooShippingRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264541B62CA644D0006C13A2 /* WooShippingRemote.swift */; };
 		264541B92CA6580E006C13A2 /* WooShippingRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264541B82CA6580E006C13A2 /* WooShippingRemoteTests.swift */; };
 		26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */; };
@@ -324,7 +321,6 @@
 		269014C32BEA9134006056E0 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B567AF2820A0FA1E00AB6C62 /* Mapper.swift */; };
 		269014C42BEA9142006056E0 /* ResponseDataValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C22913FA6400C3982B /* ResponseDataValidator.swift */; };
 		269014C52BEA914B006056E0 /* DotcomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53EF53721813806003E146F /* DotcomError.swift */; };
-		269014C72BEA9166006056E0 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 269014C62BEA9166006056E0 /* Codegen */; };
 		269014CA2BEA924B006056E0 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B556FD68211CE2EC00B5DAE7 /* NetworkError.swift */; };
 		269014CB2BEA9253006056E0 /* JetpackRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557D9FF209754FF005962F4 /* JetpackRequest.swift */; };
 		269014CC2BEA925F006056E0 /* RESTRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDBEDD296845F400293C4E /* RESTRequestConvertible.swift */; };
@@ -425,9 +421,9 @@
 		31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C8A26028D96002EDB1D /* SitePlugin.swift */; };
 		31D27C8F2602B553002EDB1D /* plugins.json in Resources */ = {isa = PBXBuildFile; fileRef = 31D27C8E2602B553002EDB1D /* plugins.json */; };
 		31D27C952602B737002EDB1D /* SitePluginsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C942602B737002EDB1D /* SitePluginsRemoteTests.swift */; };
-		3F368D9E2DCB750B0065B48F /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3F368D9D2DCB750B0065B48F /* TestKit */; };
-		3FF8370C2DD322FF0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8370B2DD322FF0049E028 /* CocoaLumberjackSwift */; };
-		3FF8371F2DD32CB30049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8371E2DD32CB30049E028 /* CocoaLumberjackSwift */; };
+		3F2B4ACE2DDC30F400E5E49C /* XcodeTarget_NetworkingTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ACD2DDC30F400E5E49C /* XcodeTarget_NetworkingTests */; };
+		3F2B4AD02DDC30FE00E5E49C /* XcodeTarget_NetworkingWatchOS in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ACF2DDC30FE00E5E49C /* XcodeTarget_NetworkingWatchOS */; };
+		3F2B4AD22DDC310600E5E49C /* XcodeTarget_Networking in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AD12DDC310600E5E49C /* XcodeTarget_Networking */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
@@ -1354,7 +1350,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				263E38402641FF1600260D3B /* Codegen in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2596,8 +2591,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				26B542452BEAC6A6003A55B5 /* Pods_NetworkingWatchOS.framework in Frameworks */,
-				269014C72BEA9166006056E0 /* Codegen in Frameworks */,
-				3FF8370C2DD322FF0049E028 /* CocoaLumberjackSwift in Frameworks */,
+				3F2B4AD02DDC30FE00E5E49C /* XcodeTarget_NetworkingWatchOS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2605,10 +2599,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				263E37D22641ACEA00260D3B /* Codegen in Frameworks */,
 				68FBC5B828928C8C00A05461 /* WooFoundation.framework in Frameworks */,
-				3FF8371F2DD32CB30049E028 /* CocoaLumberjackSwift in Frameworks */,
 				6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */,
+				3F2B4AD22DDC310600E5E49C /* XcodeTarget_Networking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2618,9 +2611,8 @@
 			files = (
 				26FB056C25F6CB9100A40B26 /* Fakes.framework in Frameworks */,
 				B557D9ED209753AA005962F4 /* Networking.framework in Frameworks */,
-				263E383F2641FF1600260D3B /* Codegen in Frameworks */,
-				3F368D9E2DCB750B0065B48F /* TestKit in Frameworks */,
 				21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */,
+				3F2B4ACE2DDC30F400E5E49C /* XcodeTarget_NetworkingTests in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4370,8 +4362,7 @@
 			);
 			name = NetworkingWatchOS;
 			packageProductDependencies = (
-				269014C62BEA9166006056E0 /* Codegen */,
-				3FF8370B2DD322FF0049E028 /* CocoaLumberjackSwift */,
+				3F2B4ACF2DDC30FE00E5E49C /* XcodeTarget_NetworkingWatchOS */,
 			);
 			productName = NetworkingWatchOS;
 			productReference = 26DAAB4F2BEA8D3400CE399E /* NetworkingWatchOS.framework */;
@@ -4393,8 +4384,7 @@
 			);
 			name = Networking;
 			packageProductDependencies = (
-				263E37D12641ACEA00260D3B /* Codegen */,
-				3FF8371E2DD32CB30049E028 /* CocoaLumberjackSwift */,
+				3F2B4AD12DDC310600E5E49C /* XcodeTarget_Networking */,
 			);
 			productName = Networking;
 			productReference = B557D9E3209753AA005962F4 /* Networking.framework */;
@@ -4418,8 +4408,7 @@
 			);
 			name = NetworkingTests;
 			packageProductDependencies = (
-				263E383E2641FF1600260D3B /* Codegen */,
-				3F368D9D2DCB750B0065B48F /* TestKit */,
+				3F2B4ACD2DDC30F400E5E49C /* XcodeTarget_NetworkingTests */,
 			);
 			productName = NetworkingTests;
 			productReference = B557D9EC209753AA005962F4 /* NetworkingTests.xctest */;
@@ -4458,9 +4447,6 @@
 				Base,
 			);
 			mainGroup = B557D9D9209753AA005962F4;
-			packageReferences = (
-				3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
-			);
 			productRefGroup = B557D9E4209753AA005962F4 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -6426,43 +6412,18 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.8.5;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		263E37D12641ACEA00260D3B /* Codegen */ = {
+		3F2B4ACD2DDC30F400E5E49C /* XcodeTarget_NetworkingTests */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_NetworkingTests;
 		};
-		263E383E2641FF1600260D3B /* Codegen */ = {
+		3F2B4ACF2DDC30FE00E5E49C /* XcodeTarget_NetworkingWatchOS */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_NetworkingWatchOS;
 		};
-		269014C62BEA9166006056E0 /* Codegen */ = {
+		3F2B4AD12DDC310600E5E49C /* XcodeTarget_Networking */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
-		};
-		3F368D9D2DCB750B0065B48F /* TestKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = TestKit;
-		};
-		3FF8370B2DD322FF0049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
-		};
-		3FF8371E2DD32CB30049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF8370A2DD322FF0049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
+			productName = XcodeTarget_Networking;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Podfile
+++ b/Podfile
@@ -33,10 +33,6 @@ def wordpress_shared
   pod 'WordPressShared', '~> 2.1-beta'
 end
 
-def svprogresshud
-  pod 'SVProgressHUD', '2.2.5'
-end
-
 def keychain
   pod 'KeychainAccess', '~> 4.2.2'
 end
@@ -231,7 +227,6 @@ end
 # ==========
 #
 def wordpress_authenticator_pods
-  svprogresshud
   gridicons
   wordpress_ui
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,6 @@ PODS:
     - Sentry/Core (= 8.46.0)
   - Sentry/Core (8.46.0)
   - StripeTerminal (4.2.0)
-  - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (2.3.0)
   - WordPress-Aztec-iOS (1.19.10)
   - WordPress-Editor-iOS (1.19.10):
@@ -57,7 +56,6 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (~> 9.0)
   - Sentry (~> 8.46.0)
   - StripeTerminal (~> 4.2.0)
-  - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 2.0)
   - WordPress-Editor-iOS (~> 1.19)
   - WordPressShared (~> 2.1-beta)
@@ -77,7 +75,6 @@ SPEC REPOS:
     - OHHTTPStubs
     - Sentry
     - StripeTerminal
-    - SVProgressHUD
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
@@ -103,7 +100,6 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
   StripeTerminal: 58a08668f6731666fc1ab878ac4a510ecfb403c9
-  SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: 8eaa928fb3a5694924ed3befac64beaae5656e12
   WordPress-Editor-iOS: 98ce1fc542c3a09e48ddc9423405b1d1e48240f1
@@ -120,6 +116,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 281acf2bb731d2a67f913cfe653ed0da9f5b2f42
   ZendeskSupportSDK: b512cfc74b6bf8490e589f02cf52e27ed4f2bebe
 
-PODFILE CHECKSUM: d34daa04154fd73f4a565d54cee6f58d87a1a730
+PODFILE CHECKSUM: e8b7a720e1a5dfbd786d981801b57560dd250395
 
 COCOAPODS: 1.16.2

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		262B270E2621412000A421CF /* ProductAddOn+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B26752621401A00A421CF /* ProductAddOn+CoreDataProperties.swift */; };
 		262B27132621412700A421CF /* ProductAddOnOption+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B26762621401A00A421CF /* ProductAddOnOption+CoreDataClass.swift */; };
 		262B27182621412D00A421CF /* ProductAddOnOption+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B26772621401A00A421CF /* ProductAddOnOption+CoreDataProperties.swift */; };
-		263E37D72641AD5100260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37D62641AD5100260D3B /* Codegen */; };
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
 		267439D624E5D45A0090696C /* FeedbackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267439D524E5D45A0090696C /* FeedbackSettings.swift */; };
 		2685C108263C88B000D9EE97 /* AddOnGroup+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C106263C88B000D9EE97 /* AddOnGroup+CoreDataClass.swift */; };
@@ -68,9 +67,8 @@
 		26EA01D524EC44B300176A57 /* GeneralAppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EA01D424EC44B300176A57 /* GeneralAppSettingsTests.swift */; };
 		31D9C8C826684AEC000AC134 /* PaymentGatewayAccount+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D9C8C626684AEC000AC134 /* PaymentGatewayAccount+CoreDataClass.swift */; };
 		31D9C8C926684AEC000AC134 /* PaymentGatewayAccount+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D9C8C726684AEC000AC134 /* PaymentGatewayAccount+CoreDataProperties.swift */; };
-		3F368D9C2DCB74DF0065B48F /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3F368D9B2DCB74DF0065B48F /* TestKit */; };
-		3FF837162DD32B150049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837152DD32B150049E028 /* CocoaLumberjackSwift */; };
-		3FF837182DD32B2E0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837172DD32B2E0049E028 /* CocoaLumberjackSwift */; };
+		3F2B4AD42DDC312600E5E49C /* XcodeTarget_Storage in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AD32DDC312600E5E49C /* XcodeTarget_Storage */; };
+		3F2B4AD62DDC312F00E5E49C /* XcodeTarget_StorageTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AD52DDC312F00E5E49C /* XcodeTarget_StorageTests */; };
 		450106892399AC7400E24722 /* TaxClass+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */; };
 		4501068B2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */; };
 		452C23B427B4129300822986 /* InboxAction+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452C23B027B4129300822986 /* InboxAction+CoreDataClass.swift */; };
@@ -688,9 +686,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				263E37D72641AD5100260D3B /* Codegen in Frameworks */,
+				3F2B4AD42DDC312600E5E49C /* XcodeTarget_Storage in Frameworks */,
 				B54CA5B520A4BC0300F38CD1 /* CoreData.framework in Frameworks */,
-				3FF837162DD32B150049E028 /* CocoaLumberjackSwift in Frameworks */,
 				B9EFC27728903F7C00667217 /* WooFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -699,9 +696,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F368D9C2DCB74DF0065B48F /* TestKit in Frameworks */,
+				3F2B4AD62DDC312F00E5E49C /* XcodeTarget_StorageTests in Frameworks */,
 				B54CA5A320A4BBA600F38CD1 /* Storage.framework in Frameworks */,
-				3FF837182DD32B2E0049E028 /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1231,8 +1227,7 @@
 			);
 			name = Storage;
 			packageProductDependencies = (
-				263E37D62641AD5100260D3B /* Codegen */,
-				3FF837152DD32B150049E028 /* CocoaLumberjackSwift */,
+				3F2B4AD32DDC312600E5E49C /* XcodeTarget_Storage */,
 			);
 			productName = Storage;
 			productReference = B54CA59920A4BBA500F38CD1 /* Storage.framework */;
@@ -1253,8 +1248,7 @@
 			);
 			name = StorageTests;
 			packageProductDependencies = (
-				3F368D9B2DCB74DF0065B48F /* TestKit */,
-				3FF837172DD32B2E0049E028 /* CocoaLumberjackSwift */,
+				3F2B4AD52DDC312F00E5E49C /* XcodeTarget_StorageTests */,
 			);
 			productName = StorageTests;
 			productReference = B54CA5A220A4BBA600F38CD1 /* StorageTests.xctest */;
@@ -1291,7 +1285,6 @@
 			);
 			mainGroup = B54CA58F20A4BBA500F38CD1;
 			packageReferences = (
-				3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 			);
 			productRefGroup = B54CA59A20A4BBA500F38CD1 /* Products */;
 			projectDirPath = "";
@@ -1987,35 +1980,14 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.8.5;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		263E37D62641AD5100260D3B /* Codegen */ = {
+		3F2B4AD32DDC312600E5E49C /* XcodeTarget_Storage */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_Storage;
 		};
-		3FF837152DD32B150049E028 /* CocoaLumberjackSwift */ = {
+		3F2B4AD52DDC312F00E5E49C /* XcodeTarget_StorageTests */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
-		};
-		3FF837172DD32B2E0049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF837142DD32B150049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
-		};
-		3F368D9B2DCB74DF0065B48F /* TestKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = TestKit;
+			productName = XcodeTarget_StorageTests;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,214 +1,213 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "AutomatticTracksiOS",
-        "repositoryURL": "https://github.com/Automattic/Automattic-Tracks-iOS",
-        "state": {
-          "branch": null,
-          "revision": "437f586a62c07c6ceec9baf043237b2afe7ea1ac",
-          "version": "3.5.2"
-        }
-      },
-      {
-        "package": "AutomatticAbout",
-        "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
-        "state": {
-          "branch": null,
-          "revision": "606384a7492faa1139d489080dd961b0b57f9fd9",
-          "version": "1.1.5"
-        }
-      },
-      {
-        "package": "DGCharts",
-        "repositoryURL": "https://github.com/danielgindi/Charts",
-        "state": {
-          "branch": null,
-          "revision": "dd9c72e3d7e751e769971092a6bd72d39198ae63",
-          "version": "5.1.0"
-        }
-      },
-      {
-        "package": "CocoaLumberjack",
-        "repositoryURL": "https://github.com/CocoaLumberjack/CocoaLumberjack",
-        "state": {
-          "branch": null,
-          "revision": "4b8714a7fb84d42393314ce897127b3939885ec3",
-          "version": "3.8.5"
-        }
-      },
-      {
-        "package": "ConfettiSwiftUI",
-        "repositoryURL": "https://github.com/simibac/ConfettiSwiftUI.git",
-        "state": {
-          "branch": null,
-          "revision": "8d3a15d0aa2991e0761749b767ef8d89bca6275a",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
-          "version": "2.2.1"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
-          "version": "2.2.2"
-        }
-      },
-      {
-        "package": "Difference",
-        "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
-        "state": {
-          "branch": "master",
-          "revision": "6b121174e4a4bfed28ef8bb725156fac6e7c12bc",
-          "version": null
-        }
-      },
-      {
-        "package": "Embassy",
-        "repositoryURL": "https://github.com/envoy/Embassy",
-        "state": {
-          "branch": null,
-          "revision": "8469f2c1b334a7c1c3566e2cb2f97826c7cca898",
-          "version": "4.1.6"
-        }
-      },
-      {
-        "package": "Inject",
-        "repositoryURL": "https://github.com/krzysztofzablocki/Inject.git",
-        "state": {
-          "branch": null,
-          "revision": "c0ed5f5de62475e286a3b7c676cec99fa34533ce",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
-          "version": "13.7.1"
-        }
-      },
-      {
-        "package": "ScreenObject",
-        "repositoryURL": "https://github.com/Automattic/ScreenObject",
-        "state": {
-          "branch": null,
-          "revision": "5a62548524a0ad65d8e2e5d4f665981c48066253",
-          "version": "0.3.0"
-        }
-      },
-      {
-        "package": "ScrollViewSectionKit",
-        "repositoryURL": "https://github.com/pavolkmet/ScrollViewSectionKit",
-        "state": {
-          "branch": null,
-          "revision": "44a0db25e86206bdb96fb7b93507417cfc36f016",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "Sentry",
-        "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
-        "state": {
-          "branch": null,
-          "revision": "6c81e671154e63464dd6749b7ba3279dd390a146",
-          "version": "8.50.1"
-        }
-      },
-      {
-        "package": "swift-algorithms",
-        "repositoryURL": "https://github.com/apple/swift-algorithms",
-        "state": {
-          "branch": null,
-          "revision": "f6919dfc309e7f1b56224378b11e28bab5bccc42",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log",
-        "state": {
-          "branch": null,
-          "revision": "3d8596ed08bd13520157f0355e35caed215ffbfa",
-          "version": "1.6.3"
-        }
-      },
-      {
-        "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics",
-        "state": {
-          "branch": null,
-          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "Sodium",
-        "repositoryURL": "https://github.com/jedisct1/swift-sodium",
-        "state": {
-          "branch": null,
-          "revision": "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "SwiftUI-Shimmer",
-        "repositoryURL": "https://github.com/markiv/SwiftUI-Shimmer",
-        "state": {
-          "branch": null,
-          "revision": "1f3a620e4abe890d00008cb2af7023d810b433a7",
-          "version": "1.4.0"
-        }
-      },
-      {
-        "package": "BuildkiteTestCollector",
-        "repositoryURL": "https://github.com/buildkite/test-collector-swift",
-        "state": {
-          "branch": null,
-          "revision": "631a2400dbe876141a3ef8c7400885907fec7f89",
-          "version": "0.4.1"
-        }
-      },
-      {
-        "package": "UIDeviceIdentifier",
-        "repositoryURL": "https://github.com/squarefrog/UIDeviceIdentifier",
-        "state": {
-          "branch": null,
-          "revision": "4699794b08bb79a4d77785edaba6ea739e298e4b",
-          "version": "2.3.0"
-        }
-      },
-      {
-        "package": "ViewControllerPresentationSpy",
-        "repositoryURL": "https://github.com/jonreid/ViewControllerPresentationSpy",
-        "state": {
-          "branch": null,
-          "revision": "1d7422b88f03065e3f25eeef6cae085cecd94911",
-          "version": "7.0.0"
-        }
-      },
-      {
-        "package": "ViewInspector",
-        "repositoryURL": "https://github.com/nalexn/ViewInspector",
-        "state": {
-          "branch": null,
-          "revision": "5acfa0a3c095ac9ad050abe51c60d1831e8321da",
-          "version": "0.10.0"
-        }
+  "originHash" : "ac14247d60042986e3c4f353c125551388bcefba2a37b88e3ad8884a742e47a8",
+  "pins" : [
+    {
+      "identity" : "automattic-tracks-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
+      "state" : {
+        "revision" : "437f586a62c07c6ceec9baf043237b2afe7ea1ac",
+        "version" : "3.5.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "automatticabout-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/automattic/AutomatticAbout-swift",
+      "state" : {
+        "revision" : "606384a7492faa1139d489080dd961b0b57f9fd9",
+        "version" : "1.1.5"
+      }
+    },
+    {
+      "identity" : "charts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/danielgindi/Charts",
+      "state" : {
+        "revision" : "dd9c72e3d7e751e769971092a6bd72d39198ae63",
+        "version" : "5.1.0"
+      }
+    },
+    {
+      "identity" : "cocoalumberjack",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack",
+      "state" : {
+        "revision" : "4b8714a7fb84d42393314ce897127b3939885ec3",
+        "version" : "3.8.5"
+      }
+    },
+    {
+      "identity" : "confettiswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/simibac/ConfettiSwiftUI.git",
+      "state" : {
+        "revision" : "8d3a15d0aa2991e0761749b767ef8d89bca6275a",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    },
+    {
+      "identity" : "difference",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzysztofzablocki/Difference.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "6b121174e4a4bfed28ef8bb725156fac6e7c12bc"
+      }
+    },
+    {
+      "identity" : "embassy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/envoy/Embassy",
+      "state" : {
+        "revision" : "8469f2c1b334a7c1c3566e2cb2f97826c7cca898",
+        "version" : "4.1.6"
+      }
+    },
+    {
+      "identity" : "inject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzysztofzablocki/Inject.git",
+      "state" : {
+        "branch" : "1.1.1",
+        "revision" : "c0ed5f5de62475e286a3b7c676cec99fa34533ce"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
+        "version" : "13.7.1"
+      }
+    },
+    {
+      "identity" : "screenobject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/ScreenObject",
+      "state" : {
+        "revision" : "5a62548524a0ad65d8e2e5d4f665981c48066253",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "scrollviewsectionkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pavolkmet/ScrollViewSectionKit",
+      "state" : {
+        "revision" : "44a0db25e86206bdb96fb7b93507417cfc36f016",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "6c81e671154e63464dd6749b7ba3279dd390a146",
+        "version" : "8.50.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium",
+      "state" : {
+        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swiftui-shimmer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/markiv/SwiftUI-Shimmer",
+      "state" : {
+        "revision" : "1f3a620e4abe890d00008cb2af7023d810b433a7",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "test-collector-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/buildkite/test-collector-swift",
+      "state" : {
+        "revision" : "631a2400dbe876141a3ef8c7400885907fec7f89",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "uideviceidentifier",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/squarefrog/UIDeviceIdentifier",
+      "state" : {
+        "revision" : "4699794b08bb79a4d77785edaba6ea739e298e4b",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "viewcontrollerpresentationspy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jonreid/ViewControllerPresentationSpy",
+      "state" : {
+        "revision" : "1d7422b88f03065e3f25eeef6cae085cecd94911",
+        "version" : "7.0.0"
+      }
+    },
+    {
+      "identity" : "viewinspector",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nalexn/ViewInspector",
+      "state" : {
+        "revision" : "5acfa0a3c095ac9ad050abe51c60d1831e8321da",
+        "version" : "0.10.0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac14247d60042986e3c4f353c125551388bcefba2a37b88e3ad8884a742e47a8",
+  "originHash" : "9ea1ab4271974e9606eddf01e2528d962e975d6abd3fb314fae28d3eeeb07fe9",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",
@@ -125,6 +125,15 @@
       "state" : {
         "revision" : "6c81e671154e63464dd6749b7ba3279dd390a146",
         "version" : "8.50.1"
+      }
+    },
+    {
+      "identity" : "svprogresshud",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SVProgressHUD/SVProgressHUD",
+      "state" : {
+        "revision" : "c33f7c775ba7feea6047a1fc3257f2e5863b44f7",
+        "version" : "2.3.1"
       }
     },
     {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -987,7 +987,6 @@
 		261E91A329C9882600A5C118 /* SubscriptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E91A229C9882600A5C118 /* SubscriptionsViewModelTests.swift */; };
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
-		2621D1F42C81085D00654C4C /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 2621D1F32C81085D00654C4C /* ViewInspector */; };
 		262418332B8D3630009A3834 /* ApplicationPasswordTutorial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */; };
 		262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */; };
 		262562352C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262562342C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift */; };
@@ -6596,7 +6595,6 @@
 				3F2B4AEC2DDC319800E5E49C /* XcodeTarget_WooCommerceTests in Frameworks */,
 				26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */,
 				B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */,
-				2621D1F42C81085D00654C4C /* ViewInspector in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14706,7 +14704,6 @@
 			);
 			name = WooCommerceTests;
 			packageProductDependencies = (
-				2621D1F32C81085D00654C4C /* ViewInspector */,
 				3F2B4AEB2DDC319800E5E49C /* XcodeTarget_WooCommerceTests */,
 			);
 			productName = WooCommerceTests;
@@ -14856,7 +14853,6 @@
 			);
 			mainGroup = B56DB3BD2049BFAA00D4AA8E;
 			packageReferences = (
-				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -19788,23 +19784,7 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/nalexn/ViewInspector";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.10.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		2621D1F32C81085D00654C4C /* ViewInspector */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */;
-			productName = ViewInspector;
-		};
 		3F2B4ADB2DDC314900E5E49C /* XcodeTarget_WordPressAuthenticatorTests */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeTarget_WordPressAuthenticatorTests;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2812,7 +2812,6 @@
 		DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA0D0672BA82EA2007786F2 /* StatsGranularityV4+UI.swift */; };
 		DEA357132ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
-		DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = DEA6BCAB2BC6A7C30017D671 /* Algorithms */; };
 		DEA6BCAF2BC6A9B10017D671 /* StoreStatsChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BCAE2BC6A9B10017D671 /* StoreStatsChart.swift */; };
 		DEA6BCB12BC6AA040017D671 /* StoreStatsChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */; };
 		DEA88F502AA9D0100037273B /* AddEditProductCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */; };
@@ -6580,7 +6579,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
@@ -14696,7 +14694,6 @@
 			name = WooCommerce;
 			packageProductDependencies = (
 				45455E312657C3F300BBB0C4 /* Shimmer */,
-				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
 				3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */,
 			);
 			productName = WooCommerce;
@@ -14876,7 +14873,6 @@
 			packageReferences = (
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
 				2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */,
 			);
@@ -19843,14 +19839,6 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/swift-algorithms.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -19943,11 +19931,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */;
 			productName = Shimmer;
-		};
-		DEA6BCAB2BC6A7C30017D671 /* Algorithms */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */;
-			productName = Algorithms;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1019,10 +1019,6 @@
 		26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */; };
 		26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
-		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
-		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		263E38462641FF3400260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; };
-		263E38472641FF3400260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		263E64202BEB419B0059D84B /* NetworkingWatchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 263E641F2BEB419B0059D84B /* NetworkingWatchOS.framework */; };
 		263E64212BEB419B0059D84B /* NetworkingWatchOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 263E641F2BEB419B0059D84B /* NetworkingWatchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		263EAF9A2A15D513008C66CB /* PrivacyBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */; };
@@ -1138,8 +1134,6 @@
 		26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */; };
 		26B542402BEAC4DC003A55B5 /* Pods_Woo_Watch_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A58DEEBCA91CDE69F439754 /* Pods_Woo_Watch_App.framework */; };
 		26B542412BEAC4DC003A55B5 /* Pods_Woo_Watch_App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6A58DEEBCA91CDE69F439754 /* Pods_Woo_Watch_App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		26B542432BEAC68B003A55B5 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 26B542422BEAC68B003A55B5 /* Codegen */; };
-		26B542442BEAC68B003A55B5 /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 26B542422BEAC68B003A55B5 /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		26B71DB6293FE490004D8052 /* RangedDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B71DB5293FE490004D8052 /* RangedDatePicker.swift */; };
 		26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B984D32BEECC610052658C /* Environment+Dependencies.swift */; };
 		26B984D62BEECF260052658C /* ConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B984D52BEECF260052658C /* ConnectView.swift */; };
@@ -1313,19 +1307,25 @@
 		3F1FA84B28B60126009E246C /* StoreWidgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */; };
 		3F1FA84C28B60126009E246C /* StoreWidgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */; };
 		3F1FA84F28B60126009E246C /* StoreWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3F1FA84028B60125009E246C /* StoreWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		3F2B4ADC2DDC314900E5E49C /* XcodeTarget_WordPressAuthenticatorTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ADB2DDC314900E5E49C /* XcodeTarget_WordPressAuthenticatorTests */; };
+		3F2B4ADE2DDC315800E5E49C /* XcodeTarget_WordPressAuthenticator in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ADD2DDC315800E5E49C /* XcodeTarget_WordPressAuthenticator */; };
+		3F2B4AE02DDC316900E5E49C /* XcodeTarget_Woo Watch App in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ADF2DDC316900E5E49C /* XcodeTarget_Woo Watch App */; };
+		3F2B4AE22DDC317500E5E49C /* XcodeTarget_NotificationExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AE12DDC317500E5E49C /* XcodeTarget_NotificationExtension */; };
+		3F2B4AE42DDC317C00E5E49C /* XcodeTarget_StoreWidgetsExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AE32DDC317C00E5E49C /* XcodeTarget_StoreWidgetsExtension */; };
+		3F2B4AE62DDC318300E5E49C /* XcodeTarget_UITestsFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AE52DDC318300E5E49C /* XcodeTarget_UITestsFoundation */; };
+		3F2B4AE82DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AE72DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests */; };
+		3F2B4AEA2DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AE92DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots */; };
+		3F2B4AEC2DDC319800E5E49C /* XcodeTarget_WooCommerceTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AEB2DDC319800E5E49C /* XcodeTarget_WooCommerceTests */; };
+		3F2B4AEE2DDC31A200E5E49C /* XcodeTarget_WooCommerce in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */; };
 		3F2C8A19285B038800B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */; };
 		3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */; };
 		3F2C8A1D285B03A400B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */; };
-		3F368D982DCB74490065B48F /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3F368D972DCB74490065B48F /* TestKit */; };
 		3F50FE4128C8319A00C89201 /* Entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 3F50FE4028C8319A00C89201 /* Entitlements */; };
 		3F50FE4328CAEBA800C89201 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		3F50FE4428CAEC5E00C89201 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		3F58701F281B947E004F7556 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F58701E281B947E004F7556 /* Main.storyboard */; };
 		3F587021281B9494004F7556 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F587020281B9494004F7556 /* LaunchScreen.storyboard */; };
 		3F587026281B9C19004F7556 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F587028281B9C19004F7556 /* InfoPlist.strings */; };
-		3F81114E2DD2A64E0042DDB6 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = 3F81114D2DD2A64E0042DDB6 /* AutomatticTracks */; };
-		3F8115072DD2AB2A0042DDB6 /* AutomatticEncryptedLogs in Frameworks */ = {isa = PBXBuildFile; productRef = 3F8115062DD2AB2A0042DDB6 /* AutomatticEncryptedLogs */; };
-		3F8BACEB2DD309E0002DD6E8 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = 3F8BACEA2DD309E0002DD6E8 /* AutomatticTracks */; };
 		3FA323272D63E0570017AE66 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FA323262D63E0570017AE66 /* XCUITestHelpers */; };
 		3FA96DF42C94043200CDA78F /* Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA96DF32C94043200CDA78F /* Yosemite.framework */; };
 		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
@@ -1337,9 +1337,6 @@
 		3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
 		3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
 		3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
-		3FF837132DD326850049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837122DD326850049E028 /* CocoaLumberjackSwift */; };
-		3FF8371A2DD32B8D0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */; };
-		3FF837212DD32F5C0049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF837202DD32F5C0049E028 /* CocoaLumberjackSwift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -3225,7 +3222,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				263E38472641FF3400260D3B /* Codegen in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3248,7 +3244,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				263E64212BEB419B0059D84B /* NetworkingWatchOS.framework in Embed Frameworks */,
-				26B542442BEAC68B003A55B5 /* Codegen in Embed Frameworks */,
 				26B542412BEAC4DC003A55B5 /* Pods_Woo_Watch_App.framework in Embed Frameworks */,
 				269FFA472BF40768004E6B86 /* WooFoundationWatchOS.framework in Embed Frameworks */,
 			);
@@ -3296,7 +3291,6 @@
 			files = (
 				3F09A3FE2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */,
 				D88FDB4625DD223B00CB0DBD /* Hardware.framework in Embed Frameworks */,
-				263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */,
 				B5C3B5EA20D189FC0072CB9D /* Storage.framework in Embed Frameworks */,
 				02AB82ED27069D5D008D7334 /* Experiments.framework in Embed Frameworks */,
 				B9151B402840EB340036180F /* WooFoundation.framework in Embed Frameworks */,
@@ -6423,7 +6417,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		3F09041C2D26A40800D8ACCE /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		3F09041C2D26A40800D8ACCE /* Exceptions for "WordPressAuthenticator" folder in "WordPressAuthenticator" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -6464,7 +6458,7 @@
 			);
 			target = 3F0904002D26A40700D8ACCE /* WordPressAuthenticator */;
 		};
-		3FD28D5E2D271391002EBB3D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		3FD28D5E2D271391002EBB3D /* Exceptions for "WordPressAuthenticatorTests" folder in "WordPressAuthenticatorTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -6478,9 +6472,41 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		2D33E6B02DD1453E000C7198 /* WooShippingPaymentMethod */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WooShippingPaymentMethod; sourceTree = "<group>"; };
-		3F0904022D26A40800D8ACCE /* WordPressAuthenticator */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3F09041C2D26A40800D8ACCE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WordPressAuthenticator; sourceTree = "<group>"; };
-		3F09040E2D26A40800D8ACCE /* WordPressAuthenticatorTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3FD28D5E2D271391002EBB3D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WordPressAuthenticatorTests; sourceTree = "<group>"; };
+		2D33E6B02DD1453E000C7198 /* WooShippingPaymentMethod */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = WooShippingPaymentMethod;
+			sourceTree = "<group>";
+		};
+		3F0904022D26A40800D8ACCE /* WordPressAuthenticator */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				3F09041C2D26A40800D8ACCE /* Exceptions for "WordPressAuthenticator" folder in "WordPressAuthenticator" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = WordPressAuthenticator;
+			sourceTree = "<group>";
+		};
+		3F09040E2D26A40800D8ACCE /* WordPressAuthenticatorTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				3FD28D5E2D271391002EBB3D /* Exceptions for "WordPressAuthenticatorTests" folder in "WordPressAuthenticatorTests" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = WordPressAuthenticatorTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -6490,6 +6516,7 @@
 			files = (
 				2679F0262AAA2A3200AF80C5 /* WooFoundation.framework in Frameworks */,
 				26CA2BC72AAA17A2003B16C2 /* SwiftUI.framework in Frameworks */,
+				3F2B4AE22DDC317500E5E49C /* XcodeTarget_NotificationExtension in Frameworks */,
 				26EE795F2AA795A000857293 /* Networking.framework in Frameworks */,
 				2608370B2AA66E4B0004A12B /* UserNotificationsUI.framework in Frameworks */,
 				260837092AA66E4B0004A12B /* UserNotifications.framework in Frameworks */,
@@ -6512,10 +6539,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				263E64202BEB419B0059D84B /* NetworkingWatchOS.framework in Frameworks */,
-				26B542432BEAC68B003A55B5 /* Codegen in Frameworks */,
+				3F2B4AE02DDC316900E5E49C /* XcodeTarget_Woo Watch App in Frameworks */,
 				26B542402BEAC4DC003A55B5 /* Pods_Woo_Watch_App.framework in Frameworks */,
 				269FFA462BF40768004E6B86 /* WooFoundationWatchOS.framework in Frameworks */,
-				3FF8371A2DD32B8D0049E028 /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6524,6 +6550,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				632DA865048E7635121D1890 /* Pods_WordPressAuthenticator.framework in Frameworks */,
+				3F2B4ADE2DDC315800E5E49C /* XcodeTarget_WordPressAuthenticator in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6532,6 +6559,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F0904092D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
+				3F2B4ADC2DDC314900E5E49C /* XcodeTarget_WordPressAuthenticatorTests in Frameworks */,
 				9075D5FFEAEF1E29E3AE0BD9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6540,6 +6568,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F2B4AE42DDC317C00E5E49C /* XcodeTarget_StoreWidgetsExtension in Frameworks */,
 				260DE20C28CA8F31009ECD7C /* Networking.framework in Frameworks */,
 				3F1FA84328B60125009E246C /* SwiftUI.framework in Frameworks */,
 				26D9E54428C107F80098DF26 /* WooFoundation.framework in Frameworks */,
@@ -6555,6 +6584,7 @@
 			files = (
 				3FF314E726FC74560012E68E /* ScreenObject in Frameworks */,
 				3FA323272D63E0570017AE66 /* XCUITestHelpers in Frameworks */,
+				3F2B4AE62DDC318300E5E49C /* XcodeTarget_UITestsFoundation in Frameworks */,
 				3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6566,18 +6596,15 @@
 				DE9F2D2C2A1B1F5D004E5957 /* ConfettiSwiftUI in Frameworks */,
 				DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
-				3F81114E2DD2A64E0042DDB6 /* AutomatticTracks in Frameworks */,
-				263E37E12641AD8300260D3B /* Codegen in Frameworks */,
 				4598298128574688003A9AFE /* Inject in Frameworks */,
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */,
 				3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
-				3FF837132DD326850049E028 /* CocoaLumberjackSwift in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
 				DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */,
-				3F8115072DD2AB2A0042DDB6 /* AutomatticEncryptedLogs in Frameworks */,
 				B5C3B5E520D189EA0072CB9D /* Storage.framework in Frameworks */,
+				3F2B4AEE2DDC31A200E5E49C /* XcodeTarget_WooCommerce in Frameworks */,
 				3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
 				B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */,
 				202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */,
@@ -6592,12 +6619,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F368D982DCB74490065B48F /* TestKit in Frameworks */,
-				263E38462641FF3400260D3B /* Codegen in Frameworks */,
+				3F2B4AEC2DDC319800E5E49C /* XcodeTarget_WooCommerceTests in Frameworks */,
 				3F2C8A19285B038800B1A5BB /* BuildkiteTestCollector in Frameworks */,
-				3FF837212DD32F5C0049E028 /* CocoaLumberjackSwift in Frameworks */,
 				2621D1F72C810DB800654C4C /* ViewControllerPresentationSpy in Frameworks */,
-				3F8BACEB2DD309E0002DD6E8 /* AutomatticTracks in Frameworks */,
 				26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */,
 				B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */,
 				2621D1F42C81085D00654C4C /* ViewInspector in Frameworks */,
@@ -6609,6 +6633,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */,
+				3F2B4AE82DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests in Frameworks */,
 				3F2C8A1D285B03A400B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */,
 				3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */,
@@ -6622,6 +6647,7 @@
 				3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */,
 				3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				24C5AC7625A53021008FD769 /* Embassy in Frameworks */,
+				3F2B4AEA2DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots in Frameworks */,
 				3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -14571,8 +14597,7 @@
 			);
 			name = "Woo Watch App";
 			packageProductDependencies = (
-				26B542422BEAC68B003A55B5 /* Codegen */,
-				3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */,
+				3F2B4ADF2DDC316900E5E49C /* XcodeTarget_Woo Watch App */,
 			);
 			productName = "Woo Watch App";
 			productReference = 26F81B152BE433A2009EC58E /* Woo Watch App.app */;
@@ -14659,6 +14684,7 @@
 			packageProductDependencies = (
 				3FF314E626FC74560012E68E /* ScreenObject */,
 				3FA323262D63E0570017AE66 /* XCUITestHelpers */,
+				3F2B4AE52DDC318300E5E49C /* XcodeTarget_UITestsFoundation */,
 			);
 			productName = UITestsFoundation;
 			productReference = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */;
@@ -14693,7 +14719,6 @@
 			);
 			name = WooCommerce;
 			packageProductDependencies = (
-				263E37E02641AD8300260D3B /* Codegen */,
 				45455E312657C3F300BBB0C4 /* Shimmer */,
 				174CA86927D90A6200126524 /* AutomatticAbout */,
 				4598298028574688003A9AFE /* Inject */,
@@ -14701,9 +14726,7 @@
 				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
 				DEA6BCA82BC6A7050017D671 /* DGCharts */,
 				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
-				3F81114D2DD2A64E0042DDB6 /* AutomatticTracks */,
-				3F8115062DD2AB2A0042DDB6 /* AutomatticEncryptedLogs */,
-				3FF837122DD326850049E028 /* CocoaLumberjackSwift */,
+				3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -14726,13 +14749,10 @@
 			);
 			name = WooCommerceTests;
 			packageProductDependencies = (
-				263E38452641FF3400260D3B /* Codegen */,
 				3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */,
 				2621D1F32C81085D00654C4C /* ViewInspector */,
 				2621D1F62C810DB800654C4C /* ViewControllerPresentationSpy */,
-				3F368D972DCB74490065B48F /* TestKit */,
-				3F8BACEA2DD309E0002DD6E8 /* AutomatticTracks */,
-				3FF837202DD32F5C0049E028 /* CocoaLumberjackSwift */,
+				3F2B4AEB2DDC319800E5E49C /* XcodeTarget_WooCommerceTests */,
 			);
 			productName = WooCommerceTests;
 			productReference = B56DB3DD2049BFAA00D4AA8E /* WooCommerceTests.xctest */;
@@ -14756,6 +14776,7 @@
 			packageProductDependencies = (
 				3FF2247226706AA3008FFA87 /* ScreenObject */,
 				3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */,
+				3F2B4AE72DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests */,
 			);
 			productName = WooCommerceUITests;
 			productReference = CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */;
@@ -14780,6 +14801,7 @@
 				247CE89B2583402A00F9D9D1 /* Embassy */,
 				3FF22489267073AE008FFA87 /* ScreenObject */,
 				3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */,
+				3F2B4AE92DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots */,
 			);
 			productName = WooCommerceScreenshots;
 			productReference = F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */;
@@ -14896,8 +14918,6 @@
 				DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
 				2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */,
-				3F81114C2DD2A64E0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */,
-				3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -15290,13 +15310,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -15475,13 +15491,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -15518,13 +15530,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -19890,28 +19898,12 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3F81114C2DD2A64E0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.5.2;
-			};
-		};
 		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.3.0;
-			};
-		};
-		3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.8.5;
 			};
 		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
@@ -19982,17 +19974,45 @@
 			package = 2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */;
 			productName = ViewControllerPresentationSpy;
 		};
-		263E37E02641AD8300260D3B /* Codegen */ = {
+		3F2B4ADB2DDC314900E5E49C /* XcodeTarget_WordPressAuthenticatorTests */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_WordPressAuthenticatorTests;
 		};
-		263E38452641FF3400260D3B /* Codegen */ = {
+		3F2B4ADD2DDC315800E5E49C /* XcodeTarget_WordPressAuthenticator */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_WordPressAuthenticator;
 		};
-		26B542422BEAC68B003A55B5 /* Codegen */ = {
+		3F2B4ADF2DDC316900E5E49C /* XcodeTarget_Woo Watch App */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = "XcodeTarget_Woo Watch App";
+		};
+		3F2B4AE12DDC317500E5E49C /* XcodeTarget_NotificationExtension */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_NotificationExtension;
+		};
+		3F2B4AE32DDC317C00E5E49C /* XcodeTarget_StoreWidgetsExtension */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_StoreWidgetsExtension;
+		};
+		3F2B4AE52DDC318300E5E49C /* XcodeTarget_UITestsFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_UITestsFoundation;
+		};
+		3F2B4AE72DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_WooCommerceUITests;
+		};
+		3F2B4AE92DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_WooCommerceScreenshots;
+		};
+		3F2B4AEB2DDC319800E5E49C /* XcodeTarget_WooCommerceTests */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_WooCommerceTests;
+		};
+		3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeTarget_WooCommerce;
 		};
 		3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -20008,25 +20028,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */;
 			productName = BuildkiteTestCollector;
-		};
-		3F368D972DCB74490065B48F /* TestKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = TestKit;
-		};
-		3F81114D2DD2A64E0042DDB6 /* AutomatticTracks */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3F81114C2DD2A64E0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
-			productName = AutomatticTracks;
-		};
-		3F8115062DD2AB2A0042DDB6 /* AutomatticEncryptedLogs */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3F81114C2DD2A64E0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
-			productName = AutomatticEncryptedLogs;
-		};
-		3F8BACEA2DD309E0002DD6E8 /* AutomatticTracks */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3F81114C2DD2A64E0042DDB6 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
-			productName = AutomatticTracks;
 		};
 		3FA323262D63E0570017AE66 /* XCUITestHelpers */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -20047,21 +20048,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;
-		};
-		3FF837122DD326850049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
-		};
-		3FF837192DD32B8D0049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
-		};
-		3FF837202DD32F5C0049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF837112DD326850049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
 		};
 		45455E312657C3F300BBB0C4 /* Shimmer */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -14852,8 +14852,6 @@
 				nl,
 			);
 			mainGroup = B56DB3BD2049BFAA00D4AA8E;
-			packageReferences = (
-			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2821,7 +2821,6 @@
 		DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA0D0672BA82EA2007786F2 /* StatsGranularityV4+UI.swift */; };
 		DEA357132ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
-		DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = DEA6BCA82BC6A7050017D671 /* DGCharts */; };
 		DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = DEA6BCAB2BC6A7C30017D671 /* Algorithms */; };
 		DEA6BCAF2BC6A9B10017D671 /* StoreStatsChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BCAE2BC6A9B10017D671 /* StoreStatsChart.swift */; };
 		DEA6BCB12BC6AA040017D671 /* StoreStatsChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */; };
@@ -6600,7 +6599,6 @@
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
-				DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */,
 				B5C3B5E520D189EA0072CB9D /* Storage.framework in Frameworks */,
 				3F2B4AEE2DDC31A200E5E49C /* XcodeTarget_WooCommerce in Frameworks */,
 				3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
@@ -14721,7 +14719,6 @@
 				4598298028574688003A9AFE /* Inject */,
 				DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */,
 				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
-				DEA6BCA82BC6A7050017D671 /* DGCharts */,
 				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
 				3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */,
 			);
@@ -14910,7 +14907,6 @@
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
 				202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */,
-				DEA6BCA72BC6A7050017D671 /* XCRemoteSwiftPackageReference "Charts" */,
 				DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
 				2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */,
@@ -19918,14 +19914,6 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		DEA6BCA72BC6A7050017D671 /* XCRemoteSwiftPackageReference "Charts" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/danielgindi/Charts.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.1.0;
-			};
-		};
 		DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-algorithms.git";
@@ -20046,11 +20034,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */;
 			productName = ConfettiSwiftUI;
-		};
-		DEA6BCA82BC6A7050017D671 /* DGCharts */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DEA6BCA72BC6A7050017D671 /* XCRemoteSwiftPackageReference "Charts" */;
-			productName = DGCharts;
 		};
 		DEA6BCAB2BC6A7C30017D671 /* Algorithms */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2817,7 +2817,6 @@
 		DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */; };
 		DE9A02A32A44441200193ABF /* RequirementsCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9A02A22A44441200193ABF /* RequirementsCheckerTests.swift */; };
 		DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9F2D282A1B1AB2004E5957 /* FirstProductCreatedView.swift */; };
-		DE9F2D2C2A1B1F5D004E5957 /* ConfettiSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */; };
 		DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA0D0672BA82EA2007786F2 /* StatsGranularityV4+UI.swift */; };
 		DEA357132ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
@@ -6591,7 +6590,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DE9F2D2C2A1B1F5D004E5957 /* ConfettiSwiftUI in Frameworks */,
 				DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
 				4598298128574688003A9AFE /* Inject in Frameworks */,
@@ -14717,7 +14715,6 @@
 			packageProductDependencies = (
 				45455E312657C3F300BBB0C4 /* Shimmer */,
 				4598298028574688003A9AFE /* Inject */,
-				DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */,
 				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
 				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
 				3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */,
@@ -14905,7 +14902,6 @@
 				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
 				202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */,
 				DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
@@ -19906,14 +19902,6 @@
 				version = 1.1.1;
 			};
 		};
-		DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/simibac/ConfettiSwiftUI.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
 		DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-algorithms.git";
@@ -20029,11 +20017,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */;
 			productName = Inject;
-		};
-		DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */;
-			productName = ConfettiSwiftUI;
 		};
 		DEA6BCAB2BC6A7C30017D671 /* Algorithms */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -948,7 +948,6 @@
 		20FCBCDF2CE241810082DCA3 /* PointOfSaleAggregateModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FCBCDE2CE241810082DCA3 /* PointOfSaleAggregateModelTests.swift */; };
 		20FCBCE12CE24CE70082DCA3 /* MockPOSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FCBCE02CE24CE70082DCA3 /* MockPOSItemProvider.swift */; };
 		20FCBCE32CE24F5D0082DCA3 /* MockPointOfSaleAggregateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FCBCE22CE24F5D0082DCA3 /* MockPointOfSaleAggregateModel.swift */; };
-		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C4F2502AEE200F49B68 /* EventLogging.swift */; };
 		2602A63D27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */; };
@@ -1324,12 +1323,8 @@
 		3F58701F281B947E004F7556 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F58701E281B947E004F7556 /* Main.storyboard */; };
 		3F587021281B9494004F7556 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F587020281B9494004F7556 /* LaunchScreen.storyboard */; };
 		3F587026281B9C19004F7556 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F587028281B9C19004F7556 /* InfoPlist.strings */; };
-		3FA323272D63E0570017AE66 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FA323262D63E0570017AE66 /* XCUITestHelpers */; };
 		3FA96DF42C94043200CDA78F /* Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA96DF32C94043200CDA78F /* Yosemite.framework */; };
-		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
-		3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF22489267073AE008FFA87 /* ScreenObject */; };
 		3FF314E126FC74450012E68E /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FF314E026FC74450012E68E /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3FF314E726FC74560012E68E /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF314E626FC74560012E68E /* ScreenObject */; };
 		3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314EF26FC784A0012E68E /* XCTest.framework */; platformFilter = ios; };
 		3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
@@ -1463,7 +1458,6 @@
 		4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */; };
 		45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EB92603F632006CDFB8 /* MapsHelper.swift */; };
 		45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EBF2604C167006CDFB8 /* PhoneHelper.swift */; };
-		4598298128574688003A9AFE /* Inject in Frameworks */ = {isa = PBXBuildFile; productRef = 4598298028574688003A9AFE /* Inject */; };
 		459DB7D52673721300E2CAD2 /* TopLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459DB7D42673721300E2CAD2 /* TopLoaderView.swift */; };
 		459DB7E2267372ED00E2CAD2 /* TopLoaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 459DB7E1267372ED00E2CAD2 /* TopLoaderView.xib */; };
 		45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0E4C92566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift */; };
@@ -6578,8 +6572,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3FF314E726FC74560012E68E /* ScreenObject in Frameworks */,
-				3FA323272D63E0570017AE66 /* XCUITestHelpers in Frameworks */,
 				3F2B4AE62DDC318300E5E49C /* XcodeTarget_UITestsFoundation in Frameworks */,
 				3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */,
 			);
@@ -6591,7 +6583,6 @@
 			files = (
 				DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
-				4598298128574688003A9AFE /* Inject in Frameworks */,
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
@@ -6628,8 +6619,6 @@
 				3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */,
 				3F2B4AE82DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests in Frameworks */,
 				3F2C8A1D285B03A400B1A5BB /* BuildkiteTestCollector in Frameworks */,
-				247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */,
-				3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6640,7 +6629,6 @@
 				3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */,
 				3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				3F2B4AEA2DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots in Frameworks */,
-				3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14674,8 +14662,6 @@
 			);
 			name = UITestsFoundation;
 			packageProductDependencies = (
-				3FF314E626FC74560012E68E /* ScreenObject */,
-				3FA323262D63E0570017AE66 /* XCUITestHelpers */,
 				3F2B4AE52DDC318300E5E49C /* XcodeTarget_UITestsFoundation */,
 			);
 			productName = UITestsFoundation;
@@ -14712,7 +14698,6 @@
 			name = WooCommerce;
 			packageProductDependencies = (
 				45455E312657C3F300BBB0C4 /* Shimmer */,
-				4598298028574688003A9AFE /* Inject */,
 				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
 				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
 				3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */,
@@ -14763,7 +14748,6 @@
 			);
 			name = WooCommerceUITests;
 			packageProductDependencies = (
-				3FF2247226706AA3008FFA87 /* ScreenObject */,
 				3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */,
 				3F2B4AE72DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests */,
 			);
@@ -14787,7 +14771,6 @@
 			);
 			name = WooCommerceScreenshots;
 			packageProductDependencies = (
-				3FF22489267073AE008FFA87 /* ScreenObject */,
 				3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */,
 				3F2B4AE92DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots */,
 			);
@@ -14895,8 +14878,6 @@
 			mainGroup = B56DB3BD2049BFAA00D4AA8E;
 			packageReferences = (
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
-				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
-				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */,
 				DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
@@ -19842,14 +19823,6 @@
 				minimumVersion = 1.2.0;
 			};
 		};
-		247CE89A2583402A00F9D9D1 /* XCRemoteSwiftPackageReference "Embassy" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/envoy/Embassy";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.1.2;
-			};
-		};
 		2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nalexn/ViewInspector";
@@ -19874,28 +19847,12 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Automattic/ScreenObject";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
-			};
-		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/markiv/SwiftUI-Shimmer";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.0;
-			};
-		};
-		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/krzysztofzablocki/Inject.git";
-			requirement = {
-				kind = exactVersion;
-				version = 1.1.1;
 			};
 		};
 		DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
@@ -19913,11 +19870,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */;
 			productName = ScrollViewSectionKit;
-		};
-		247CE89B2583402A00F9D9D1 /* Embassy */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 247CE89A2583402A00F9D9D1 /* XCRemoteSwiftPackageReference "Embassy" */;
-			productName = Embassy;
 		};
 		2621D1F32C81085D00654C4C /* ViewInspector */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -20008,11 +19960,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */;
 			productName = Shimmer;
-		};
-		4598298028574688003A9AFE /* Inject */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */;
-			productName = Inject;
 		};
 		DEA6BCAB2BC6A7C30017D671 /* Algorithms */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -988,7 +988,6 @@
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		2621D1F42C81085D00654C4C /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 2621D1F32C81085D00654C4C /* ViewInspector */; };
-		2621D1F72C810DB800654C4C /* ViewControllerPresentationSpy in Frameworks */ = {isa = PBXBuildFile; productRef = 2621D1F62C810DB800654C4C /* ViewControllerPresentationSpy */; };
 		262418332B8D3630009A3834 /* ApplicationPasswordTutorial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */; };
 		262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */; };
 		262562352C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262562342C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift */; };
@@ -6595,7 +6594,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F2B4AEC2DDC319800E5E49C /* XcodeTarget_WooCommerceTests in Frameworks */,
-				2621D1F72C810DB800654C4C /* ViewControllerPresentationSpy in Frameworks */,
 				26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */,
 				B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */,
 				2621D1F42C81085D00654C4C /* ViewInspector in Frameworks */,
@@ -14709,7 +14707,6 @@
 			name = WooCommerceTests;
 			packageProductDependencies = (
 				2621D1F32C81085D00654C4C /* ViewInspector */,
-				2621D1F62C810DB800654C4C /* ViewControllerPresentationSpy */,
 				3F2B4AEB2DDC319800E5E49C /* XcodeTarget_WooCommerceTests */,
 			);
 			productName = WooCommerceTests;
@@ -14860,7 +14857,6 @@
 			mainGroup = B56DB3BD2049BFAA00D4AA8E;
 			packageReferences = (
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
-				2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -19801,14 +19797,6 @@
 				minimumVersion = 0.10.0;
 			};
 		};
-		2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/jonreid/ViewControllerPresentationSpy";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -19816,11 +19804,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */;
 			productName = ViewInspector;
-		};
-		2621D1F62C810DB800654C4C /* ViewControllerPresentationSpy */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */;
-			productName = ViewControllerPresentationSpy;
 		};
 		3F2B4ADB2DDC314900E5E49C /* XcodeTarget_WordPressAuthenticatorTests */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -786,7 +786,6 @@
 		09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EA565327C8ACEE00407D40 /* BulkUpdateViewController.swift */; };
 		09EA565627C8ACEE00407D40 /* BulkUpdateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09EA565427C8ACEE00407D40 /* BulkUpdateViewController.xib */; };
 		09F5DE5D27CF948000E5A4D2 /* BulkUpdateOptionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F5DE5C27CF948000E5A4D2 /* BulkUpdateOptionsModel.swift */; };
-		174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */ = {isa = PBXBuildFile; productRef = 174CA86927D90A6200126524 /* AutomatticAbout */; };
 		174CA86C27D90E8900126524 /* WooAboutScreenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA86B27D90E8900126524 /* WooAboutScreenConfiguration.swift */; };
 		174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA86D27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift */; };
 		200190002C80AEAC002C1E4B /* PointOfSaleItemListFullscreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20018FFF2C80AEAC002C1E4B /* PointOfSaleItemListFullscreenView.swift */; };
@@ -6599,7 +6598,6 @@
 				4598298128574688003A9AFE /* Inject in Frameworks */,
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
-				174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */,
 				3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
 				DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */,
@@ -14720,7 +14718,6 @@
 			name = WooCommerce;
 			packageProductDependencies = (
 				45455E312657C3F300BBB0C4 /* Shimmer */,
-				174CA86927D90A6200126524 /* AutomatticAbout */,
 				4598298028574688003A9AFE /* Inject */,
 				DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */,
 				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
@@ -14909,7 +14906,6 @@
 				247CE89A2583402A00F9D9D1 /* XCRemoteSwiftPackageReference "Embassy" */,
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
-				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
@@ -19850,14 +19846,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.5;
-			};
-		};
 		202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pavolkmet/ScrollViewSectionKit";
@@ -19949,11 +19937,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		174CA86927D90A6200126524 /* AutomatticAbout */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */;
-			productName = AutomatticAbout;
-		};
 		202496632B0B9E0D00EE527D /* ScrollViewSectionKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -818,7 +818,6 @@
 		20134CE82D4D38E000076A80 /* CardPresentPaymentPlugin+SetUpTapToPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20134CE72D4D38E000076A80 /* CardPresentPaymentPlugin+SetUpTapToPay.swift */; };
 		20203AB22B31EEF1009D0C11 /* ExpandableBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */; };
 		2023E2AE2C21D8EA00FC365A /* PointOfSaleCardPresentPaymentInLineMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2023E2AD2C21D8EA00FC365A /* PointOfSaleCardPresentPaymentInLineMessage.swift */; };
-		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
 		2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */; };
 		2026ECE92C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026ECE82C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift */; };
 		2027F74F2C8F0858004BDF73 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2027F74E2C8F0858004BDF73 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift */; };
@@ -6591,7 +6590,6 @@
 				3F2B4AEE2DDC31A200E5E49C /* XcodeTarget_WooCommerce in Frameworks */,
 				3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
 				B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */,
-				202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */,
 				B5C3B5E320D189E60072CB9D /* Networking.framework in Frameworks */,
 				45455E322657C3F300BBB0C4 /* Shimmer in Frameworks */,
 				86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */,
@@ -14698,7 +14696,6 @@
 			name = WooCommerce;
 			packageProductDependencies = (
 				45455E312657C3F300BBB0C4 /* Shimmer */,
-				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
 				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
 				3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */,
 			);
@@ -14879,7 +14876,6 @@
 			packageReferences = (
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */,
 				DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
 				2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */,
@@ -19815,14 +19811,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pavolkmet/ScrollViewSectionKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
-			};
-		};
 		2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nalexn/ViewInspector";
@@ -19866,11 +19854,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		202496632B0B9E0D00EE527D /* ScrollViewSectionKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */;
-			productName = ScrollViewSectionKit;
-		};
 		2621D1F32C81085D00654C4C /* ViewInspector */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -950,7 +950,6 @@
 		20FCBCE32CE24F5D0082DCA3 /* MockPointOfSaleAggregateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FCBCE22CE24F5D0082DCA3 /* MockPointOfSaleAggregateModel.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
-		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C4F2502AEE200F49B68 /* EventLogging.swift */; };
 		2602A63D27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A63C27BD3C8C00B347F1 /* RemoteOrderSynchronizer.swift */; };
 		2602A63F27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A63E27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift */; };
@@ -6640,7 +6639,6 @@
 			files = (
 				3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */,
 				3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */,
-				24C5AC7625A53021008FD769 /* Embassy in Frameworks */,
 				3F2B4AEA2DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots in Frameworks */,
 				3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */,
 			);
@@ -14789,7 +14787,6 @@
 			);
 			name = WooCommerceScreenshots;
 			packageProductDependencies = (
-				247CE89B2583402A00F9D9D1 /* Embassy */,
 				3FF22489267073AE008FFA87 /* ScreenObject */,
 				3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */,
 				3F2B4AE92DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots */,
@@ -14897,7 +14894,6 @@
 			);
 			mainGroup = B56DB3BD2049BFAA00D4AA8E;
 			packageReferences = (
-				247CE89A2583402A00F9D9D1 /* XCRemoteSwiftPackageReference "Embassy" */,
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1313,9 +1313,6 @@
 		3F2B4AEA2DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AE92DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots */; };
 		3F2B4AEC2DDC319800E5E49C /* XcodeTarget_WooCommerceTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AEB2DDC319800E5E49C /* XcodeTarget_WooCommerceTests */; };
 		3F2B4AEE2DDC31A200E5E49C /* XcodeTarget_WooCommerce in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */; };
-		3F2C8A19285B038800B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */; };
-		3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */; };
-		3F2C8A1D285B03A400B1A5BB /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */; };
 		3F50FE4128C8319A00C89201 /* Entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 3F50FE4028C8319A00C89201 /* Entitlements */; };
 		3F50FE4328CAEBA800C89201 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		3F50FE4428CAEC5E00C89201 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
@@ -1393,7 +1390,6 @@
 		4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4541D889270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift */; };
 		454453C82755171E00464AC5 /* HubMenuCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454453C72755171E00464AC5 /* HubMenuCoordinatorTests.swift */; };
 		454453CA27566CDE00464AC5 /* HubMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454453C927566CDE00464AC5 /* HubMenuViewModel.swift */; };
-		45455E322657C3F300BBB0C4 /* Shimmer in Frameworks */ = {isa = PBXBuildFile; productRef = 45455E312657C3F300BBB0C4 /* Shimmer */; };
 		45455EFA26580B5D00BBB0C4 /* ShippingLabelCarrierRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45455EF926580B5D00BBB0C4 /* ShippingLabelCarrierRowViewModel.swift */; };
 		4546E09A271F0942003836F3 /* FilteredOrdersHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4546E098271F0942003836F3 /* FilteredOrdersHeaderBar.swift */; };
 		4546E09B271F0942003836F3 /* FilteredOrdersHeaderBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4546E099271F0942003836F3 /* FilteredOrdersHeaderBar.xib */; };
@@ -6589,7 +6585,6 @@
 				3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
 				B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */,
 				B5C3B5E320D189E60072CB9D /* Networking.framework in Frameworks */,
-				45455E322657C3F300BBB0C4 /* Shimmer in Frameworks */,
 				86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */,
 				02AB82EC27069D5D008D7334 /* Experiments.framework in Frameworks */,
 			);
@@ -6600,7 +6595,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F2B4AEC2DDC319800E5E49C /* XcodeTarget_WooCommerceTests in Frameworks */,
-				3F2C8A19285B038800B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				2621D1F72C810DB800654C4C /* ViewControllerPresentationSpy in Frameworks */,
 				26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */,
 				B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */,
@@ -6614,7 +6608,6 @@
 			files = (
 				3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */,
 				3F2B4AE82DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests in Frameworks */,
-				3F2C8A1D285B03A400B1A5BB /* BuildkiteTestCollector in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6623,7 +6616,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */,
-				3F2C8A1B285B039900B1A5BB /* BuildkiteTestCollector in Frameworks */,
 				3F2B4AEA2DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -14693,7 +14685,6 @@
 			);
 			name = WooCommerce;
 			packageProductDependencies = (
-				45455E312657C3F300BBB0C4 /* Shimmer */,
 				3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */,
 			);
 			productName = WooCommerce;
@@ -14717,7 +14708,6 @@
 			);
 			name = WooCommerceTests;
 			packageProductDependencies = (
-				3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */,
 				2621D1F32C81085D00654C4C /* ViewInspector */,
 				2621D1F62C810DB800654C4C /* ViewControllerPresentationSpy */,
 				3F2B4AEB2DDC319800E5E49C /* XcodeTarget_WooCommerceTests */,
@@ -14742,7 +14732,6 @@
 			);
 			name = WooCommerceUITests;
 			packageProductDependencies = (
-				3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */,
 				3F2B4AE72DDC318B00E5E49C /* XcodeTarget_WooCommerceUITests */,
 			);
 			productName = WooCommerceUITests;
@@ -14765,7 +14754,6 @@
 			);
 			name = WooCommerceScreenshots;
 			packageProductDependencies = (
-				3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */,
 				3F2B4AE92DDC319100E5E49C /* XcodeTarget_WooCommerceScreenshots */,
 			);
 			productName = WooCommerceScreenshots;
@@ -14871,8 +14859,6 @@
 			);
 			mainGroup = B56DB3BD2049BFAA00D4AA8E;
 			packageReferences = (
-				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
-				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				2621D1F22C81085D00654C4C /* XCRemoteSwiftPackageReference "ViewInspector" */,
 				2621D1F52C810DB800654C4C /* XCRemoteSwiftPackageReference "ViewControllerPresentationSpy" */,
 			);
@@ -19823,22 +19809,6 @@
 				minimumVersion = 7.0.0;
 			};
 		};
-		3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/buildkite/test-collector-swift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
-			};
-		};
-		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/markiv/SwiftUI-Shimmer";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -19891,46 +19861,6 @@
 		3F2B4AED2DDC31A200E5E49C /* XcodeTarget_WooCommerce */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeTarget_WooCommerce;
-		};
-		3F2C8A18285B038800B1A5BB /* BuildkiteTestCollector */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */;
-			productName = BuildkiteTestCollector;
-		};
-		3F2C8A1A285B039900B1A5BB /* BuildkiteTestCollector */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */;
-			productName = BuildkiteTestCollector;
-		};
-		3F2C8A1C285B03A400B1A5BB /* BuildkiteTestCollector */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */;
-			productName = BuildkiteTestCollector;
-		};
-		3FA323262D63E0570017AE66 /* XCUITestHelpers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
-			productName = XCUITestHelpers;
-		};
-		3FF2247226706AA3008FFA87 /* ScreenObject */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
-			productName = ScreenObject;
-		};
-		3FF22489267073AE008FFA87 /* ScreenObject */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
-			productName = ScreenObject;
-		};
-		3FF314E626FC74560012E68E /* ScreenObject */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
-			productName = ScreenObject;
-		};
-		45455E312657C3F300BBB0C4 /* Shimmer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */;
-			productName = Shimmer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -18,13 +18,11 @@
 		03597A9B28F87BFC005E4A98 /* WooCommerceComUTMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03597A9A28F87BFC005E4A98 /* WooCommerceComUTMProvider.swift */; };
 		03597A9D28F93409005E4A98 /* WooCommerceComUTMProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03597A9C28F93409005E4A98 /* WooCommerceComUTMProviderTests.swift */; };
 		035BA3A6290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A5290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift */; };
-		036563D728F93F8D00D84BFD /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 036563D628F93F8D00D84BFD /* TestKit */; };
 		03B8C3892914083F002235B1 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8C3882914083F002235B1 /* Bundle+Woo.swift */; };
 		2027F74D2C8F07DF004BDF73 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2027F74C2C8F07DF004BDF73 /* Scheduler.swift */; };
 		2027F7522C8F0B95004BDF73 /* MockScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2027F7512C8F0B95004BDF73 /* MockScheduler.swift */; };
 		203758752AD55670000E4281 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203758742AD55670000E4281 /* CountryCode.swift */; };
 		20A3AFE92B14BAB20033AF2D /* Color+Adaptivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE82B14BAB20033AF2D /* Color+Adaptivity.swift */; };
-		20AD34D32B0CDB8900F38F44 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 20AD34D22B0CDB8900F38F44 /* Codegen */; };
 		264E9E9E2BF4037D009C48FD /* WooFoundationWatchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 264E9E9D2BF4037D009C48FD /* WooFoundationWatchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		264E9EA32BF403E1009C48FD /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */; };
 		264E9EA42BF4040E009C48FD /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C662283E7296001B879F /* Logging.swift */; };
@@ -34,7 +32,6 @@
 		265C99DF28B94271005E6117 /* MurielColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265C99DE28B94271005E6117 /* MurielColorTests.swift */; };
 		269FFA4C2BF5AFC8004E6B86 /* CurrencySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65C283E71C8001B879F /* CurrencySettings.swift */; };
 		269FFA4D2BF5AFCF004E6B86 /* CurrencyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B987B06E284540D300C53CF6 /* CurrencyCode.swift */; };
-		269FFA4F2BF5B040004E6B86 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 269FFA4E2BF5B040004E6B86 /* Codegen */; };
 		26A0B2CF2BF9A51E002E9620 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65B283E71C8001B879F /* CurrencyFormatter.swift */; };
 		26A0B2D02BF9A550002E9620 /* NSDecimalNumber+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C658283E7195001B879F /* NSDecimalNumber+Helpers.swift */; };
 		26A0B2D12BF9A58C002E9620 /* Double+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65F283E71F4001B879F /* Double+Woo.swift */; };
@@ -44,8 +41,9 @@
 		26AF1F5528B8362800937BA9 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5128B8362800937BA9 /* UIColor+ColorStudio.swift */; };
 		26AF1F5628B8362800937BA9 /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5228B8362800937BA9 /* UIColor+SystemColors.swift */; };
 		26AF1F5928B9011100937BA9 /* WooStyleModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5828B9011100937BA9 /* WooStyleModifiers.swift */; };
-		3FF80E382DD322300049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF80E372DD322300049E028 /* CocoaLumberjackSwift */; };
-		3FF8370E2DD323380049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8370D2DD323380049E028 /* CocoaLumberjackSwift */; };
+		3F2B4ABC2DDC308F00E5E49C /* XcodeTarget_WooFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ABB2DDC308F00E5E49C /* XcodeTarget_WooFoundation */; };
+		3F2B4ABE2DDC309E00E5E49C /* XcodeTarget_WooFoundationWatchOS in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ABD2DDC309E00E5E49C /* XcodeTarget_WooFoundationWatchOS */; };
+		3F2B4AC02DDC30A700E5E49C /* XcodeTarget_WooFoundationTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4ABF2DDC30A700E5E49C /* XcodeTarget_WooFoundationTests */; };
 		686BE912288EE0D300967C86 /* TypedPredicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE911288EE0D300967C86 /* TypedPredicates.swift */; };
 		686BE915288EE2CA00967C86 /* TypedPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE914288EE2CA00967C86 /* TypedPredicateTests.swift */; };
 		6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6874E81328998AD300074A97 /* LogErrorAndExit.swift */; };
@@ -177,8 +175,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3FF8370E2DD323380049E028 /* CocoaLumberjackSwift in Frameworks */,
-				269FFA4F2BF5B040004E6B86 /* Codegen in Frameworks */,
+				3F2B4ABE2DDC309E00E5E49C /* XcodeTarget_WooFoundationWatchOS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -186,8 +183,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3FF80E382DD322300049E028 /* CocoaLumberjackSwift in Frameworks */,
-				20AD34D32B0CDB8900F38F44 /* Codegen in Frameworks */,
+				3F2B4ABC2DDC308F00E5E49C /* XcodeTarget_WooFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -195,8 +191,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				036563D728F93F8D00D84BFD /* TestKit in Frameworks */,
 				B9C9C63F283E703C001B879F /* WooFoundation.framework in Frameworks */,
+				3F2B4AC02DDC30A700E5E49C /* XcodeTarget_WooFoundationTests in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -460,8 +456,7 @@
 			);
 			name = WooFoundationWatchOS;
 			packageProductDependencies = (
-				269FFA4E2BF5B040004E6B86 /* Codegen */,
-				3FF8370D2DD323380049E028 /* CocoaLumberjackSwift */,
+				3F2B4ABD2DDC309E00E5E49C /* XcodeTarget_WooFoundationWatchOS */,
 			);
 			productName = WooFoundationWatchOS;
 			productReference = 264E9E9B2BF4037D009C48FD /* WooFoundationWatchOS.framework */;
@@ -483,8 +478,7 @@
 			);
 			name = WooFoundation;
 			packageProductDependencies = (
-				20AD34D22B0CDB8900F38F44 /* Codegen */,
-				3FF80E372DD322300049E028 /* CocoaLumberjackSwift */,
+				3F2B4ABB2DDC308F00E5E49C /* XcodeTarget_WooFoundation */,
 			);
 			productName = Tools;
 			productReference = B9C9C635283E703C001B879F /* WooFoundation.framework */;
@@ -505,7 +499,7 @@
 			);
 			name = WooFoundationTests;
 			packageProductDependencies = (
-				036563D628F93F8D00D84BFD /* TestKit */,
+				3F2B4ABF2DDC30A700E5E49C /* XcodeTarget_WooFoundationTests */,
 			);
 			productName = ToolsTests;
 			productReference = B9C9C63E283E703C001B879F /* WooFoundationTests.xctest */;
@@ -542,7 +536,6 @@
 			);
 			mainGroup = B9C9C5ED283E6FAA001B879F;
 			packageReferences = (
-				3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 			);
 			productRefGroup = B9C9C5FB283E6FAB001B879F /* Products */;
 			projectDirPath = "";
@@ -1168,39 +1161,18 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.8.5;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		036563D628F93F8D00D84BFD /* TestKit */ = {
+		3F2B4ABB2DDC308F00E5E49C /* XcodeTarget_WooFoundation */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = TestKit;
+			productName = XcodeTarget_WooFoundation;
 		};
-		20AD34D22B0CDB8900F38F44 /* Codegen */ = {
+		3F2B4ABD2DDC309E00E5E49C /* XcodeTarget_WooFoundationWatchOS */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_WooFoundationWatchOS;
 		};
-		269FFA4E2BF5B040004E6B86 /* Codegen */ = {
+		3F2B4ABF2DDC30A700E5E49C /* XcodeTarget_WooFoundationTests */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
-		};
-		3FF80E372DD322300049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
-		};
-		3FF8370D2DD323380049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF80E362DD322300049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
+			productName = XcodeTarget_WooFoundationTests;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -214,9 +214,6 @@
 		261CF2C7255C445A0090D8D3 /* PaymentGatewayStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF2C6255C445A0090D8D3 /* PaymentGatewayStoreTests.swift */; };
 		261F94E4242EFA6D00762B58 /* ProductCategoryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */; };
 		261F94E6242EFF8700762B58 /* ProductCategoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */; };
-		263E37DC2641AD6B00260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37DB2641AD6B00260D3B /* Codegen */; };
-		263E38422641FF2300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38412641FF2300260D3B /* Codegen */; };
-		263E38442641FF2300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E38412641FF2300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		264D2C832B0B19F200FD2C05 /* SystemInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264D2C822B0B19F200FD2C05 /* SystemInformation.swift */; };
 		26577517243D5E42003168A5 /* ProductCategoryUpdated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */; };
 		265BCA0024301ACD004E53EE /* ProductCategoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BC9FF24301ACD004E53EE /* ProductCategoryStoreTests.swift */; };
@@ -238,9 +235,9 @@
 		31799AFA27050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31799AF927050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift */; };
 		31A89EE6278CC38F002A588E /* StripeAccount+PaymentGatewayAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A89EE5278CC38F002A588E /* StripeAccount+PaymentGatewayAccount.swift */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
-		3F368D9A2DCB74B80065B48F /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3F368D992DCB74B80065B48F /* TestKit */; };
+		3F2B4AD82DDC313800E5E49C /* XcodeTarget_Yosemite in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AD72DDC313800E5E49C /* XcodeTarget_Yosemite */; };
+		3F2B4ADA2DDC313E00E5E49C /* XcodeTarget_YosemiteTests in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AD92DDC313E00E5E49C /* XcodeTarget_YosemiteTests */; };
 		3F7E6AC82DDAD3C1008309F0 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7E6AC72DDAD3C1008309F0 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift */; };
-		3FF8371D2DD32C360049E028 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF8371C2DD32C360049E028 /* CocoaLumberjackSwift */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
 		45010693239A6C9F00E24722 /* TaxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010692239A6C9F00E24722 /* TaxStore.swift */; };
 		45010695239A6CDE00E24722 /* TaxAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010694239A6CDE00E24722 /* TaxAction.swift */; };
@@ -570,7 +567,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				263E38442641FF2300260D3B /* Codegen in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1136,10 +1132,9 @@
 			files = (
 				B5B19DE220E6A45E00899568 /* Networking.framework in Frameworks */,
 				689D11D52891B9A400F6A83F /* WooFoundation.framework in Frameworks */,
+				3F2B4AD82DDC313800E5E49C /* XcodeTarget_Yosemite in Frameworks */,
 				D88FDB3E25DD222600CB0DBD /* Hardware.framework in Frameworks */,
 				B5B19DE020E6A45900899568 /* Storage.framework in Frameworks */,
-				3FF8371D2DD32C360049E028 /* CocoaLumberjackSwift in Frameworks */,
-				263E37DC2641AD6B00260D3B /* Codegen in Frameworks */,
 				0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1148,10 +1143,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F2B4ADA2DDC313E00E5E49C /* XcodeTarget_YosemiteTests in Frameworks */,
 				26FB056A25F6CB7600A40B26 /* Fakes.framework in Frameworks */,
 				B5C9DDFF2087FEC0006B910A /* Yosemite.framework in Frameworks */,
-				263E38422641FF2300260D3B /* Codegen in Frameworks */,
-				3F368D9A2DCB74B80065B48F /* TestKit in Frameworks */,
 				36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2304,8 +2298,7 @@
 			);
 			name = Yosemite;
 			packageProductDependencies = (
-				263E37DB2641AD6B00260D3B /* Codegen */,
-				3FF8371C2DD32C360049E028 /* CocoaLumberjackSwift */,
+				3F2B4AD72DDC313800E5E49C /* XcodeTarget_Yosemite */,
 			);
 			productName = FluxC;
 			productReference = B5C9DDF52087FEC0006B910A /* Yosemite.framework */;
@@ -2329,8 +2322,7 @@
 			);
 			name = YosemiteTests;
 			packageProductDependencies = (
-				263E38412641FF2300260D3B /* Codegen */,
-				3F368D992DCB74B80065B48F /* TestKit */,
+				3F2B4AD92DDC313E00E5E49C /* XcodeTarget_YosemiteTests */,
 			);
 			productName = FluxCTests;
 			productReference = B5C9DDFE2087FEC0006B910A /* YosemiteTests.xctest */;
@@ -2367,7 +2359,6 @@
 			);
 			mainGroup = B5C9DDEB2087FEC0006B910A;
 			packageReferences = (
-				3FF8371B2DD32C360049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 			);
 			productRefGroup = B5C9DDF62087FEC0006B910A /* Products */;
 			projectDirPath = "";
@@ -3380,34 +3371,14 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3FF8371B2DD32C360049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.8.5;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		263E37DB2641AD6B00260D3B /* Codegen */ = {
+		3F2B4AD72DDC313800E5E49C /* XcodeTarget_Yosemite */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
+			productName = XcodeTarget_Yosemite;
 		};
-		263E38412641FF2300260D3B /* Codegen */ = {
+		3F2B4AD92DDC313E00E5E49C /* XcodeTarget_YosemiteTests */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Codegen;
-		};
-		3F368D992DCB74B80065B48F /* TestKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = TestKit;
-		};
-		3FF8371C2DD32C360049E028 /* CocoaLumberjackSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF8371B2DD32C360049E028 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
-			productName = CocoaLumberjackSwift;
+			productName = XcodeTarget_YosemiteTests;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
## Description
The title, aligned with https://linear.app/a8c/issue/AINFRA-399 so I can link the work to our project management system, doesn't fully explain what this PR does.

The end result is that SVProgressHUD is no longer provisioned via CocoaPods, but along the way:

- An Xcode support system to provision targets with SwiftPM has been established—inspired by the work @jkmassel, @kean , and @crazytonyli did on WordPress iOS
- All existing Swift packages configured in the project have been moved to this system

This system will allow moving the existing frameworks (Networking, Storage, etc.) to `Modules/` as well as removing CocoaPods without wasting time.

With this system, every target (WooCommerce, NotificationExtension, unit and UI tests, etc.) that needs a dependency has a matching `XcodeTarget_<target name>` target in `Modules/`. All the dependencies a target needs, be them third-party or internal modules, can be listed in its supporting target in `Modules/Package.swift`.

## Steps to reproduce & Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
See green CI and prototype build.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.