### PR TITLE
Update eligibility check for shipping label creation to use plugin path instead of name

### DIFF
--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -4,8 +4,6 @@ import Yosemite
 ///
 extension SitePlugin {
     enum SupportedPlugin {
-        public static let LegacyWCShip = "WooCommerce Shipping &amp; Tax"
-        public static let WooShipping = ["Woo Shipping", "WooCommerce Shipping"]
         public static let WCTracking = "WooCommerce Shipment Tracking"
         public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
         public static let WCProductBundles = ["WooCommerce Product Bundles", "Woo Product Bundles"]
@@ -13,5 +11,10 @@ extension SitePlugin {
         public static let square = "WooCommerce Square"
         public static let WCGiftCards = ["WooCommerce Gift Cards", "Woo Gift Cards"]
         public static let GoogleForWooCommerce = ["Google Listings and Ads", "Google for WooCommerce"]
+    }
+
+    enum SupportedPluginPath {
+        public static let LegacyWCShip = "woocommerce-services/woocommerce-services.php"
+        public static let WooShipping = "woocommerce-shipping/woocommerce-shipping.php"
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -89,7 +89,7 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var shouldAllowWCShipInstallation: Bool {
         let isFeatureFlagEnabled = featureFlags.isFeatureFlagEnabled(.shippingLabelsOnboardingM1)
-        let plugin = resultsControllers.sitePlugins.first { $0.name == SitePlugin.SupportedPlugin.LegacyWCShip }
+        let plugin = resultsControllers.sitePlugins.first { $0.plugin == SitePlugin.SupportedPluginPath.LegacyWCShip }
         let isPluginInstalled = plugin != nil && resultsControllers.sitePlugins.count > 0
         let isPluginActive = plugin?.status.isActive ?? false
         let isCountryCodeUS = SiteAddress(siteSettings: siteSettings).countryCode == CountryCode.US

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -796,11 +796,11 @@ extension OrderDetailsViewModel {
             return false
         }
 
-        guard await !isPluginActive(SitePlugin.SupportedPlugin.LegacyWCShip) else {
+        guard await !isPluginActive(pluginPath: SitePlugin.SupportedPluginPath.LegacyWCShip) else {
             return true
         }
 
-        return await isPluginActive(SitePlugin.SupportedPlugin.WooShipping)
+        return await isPluginActive(pluginPath: SitePlugin.SupportedPluginPath.WooShipping)
     }
 
     /// Checks if the Woo Shipping extension is active, with the minimum version required for its shipping label flow.
@@ -808,7 +808,7 @@ extension OrderDetailsViewModel {
     @MainActor
     func isWooShippingSupported() async -> Bool {
         guard featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation),
-              let plugin = await fetchPlugin(SitePlugin.SupportedPlugin.WooShipping) else {
+              let plugin = await fetchPluginByPath(SitePlugin.SupportedPluginPath.WooShipping) else {
             return false
         }
 
@@ -885,7 +885,7 @@ extension OrderDetailsViewModel {
     ///
     private func isPluginActive(_ pluginNames: [String], completion: @escaping (Bool) -> (Void)) {
         Task { @MainActor in
-            let plugin = await fetchPlugin(pluginNames)
+            let plugin = await fetchPluginByNames(pluginNames)
             completion(plugin?.active == true)
         }
     }
@@ -894,7 +894,7 @@ extension OrderDetailsViewModel {
     /// Additionally it logs to tracks if the plugin store is accessed without it being in sync so we can handle that edge-case if it happens recurrently.
     ///
     @MainActor
-    private func fetchPlugin(_ pluginNames: [String]) async -> SystemPlugin? {
+    private func fetchPluginByNames(_ pluginNames: [String]) async -> SystemPlugin? {
         guard arePluginsSynced() else {
             DDLogError("⚠️ SystemPlugins accessed without being in sync.")
             ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.pluginsNotSyncedYet())
@@ -903,6 +903,24 @@ extension OrderDetailsViewModel {
 
         return await withCheckedContinuation { continuation in
             stores.dispatch(SystemStatusAction.fetchSystemPluginListWithNameList(siteID: order.siteID, systemPluginNameList: pluginNames, onCompletion: { plugin in
+                continuation.resume(returning: plugin)
+            }))
+        }
+    }
+
+    /// Fetches a plugin from storage, based on the provided plugin path.
+    /// Additionally it logs to tracks if the plugin store is accessed without it being in sync so we can handle that edge-case if it happens recurrently.
+    ///
+    @MainActor
+    private func fetchPluginByPath(_ path: String) async -> SystemPlugin? {
+        guard arePluginsSynced() else {
+            DDLogError("⚠️ SystemPlugins accessed without being in sync.")
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.pluginsNotSyncedYet())
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(SystemStatusAction.fetchSystemPluginWithPath(siteID: order.siteID, pluginPath: path, onCompletion: { plugin in
                 continuation.resume(returning: plugin)
             }))
         }
@@ -944,6 +962,12 @@ private extension OrderDetailsViewModel {
                 continuation.resume(returning: isActive)
             }
         }
+    }
+
+    @MainActor
+    func isPluginActive(pluginPath: String) async -> Bool {
+        let plugin = await fetchPluginByPath(pluginPath)
+        return plugin?.active == true
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -96,7 +96,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.LegacyWCShip, siteID: order.siteID, isActive: true)
+        let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.LegacyWCShip, siteID: order.siteID, isActive: true)
         whenFetchingSystemPlugin(thenReturn: plugin)
         whenSyncingShippingLabels(thenReturn: .success([]))
 
@@ -108,13 +108,13 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         // SystemStatusAction.fetchSystemPlugin
         let firstAction = try XCTUnwrap(storesManager.receivedActions.first as? SystemStatusAction)
-        guard case let SystemStatusAction.fetchSystemPluginListWithNameList(siteID, systemPluginNameList, _) = firstAction else {
+        guard case let SystemStatusAction.fetchSystemPluginWithPath(siteID, path, _) = firstAction else {
             XCTFail("Expected \(firstAction) to be \(SystemStatusAction.self)")
             return
         }
 
         XCTAssertEqual(siteID, order.siteID)
-        XCTAssertEqual(systemPluginNameList, [SitePlugin.SupportedPlugin.LegacyWCShip])
+        XCTAssertEqual(path, SitePlugin.SupportedPluginPath.LegacyWCShip)
 
         // ShippingLabelAction.synchronizeShippingLabels
         let secondAction = try XCTUnwrap(storesManager.receivedActions.last as? ShippingLabelAction)
@@ -143,7 +143,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_checkShippingLabelCreationEligibility_with_a_non_virtual_product_returns_value_from_action() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6, virtual: false)])
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.LegacyWCShip, siteID: order.siteID, isActive: true)
+        let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.LegacyWCShip, siteID: order.siteID, isActive: true)
         whenFetchingSystemPlugin(thenReturn: plugin)
         whenCheckingShippingLabelCreationEligibility(thenReturn: true)
 
@@ -174,7 +174,8 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 
         // Make sure the are plugins synced
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.LegacyWCShip, siteID: order.siteID, isActive: true)
+        let path = SitePlugin.SupportedPluginPath.LegacyWCShip
+        let plugin = insertSystemPlugin(path: path, siteID: order.siteID, isActive: true)
         whenFetchingSystemPlugin(thenReturn: plugin)
         whenCheckingShippingLabelCreationEligibility(thenReturn: true)
 
@@ -186,13 +187,13 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         // SystemStatusAction.fetchSystemPlugin
         let firstAction = try XCTUnwrap(storesManager.receivedActions.first as? SystemStatusAction)
-        guard case let SystemStatusAction.fetchSystemPluginListWithNameList(siteID, systemPluginNameList, _) = firstAction else {
+        guard case let SystemStatusAction.fetchSystemPluginWithPath(siteID: siteID, pluginPath: path, onCompletion: _) = firstAction else {
             XCTFail("Expected \(firstAction) to be \(SystemStatusAction.self)")
             return
         }
 
         XCTAssertEqual(siteID, order.siteID)
-        XCTAssertEqual(systemPluginNameList, [SitePlugin.SupportedPlugin.LegacyWCShip])
+        XCTAssertEqual(path, SitePlugin.SupportedPluginPath.LegacyWCShip)
 
         // ShippingLabelAction.synchronizeShippingLabels
         let secondAction = try XCTUnwrap(storesManager.receivedActions.last as? ShippingLabelAction)
@@ -430,7 +431,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: true, version: "1.0.5")
+        let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, siteID: order.siteID, isActive: true, version: "1.0.5")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When
@@ -444,7 +445,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: false)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: true, version: "1.0.5")
+        let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, siteID: order.siteID, isActive: true, version: "1.0.5")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When
@@ -458,7 +459,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: false, version: "1.0.5")
+        let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, siteID: order.siteID, isActive: false, version: "1.0.5")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When
@@ -472,7 +473,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: false, version: "1.0.4")
+        let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, siteID: order.siteID, isActive: false, version: "1.0.4")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When
@@ -487,6 +488,13 @@ private extension OrderDetailsViewModelTests {
     @discardableResult
     func insertSystemPlugin(name: String, siteID: Int64, isActive: Bool, version: String? = nil) -> SystemPlugin {
         let plugin = SystemPlugin.fake().copy(siteID: siteID, name: name, version: version, active: isActive)
+        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
+        return plugin
+    }
+
+    @discardableResult
+    func insertSystemPlugin(path: String, siteID: Int64, isActive: Bool, version: String? = nil) -> SystemPlugin {
+        let plugin = SystemPlugin.fake().copy(siteID: siteID, plugin: path, version: version, active: isActive)
         storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
         return plugin
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -516,8 +516,10 @@ private extension OrderDetailsViewModelTests {
                 onCompletion(plugin)
             case let .fetchSystemPluginListWithNameList(_, _, onCompletion):
                 onCompletion(plugin)
-                default:
-                    break
+            case let .fetchSystemPluginWithPath(_, _, onCompletion):
+                onCompletion(plugin)
+            default:
+                break
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -381,7 +381,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let sampleSiteID: Int64 = 1234
         let order = makeOrder()
-        let activePlugin = SitePlugin.fake().copy(siteID: sampleSiteID, status: .active, name: SitePlugin.SupportedPlugin.LegacyWCShip)
+        let activePlugin = SitePlugin.fake().copy(siteID: sampleSiteID, plugin: SitePlugin.SupportedPluginPath.LegacyWCShip, status: .active,)
         insert(activePlugin)
 
         let currencySettings = CurrencySettings(currencyCode: .USD,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -381,7 +381,9 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let sampleSiteID: Int64 = 1234
         let order = makeOrder()
-        let activePlugin = SitePlugin.fake().copy(siteID: sampleSiteID, plugin: SitePlugin.SupportedPluginPath.LegacyWCShip, status: .active,)
+        let activePlugin = SitePlugin.fake().copy(siteID: sampleSiteID,
+                                                  plugin: SitePlugin.SupportedPluginPath.LegacyWCShip,
+                                                  status: .active,)
         insert(activePlugin)
 
         let currencySettings = CurrencySettings(currencyCode: .USD,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -383,7 +383,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = makeOrder()
         let activePlugin = SitePlugin.fake().copy(siteID: sampleSiteID,
                                                   plugin: SitePlugin.SupportedPluginPath.LegacyWCShip,
-                                                  status: .active,)
+                                                  status: .active)
         insert(activePlugin)
 
         let currencySettings = CurrencySettings(currencyCode: .USD,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-502

<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

During smoke testing of iOS 22.3 [p91TBi-di8-p2], Jaclyn found an issue with the Create shipping label button on the order details screen:

> I wasn’t able to see the shipping label CTA in the instructed test site. I tried with another personal test site that I used to be able to create shipping labels and also didn’t see the CTA.

The issue is due to our check for the legacy Woo Shipping & Tax plugin name when it's has been updated in [version 3.0.0](https://github.com/Automattic/woocommerce-services/releases/tag/3.0.0).

The solution is to check for the plugin path for more reliable solution and avoid similar issue in the future. I applied the same solution to check for the new plugin Woo Shipping.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### TC1: Site with legacy plugin
1. Disable the feature flag `revampedShippingLabelCreation` and build the app.
2. Log in to a test store with the legacy WooCommerce Shipping & Tax plugin set up.
3. Navigate to the Orders tab and select a paid order with physical products with no label created yet.
4. Confirm that the Create shipping label button is available.

### TC2: Site with new plugin
1. Enable the feature flag `revampedShippingLabelCreation` and build the app.
2. Log in to a test store with the Woo Shipping plugin set up.
3. Navigate to the Orders tab and select a paid order with physical products.
4. Confirm that the Create shipping label button is available.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on simulator iPhone 16 Pro iOS 18.2 and confirmed both test cases above.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/361955ef-0477-4529-afc6-919b8d34f685" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
