### PR TITLE
[Woo POS] Handle payment intent creation error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.5
 -----
 - [internal] Optimized product image handling to reduce memory pressure by leveraging KingFisher's built-in capabilities [https://github.com/woocommerce/woocommerce-ios/pull/15629]
+- [internal] POS: Handle payment intent creation error. [https://github.com/woocommerce/woocommerce-ios/pull/15661]
 
 22.4
 -----

--- a/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSalePaymentState.swift
@@ -11,6 +11,7 @@ enum PointOfSaleCardPaymentState: Equatable {
     case cardInserted
     case validatingOrder
     case validatingOrderError
+    case paymentIntentCreationError
     case preparingReader
     case processingPayment
     case paymentError
@@ -53,6 +54,8 @@ extension PointOfSalePaymentState {
             self = .card(.paymentError)
         case .show(.paymentSuccess):
             self = .card(.cardPaymentSuccessful)
+        case .show(.paymentIntentCreationError):
+            self = .card(.paymentIntentCreationError)
         default:
             return nil
         }
@@ -67,6 +70,7 @@ extension PointOfSalePaymentState {
         case .card(.idle),
                 .card(.validatingOrder),
                 .card(.validatingOrderError),
+                .card(.paymentIntentCreationError),
                 .card(.preparingReader),
                 .card(.acceptingCard),
                 .card(.cardInserted):

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
@@ -41,6 +41,7 @@ struct PointOfSaleCardPresentPaymentIntentCreationErrorMessageView: View {
                     .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                 }
             }
+            .minimumScaleFactor(1)
             .dynamicWidthScaling(containerWidth: width)
         }
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -326,7 +326,8 @@ private extension TotalsView {
         switch posModel.paymentState {
         case .card(let cardPaymentState):
             switch cardPaymentState {
-            case .validatingOrderError:
+            case .validatingOrderError,
+                    .paymentIntentCreationError:
                 return .outlined
             case .paymentError:
                 return PaymentViewLayout(backgroundColor: backgroundColor,

--- a/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
@@ -41,7 +41,10 @@ private extension PointOfSalePaymentState {
                     .preparingReader,
                     .cardInserted:
                 return false
-            case .idle, .validatingOrderError, .acceptingCard:
+            case .idle,
+                    .validatingOrderError,
+                    .paymentIntentCreationError,
+                    .acceptingCard:
                 return true
             }
         case .cash:

--- a/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/TotalsViewHelper.swift
@@ -10,6 +10,7 @@ struct TotalsViewHelper {
                     .cardInserted,
                     .validatingOrder,
                     .validatingOrderError,
+                    .paymentIntentCreationError,
                     .preparingReader:
                 return true
             case .processingPayment,
@@ -34,6 +35,7 @@ struct TotalsViewHelper {
             return true
         case .validatingOrder,
                 .validatingOrderError,
+                .paymentIntentCreationError,
                 .processingPayment,
                 .cardInserted,
                 .paymentError,
@@ -60,6 +62,7 @@ struct TotalsViewHelper {
 
         switch cardState {
         case .validatingOrderError,
+                .paymentIntentCreationError,
              .acceptingCard:
             return true
         default:

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
@@ -78,6 +78,19 @@ struct CartViewHelperTests {
                                              paymentState: .card(.cardInserted)) == true)
     }
 
+    @Test func shouldPreventCartEditing_false_when_card_paymentState_paymentIntentCreationError() async throws {
+        // When
+        let orderLoaded = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
+            cartTotal: "$10.00",
+            orderTotal: "$12.00",
+            taxTotal: "$2.00",
+            orderTotalDecimal: 12.0))
+
+        // Then
+        #expect(sut.shouldPreventCartEditing(orderState: orderLoaded,
+                                             paymentState: .card(.paymentIntentCreationError)) == false)
+    }
+
     @Test(arguments: zip([0, 1, 2, 3], [nil, "1 item", "2 items", "3 items"]))
     func itemsInCartLabel(_ count: Int, _ expected: String?) async throws {
         // Given

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/TotalsViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/TotalsViewHelperTests.swift
@@ -38,6 +38,7 @@ struct TotalsViewHelperTests {
         (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.processingPayment),
         (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.validatingOrder),
         (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.validatingOrderError),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.paymentIntentCreationError),
         (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.cardInserted)
     ])
     func test_shouldShowDisconnectedMessage_returns_false_when_reader_connected(
@@ -50,7 +51,8 @@ struct TotalsViewHelperTests {
     @Test(arguments: [
         (PointOfSalePaymentState.card(.validatingOrderError)),
         (PointOfSalePaymentState.card(.acceptingCard)),
-        (PointOfSalePaymentState.card(.cardInserted))
+        (PointOfSalePaymentState.card(.cardInserted)),
+        (PointOfSalePaymentState.card(.paymentIntentCreationError))
     ])
     func test_shouldShowCollectCashPaymentButton_returns_true_for_supported_states(
         paymentState: PointOfSalePaymentState) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Context: pdfdoF-7ex-p2

POS didn't explicitly handle `paymentIntentCreationError`. Due to this, the back button is kept in a disabled state.

I created `.paymentIntentCreationError` card state and explicitly described how `CartView` and `TotalsView` should behave when this state happens: 

- Show cash payment button
- Show totals fields
- Allow going back
- Don't start showing the card reader disconnection message

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Add products over $1M
3. Connect reader
4. Check out
5. Confirm `Payment preparation error` is shown
6. Confirm back button continues to work

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air M2 18.2 Simulator. Tested various cases with disconnecting and connecting reader at different times, coming back, retrying the payment.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/fc4c95cb-b47e-46a9-8f5c-4b25ad018997


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.