### PR TITLE
Showcase Wormholy 1.7.0 SwiftPM issue

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "984e5b3d264e4cd48aa74aa493904155fa8e3c059e0b2c6b5fa3fdbde3ce7265",
+  "originHash" : "2398c7dd98d5b2131ac4e382a3b1ccb5241a60b1f2401b4aab6e77e2e361aca5",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -349,6 +349,15 @@
       "state" : {
         "revision" : "788e7879d38a839c4e348ab0762dcc0364e646a2",
         "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "wormholy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pmusolino/Wormholy",
+      "state" : {
+        "revision" : "695ccee03c595177ddc4b9356e2381254aae8eba",
+        "version" : "1.7.0"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
         .package(url: "https://github.com/markiv/SwiftUI-Shimmer", from: "1.0.0"),
         .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.0"),
         .package(url: "https://github.com/onevcat/Kingfisher", from: "7.6.2"),
+        .package(url: "https://github.com/pmusolino/Wormholy", from: "1.6.6"),
         .package(url: "https://github.com/pavolkmet/ScrollViewSectionKit", from: "1.2.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
         .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
@@ -262,6 +263,7 @@ enum XcodeSupport {
                     .product(name: "Shimmer", package: "SwiftUI-Shimmer"),
                     .product(name: "StripeTerminal", package: "stripe-terminal-ios"),
                     .product(name: "WordPressEditor", package: "AztecEditor-iOS"),
+                    .product(name: "Wormholy", package: "Wormholy"),
                     .product(name: "ZendeskSupportSDK", package: "support_sdk_ios"),
                 ]
             ),

--- a/Podfile
+++ b/Podfile
@@ -51,11 +51,6 @@ target 'WooCommerce' do
   pod 'WPMediaPicker', '~> 1.8'
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', commit: ''
 
-  # External Libraries
-  # ==================
-  #
-  pod 'Wormholy', '~> 1.6.6', configurations: ['Debug']
-
   # Unit Tests
   # ==========
   #

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,28 +1,24 @@
 PODS:
   - WordPressShared (2.1.0)
   - WordPressUI (1.15.1)
-  - Wormholy (1.6.6)
   - WPMediaPicker (1.8.12)
 
 DEPENDENCIES:
   - WordPressShared (~> 2.1-beta)
   - WordPressUI (~> 1.15)
-  - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8)
 
 SPEC REPOS:
   trunk:
     - WordPressShared
     - WordPressUI
-    - Wormholy
     - WPMediaPicker
 
 SPEC CHECKSUMS:
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 700e3ec5a9f77b6920c8104c338c85788036ab3c
-  Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
   WPMediaPicker: e9eaa804e1b0288d7969776608053ae0ea2941f2
 
-PODFILE CHECKSUM: bba16ee5a26e554750998f34114b2c9de00861a0
+PODFILE CHECKSUM: b6412eeca60cfd3a8be308f43ef4e8dbd03c2bd8
 
 COCOAPODS: 1.16.2

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "30ecaceed4e1b487697506426e20d60843bbce1a647790dd9bc8b78d8b2edcf7",
+  "originHash" : "2398c7dd98d5b2131ac4e382a3b1ccb5241a60b1f2401b4aab6e77e2e361aca5",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -349,6 +349,15 @@
       "state" : {
         "revision" : "5acfa0a3c095ac9ad050abe51c60d1831e8321da",
         "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "wormholy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pmusolino/Wormholy",
+      "state" : {
+        "revision" : "695ccee03c595177ddc4b9356e2381254aae8eba",
+        "version" : "1.7.0"
       }
     },
     {


### PR DESCRIPTION
As you can see from CI or by attempting the package resolution locally, the current stable Wormholy version is not compatible with the latest Swift package manager:

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/238639a5-a433-4cd3-a2ed-c1538895df8c" />

This is consistent with what's reported in https://github.com/pmusolino/Wormholy/pull/154, which is where I would start looking for a solution.

In the meantime, as discussed internally, ref p91TBi-diV-p2, we'll remove Wormholy just so we can close the CocoaPods migration project, see https://linear.app/a8c/issue/AINFRA-216