### PR TITLE
Temporarily remove Wormholy

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -44,11 +44,6 @@ target 'WooCommerce' do
   pod 'WPMediaPicker', '~> 1.8'
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', commit: ''
 
-  # External Libraries
-  # ==================
-  #
-  pod 'Wormholy', '~> 1.6.6', configurations: ['Debug']
-
   # Unit Tests
   # ==========
   #

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,20 @@
 PODS:
   - WordPressShared (2.1.0)
-  - Wormholy (1.6.6)
   - WPMediaPicker (1.8.12)
 
 DEPENDENCIES:
   - WordPressShared (~> 2.1-beta)
-  - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8)
 
 SPEC REPOS:
   trunk:
     - WordPressShared
-    - Wormholy
     - WPMediaPicker
 
 SPEC CHECKSUMS:
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
-  Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
   WPMediaPicker: e9eaa804e1b0288d7969776608053ae0ea2941f2
 
-PODFILE CHECKSUM: dc92ad9048fcc52de0e242c76e3cf53e735aa975
+PODFILE CHECKSUM: 3cdc2cfeea28093a0febd43eee21482afb084eeb
 
 COCOAPODS: 1.16.2

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -19,11 +19,6 @@ import class Yosemite.ScreenshotStoresManager
 // In that way, Inject will be available in the entire target.
 @_exported import Inject
 
-#if DEBUG
-import Wormholy
-#endif
-
-
 // MARK: - Woo's App Delegate!
 //
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -82,7 +77,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupLogLevel(.verbose)
         setupPushNotificationsManagerIfPossible(pushNotesManager, stores: stores)
         setupAppRatingManager()
-        setupWormholy()
         setupKeyboardStateProvider()
         handleLaunchArguments()
         setupUserNotificationCenter()
@@ -411,15 +405,6 @@ private extension AppDelegate {
         appRating.register(section: "notifications", significantEventCount: WooConstants.notificationEventCount)
         appRating.systemWideSignificantEventCountRequiredForPrompt = WooConstants.systemEventCount
         appRating.setVersion(version)
-    }
-
-    /// Set up Wormholy only in Debug build configuration
-    ///
-    func setupWormholy() {
-        #if DEBUG
-        /// We want to activate it programmatically, not using the shake.
-        Wormholy.shakeEnabled = false
-        #endif
     }
 
     /// Set up `KeyboardStateProvider`

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -168,8 +168,6 @@ private extension SettingsViewController {
             configureWhatsNew(cell: cell)
         case let cell as BasicTableViewCell where row == .deviceSettings:
             configureAppSettings(cell: cell)
-        case let cell as BasicTableViewCell where row == .wormholy:
-            configureWormholy(cell: cell)
         case let cell as BasicTableViewCell where row == .accountSettings:
             configureAccountSettings(cell: cell)
         case let cell as BasicTableViewCell where row == .logout:
@@ -274,12 +272,6 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.openDeviceSettings
-    }
-
-    func configureWormholy(cell: BasicTableViewCell) {
-        cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .default
-        cell.textLabel?.text = Localization.launchWormHolyDebug
     }
 
     func configureWhatsNew(cell: BasicTableViewCell) {
@@ -511,11 +503,6 @@ private extension SettingsViewController {
         UIApplication.shared.open(targetURL)
     }
 
-    func wormholyWasPressed() {
-        // Fire a local notification, which fires Wormholy if enabled.
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "wormholy_fire"), object: nil)
-    }
-
     func whatsNewWasPressed() {
         ServiceLocator.analytics.track(event: .featureAnnouncementShown(source: .appSettings))
         guard let announcement = viewModel.announcement else { return }
@@ -671,8 +658,6 @@ extension SettingsViewController: UITableViewDelegate {
             aboutWasPressed()
         case .deviceSettings:
             deviceSettingsWasPressed()
-        case .wormholy:
-            wormholyWasPressed()
         case .whatsNew:
             whatsNewWasPressed()
         case .accountSettings:
@@ -761,7 +746,6 @@ extension SettingsViewController {
 
         // Other
         case deviceSettings
-        case wormholy
 
         // Account settings
         case accountSettings
@@ -805,8 +789,6 @@ extension SettingsViewController {
             case .about:
                 return BasicTableViewCell.self
             case .deviceSettings:
-                return BasicTableViewCell.self
-            case .wormholy:
                 return BasicTableViewCell.self
             case .whatsNew:
                 return BasicTableViewCell.self
@@ -917,11 +899,6 @@ private extension SettingsViewController {
         static let openDeviceSettings = NSLocalizedString(
             "Open Device Settings",
             comment: "Opens iOS's Device Settings for the app"
-        )
-
-        static let launchWormHolyDebug = NSLocalizedString(
-            "Launch Wormholy Debug",
-            comment: "Opens an internal library called Wormholy. Not visible to users."
         )
 
         static let whatsNew = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -320,14 +320,8 @@ private extension SettingsViewModel {
 
         // Other
         let otherSection: Section = {
-            let rows: [Row]
-            #if DEBUG
-            rows = [.deviceSettings, .wormholy]
-            #else
-            rows = [.deviceSettings]
-            #endif
             return Section(title: Localization.otherTitle,
-                           rows: rows,
+                           rows: [.deviceSettings],
                            footerHeight: UITableView.automaticDimension)
         }()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
#15663 shows how Wormholy currently does not build with SwiftPM. This PR temporarily removes it in the interest of finishing the CocoaPods removal.

I say _temporarily_ because, as discussed internally, we value having a library like Wormholy in the app.

I considered simply leaving the library as the only CocoaPods one. Given it's only used in the app target, it wouldn't affect the upcoming modules move work. But I think we're better off getting rid of CocoaPods sooner rather than later. This would make the setup leaner and unlock further improvements such as dropping the workspace file

## Steps to reproduce && Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I guess referring to green CI is enough here.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.