### PR TITLE
[Woo POS] Receipts: enable feature flag with analytics

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -108,7 +108,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .inventoryProductLabelsInPOS:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleReceipts:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .productImageOptimizedHandling:
             return true
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,8 @@
 22.5
 -----
 - [*] Payments: payment method icons on the payment methods screen no longer appear blurry. [https://github.com/woocommerce/woocommerce-ios/pull/15659]
-- [*] POS: for WooCommerce version 10.0.0 and higher, a new check for POS feature switch value (in wp-admin WooCommerce Settings > Advanced > Features) was added for the POS entry point. [https://github.com/woocommerce/woocommerce-ios/pull/15662]
+- [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June), a new check for POS feature switch value (in wp-admin WooCommerce Settings > Advanced > Features) was added for the POS entry point. [https://github.com/woocommerce/woocommerce-ios/pull/15662]
+- [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June) and stores eligible for POS, sending email from the payment success screen sends out POS specific email receipts with product unit price, additional cash/card payment details, and customizable store details from POS settings in wp-admin WooCommerce Settings > Point of Sale. [https://github.com/woocommerce/woocommerce-ios/pull/15674]
 - [internal] Optimized product image handling to reduce memory pressure by leveraging KingFisher's built-in capabilities [https://github.com/woocommerce/woocommerce-ios/pull/15629]
 - [*] Payments: Added a two-minute timeout when waiting for card payments, to reduce the risk of battery drain or mistaken payments. [https://github.com/woocommerce/woocommerce-ios/pull/15665]
 - [internal] POS: Handle payment intent creation error. [https://github.com/woocommerce/woocommerce-ios/pull/15661]

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -105,22 +105,36 @@ protocol PointOfSaleOrderControllerProtocol {
     }
 
     func sendReceipt(recipientEmail: String) async throws {
-        guard let order = order else {
-            return
-        }
-        try await orderService.updatePOSOrder(order: order, recipientEmail: recipientEmail)
+        var isEligibleForPOSReceipt: Bool?
+        do {
+            guard let order else {
+                throw PointOfSaleOrderControllerError.noOrder
+            }
 
-        let isEligibleForPOSReceipt: Bool
-        if featureFlagService.isFeatureFlagEnabled(.pointOfSaleReceipts) {
-            isEligibleForPOSReceipt = await isPluginSupported(
-                POSReceiptEligibilityConstants.wcPluginName,
-                minimumVersion: POSReceiptEligibilityConstants.wcPluginMinimumVersion,
-                siteID: order.siteID
-            )
-        } else {
-            isEligibleForPOSReceipt = false
+            try await orderService.updatePOSOrder(order: order, recipientEmail: recipientEmail)
+
+            let posReceiptEligibility: Bool
+            if featureFlagService.isFeatureFlagEnabled(.pointOfSaleReceipts) {
+                posReceiptEligibility = await isPluginSupported(
+                    POSReceiptEligibilityConstants.wcPluginName,
+                    minimumVersion: POSReceiptEligibilityConstants.wcPluginMinimumVersion,
+                    siteID: order.siteID
+                )
+            } else {
+                posReceiptEligibility = false
+            }
+            isEligibleForPOSReceipt = posReceiptEligibility
+
+            try await receiptService.sendReceipt(order: order, recipientEmail: recipientEmail, isEligibleForPOSReceipt: posReceiptEligibility)
+
+            analytics.track(.receiptEmailSuccess, withProperties: ["eligible_for_pos_receipt": posReceiptEligibility])
+        } catch {
+            let properties = [
+                "eligible_for_pos_receipt": isEligibleForPOSReceipt
+            ].compactMapValues( { $0 })
+            analytics.track(.receiptEmailFailed, properties: properties, error: error)
+            throw error
         }
-        try await receiptService.sendReceipt(order: order, recipientEmail: recipientEmail, isEligibleForPOSReceipt: isEligibleForPOSReceipt)
     }
 
     func clearOrder() {

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -215,14 +215,10 @@ private extension PointOfSaleOrderController {
                     return continuation.resume(returning: false)
                 }
 
-                // Checking for concrete versions to cover dev and beta versions
-                if plugin.version.contains(minimumVersion) {
-                    return continuation.resume(returning: true)
-                }
-
                 // If plugin version is higher than minimum required version, mark as eligible
                 let isSupported = VersionHelpers.isVersionSupported(version: plugin.version,
-                                                                    minimumRequired: minimumVersion)
+                                                                    minimumRequired: minimumVersion,
+                                                                    includesDevAndBetaVersions: true)
                 continuation.resume(returning: isSupported)
             }
             stores.dispatch(action)

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -304,14 +304,7 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     func sendReceipt(to emailAddress: String) async throws {
-        do {
-            try await orderController.sendReceipt(recipientEmail: emailAddress)
-            analytics.track(.receiptEmailSuccess)
-        } catch {
-            // Catch and re-throw in order to capture the error event, but still allow the UI to handle the error state.
-            analytics.track(.receiptEmailFailed)
-            throw error
-        }
+        try await orderController.sendReceipt(recipientEmail: emailAddress)
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -195,11 +195,14 @@ struct PointOfSaleOrderControllerTests {
         let email = "test@example.com"
 
         // When
-        try await sut.sendReceipt(recipientEmail: email)
-
-        // Then
-        #expect(!mockOrderService.updateOrderWasCalled)
-        #expect(mockReceiptService.sendReceiptWasCalled == nil)
+        do {
+            try await sut.sendReceipt(recipientEmail: email)
+        } catch {
+            // Then
+            #expect(error as? PointOfSaleOrderController.PointOfSaleOrderControllerError == .noOrder)
+            #expect(!mockOrderService.updateOrderWasCalled)
+            #expect(mockReceiptService.sendReceiptWasCalled == nil)
+        }
     }
 
     @available(iOS 17.0, *)
@@ -569,6 +572,7 @@ struct PointOfSaleOrderControllerTests {
         }
     }
 
+    @MainActor
     struct AnalyticsTests {
         private let analytics: WooAnalytics
         private let analyticsProvider = MockAnalyticsProvider()
@@ -640,6 +644,87 @@ struct PointOfSaleOrderControllerTests {
 
             // Then
             #expect(mockAnalyticsProvider.receivedEvents.first(where: { $0 == "cash_payment_failed" }) != nil)
+        }
+
+        @available(iOS 17.0, *)
+        @Test func sendReceipt_tracks_success_with_eligible_for_pos_receipt() async throws {
+            // Given
+            let mockStores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+            let sut = PointOfSaleOrderController(orderService: orderService,
+                                                 receiptService: receiptService,
+                                                 stores: mockStores,
+                                                 analytics: analytics)
+            let order = Order.fake()
+            orderService.orderToReturn = order
+
+            // We need an existing order before we can send a receipt
+            await sut.syncOrder(for: .init(purchasableItems: [makeItem()]), retryHandler: { })
+
+            mockStores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+                if case let .fetchSystemPlugin(_, systemPluginName, onCompletion) = action {
+                    let plugin = SystemPlugin.fake().copy(name: systemPluginName, version: "10.0.0-dev", active: true)
+                    onCompletion(plugin)
+                }
+            }
+
+            // When
+            try await sut.sendReceipt(recipientEmail: "test@example.com")
+
+            // Then
+            let indexOfEvent = try #require(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "receipt_email_success" }))
+            #expect(analyticsProvider.receivedProperties[indexOfEvent]["eligible_for_pos_receipt"] as? Bool == true)
+        }
+
+        @available(iOS 17.0, *)
+        @Test func sendReceipt_without_order_tracks_failure_without_eligible_for_pos_receipt() async throws {
+            // Given
+            let sut = PointOfSaleOrderController(orderService: orderService,
+                                                 receiptService: receiptService,
+                                                 analytics: analytics)
+
+            // When
+            do {
+                try await sut.sendReceipt(recipientEmail: "test@example.com")
+            } catch {
+                // Then
+                let indexOfEvent = try #require(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "receipt_email_failed" }))
+                #expect(analyticsProvider.receivedProperties[indexOfEvent]["eligible_for_pos_receipt"] == nil)
+            }
+        }
+
+        @available(iOS 17.0, *)
+        @Test func sendReceipt_tracks_failure_with_eligible_for_pos_receipt() async throws {
+            // Given
+            let mockStores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+            let sut = PointOfSaleOrderController(orderService: orderService,
+                                                 receiptService: receiptService,
+                                                 stores: mockStores,
+                                                 analytics: analytics)
+
+            receiptService.sendReceiptResult = .failure(DotcomError.unknown(code: "test_error", message: "Test error"))
+
+            let order = Order.fake()
+            orderService.orderToReturn = order
+
+            // We need an existing order before we can send a receipt
+            await sut.syncOrder(for: .init(purchasableItems: [makeItem()]), retryHandler: { })
+
+            mockStores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+                if case let .fetchSystemPlugin(_, systemPluginName, onCompletion) = action {
+                    let plugin = SystemPlugin.fake().copy(name: systemPluginName, version: "10.0.0-dev", active: true)
+                    onCompletion(plugin)
+                }
+            }
+
+            // When
+            do {
+                try await sut.sendReceipt(recipientEmail: "test@example.com")
+            } catch {
+                // Then
+                let indexOfEvent = try #require(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "receipt_email_failed" }))
+                #expect(analyticsProvider.receivedProperties[indexOfEvent]["eligible_for_pos_receipt"] as? Bool == true)
+                #expect(analyticsProvider.receivedProperties[indexOfEvent]["error_description"] as? String != nil)
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockReceiptService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockReceiptService.swift
@@ -4,9 +4,16 @@ import Foundation
 final class MockReceiptService: POSReceiptServiceProtocol {
     var sendReceiptWasCalled: Bool?
     var spyIsEligibleForPOSReceipt: Bool?
+    var sendReceiptResult: Result<Void, Error> = .success(())
 
     func sendReceipt(order: Yosemite.Order, recipientEmail: String, isEligibleForPOSReceipt: Bool) async throws {
         sendReceiptWasCalled = true
         spyIsEligibleForPOSReceipt = isEligibleForPOSReceipt
+        switch sendReceiptResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
     }
 }

--- a/Yosemite/Yosemite/Tools/POS/POSReceiptService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSReceiptService.swift
@@ -33,13 +33,13 @@ public final class POSReceiptService: POSReceiptServiceProtocol {
                 try await receiptsRemote.sendReceipt(siteID: siteID, orderID: order.orderID)
             }
         } catch {
-            throw POSReceiptServiceError.sendReceiptFailed
+            throw POSReceiptServiceError.sendReceiptFailed(underlyingError: error as NSError)
         }
     }
 }
 
 public extension POSReceiptService {
     enum POSReceiptServiceError: Error {
-        case sendReceiptFailed
+        case sendReceiptFailed(underlyingError: NSError)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Fixes WOOPRD-536

- [x] @jaclync registers new event properties in affected events after the PR is approved

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request enabled the local POS receipts feature flag, and added analytics for tracking receipt sneding success and failure for non-POS and POS receipts.

### Analytics Plan from WOOPRD-535

> 1. Adding `eligible_for_pos_receipt` property to `pos_receipt_email_success` and `pos_receipt_email_failed` events
>   For this new event property:
>   - If the eligibility check is not performed (e.g. receipt cannot be sent because there is no stored order as a potential case in iOS, or the first order update API request fails before the WC version check), this property is not included.
>   - Value is a boolean when tracked.
>
> 2. Tracking error in `pos_receipt_email_failed` event
> If pos_receipt_email_failed event currently does not track the error, let's also include the error details for us to understand more about the failure events. The error is tracked the same way as we track errors in other events.

### Feature Flag Updates:
* [`Experiments/Experiments/DefaultFeatureFlagService.swift`](diffhunk://#diff-26c9afc49bb1f1a168517d43d5e36a64ff45adb046469369ef3e4d6800ccc19bL111-R111): The `pointOfSaleReceipts` feature flag now always returns `true`, enabling this feature across all build configurations.

### Error Handling Enhancements:
* [`WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift`](diffhunk://#diff-4f783ba2e4afdacfb1a907a04f2f0216e1e7dd316c503a54584834c47d0867d2L108-L123): Improved error handling in the `sendReceipt` method by introducing a custom error (`PointOfSaleOrderControllerError.noOrder`) and tracking analytics for success and failure scenarios with detailed properties.
* [`WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift`](diffhunk://#diff-b9d72a7102bb1a5778e338bc3b2046cd3490aa8dc893fc3a05f18cb655ce698cL307-L314): Removed error tracking logic from the `sendReceipt` method now that the tracking is in `PointOfSaleOrderController`, centralizing analytics tracking within the controller logic.

### Analytics Tracking Testing:
* [`WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift`](diffhunk://#diff-b2da4a624dc5cef2722f4ad046beed9819f9af13b47a1fe03a2424b1d27297aeR648-R728): Added tests to validate analytics tracking for receipt success and failure scenarios, including cases with and without eligibility for POS receipts.
* [`WooCommerce/WooCommerceTests/POS/Mocks/MockReceiptService.swift`](diffhunk://#diff-dabe0d367e9699e8c77d0a12464cc1dc5066c8818c6a58c607559a3a227a8effR7-R17): Updated the `MockReceiptService` to simulate success or failure scenarios using the `sendReceiptResult` property, enabling more robust testing of receipt handling logic.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Store with WC version < 10.0.0 (not eligible for POS receipts)

Prerequisite: the store is eligible for POS

- Go to the Menu tab
- Enter POS
- Add item(s) to cart, then check out
- Pay with card or cash
- In the success screen, tap `Email receipt`
- Enter a valid email and tap to send --> `pos_receipt_email_success` event should have a property `eligible_for_pos_receipt: false`
- In the success screen, tap `Email receipt` again
- Turn off network to simulate network error. Enter a valid email and tap to send --> `pos_receipt_email_failed` event should **not** have a property `eligible_for_pos_receipt: false` (because the order sync API request fails and returns early before eligibility check) and error properties

### Store with WC version >= 10.0.0 (eligible for POS receipts)

Prerequisite: the store is eligible for POS, and POS feature is enabled in WC Settings > Advanced > Features

- Go to the Menu tab
- Enter POS
- Add item(s) to cart, then check out
- Pay with card or cash
- In the success screen, tap `Email receipt`
- Enter a valid email and tap to send --> `pos_receipt_email_success` event should have a property `eligible_for_pos_receipt: true`
- In the success screen, tap `Email receipt` again
- Turn off network to simulate network error. Enter a valid email and tap to send --> `pos_receipt_email_failed` event should **not** have a property `eligible_for_pos_receipt: true` (because the order sync API request fails and returns early before eligibility check) and error properties

### Optional - Store with WC version >= 10.0.0 with eceipt sending error

Prerequisite: the store is eligible for POS, and POS feature is enabled in WC Settings > Advanced > Features. Receipt sending fails, this can be simulated by updating the [template ID](https://github.com/woocommerce/woocommerce-ios/blob/a9eae7b93fb1f1d4a8b2c62ecf88975291b1db21/Networking/Sources/Extended/Remote/ReceiptRemote.swift#L85) to an invalid one like `customer_pose_completed_order`

- Go to the Menu tab
- Enter POS
- Add item(s) to cart, then check out
- Pay with card or cash
- In the success screen, tap `Email receipt`
- Enter a valid email and tap to send --> `pos_receipt_email_failed` event should have a property `eligible_for_pos_receipt: true` with error properties like `error_description: Yosemite.POSReceiptService.POSReceiptServiceError.sendReceiptFailed(underlyingError: Dotcom Error: [rest_invalid_param] Invalid parameter(s): template_id)`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested all cases above on iPad Pro 11in 3rd gen iOS 18.5.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.