### PR TITLE
[Woo POS][Product Labels] Display stock levels for variations

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -150,7 +150,10 @@ private extension ChildItemList {
                             price: "5.75",
                             productID: 134,
                             variationID: 256,
-                            parentProductName: parentProduct.name
+                            parentProductName: parentProduct.name,
+                            manageStock: true,
+                            stockQuantity: 5,
+                            stockStatusKey: "instock"
                         )
                     ),
                     .variation(
@@ -161,7 +164,10 @@ private extension ChildItemList {
                             price: "6.5",
                             productID: 134,
                             variationID: 256,
-                            parentProductName: parentProduct.name
+                            parentProductName: parentProduct.name,
+                            manageStock: true,
+                            stockQuantity: 5,
+                            stockStatusKey: "instock"
                         )
                     )
                 ], hasMoreItems: false)])

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
@@ -11,6 +11,10 @@ struct VariationCardView: View {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
     }
 
+    private var shouldShowProductLabels: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inventoryProductLabelsInPOS)
+    }
+
     init(variation: POSVariation) {
         self.variation = variation
     }
@@ -32,6 +36,8 @@ struct VariationCardView: View {
                 Text(variation.formattedPrice)
                     .foregroundStyle(Constants.detailColor)
                     .font(Constants.itemDetailFont)
+                Text(variation.stockStatusKey)
+                    .renderedIf(shouldShowProductLabels)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
@@ -54,7 +60,10 @@ private extension VariationCardView {
                                  price: "5.00",
                                  productID: 134,
                                  variationID: 256,
-                                 parentProductName: "Coffee")
+                                 parentProductName: "Coffee",
+                                 manageStock: true,
+                                 stockQuantity: 5,
+                                 stockStatusKey: "instock")
     VariationCardView(variation: variation)
 }
 
@@ -66,6 +75,9 @@ private extension VariationCardView {
                                  productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg",
                                  productID: 134,
                                  variationID: 256,
-                                 parentProductName: "Coffee")
+                                 parentProductName: "Coffee",
+                                 manageStock: true,
+                                 stockQuantity: 5,
+                                 stockStatusKey: "instock")
     VariationCardView(variation: variation)
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/VariationCardView.swift
@@ -36,7 +36,9 @@ struct VariationCardView: View {
                 Text(variation.formattedPrice)
                     .foregroundStyle(Constants.detailColor)
                     .font(Constants.itemDetailFont)
-                Text(variation.stockStatusKey)
+                Text(POSStockFormatter.stockStatusLabel(for: variation))
+                    .foregroundStyle(Constants.detailColor)
+                    .font(Constants.itemDetailFont)
                     .renderedIf(shouldShowProductLabels)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))

--- a/WooCommerce/Classes/POS/Utils/POSStockFormatter.swift
+++ b/WooCommerce/Classes/POS/Utils/POSStockFormatter.swift
@@ -1,20 +1,43 @@
 import Foundation
 import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
+
+protocol POSStockManageable {
+    var manageStock: Bool { get }
+    var stockQuantity: Decimal? { get }
+    var stockStatusKey: String { get }
+}
+
+extension POSSimpleProduct: POSStockManageable {}
+extension POSVariation: POSStockManageable {}
 
 struct POSStockFormatter {
-    static func stockStatusLabel(for product: POSSimpleProduct) -> String {
+    static func stockStatusLabel(for product: POSStockManageable) -> String {
         switch product.manageStock {
         case false:
-            return product.productStockStatus.description
+            return label(for: product.stockStatusKey)
         case true:
             guard let stock = product.stockQuantity else {
-                return product.productStockStatus.description
+                return label(for: product.stockStatusKey)
             }
             if stock <= 0 {
                 return Localization.outOfStock
             } else {
                 return String.localizedStringWithFormat(Localization.inStockWithQuantity, "\(stock)")
             }
+        }
+    }
+
+    private static func label(for key: String) -> String {
+        switch key {
+        case "instock":
+            return Localization.inStock
+        case "outofstock":
+            return Localization.outOfStock
+        case "onbackorder":
+            return Localization.onBackOrder
+        default:
+            return ""
         }
     }
 
@@ -25,8 +48,18 @@ struct POSStockFormatter {
             comment: "Label to be displayed in the product's card when out of stock")
 
         static let inStockWithQuantity = NSLocalizedString(
-            "pos.stockStatusLabel.outofstock",
+            "pos.stockStatusLabel.instockwithquantity",
             value: "%1$@ in stock",
             comment: "Label to be displayed in the product's card when there's stock of a given product")
+
+        static let inStock = NSLocalizedString(
+            "pos.stockStatusLabel.instock",
+            value: "In stock",
+            comment: "Label to be displayed in the product's card when in stock")
+
+        static let onBackOrder = NSLocalizedString(
+            "pos.stockStatusLabel.onbackorder",
+            value: "On back order",
+            comment: "Label to be displayed in the product's card when on back order")
     }
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -197,14 +197,20 @@ private var mockVariationItems: [POSItem] {
                          price: "1.00",
                          productID: 134,
                          variationID: 256,
-                         parentProductName: "Variable product")),
+                         parentProductName: "Variable product",
+                         manageStock: true,
+                         stockQuantity: 5,
+                         stockStatusKey: "instock")),
         .variation(.init(id: UUID(),
                          name: "Variation 2",
                          formattedPrice: "$2.00",
                          price: "2.00",
                          productID: 134,
                          variationID: 256,
-                         parentProductName: "Variable product")),
+                         parentProductName: "Variable product",
+                         manageStock: true,
+                         stockQuantity: 5,
+                         stockStatusKey: "instock")),
     ]
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSItemProvider.swift
@@ -107,7 +107,10 @@ extension MockPointOfSaleItemService {
                                       price: "2.00",
                                       productID: 1,
                                       variationID: 1,
-                                      parentProductName: "Ice cream")
+                                      parentProductName: "Ice cream",
+                                      manageStock: true,
+                                      stockQuantity: 5,
+                                      stockStatusKey: "instock")
 
         let variation2 = POSVariation(id: fakeUUID2,
                                       name: "Vanilla",
@@ -115,7 +118,10 @@ extension MockPointOfSaleItemService {
                                       price: "2.00",
                                       productID: 1,
                                       variationID: 2,
-                                      parentProductName: "Ice cream")
+                                      parentProductName: "Ice cream",
+                                      manageStock: true,
+                                      stockQuantity: 5,
+                                      stockStatusKey: "instock")
         return [.variation(variation1), .variation(variation2)]
     }
 
@@ -129,7 +135,10 @@ extension MockPointOfSaleItemService {
                                       price: "2.00",
                                       productID: 1,
                                       variationID: 3,
-                                      parentProductName: "Ice cream")
+                                      parentProductName: "Ice cream",
+                                      manageStock: true,
+                                      stockQuantity: 5,
+                                      stockStatusKey: "instock")
 
         let variation4 = POSVariation(id: fakeUUID4,
                                       name: "Pistachio",
@@ -137,7 +146,10 @@ extension MockPointOfSaleItemService {
                                       price: "2.00",
                                       productID: 1,
                                       variationID: 4,
-                                      parentProductName: "Ice cream")
+                                      parentProductName: "Ice cream",
+                                      manageStock: true,
+                                      stockQuantity: 5,
+                                      stockStatusKey: "instock")
         return [.variation(variation3), .variation(variation4)]
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerFactoryTests.swift
@@ -186,6 +186,9 @@ private func makeVariationItem() -> POSItem {
         price: "2",
         productID: 2,
         variationID: 1,
-        parentProductName: "")
+        parentProductName: "",
+        manageStock: true,
+        stockQuantity: 5,
+        stockStatusKey: "instock")
     )
 }

--- a/Yosemite/Yosemite/PointOfSale/Items/POSVariation.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSVariation.swift
@@ -17,6 +17,11 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
     // Variation specific
     public let parentProductName: String
 
+    // Stock
+    public let manageStock: Bool
+    public let stockQuantity: Decimal?
+    public let stockStatusKey: String
+
     public init(id: UUID,
                 name: String,
                 formattedPrice: String,
@@ -24,7 +29,10 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
                 productImageSource: String? = nil,
                 productID: Int64,
                 variationID: Int64,
-                parentProductName: String) {
+                parentProductName: String,
+                manageStock: Bool,
+                stockQuantity: Decimal?,
+                stockStatusKey: String) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -33,6 +41,9 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
         self.productID = productID
         self.productVariationID = variationID
         self.parentProductName = parentProductName
+        self.manageStock = manageStock
+        self.stockQuantity = stockQuantity
+        self.stockStatusKey = stockStatusKey
     }
 }
 

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
@@ -66,7 +66,10 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                                          productImageSource: variation.image?.src,
                                          productID: variation.productID,
                                          variationID: variation.productVariationID,
-                                         parentProductName: parentProduct.name))
+                                         parentProductName: parentProduct.name,
+                                         manageStock: variation.manageStock,
+                                         stockQuantity: variation.stockQuantity,
+                                         stockStatusKey: variation.stockStatus.rawValue))
                 }),
                 hasMorePages: pagedVariations.hasMorePages,
                 totalItems: pagedVariations.totalItems


### PR DESCRIPTION
Closes WOOMOB-495

## Description

As continuation of https://github.com/woocommerce/woocommerce-ios/pull/15647/ , this PR adapts the `POSVariation` model to use `manageStock`, `stockQuantity`, and `stockStatusKey` properties. As well as render them on the view (final UI TBD)

## Testing
* Create a variable product with different variations in different stages of managed and non-managed stock. For simplicity when testing you can load POS for https://indiemelon.mystagingwebsite.com/ and look for "Variable product with managed stock" product, which contains these.
* Observe that a variation shows: 
  * If not managed, just In Stock or Out of Stock.
  * If managed, the number of items in stock, or Out of Stock.

![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-05-27 at 17 29 01](https://github.com/user-attachments/assets/06f072ee-b11d-46b6-9796-189c0f874a4d)

* You can play with those in wp-admin and exit/enter POS or PTR to fetch the latest state. This is under Products > "Variable product with managed stock" > Edit > Variation > Click on the row to edit stock status or stock levels

<img width="1492" alt="Screenshot 2025-05-27 at 17 38 22" src="https://github.com/user-attachments/assets/7407c68b-2a33-479e-add1-076f632fdb37" />

* When feature flag `inventoryProductLabelsInPOS` is disabled we shouldn't see any changes in the variation cards

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
